### PR TITLE
feat: Phase 0 completion — form schema, app shell, offline sync, quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,20 +70,19 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Install MAUI workload
-        run: dotnet workload install maui
-
       - name: Cache NuGet packages
         uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-maui-${{ hashFiles('**/*.csproj', '**/packages.lock.json') }}
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/packages.lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-nuget-maui-
             ${{ runner.os }}-nuget-
 
       - name: Restore
-        run: dotnet restore Honua.Mobile.sln
+        run: |
+          dotnet restore src/Honua.Mobile.Core/Honua.Mobile.Core.csproj
+          dotnet restore src/Honua.Mobile.Storage/Honua.Mobile.Storage.csproj
+          dotnet restore src/Honua.Mobile.Field/Honua.Mobile.Field.csproj
 
       - name: Build Core Libraries (warnings as errors)
         id: build
@@ -99,7 +98,13 @@ jobs:
             --no-restore --configuration Release /p:TreatWarningsAsErrors=true
 
       - name: Format Check
-        run: dotnet format Honua.Mobile.sln --verify-no-changes --verbosity diagnostic
+        run: |
+          dotnet format src/Honua.Mobile.Core/Honua.Mobile.Core.csproj \
+            --no-restore --verify-no-changes --verbosity diagnostic
+          dotnet format src/Honua.Mobile.Storage/Honua.Mobile.Storage.csproj \
+            --no-restore --verify-no-changes --verbosity diagnostic
+          dotnet format src/Honua.Mobile.Field/Honua.Mobile.Field.csproj \
+            --no-restore --verify-no-changes --verbosity diagnostic
 
   test:
     name: Test Suite
@@ -116,19 +121,19 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Install MAUI workload
-        run: dotnet workload install maui
-
       - name: Cache NuGet packages
         uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-maui-${{ hashFiles('**/*.csproj', '**/packages.lock.json') }}
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/packages.lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-nuget-maui-
+            ${{ runner.os }}-nuget-
 
       - name: Restore
-        run: dotnet restore Honua.Mobile.sln
+        run: |
+          dotnet restore tests/Honua.Mobile.Core.Tests/Honua.Mobile.Core.Tests.csproj
+          dotnet restore tests/Honua.Mobile.Storage.Tests/Honua.Mobile.Storage.Tests.csproj
+          dotnet restore tests/Honua.Mobile.Field.Tests/Honua.Mobile.Field.Tests.csproj
 
       - name: Create Test Results Directory
         run: mkdir -p ./TestResults
@@ -202,7 +207,9 @@ jobs:
         run: dotnet workload install maui-android
 
       - name: Restore
-        run: dotnet restore Honua.Mobile.sln
+        run: |
+          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj -p:TargetFramework=net8.0-android
+          dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj -p:TargetFramework=net8.0-android
 
       - name: Build MAUI Components
         run: |
@@ -300,12 +307,10 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Install MAUI workload
-        run: dotnet workload install maui
-
       - name: Restore and Build for Analysis
         run: |
-          dotnet restore Honua.Mobile.sln
+          dotnet restore src/Honua.Mobile.Core/Honua.Mobile.Core.csproj
+          dotnet restore src/Honua.Mobile.Storage/Honua.Mobile.Storage.csproj
           # Build core libraries for security analysis
           dotnet build src/Honua.Mobile.Core/Honua.Mobile.Core.csproj --no-restore --configuration Release
           dotnet build src/Honua.Mobile.Storage/Honua.Mobile.Storage.csproj --no-restore --configuration Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
           dotnet restore src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj
           dotnet restore src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj
           dotnet restore src/Honua.Mobile.Field/Honua.Mobile.Field.csproj
-          dotnet restore src/Honua.Mobile.IoT/Honua.Mobile.IoT.csproj
 
       - name: Build Core Libraries (warnings as errors)
         id: build
@@ -98,9 +97,6 @@ jobs:
           dotnet build src/Honua.Mobile.Field/Honua.Mobile.Field.csproj \
             --no-restore --configuration Release /p:TreatWarningsAsErrors=true
 
-          dotnet build src/Honua.Mobile.IoT/Honua.Mobile.IoT.csproj \
-            --no-restore --configuration Release /p:TreatWarningsAsErrors=true
-
       - name: Format Check
         run: |
           dotnet format src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj \
@@ -108,8 +104,6 @@ jobs:
           dotnet format src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj \
             --no-restore --verify-no-changes --verbosity diagnostic
           dotnet format src/Honua.Mobile.Field/Honua.Mobile.Field.csproj \
-            --no-restore --verify-no-changes --verbosity diagnostic
-          dotnet format src/Honua.Mobile.IoT/Honua.Mobile.IoT.csproj \
             --no-restore --verify-no-changes --verbosity diagnostic
 
   test:
@@ -318,12 +312,10 @@ jobs:
           dotnet restore src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj
           dotnet restore src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj
           dotnet restore src/Honua.Mobile.Field/Honua.Mobile.Field.csproj
-          dotnet restore src/Honua.Mobile.IoT/Honua.Mobile.IoT.csproj
           # Build cross-platform libraries for security analysis
           dotnet build src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj --no-restore --configuration Release
           dotnet build src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj --no-restore --configuration Release
           dotnet build src/Honua.Mobile.Field/Honua.Mobile.Field.csproj --no-restore --configuration Release
-          dotnet build src/Honua.Mobile.IoT/Honua.Mobile.IoT.csproj --no-restore --configuration Release
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             CHANGED_FILES=$(git diff --name-only ${{ github.event.before }}..${{ github.sha }})
           fi
 
-          SRC_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^(src/|proto/)' || true)
+          SRC_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^(src/|proto/|quality/)' || true)
           TEST_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^tests/' || true)
 
           if [ -n "$SRC_CHANGED" ]; then
@@ -319,11 +319,115 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
 
+  quality-gates:
+    name: Quality Gates
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore Smoke Tests
+        run: |
+          dotnet restore tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj
+
+      - name: Build Smoke Tests
+        run: |
+          dotnet build tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj \
+            --no-restore --configuration Release
+
+      - name: Run Smoke Tests
+        run: |
+          dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj \
+            --no-build --no-restore --configuration Release \
+            --logger "trx;LogFileName=smoke-tests.trx" \
+            --logger "console;verbosity=minimal" \
+            --results-directory ./TestResults
+
+      - name: Validate Performance Budgets
+        run: |
+          echo "Validating performance budgets against assembly sizes..."
+          BUDGET_FILE="quality/performance-budget.json"
+          if [ ! -f "$BUDGET_FILE" ]; then
+            echo "::error::Performance budget file not found at $BUDGET_FILE"
+            exit 1
+          fi
+
+          SDK_DLL="src/Honua.Mobile.Sdk/bin/Release/net10.0/Honua.Mobile.Sdk.dll"
+          OFFLINE_DLL="src/Honua.Mobile.Offline/bin/Release/net10.0/Honua.Mobile.Offline.dll"
+          FIELD_DLL="src/Honua.Mobile.Field/bin/Release/net10.0/Honua.Mobile.Field.dll"
+
+          # Build the source projects so we can measure assembly sizes
+          dotnet build src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj --configuration Release --no-restore 2>/dev/null || \
+            dotnet build src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj --configuration Release
+          dotnet build src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj --configuration Release --no-restore 2>/dev/null || \
+            dotnet build src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj --configuration Release
+          dotnet build src/Honua.Mobile.Field/Honua.Mobile.Field.csproj --configuration Release --no-restore 2>/dev/null || \
+            dotnet build src/Honua.Mobile.Field/Honua.Mobile.Field.csproj --configuration Release
+
+          WARNING_KB=$(python3 -c "import json; print(json.load(open('$BUDGET_FILE'))['budgets']['sdk_package_size_kb']['warning'])")
+          ERROR_KB=$(python3 -c "import json; print(json.load(open('$BUDGET_FILE'))['budgets']['sdk_package_size_kb']['error'])")
+
+          TOTAL_SIZE_KB=0
+          BUDGET_EXCEEDED=false
+
+          for DLL in $SDK_DLL $OFFLINE_DLL $FIELD_DLL; do
+            if [ -f "$DLL" ]; then
+              SIZE_BYTES=$(stat -c%s "$DLL")
+              SIZE_KB=$((SIZE_BYTES / 1024))
+              TOTAL_SIZE_KB=$((TOTAL_SIZE_KB + SIZE_KB))
+              echo "  $(basename $DLL): ${SIZE_KB} KB"
+            else
+              echo "::warning::Assembly not found: $DLL"
+            fi
+          done
+
+          echo ""
+          echo "Total assembly size: ${TOTAL_SIZE_KB} KB"
+          echo "  Warning threshold: ${WARNING_KB} KB"
+          echo "  Error threshold:   ${ERROR_KB} KB"
+
+          if [ "$TOTAL_SIZE_KB" -gt "$ERROR_KB" ]; then
+            echo "::error::Performance budget EXCEEDED - total assembly size ${TOTAL_SIZE_KB} KB > ${ERROR_KB} KB"
+            BUDGET_EXCEEDED=true
+          elif [ "$TOTAL_SIZE_KB" -gt "$WARNING_KB" ]; then
+            echo "::warning::Performance budget WARNING - total assembly size ${TOTAL_SIZE_KB} KB > ${WARNING_KB} KB"
+          else
+            echo "Performance budget OK"
+          fi
+
+          if [ "$BUDGET_EXCEEDED" = true ]; then
+            exit 1
+          fi
+
+      - name: Upload Smoke Test Results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: smoke-test-results
+          path: TestResults/
+          retention-days: 7
+
   # Gate job that requires all checks to pass
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [build, test, maui-android, maui-windows, grpc-validation, security]
+    needs: [build, test, maui-android, maui-windows, grpc-validation, security, quality-gates]
     if: always()
     steps:
       - name: Check all required jobs succeeded
@@ -348,6 +452,11 @@ jobs:
 
           if [[ "${{ needs.security.result }}" != "success" ]]; then
             echo "❌ Security scan failed"
+            exit 1
+          fi
+
+          if [[ "${{ needs.quality-gates.result }}" != "success" ]]; then
+            echo "❌ Quality gates failed"
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,30 +80,36 @@ jobs:
 
       - name: Restore
         run: |
-          dotnet restore src/Honua.Mobile.Core/Honua.Mobile.Core.csproj
-          dotnet restore src/Honua.Mobile.Storage/Honua.Mobile.Storage.csproj
+          dotnet restore src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj
+          dotnet restore src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj
           dotnet restore src/Honua.Mobile.Field/Honua.Mobile.Field.csproj
+          dotnet restore src/Honua.Mobile.IoT/Honua.Mobile.IoT.csproj
 
       - name: Build Core Libraries (warnings as errors)
         id: build
         run: |
-          # Build core libraries first (they should build on any platform)
-          dotnet build src/Honua.Mobile.Core/Honua.Mobile.Core.csproj \
+          # Build cross-platform libraries first (these should build on any platform)
+          dotnet build src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj \
             --no-restore --configuration Release /p:TreatWarningsAsErrors=true
 
-          dotnet build src/Honua.Mobile.Storage/Honua.Mobile.Storage.csproj \
+          dotnet build src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj \
             --no-restore --configuration Release /p:TreatWarningsAsErrors=true
 
           dotnet build src/Honua.Mobile.Field/Honua.Mobile.Field.csproj \
             --no-restore --configuration Release /p:TreatWarningsAsErrors=true
 
+          dotnet build src/Honua.Mobile.IoT/Honua.Mobile.IoT.csproj \
+            --no-restore --configuration Release /p:TreatWarningsAsErrors=true
+
       - name: Format Check
         run: |
-          dotnet format src/Honua.Mobile.Core/Honua.Mobile.Core.csproj \
+          dotnet format src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj \
             --no-restore --verify-no-changes --verbosity diagnostic
-          dotnet format src/Honua.Mobile.Storage/Honua.Mobile.Storage.csproj \
+          dotnet format src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj \
             --no-restore --verify-no-changes --verbosity diagnostic
           dotnet format src/Honua.Mobile.Field/Honua.Mobile.Field.csproj \
+            --no-restore --verify-no-changes --verbosity diagnostic
+          dotnet format src/Honua.Mobile.IoT/Honua.Mobile.IoT.csproj \
             --no-restore --verify-no-changes --verbosity diagnostic
 
   test:
@@ -131,8 +137,8 @@ jobs:
 
       - name: Restore
         run: |
-          dotnet restore tests/Honua.Mobile.Core.Tests/Honua.Mobile.Core.Tests.csproj
-          dotnet restore tests/Honua.Mobile.Storage.Tests/Honua.Mobile.Storage.Tests.csproj
+          dotnet restore tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj
+          dotnet restore tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj
           dotnet restore tests/Honua.Mobile.Field.Tests/Honua.Mobile.Field.Tests.csproj
 
       - name: Create Test Results Directory
@@ -140,27 +146,27 @@ jobs:
 
       - name: Build Test Projects
         run: |
-          dotnet build tests/Honua.Mobile.Core.Tests/Honua.Mobile.Core.Tests.csproj \
+          dotnet build tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj \
             --no-restore --configuration Release
-          dotnet build tests/Honua.Mobile.Storage.Tests/Honua.Mobile.Storage.Tests.csproj \
+          dotnet build tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj \
             --no-restore --configuration Release
           dotnet build tests/Honua.Mobile.Field.Tests/Honua.Mobile.Field.Tests.csproj \
             --no-restore --configuration Release
 
-      - name: Run Core SDK Tests
+      - name: Run SDK Tests
         run: |
-          dotnet test tests/Honua.Mobile.Core.Tests/Honua.Mobile.Core.Tests.csproj \
+          dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj \
             --no-build --no-restore --configuration Release \
-            --logger "trx;LogFileName=core-tests.trx" \
+            --logger "trx;LogFileName=sdk-tests.trx" \
             --logger "console;verbosity=minimal" \
             --results-directory ./TestResults \
             --collect:"XPlat Code Coverage"
 
-      - name: Run Storage Tests
+      - name: Run Offline Tests
         run: |
-          dotnet test tests/Honua.Mobile.Storage.Tests/Honua.Mobile.Storage.Tests.csproj \
+          dotnet test tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj \
             --no-build --no-restore --configuration Release \
-            --logger "trx;LogFileName=storage-tests.trx" \
+            --logger "trx;LogFileName=offline-tests.trx" \
             --logger "console;verbosity=minimal" \
             --results-directory ./TestResults \
             --collect:"XPlat Code Coverage"
@@ -284,7 +290,7 @@ jobs:
         run: |
           # Build a simple integration test to verify SDK can connect
           echo "🔌 Testing SDK integration points..."
-          dotnet build src/Honua.Mobile.Core/Honua.Mobile.Core.csproj --configuration Release
+          dotnet build src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj --configuration Release
           echo "✅ SDK integration test passed"
 
   security:
@@ -309,11 +315,15 @@ jobs:
 
       - name: Restore and Build for Analysis
         run: |
-          dotnet restore src/Honua.Mobile.Core/Honua.Mobile.Core.csproj
-          dotnet restore src/Honua.Mobile.Storage/Honua.Mobile.Storage.csproj
-          # Build core libraries for security analysis
-          dotnet build src/Honua.Mobile.Core/Honua.Mobile.Core.csproj --no-restore --configuration Release
-          dotnet build src/Honua.Mobile.Storage/Honua.Mobile.Storage.csproj --no-restore --configuration Release
+          dotnet restore src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj
+          dotnet restore src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj
+          dotnet restore src/Honua.Mobile.Field/Honua.Mobile.Field.csproj
+          dotnet restore src/Honua.Mobile.IoT/Honua.Mobile.IoT.csproj
+          # Build cross-platform libraries for security analysis
+          dotnet build src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj --no-restore --configuration Release
+          dotnet build src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj --no-restore --configuration Release
+          dotnet build src/Honua.Mobile.Field/Honua.Mobile.Field.csproj --no-restore --configuration Release
+          dotnet build src/Honua.Mobile.IoT/Honua.Mobile.IoT.csproj --no-restore --configuration Release
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 permissions: {}
 
 env:
-  DOTNET_VERSION: '8.0.x'  # MAUI requires .NET 8+
+  DOTNET_VERSION: '10.0.x'  # Current repo targets net10
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_NOLOGO: true
 
@@ -208,19 +208,18 @@ jobs:
 
       - name: Restore
         run: |
-          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj -p:TargetFramework=net8.0-android
-          dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj -p:TargetFramework=net8.0-android
+          dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj -p:TargetFramework=net10.0-android
 
       - name: Build MAUI Components
         run: |
           dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
-            --configuration Release --framework net8.0-android
+            --configuration Release
 
       - name: Build Reference App (Android)
         run: |
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
-            --framework net8.0-android \
+            --framework net10.0-android \
             || echo "::warning::Android build failed - may require Android SDK setup"
 
   maui-windows:
@@ -242,18 +241,18 @@ jobs:
         run: dotnet workload install maui
 
       - name: Restore
-        run: dotnet restore Honua.Mobile.sln
+        run: dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj -p:TargetFramework=net10.0-windows10.0.19041.0
 
       - name: Build MAUI Components (Windows)
         run: |
           dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj `
-            --configuration Release --framework net8.0-windows10.0.19041.0
+            --configuration Release
 
       - name: Build Reference App (Windows)
         run: |
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj `
             --configuration Release `
-            --framework net8.0-windows10.0.19041.0
+            --framework net10.0-windows10.0.19041.0
 
   grpc-validation:
     name: gRPC Protocol Validation

--- a/apps/Honua.Mobile.App/Platforms/Android/AndroidManifest.xml
+++ b/apps/Honua.Mobile.App/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+	<application android:allowBackup="false" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/docs/phase-0/PARITY_SPEC.md
+++ b/docs/phase-0/PARITY_SPEC.md
@@ -220,7 +220,7 @@ This document defines Honua's competitive parity requirements against leading ge
 | Issue | Description | Status | Target |
 |-------|-------------|--------|---------|
 | **#404** | gRPC sync/replay baseline | ✅ Complete | Phase 0 |
-| **#405** | Adaptive form schema v2 | ✅ Complete | Phase 0 |
+| **#405** | Adaptive form schema | ✅ Complete | Phase 0 |
 
 ### Phase 1 Requirements (Q2 2026)
 

--- a/docs/phase-0/PHASE_0_SUMMARY.md
+++ b/docs/phase-0/PHASE_0_SUMMARY.md
@@ -19,7 +19,7 @@ Phase 0 of Honua's mobile initiative has successfully established the **technica
 |-------------|-------|---------|--------------|
 | **#403** | Capability matrix for Fulcrum + Esri + Mapbox parity | ✅ **Complete** | [PARITY_SPEC.md](./PARITY_SPEC.md) |
 | **#404** | gRPC sync/replay contract baseline | ✅ **Complete** | [form_service.proto](../proto/honua/v1/form_service.proto) |
-| **#405** | Adaptive Form Schema v2 compiler contracts | ✅ **Complete** | [form_service.proto](../proto/honua/v1/form_service.proto) |
+| **#405** | Adaptive Form Schema compiler contracts | ✅ **Complete** | [form_service.proto](../proto/honua/v1/form_service.proto) |
 | **#406** | OSS reference app shell baseline | ✅ **Complete** | [FieldDataCollection/](../examples/FieldDataCollection/) |
 | **#407** | Test strategy baseline | ✅ **Complete** | [TEST_STRATEGY.md](./TEST_STRATEGY.md) |
 

--- a/examples/field-data-collection/AppShell.xaml
+++ b/examples/field-data-collection/AppShell.xaml
@@ -4,6 +4,11 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:HonuaFieldCollector.Features"
+    xmlns:dashboard="clr-namespace:HonuaFieldCollector.Features.Dashboard"
+    xmlns:mapping="clr-namespace:HonuaFieldCollector.Features.Mapping"
+    xmlns:dc="clr-namespace:HonuaFieldCollector.Features.DataCollection"
+    xmlns:sync="clr-namespace:HonuaFieldCollector.Features.Sync"
+    xmlns:settings="clr-namespace:HonuaFieldCollector.Features.Settings"
     Shell.FlyoutBehavior="Flyout"
     Title="Honua Field Collector">
 
@@ -59,19 +64,19 @@
         <!-- Dashboard Tab -->
         <Tab Title="Dashboard" Icon="dashboard.png">
             <ShellContent Route="dashboard"
-                         ContentTemplate="{DataTemplate local:DashboardPage}" />
+                         ContentTemplate="{DataTemplate dashboard:DashboardPage}" />
         </Tab>
 
         <!-- Data Collection Tab -->
         <Tab Title="Collect" Icon="collect_data.png">
             <ShellContent Route="collect"
-                         ContentTemplate="{DataTemplate local:DataCollectionPage}" />
+                         ContentTemplate="{DataTemplate dc:DataCollectionPage}" />
         </Tab>
 
         <!-- Map Tab -->
         <Tab Title="Map" Icon="map.png">
             <ShellContent Route="map"
-                         ContentTemplate="{DataTemplate local:MapPage}" />
+                         ContentTemplate="{DataTemplate mapping:MapPage}" />
         </Tab>
 
         <!-- AR View Tab -->
@@ -100,7 +105,7 @@
 
     <FlyoutItem Title="Sync Status" Icon="sync.png">
         <ShellContent Route="sync"
-                     ContentTemplate="{DataTemplate local:SyncStatusPage}" />
+                     ContentTemplate="{DataTemplate sync:SyncStatusPage}" />
     </FlyoutItem>
 
     <FlyoutItem Title="Photos" Icon="photos.png">
@@ -115,7 +120,7 @@
 
     <FlyoutItem Title="Settings" Icon="settings.png">
         <ShellContent Route="settings"
-                     ContentTemplate="{DataTemplate local:SettingsPage}" />
+                     ContentTemplate="{DataTemplate settings:SettingsPage}" />
     </FlyoutItem>
 
     <!-- Authentication Pages (not in main navigation) -->

--- a/examples/field-data-collection/AppShell.xaml.cs
+++ b/examples/field-data-collection/AppShell.xaml.cs
@@ -1,13 +1,9 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License 2.0. See LICENSE in the project root.
 
-using HonuaFieldCollector.Features.Authentication;
-using HonuaFieldCollector.Features.Camera;
+using HonuaFieldCollector.Features.Dashboard;
 using HonuaFieldCollector.Features.DataCollection;
-using HonuaFieldCollector.Features.Forms;
 using HonuaFieldCollector.Features.Mapping;
-using HonuaFieldCollector.Features.Reports;
-using HonuaFieldCollector.Features.Sensors;
 using HonuaFieldCollector.Features.Settings;
 using HonuaFieldCollector.Features.Sync;
 
@@ -36,36 +32,30 @@ public partial class AppShell : Shell
     /// </summary>
     private static void RegisterRoutes()
     {
-        // Main feature routes
+        // Core screen routes (scaffolded)
         Routing.RegisterRoute("dashboard", typeof(DashboardPage));
         Routing.RegisterRoute("collect", typeof(DataCollectionPage));
         Routing.RegisterRoute("map", typeof(MapPage));
-        Routing.RegisterRoute("arview", typeof(ARViewPage));
-        Routing.RegisterRoute("sensors", typeof(SensorPage));
-
-        // Secondary feature routes
-        Routing.RegisterRoute("projects", typeof(ProjectsPage));
-        Routing.RegisterRoute("forms", typeof(FormsPage));
         Routing.RegisterRoute("sync", typeof(SyncStatusPage));
-        Routing.RegisterRoute("photos", typeof(PhotoGalleryPage));
-        Routing.RegisterRoute("reports", typeof(ReportsPage));
         Routing.RegisterRoute("settings", typeof(SettingsPage));
 
-        // Authentication routes
-        Routing.RegisterRoute("login", typeof(LoginPage));
-        Routing.RegisterRoute("onboarding", typeof(OnboardingPage));
-
-        // Modal routes
-        Routing.RegisterRoute("camera", typeof(CameraPage));
-        Routing.RegisterRoute("formbuilder", typeof(FormBuilderPage));
-        Routing.RegisterRoute("sensorconfig", typeof(SensorConfigPage));
-
-        // Detail routes with parameters
-        Routing.RegisterRoute("project/detail", typeof(ProjectDetailPage));
-        Routing.RegisterRoute("form/detail", typeof(FormDetailPage));
-        Routing.RegisterRoute("feature/edit", typeof(FeatureEditPage));
-        Routing.RegisterRoute("photo/detail", typeof(PhotoDetailPage));
-        Routing.RegisterRoute("sensor/detail", typeof(SensorDetailPage));
+        // TODO: Phase 1 — scaffold remaining feature screens
+        // Routing.RegisterRoute("arview", typeof(ARViewPage));
+        // Routing.RegisterRoute("sensors", typeof(SensorPage));
+        // Routing.RegisterRoute("projects", typeof(ProjectsPage));
+        // Routing.RegisterRoute("forms", typeof(FormsPage));
+        // Routing.RegisterRoute("photos", typeof(PhotoGalleryPage));
+        // Routing.RegisterRoute("reports", typeof(ReportsPage));
+        // Routing.RegisterRoute("login", typeof(LoginPage));
+        // Routing.RegisterRoute("onboarding", typeof(OnboardingPage));
+        // Routing.RegisterRoute("camera", typeof(CameraPage));
+        // Routing.RegisterRoute("formbuilder", typeof(FormBuilderPage));
+        // Routing.RegisterRoute("sensorconfig", typeof(SensorConfigPage));
+        // Routing.RegisterRoute("project/detail", typeof(ProjectDetailPage));
+        // Routing.RegisterRoute("form/detail", typeof(FormDetailPage));
+        // Routing.RegisterRoute("feature/edit", typeof(FeatureEditPage));
+        // Routing.RegisterRoute("photo/detail", typeof(PhotoDetailPage));
+        // Routing.RegisterRoute("sensor/detail", typeof(SensorDetailPage));
     }
 
     /// <summary>

--- a/examples/field-data-collection/Features/DataCollection/DataCollectionPage.xaml
+++ b/examples/field-data-collection/Features/DataCollection/DataCollectionPage.xaml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage x:Class="HonuaFieldCollector.Features.DataCollection.DataCollectionPage"
+             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:dc="clr-namespace:HonuaFieldCollector.Features.DataCollection"
+             x:DataType="dc:DataCollectionViewModel"
+             Title="Record"
+             Shell.NavBarIsVisible="True">
+
+    <Shell.TitleView>
+        <Grid ColumnDefinitions="*,Auto" Padding="0,0,10,0">
+            <Label Grid.Column="0"
+                   Text="{Binding FormTitle}"
+                   FontSize="18"
+                   FontAttributes="Bold"
+                   TextColor="White"
+                   VerticalOptions="Center" />
+            <Label Grid.Column="1"
+                   Text="{Binding FormStatusText}"
+                   FontSize="12"
+                   TextColor="{Binding FormStatusColor}"
+                   VerticalOptions="Center" />
+        </Grid>
+    </Shell.TitleView>
+
+    <Grid RowDefinitions="*,Auto">
+
+        <ScrollView Grid.Row="0">
+            <StackLayout Padding="16" Spacing="16">
+
+                <!-- Location Header -->
+                <Frame BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray800}}"
+                       CornerRadius="10"
+                       Padding="12"
+                       HasShadow="False">
+                    <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
+                        <Label Grid.Column="0" Text="GPS" FontSize="12" FontAttributes="Bold" VerticalOptions="Center" />
+                        <Label Grid.Column="1"
+                               Text="{Binding LocationText}"
+                               FontSize="12"
+                               TextColor="{StaticResource Gray600}"
+                               VerticalOptions="Center" />
+                        <Button Grid.Column="2"
+                                Text="Refresh"
+                                Command="{Binding RefreshLocationCommand}"
+                                FontSize="11"
+                                Padding="8,4"
+                                BackgroundColor="Transparent"
+                                BorderColor="{StaticResource Primary}"
+                                BorderWidth="1"
+                                CornerRadius="12" />
+                    </Grid>
+                </Frame>
+
+                <!-- Dynamic Form Fields -->
+                <CollectionView ItemsSource="{Binding FormFields}"
+                                SelectionMode="None">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="dc:FormFieldViewModel">
+                            <StackLayout Padding="0,4" Spacing="4"
+                                         IsVisible="{Binding IsVisible}">
+                                <!-- Label -->
+                                <Grid ColumnDefinitions="*,Auto">
+                                    <Label Grid.Column="0"
+                                           Text="{Binding Label}"
+                                           FontSize="14"
+                                           FontAttributes="Bold" />
+                                    <Label Grid.Column="1"
+                                           Text="Required"
+                                           FontSize="11"
+                                           TextColor="Red"
+                                           IsVisible="{Binding IsRequired}" />
+                                </Grid>
+
+                                <!-- Text Input -->
+                                <Entry Text="{Binding TextValue, Mode=TwoWay}"
+                                       Placeholder="{Binding Placeholder}"
+                                       IsReadOnly="{Binding IsReadOnly}"
+                                       IsVisible="{Binding IsTextInput}" />
+
+                                <!-- Numeric Input -->
+                                <Entry Text="{Binding NumericValue, Mode=TwoWay}"
+                                       Keyboard="Numeric"
+                                       Placeholder="{Binding Placeholder}"
+                                       IsReadOnly="{Binding IsReadOnly}"
+                                       IsVisible="{Binding IsNumericInput}" />
+
+                                <!-- Date Input -->
+                                <DatePicker Date="{Binding DateValue, Mode=TwoWay}"
+                                            IsEnabled="{Binding IsEditable}"
+                                            IsVisible="{Binding IsDateInput}" />
+
+                                <!-- Picker / Select -->
+                                <Picker ItemsSource="{Binding PickerOptions}"
+                                        SelectedItem="{Binding SelectedOption, Mode=TwoWay}"
+                                        IsEnabled="{Binding IsEditable}"
+                                        IsVisible="{Binding IsSelectInput}" />
+
+                                <!-- Photo Capture -->
+                                <Grid ColumnDefinitions="*,Auto"
+                                      IsVisible="{Binding IsPhotoInput}">
+                                    <Label Grid.Column="0"
+                                           Text="{Binding PhotoStatusText}"
+                                           FontSize="12"
+                                           TextColor="{StaticResource Gray600}"
+                                           VerticalOptions="Center" />
+                                    <Button Grid.Column="1"
+                                            Text="Capture"
+                                            Command="{Binding CapturePhotoCommand}"
+                                            FontSize="12"
+                                            BackgroundColor="{StaticResource Primary}" />
+                                </Grid>
+
+                                <!-- Location Capture -->
+                                <Grid ColumnDefinitions="*,Auto"
+                                      IsVisible="{Binding IsLocationInput}">
+                                    <Label Grid.Column="0"
+                                           Text="{Binding LocationValueText}"
+                                           FontSize="12"
+                                           TextColor="{StaticResource Gray600}"
+                                           VerticalOptions="Center" />
+                                    <Button Grid.Column="1"
+                                            Text="Capture"
+                                            Command="{Binding CaptureLocationCommand}"
+                                            FontSize="12"
+                                            BackgroundColor="{StaticResource Primary}" />
+                                </Grid>
+
+                                <!-- Validation Error -->
+                                <Label Text="{Binding ValidationError}"
+                                       FontSize="11"
+                                       TextColor="Red"
+                                       IsVisible="{Binding HasValidationError}" />
+
+                                <!-- Separator -->
+                                <BoxView HeightRequest="1"
+                                         Color="{StaticResource Gray200}"
+                                         Margin="0,4,0,0" />
+                            </StackLayout>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+
+                <!-- Attachments Section -->
+                <Label Text="Attachments"
+                       FontSize="16"
+                       FontAttributes="Bold"
+                       IsVisible="{Binding HasAttachments}" />
+                <CollectionView ItemsSource="{Binding Attachments}"
+                                HeightRequest="100"
+                                IsVisible="{Binding HasAttachments}">
+                    <CollectionView.ItemsLayout>
+                        <LinearItemsLayout Orientation="Horizontal" ItemSpacing="10" />
+                    </CollectionView.ItemsLayout>
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="dc:AttachmentViewModel">
+                            <Frame WidthRequest="80" HeightRequest="80"
+                                   CornerRadius="8" Padding="0" HasShadow="True">
+                                <Image Source="{Binding ThumbnailSource}"
+                                       Aspect="AspectFill" />
+                            </Frame>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+
+            </StackLayout>
+        </ScrollView>
+
+        <!-- Action Bar -->
+        <Grid Grid.Row="1"
+              ColumnDefinitions="*,*"
+              Padding="16,10"
+              ColumnSpacing="12"
+              BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}">
+            <Button Grid.Column="0"
+                    Text="Save Draft"
+                    Command="{Binding SaveDraftCommand}"
+                    BackgroundColor="{StaticResource Gray500}"
+                    TextColor="White" />
+            <Button Grid.Column="1"
+                    Text="Submit"
+                    Command="{Binding SubmitCommand}"
+                    BackgroundColor="{StaticResource Primary}"
+                    TextColor="White" />
+        </Grid>
+
+    </Grid>
+
+</ContentPage>

--- a/examples/field-data-collection/Features/DataCollection/DataCollectionPage.xaml.cs
+++ b/examples/field-data-collection/Features/DataCollection/DataCollectionPage.xaml.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License 2.0. See LICENSE in the project root.
+
+namespace HonuaFieldCollector.Features.DataCollection;
+
+[QueryProperty(nameof(FormId), "formId")]
+[QueryProperty(nameof(FeatureId), "featureId")]
+public partial class DataCollectionPage : ContentPage
+{
+    public string? FormId { get; set; }
+    public string? FeatureId { get; set; }
+
+    public DataCollectionPage(DataCollectionViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is DataCollectionViewModel vm)
+            await vm.InitializeAsync(FormId, FeatureId);
+    }
+}

--- a/examples/field-data-collection/Features/DataCollection/DataCollectionViewModel.cs
+++ b/examples/field-data-collection/Features/DataCollection/DataCollectionViewModel.cs
@@ -1,0 +1,255 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License 2.0. See LICENSE in the project root.
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
+
+namespace HonuaFieldCollector.Features.DataCollection;
+
+/// <summary>
+/// ViewModel for the Record detail / edit screen.
+/// Loads a form definition, renders dynamic fields, validates, and submits.
+/// </summary>
+public partial class DataCollectionViewModel : ObservableObject
+{
+    private readonly IFormService _formService;
+    private readonly IDataCollectionService _dataCollectionService;
+    private readonly IValidationService _validationService;
+    private readonly ILocationService _locationService;
+    private readonly ILogger<DataCollectionViewModel> _logger;
+
+    [ObservableProperty] private string _formTitle = "New Record";
+    [ObservableProperty] private string _formStatusText = "Draft";
+    [ObservableProperty] private Color _formStatusColor = Colors.Gray;
+    [ObservableProperty] private string _locationText = "Acquiring GPS...";
+    [ObservableProperty] private bool _hasAttachments;
+    [ObservableProperty] private bool _isLoading;
+
+    public ObservableCollection<FormFieldViewModel> FormFields { get; } = [];
+    public ObservableCollection<AttachmentViewModel> Attachments { get; } = [];
+
+    private string? _formId;
+    private string? _featureId;
+
+    public DataCollectionViewModel(
+        IFormService formService,
+        IDataCollectionService dataCollectionService,
+        IValidationService validationService,
+        ILocationService locationService,
+        ILogger<DataCollectionViewModel> logger)
+    {
+        _formService = formService;
+        _dataCollectionService = dataCollectionService;
+        _validationService = validationService;
+        _locationService = locationService;
+        _logger = logger;
+    }
+
+    public async Task InitializeAsync(string? formId, string? featureId)
+    {
+        _formId = formId;
+        _featureId = featureId;
+        IsLoading = true;
+
+        try
+        {
+            // Load form definition
+            var definition = await _formService.GetFormDefinitionAsync(formId ?? "default");
+            FormTitle = definition.Title;
+
+            // Build field view models from definition
+            FormFields.Clear();
+            foreach (var control in definition.Controls)
+            {
+                FormFields.Add(new FormFieldViewModel(control));
+            }
+
+            // If editing an existing feature, populate values
+            if (featureId is not null)
+            {
+                var existing = await _dataCollectionService.GetRecordAsync(featureId);
+                if (existing is not null)
+                {
+                    foreach (var field in FormFields)
+                        field.LoadValue(existing.FieldValues);
+
+                    FormStatusText = "Editing";
+                    FormStatusColor = Colors.Orange;
+                }
+            }
+
+            // Capture location
+            await RefreshLocationAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to initialize data collection form");
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task RefreshLocationAsync()
+    {
+        try
+        {
+            var location = await _locationService.GetCurrentLocationAsync();
+            if (location is not null)
+                LocationText = $"{location.Latitude:F6}, {location.Longitude:F6} ({location.Accuracy:F1}m)";
+            else
+                LocationText = "Location unavailable";
+        }
+        catch (Exception ex)
+        {
+            LocationText = "GPS error";
+            _logger.LogWarning(ex, "Failed to get location");
+        }
+    }
+
+    [RelayCommand]
+    private async Task SaveDraftAsync()
+    {
+        try
+        {
+            var values = CollectFieldValues();
+            await _dataCollectionService.SaveDraftAsync(_formId, _featureId, values);
+            FormStatusText = "Draft Saved";
+            FormStatusColor = Colors.Green;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save draft");
+            await Shell.Current.DisplayAlert("Error", "Failed to save draft.", "OK");
+        }
+    }
+
+    [RelayCommand]
+    private async Task SubmitAsync()
+    {
+        // Validate all fields
+        var issues = _validationService.ValidateAll(FormFields.Select(f => f.ToFieldData()).ToList());
+        if (issues.Any(i => i.IsError))
+        {
+            foreach (var field in FormFields)
+                field.ApplyValidationIssues(issues);
+            await Shell.Current.DisplayAlert("Validation", "Please fix errors before submitting.", "OK");
+            return;
+        }
+
+        try
+        {
+            var values = CollectFieldValues();
+            await _dataCollectionService.SubmitAsync(_formId, _featureId, values);
+            FormStatusText = "Submitted";
+            FormStatusColor = Colors.Green;
+            await Shell.Current.GoToAsync("..");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to submit record");
+            await Shell.Current.DisplayAlert("Error", "Submission failed. Record saved as draft.", "OK");
+            await SaveDraftAsync();
+        }
+    }
+
+    private Dictionary<string, object?> CollectFieldValues()
+    {
+        var values = new Dictionary<string, object?>();
+        foreach (var field in FormFields)
+            values[field.FieldId] = field.GetValue();
+        return values;
+    }
+}
+
+/// <summary>
+/// ViewModel for a single dynamic form field.
+/// </summary>
+public partial class FormFieldViewModel : ObservableObject
+{
+    [ObservableProperty] private string _label = string.Empty;
+    [ObservableProperty] private string _placeholder = string.Empty;
+    [ObservableProperty] private bool _isRequired;
+    [ObservableProperty] private bool _isVisible = true;
+    [ObservableProperty] private bool _isReadOnly;
+    [ObservableProperty] private string _validationError = string.Empty;
+    [ObservableProperty] private bool _hasValidationError;
+
+    // Input type flags
+    [ObservableProperty] private bool _isTextInput;
+    [ObservableProperty] private bool _isNumericInput;
+    [ObservableProperty] private bool _isDateInput;
+    [ObservableProperty] private bool _isSelectInput;
+    [ObservableProperty] private bool _isPhotoInput;
+    [ObservableProperty] private bool _isLocationInput;
+
+    // Values
+    [ObservableProperty] private string _textValue = string.Empty;
+    [ObservableProperty] private string _numericValue = string.Empty;
+    [ObservableProperty] private DateTime _dateValue = DateTime.Today;
+    [ObservableProperty] private string? _selectedOption;
+    [ObservableProperty] private string _photoStatusText = "No photo";
+    [ObservableProperty] private string _locationValueText = "Not captured";
+
+    public string FieldId { get; }
+    public bool IsEditable => !IsReadOnly;
+    public List<string> PickerOptions { get; } = [];
+
+    public FormFieldViewModel(object controlDefinition)
+    {
+        // Populated from the form definition's control type
+        FieldId = string.Empty;
+        // Real implementation maps control definition to the appropriate input type
+    }
+
+    public void LoadValue(Dictionary<string, object?> values)
+    {
+        if (values.TryGetValue(FieldId, out var val) && val is not null)
+        {
+            if (IsTextInput) TextValue = val.ToString() ?? string.Empty;
+            else if (IsNumericInput) NumericValue = val.ToString() ?? string.Empty;
+        }
+    }
+
+    public object? GetValue()
+    {
+        if (IsTextInput) return TextValue;
+        if (IsNumericInput) return double.TryParse(NumericValue, out var n) ? n : null;
+        if (IsDateInput) return DateValue;
+        if (IsSelectInput) return SelectedOption;
+        return null;
+    }
+
+    public object ToFieldData() => new { FieldId, Value = GetValue(), IsRequired };
+
+    public void ApplyValidationIssues(IEnumerable<object> issues) { /* wire per-field errors */ }
+
+    [RelayCommand]
+    private async Task CapturePhotoAsync()
+    {
+        var photo = await MediaPicker.Default.CapturePhotoAsync();
+        if (photo is not null)
+            PhotoStatusText = photo.FileName;
+    }
+
+    [RelayCommand]
+    private async Task CaptureLocationAsync()
+    {
+        var loc = await Geolocation.Default.GetLocationAsync();
+        if (loc is not null)
+            LocationValueText = $"{loc.Latitude:F6}, {loc.Longitude:F6}";
+    }
+}
+
+/// <summary>
+/// ViewModel for a photo/file attachment thumbnail.
+/// </summary>
+public partial class AttachmentViewModel : ObservableObject
+{
+    [ObservableProperty] private string _thumbnailSource = string.Empty;
+    [ObservableProperty] private string _fileName = string.Empty;
+}

--- a/examples/field-data-collection/Features/Mapping/MapPage.xaml
+++ b/examples/field-data-collection/Features/Mapping/MapPage.xaml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage x:Class="HonuaFieldCollector.Features.Mapping.MapPage"
+             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:mapping="clr-namespace:HonuaFieldCollector.Features.Mapping"
+             x:DataType="mapping:MapViewModel"
+             Title="Map"
+             Shell.NavBarIsVisible="True">
+
+    <Grid RowDefinitions="*,Auto">
+
+        <!-- Map Container -->
+        <Grid Grid.Row="0">
+
+            <!-- Platform map view (wired via handler) -->
+            <ContentView x:Name="MapContainer"
+                         HorizontalOptions="FillAndExpand"
+                         VerticalOptions="FillAndExpand" />
+
+            <!-- GPS Accuracy Badge -->
+            <Frame BackgroundColor="{Binding LocationAccuracyColor}"
+                   CornerRadius="20"
+                   Padding="10,5"
+                   HorizontalOptions="Start"
+                   VerticalOptions="Start"
+                   Margin="15"
+                   HasShadow="True"
+                   IsVisible="{Binding HasLocation}">
+                <Label Text="{Binding LocationAccuracyText}"
+                       FontSize="12"
+                       TextColor="White"
+                       FontAttributes="Bold" />
+            </Frame>
+
+            <!-- Feature Info Card (shown on selection) -->
+            <Frame BackgroundColor="White"
+                   CornerRadius="12"
+                   Padding="15"
+                   HorizontalOptions="Fill"
+                   VerticalOptions="End"
+                   Margin="15"
+                   HasShadow="True"
+                   IsVisible="{Binding HasSelectedFeature}">
+                <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto,Auto" RowSpacing="4">
+                    <Label Grid.Row="0" Grid.Column="0"
+                           Text="{Binding SelectedFeatureTitle}"
+                           FontSize="16"
+                           FontAttributes="Bold" />
+                    <Label Grid.Row="1" Grid.Column="0"
+                           Text="{Binding SelectedFeatureSubtitle}"
+                           FontSize="13"
+                           TextColor="{StaticResource Gray600}" />
+                    <Label Grid.Row="2" Grid.Column="0"
+                           Text="{Binding SelectedFeatureCoordinates}"
+                           FontSize="11"
+                           TextColor="{StaticResource Gray500}"
+                           FontFamily="Monospace" />
+                    <Button Grid.Row="0" Grid.RowSpan="3" Grid.Column="1"
+                            Text="Edit"
+                            Command="{Binding EditSelectedFeatureCommand}"
+                            VerticalOptions="Center"
+                            BackgroundColor="{StaticResource Primary}" />
+                </Grid>
+            </Frame>
+
+            <!-- Loading -->
+            <ActivityIndicator IsRunning="{Binding IsLoading}"
+                               IsVisible="{Binding IsLoading}"
+                               Color="{StaticResource Primary}"
+                               Scale="2"
+                               HorizontalOptions="Center"
+                               VerticalOptions="Center" />
+        </Grid>
+
+        <!-- Bottom Toolbar -->
+        <Grid Grid.Row="1"
+              ColumnDefinitions="*,*,*,*"
+              Padding="10"
+              BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}">
+            <Button Grid.Column="0"
+                    Text="Layers"
+                    Command="{Binding ToggleLayersCommand}"
+                    FontSize="12"
+                    BackgroundColor="Transparent" />
+            <Button Grid.Column="1"
+                    Text="My Location"
+                    Command="{Binding GoToMyLocationCommand}"
+                    FontSize="12"
+                    BackgroundColor="Transparent" />
+            <Button Grid.Column="2"
+                    Text="Query"
+                    Command="{Binding StartSpatialQueryCommand}"
+                    FontSize="12"
+                    BackgroundColor="Transparent" />
+            <Button Grid.Column="3"
+                    Text="Add Feature"
+                    Command="{Binding AddFeatureAtLocationCommand}"
+                    FontSize="12"
+                    BackgroundColor="Transparent" />
+        </Grid>
+
+    </Grid>
+
+</ContentPage>

--- a/examples/field-data-collection/Features/Mapping/MapPage.xaml.cs
+++ b/examples/field-data-collection/Features/Mapping/MapPage.xaml.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License 2.0. See LICENSE in the project root.
+
+namespace HonuaFieldCollector.Features.Mapping;
+
+public partial class MapPage : ContentPage
+{
+    public MapPage(MapViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is MapViewModel vm)
+            vm.OnAppearingCommand.Execute(null);
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        if (BindingContext is MapViewModel vm)
+            vm.OnDisappearingCommand.Execute(null);
+    }
+}

--- a/examples/field-data-collection/Features/Mapping/MapViewModel.cs
+++ b/examples/field-data-collection/Features/Mapping/MapViewModel.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License 2.0. See LICENSE in the project root.
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
+
+namespace HonuaFieldCollector.Features.Mapping;
+
+/// <summary>
+/// ViewModel for the Map screen. Manages GPS tracking, feature selection,
+/// layer visibility, and spatial queries.
+/// </summary>
+public partial class MapViewModel : ObservableObject
+{
+    private readonly IMapService _mapService;
+    private readonly ILocationService _locationService;
+    private readonly ISpatialService _spatialService;
+    private readonly ILogger<MapViewModel> _logger;
+
+    [ObservableProperty] private bool _isLoading;
+    [ObservableProperty] private bool _hasLocation;
+    [ObservableProperty] private string _locationAccuracyText = "No GPS";
+    [ObservableProperty] private Color _locationAccuracyColor = Colors.Gray;
+    [ObservableProperty] private bool _hasSelectedFeature;
+    [ObservableProperty] private string _selectedFeatureTitle = string.Empty;
+    [ObservableProperty] private string _selectedFeatureSubtitle = string.Empty;
+    [ObservableProperty] private string _selectedFeatureCoordinates = string.Empty;
+    [ObservableProperty] private long _selectedFeatureId;
+
+    public MapViewModel(
+        IMapService mapService,
+        ILocationService locationService,
+        ISpatialService spatialService,
+        ILogger<MapViewModel> logger)
+    {
+        _mapService = mapService;
+        _locationService = locationService;
+        _spatialService = spatialService;
+        _logger = logger;
+    }
+
+    [RelayCommand]
+    private async Task OnAppearingAsync()
+    {
+        IsLoading = true;
+        try
+        {
+            await _locationService.StartTrackingAsync();
+            _locationService.LocationChanged += OnLocationChanged;
+            await _mapService.LoadLayersAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to initialize map");
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    [RelayCommand]
+    private void OnDisappearing()
+    {
+        _locationService.LocationChanged -= OnLocationChanged;
+        _locationService.StopTracking();
+    }
+
+    [RelayCommand]
+    private async Task GoToMyLocationAsync()
+    {
+        var location = await _locationService.GetCurrentLocationAsync();
+        if (location is not null)
+            await _mapService.PanToAsync(location.Latitude, location.Longitude, zoomLevel: 17);
+    }
+
+    [RelayCommand]
+    private async Task ToggleLayersAsync()
+    {
+        await Shell.Current.GoToAsync("layers");
+    }
+
+    [RelayCommand]
+    private async Task StartSpatialQueryAsync()
+    {
+        await _mapService.ActivateSpatialQueryAsync();
+    }
+
+    [RelayCommand]
+    private async Task AddFeatureAtLocationAsync()
+    {
+        var location = await _locationService.GetCurrentLocationAsync();
+        if (location is not null)
+            await Shell.Current.GoToAsync($"feature/edit?lat={location.Latitude}&lon={location.Longitude}");
+    }
+
+    [RelayCommand]
+    private async Task EditSelectedFeatureAsync()
+    {
+        if (HasSelectedFeature)
+            await Shell.Current.GoToAsync($"feature/edit?featureId={SelectedFeatureId}");
+    }
+
+    private void OnLocationChanged(object? sender, LocationEventArgs e)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            HasLocation = true;
+            var accuracy = e.Accuracy;
+            LocationAccuracyText = $"{accuracy:F1}m";
+            LocationAccuracyColor = accuracy switch
+            {
+                <= 5 => Colors.Green,
+                <= 15 => Colors.Orange,
+                _ => Colors.Red,
+            };
+        });
+    }
+
+    /// <summary>
+    /// Called by the map handler when a feature is tapped.
+    /// </summary>
+    public void OnFeatureSelected(long featureId, string title, string subtitle, double lat, double lon)
+    {
+        SelectedFeatureId = featureId;
+        SelectedFeatureTitle = title;
+        SelectedFeatureSubtitle = subtitle;
+        SelectedFeatureCoordinates = $"{lat:F6}, {lon:F6}";
+        HasSelectedFeature = true;
+    }
+}

--- a/examples/field-data-collection/Features/Settings/SettingsPage.xaml
+++ b/examples/field-data-collection/Features/Settings/SettingsPage.xaml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage x:Class="HonuaFieldCollector.Features.Settings.SettingsPage"
+             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:settings="clr-namespace:HonuaFieldCollector.Features.Settings"
+             x:DataType="settings:SettingsViewModel"
+             Title="Settings"
+             Shell.NavBarIsVisible="True">
+
+    <ScrollView>
+        <StackLayout Padding="16" Spacing="16">
+
+            <!-- Auth / Session Section -->
+            <Frame CornerRadius="12" Padding="16" HasShadow="True">
+                <StackLayout Spacing="10">
+                    <Label Text="Account" FontSize="18" FontAttributes="Bold" />
+
+                    <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto" RowSpacing="6" ColumnSpacing="12">
+                        <Label Grid.Row="0" Grid.Column="0" Text="User" FontAttributes="Bold" FontSize="13" />
+                        <Label Grid.Row="0" Grid.Column="1" Text="{Binding UserDisplayName}" FontSize="13" />
+
+                        <Label Grid.Row="1" Grid.Column="0" Text="Server" FontAttributes="Bold" FontSize="13" />
+                        <Label Grid.Row="1" Grid.Column="1" Text="{Binding ServerUrl}" FontSize="13" TextColor="{StaticResource Gray600}" />
+
+                        <Label Grid.Row="2" Grid.Column="0" Text="Session" FontAttributes="Bold" FontSize="13" />
+                        <Label Grid.Row="2" Grid.Column="1" Text="{Binding SessionStatusText}"
+                               FontSize="13" TextColor="{Binding SessionStatusColor}" />
+                    </Grid>
+
+                    <Button Text="Sign Out"
+                            Command="{Binding SignOutCommand}"
+                            BackgroundColor="Red"
+                            TextColor="White"
+                            Margin="0,8,0,0" />
+                </StackLayout>
+            </Frame>
+
+            <!-- Server Configuration -->
+            <Frame CornerRadius="12" Padding="16" HasShadow="True">
+                <StackLayout Spacing="10">
+                    <Label Text="Server" FontSize="18" FontAttributes="Bold" />
+
+                    <Label Text="Server URL" FontSize="12" TextColor="{StaticResource Gray600}" />
+                    <Entry Text="{Binding ServerUrlEntry, Mode=TwoWay}"
+                           Placeholder="https://api.honua.io"
+                           Keyboard="Url" />
+
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                        <Button Grid.Column="0"
+                                Text="Save"
+                                Command="{Binding SaveServerUrlCommand}"
+                                BackgroundColor="{StaticResource Primary}" />
+                        <Button Grid.Column="1"
+                                Text="Test"
+                                Command="{Binding TestConnectionCommand}"
+                                BackgroundColor="{StaticResource Gray500}" />
+                    </Grid>
+
+                    <Label Text="{Binding ConnectionTestResult}"
+                           FontSize="12"
+                           TextColor="{Binding ConnectionTestColor}"
+                           IsVisible="{Binding HasConnectionTestResult}" />
+                </StackLayout>
+            </Frame>
+
+            <!-- Offline / Sync Settings -->
+            <Frame CornerRadius="12" Padding="16" HasShadow="True">
+                <StackLayout Spacing="10">
+                    <Label Text="Offline &amp; Sync" FontSize="18" FontAttributes="Bold" />
+
+                    <Grid ColumnDefinitions="*,Auto">
+                        <Label Grid.Column="0" Text="Auto-sync interval" VerticalOptions="Center" />
+                        <Picker Grid.Column="1"
+                                ItemsSource="{Binding SyncIntervalOptions}"
+                                SelectedItem="{Binding SelectedSyncInterval, Mode=TwoWay}" />
+                    </Grid>
+
+                    <Grid ColumnDefinitions="*,Auto">
+                        <Label Grid.Column="0" Text="Sync on WiFi only" VerticalOptions="Center" />
+                        <Switch Grid.Column="1" IsToggled="{Binding SyncWifiOnly, Mode=TwoWay}" />
+                    </Grid>
+
+                    <Grid ColumnDefinitions="*,Auto">
+                        <Label Grid.Column="0" Text="Offline database size" VerticalOptions="Center" />
+                        <Label Grid.Column="1" Text="{Binding OfflineDbSize}" TextColor="{StaticResource Gray600}" VerticalOptions="Center" />
+                    </Grid>
+
+                    <Button Text="Clear Offline Cache"
+                            Command="{Binding ClearCacheCommand}"
+                            BackgroundColor="Orange"
+                            TextColor="White" />
+                </StackLayout>
+            </Frame>
+
+            <!-- Diagnostics Section -->
+            <Frame CornerRadius="12" Padding="16" HasShadow="True">
+                <StackLayout Spacing="10">
+                    <Label Text="Diagnostics" FontSize="18" FontAttributes="Bold" />
+
+                    <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" RowSpacing="6" ColumnSpacing="12">
+                        <Label Grid.Row="0" Grid.Column="0" Text="App Version" FontAttributes="Bold" FontSize="12" />
+                        <Label Grid.Row="0" Grid.Column="1" Text="{Binding AppVersion}" FontSize="12" />
+
+                        <Label Grid.Row="1" Grid.Column="0" Text="Platform" FontAttributes="Bold" FontSize="12" />
+                        <Label Grid.Row="1" Grid.Column="1" Text="{Binding PlatformInfo}" FontSize="12" />
+
+                        <Label Grid.Row="2" Grid.Column="0" Text="Network" FontAttributes="Bold" FontSize="12" />
+                        <Label Grid.Row="2" Grid.Column="1" Text="{Binding NetworkStatus}" FontSize="12" />
+
+                        <Label Grid.Row="3" Grid.Column="0" Text="GPS" FontAttributes="Bold" FontSize="12" />
+                        <Label Grid.Row="3" Grid.Column="1" Text="{Binding GpsStatus}" FontSize="12" />
+
+                        <Label Grid.Row="4" Grid.Column="0" Text="gRPC" FontAttributes="Bold" FontSize="12" />
+                        <Label Grid.Row="4" Grid.Column="1" Text="{Binding GrpcStatus}" FontSize="12" />
+                    </Grid>
+
+                    <Button Text="Export Diagnostics"
+                            Command="{Binding ExportDiagnosticsCommand}"
+                            BackgroundColor="{StaticResource Gray500}"
+                            TextColor="White" />
+
+                    <Button Text="View Logs"
+                            Command="{Binding ViewLogsCommand}"
+                            BackgroundColor="Transparent"
+                            BorderColor="{StaticResource Gray500}"
+                            BorderWidth="1"
+                            TextColor="{StaticResource Gray700}" />
+                </StackLayout>
+            </Frame>
+
+            <!-- Permissions -->
+            <Frame CornerRadius="12" Padding="16" HasShadow="True">
+                <StackLayout Spacing="10">
+                    <Label Text="Permissions" FontSize="18" FontAttributes="Bold" />
+
+                    <CollectionView ItemsSource="{Binding Permissions}" SelectionMode="None">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate x:DataType="settings:PermissionItemViewModel">
+                                <Grid ColumnDefinitions="*,Auto" Padding="0,4">
+                                    <Label Grid.Column="0" Text="{Binding Name}" FontSize="14" VerticalOptions="Center" />
+                                    <Label Grid.Column="1" Text="{Binding StatusText}"
+                                           FontSize="13" TextColor="{Binding StatusColor}" VerticalOptions="Center" />
+                                </Grid>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+
+                    <Button Text="Request All Permissions"
+                            Command="{Binding RequestPermissionsCommand}"
+                            BackgroundColor="{StaticResource Primary}" />
+                </StackLayout>
+            </Frame>
+
+        </StackLayout>
+    </ScrollView>
+
+</ContentPage>

--- a/examples/field-data-collection/Features/Settings/SettingsPage.xaml.cs
+++ b/examples/field-data-collection/Features/Settings/SettingsPage.xaml.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License 2.0. See LICENSE in the project root.
+
+namespace HonuaFieldCollector.Features.Settings;
+
+public partial class SettingsPage : ContentPage
+{
+    public SettingsPage(SettingsViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is SettingsViewModel vm)
+            vm.RefreshCommand.Execute(null);
+    }
+}

--- a/examples/field-data-collection/Features/Settings/SettingsViewModel.cs
+++ b/examples/field-data-collection/Features/Settings/SettingsViewModel.cs
@@ -1,0 +1,259 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License 2.0. See LICENSE in the project root.
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
+
+namespace HonuaFieldCollector.Features.Settings;
+
+/// <summary>
+/// ViewModel for the Settings / Diagnostics screen.
+/// Manages server configuration, authentication session, offline settings,
+/// and device diagnostics.
+/// </summary>
+public partial class SettingsViewModel : ObservableObject
+{
+    private readonly IAuthenticationService _authService;
+    private readonly IApplicationConfigurationService _configService;
+    private readonly IConnectivity _connectivity;
+    private readonly IGeolocation _geolocation;
+    private readonly ILogger<SettingsViewModel> _logger;
+
+    // Account
+    [ObservableProperty] private string _userDisplayName = "Not signed in";
+    [ObservableProperty] private string _serverUrl = string.Empty;
+    [ObservableProperty] private string _sessionStatusText = "No session";
+    [ObservableProperty] private Color _sessionStatusColor = Colors.Gray;
+
+    // Server config
+    [ObservableProperty] private string _serverUrlEntry = string.Empty;
+    [ObservableProperty] private string _connectionTestResult = string.Empty;
+    [ObservableProperty] private Color _connectionTestColor = Colors.Gray;
+    [ObservableProperty] private bool _hasConnectionTestResult;
+
+    // Offline / Sync
+    [ObservableProperty] private string _selectedSyncInterval = "2 minutes";
+    [ObservableProperty] private bool _syncWifiOnly;
+    [ObservableProperty] private string _offlineDbSize = "Calculating...";
+
+    // Diagnostics
+    [ObservableProperty] private string _appVersion = string.Empty;
+    [ObservableProperty] private string _platformInfo = string.Empty;
+    [ObservableProperty] private string _networkStatus = string.Empty;
+    [ObservableProperty] private string _gpsStatus = string.Empty;
+    [ObservableProperty] private string _grpcStatus = string.Empty;
+
+    public List<string> SyncIntervalOptions { get; } = ["1 minute", "2 minutes", "5 minutes", "15 minutes", "Manual"];
+    public ObservableCollection<PermissionItemViewModel> Permissions { get; } = [];
+
+    public SettingsViewModel(
+        IAuthenticationService authService,
+        IApplicationConfigurationService configService,
+        IConnectivity connectivity,
+        IGeolocation geolocation,
+        ILogger<SettingsViewModel> logger)
+    {
+        _authService = authService;
+        _configService = configService;
+        _connectivity = connectivity;
+        _geolocation = geolocation;
+        _logger = logger;
+    }
+
+    [RelayCommand]
+    private async Task RefreshAsync()
+    {
+        try
+        {
+            // Account info
+            if (_authService.IsAuthenticated)
+            {
+                UserDisplayName = _authService.CurrentUser?.DisplayName ?? "Unknown";
+                SessionStatusText = "Active";
+                SessionStatusColor = Colors.Green;
+            }
+            else
+            {
+                UserDisplayName = "Not signed in";
+                SessionStatusText = "No session";
+                SessionStatusColor = Colors.Gray;
+            }
+
+            ServerUrl = _configService.GetServerUrl();
+            ServerUrlEntry = ServerUrl;
+
+            // Diagnostics
+            AppVersion = $"{AppInfo.VersionString} ({AppInfo.BuildString})";
+            PlatformInfo = $"{DeviceInfo.Platform} {DeviceInfo.VersionString} — {DeviceInfo.Manufacturer} {DeviceInfo.Model}";
+            NetworkStatus = _connectivity.NetworkAccess.ToString();
+
+            try
+            {
+                var loc = await _geolocation.GetLastKnownLocationAsync();
+                GpsStatus = loc is not null ? $"Available ({loc.Accuracy:F1}m)" : "No fix";
+            }
+            catch
+            {
+                GpsStatus = "Unavailable";
+            }
+
+            GrpcStatus = _configService.IsGrpcAvailable() ? "Connected" : "Disconnected";
+
+            // Offline DB size
+            var dbPath = _configService.GetOfflineDatabasePath();
+            if (File.Exists(dbPath))
+            {
+                var size = new FileInfo(dbPath).Length;
+                OfflineDbSize = size switch
+                {
+                    < 1024 => $"{size} B",
+                    < 1024 * 1024 => $"{size / 1024.0:F1} KB",
+                    _ => $"{size / (1024.0 * 1024.0):F1} MB",
+                };
+            }
+            else
+            {
+                OfflineDbSize = "No database";
+            }
+
+            // Permissions
+            await RefreshPermissionsAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to refresh settings");
+        }
+    }
+
+    [RelayCommand]
+    private async Task SignOutAsync()
+    {
+        var confirmed = await Shell.Current.DisplayAlert("Sign Out", "Are you sure?", "Sign Out", "Cancel");
+        if (!confirmed) return;
+
+        await _authService.LogoutAsync();
+        await Shell.Current.GoToAsync("//login");
+    }
+
+    [RelayCommand]
+    private void SaveServerUrl()
+    {
+        _configService.SetServerUrl(ServerUrlEntry);
+        ServerUrl = ServerUrlEntry;
+    }
+
+    [RelayCommand]
+    private async Task TestConnectionAsync()
+    {
+        HasConnectionTestResult = true;
+        ConnectionTestResult = "Testing...";
+        ConnectionTestColor = Colors.Gray;
+
+        try
+        {
+            var ok = await _configService.TestConnectionAsync(ServerUrlEntry);
+            ConnectionTestResult = ok ? "Connection successful" : "Connection failed";
+            ConnectionTestColor = ok ? Colors.Green : Colors.Red;
+        }
+        catch (Exception ex)
+        {
+            ConnectionTestResult = $"Error: {ex.Message}";
+            ConnectionTestColor = Colors.Red;
+        }
+    }
+
+    [RelayCommand]
+    private async Task ClearCacheAsync()
+    {
+        var confirmed = await Shell.Current.DisplayAlert(
+            "Clear Cache", "This will remove all offline data. Unsynced changes will be lost.", "Clear", "Cancel");
+        if (!confirmed) return;
+
+        _configService.ClearOfflineCache();
+        OfflineDbSize = "No database";
+    }
+
+    [RelayCommand]
+    private async Task ExportDiagnosticsAsync()
+    {
+        var diagnostics = $"""
+            Honua Field Collector Diagnostics
+            ==================================
+            App Version: {AppVersion}
+            Platform: {PlatformInfo}
+            Network: {NetworkStatus}
+            GPS: {GpsStatus}
+            gRPC: {GrpcStatus}
+            Server: {ServerUrl}
+            Offline DB: {OfflineDbSize}
+            Session: {SessionStatusText}
+            Timestamp: {DateTime.UtcNow:O}
+            """;
+
+        var path = Path.Combine(FileSystem.CacheDirectory, $"honua-diagnostics-{DateTime.Now:yyyyMMdd-HHmmss}.txt");
+        await File.WriteAllTextAsync(path, diagnostics);
+        await Share.Default.RequestAsync(new ShareFileRequest
+        {
+            Title = "Honua Diagnostics",
+            File = new ShareFile(path)
+        });
+    }
+
+    [RelayCommand]
+    private async Task ViewLogsAsync()
+    {
+        var logDir = Path.Combine(FileSystem.AppDataDirectory, "logs");
+        if (Directory.Exists(logDir))
+        {
+            var latest = Directory.GetFiles(logDir, "*.log")
+                .OrderByDescending(f => f)
+                .FirstOrDefault();
+
+            if (latest is not null)
+            {
+                var content = await File.ReadAllTextAsync(latest);
+                await Shell.Current.DisplayAlert("Logs", content.Length > 2000 ? content[..2000] + "..." : content, "OK");
+            }
+        }
+    }
+
+    [RelayCommand]
+    private async Task RequestPermissionsAsync()
+    {
+        await Permissions.RequestAsync<Permissions.LocationWhenInUse>();
+        await Permissions.RequestAsync<Permissions.Camera>();
+        await Permissions.RequestAsync<Permissions.StorageRead>();
+        await RefreshPermissionsAsync();
+    }
+
+    private async Task RefreshPermissionsAsync()
+    {
+        Permissions.Clear();
+        Permissions.Add(await CheckPermission<Microsoft.Maui.ApplicationModel.Permissions.LocationWhenInUse>("Location"));
+        Permissions.Add(await CheckPermission<Microsoft.Maui.ApplicationModel.Permissions.Camera>("Camera"));
+        Permissions.Add(await CheckPermission<Microsoft.Maui.ApplicationModel.Permissions.StorageRead>("Storage"));
+    }
+
+    private static async Task<PermissionItemViewModel> CheckPermission<T>(string name) where T : Microsoft.Maui.ApplicationModel.Permissions.BasePermission, new()
+    {
+        var status = await Microsoft.Maui.ApplicationModel.Permissions.CheckStatusAsync<T>();
+        return new PermissionItemViewModel
+        {
+            Name = name,
+            StatusText = status.ToString(),
+            StatusColor = status == PermissionStatus.Granted ? Colors.Green : Colors.Red,
+        };
+    }
+}
+
+/// <summary>
+/// ViewModel for a single permission status row.
+/// </summary>
+public partial class PermissionItemViewModel : ObservableObject
+{
+    [ObservableProperty] private string _name = string.Empty;
+    [ObservableProperty] private string _statusText = string.Empty;
+    [ObservableProperty] private Color _statusColor = Colors.Gray;
+}

--- a/examples/field-data-collection/Features/Sync/SyncStatusPage.xaml
+++ b/examples/field-data-collection/Features/Sync/SyncStatusPage.xaml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage x:Class="HonuaFieldCollector.Features.Sync.SyncStatusPage"
+             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:sync="clr-namespace:HonuaFieldCollector.Features.Sync"
+             x:DataType="sync:SyncStatusViewModel"
+             Title="Sync Center"
+             Shell.NavBarIsVisible="True">
+
+    <Grid RowDefinitions="Auto,Auto,*,Auto">
+
+        <!-- Overall Status Card -->
+        <Frame Grid.Row="0"
+               BackgroundColor="{Binding SyncStatusColor}"
+               CornerRadius="12"
+               Padding="16"
+               Margin="16,16,16,8"
+               HasShadow="True">
+            <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto" RowSpacing="4">
+                <Label Grid.Row="0" Grid.Column="0"
+                       Text="{Binding SyncStatusTitle}"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White" />
+                <Label Grid.Row="1" Grid.Column="0"
+                       Text="{Binding LastSyncText}"
+                       FontSize="13"
+                       TextColor="#E0E0E0" />
+                <ActivityIndicator Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                                   IsRunning="{Binding IsSyncing}"
+                                   IsVisible="{Binding IsSyncing}"
+                                   Color="White" />
+            </Grid>
+        </Frame>
+
+        <!-- Stats Row -->
+        <Grid Grid.Row="1"
+              ColumnDefinitions="*,*,*"
+              Padding="16,0"
+              ColumnSpacing="8">
+            <Frame Grid.Column="0" CornerRadius="10" Padding="10" HasShadow="True">
+                <StackLayout HorizontalOptions="Center">
+                    <Label Text="{Binding PendingCount}" FontSize="24" FontAttributes="Bold" HorizontalOptions="Center" />
+                    <Label Text="Pending" FontSize="11" TextColor="{StaticResource Gray600}" HorizontalOptions="Center" />
+                </StackLayout>
+            </Frame>
+            <Frame Grid.Column="1" CornerRadius="10" Padding="10" HasShadow="True">
+                <StackLayout HorizontalOptions="Center">
+                    <Label Text="{Binding ConflictCount}" FontSize="24" FontAttributes="Bold"
+                           TextColor="{Binding ConflictCountColor}" HorizontalOptions="Center" />
+                    <Label Text="Conflicts" FontSize="11" TextColor="{StaticResource Gray600}" HorizontalOptions="Center" />
+                </StackLayout>
+            </Frame>
+            <Frame Grid.Column="2" CornerRadius="10" Padding="10" HasShadow="True">
+                <StackLayout HorizontalOptions="Center">
+                    <Label Text="{Binding UploadedCount}" FontSize="24" FontAttributes="Bold" HorizontalOptions="Center" />
+                    <Label Text="Uploaded" FontSize="11" TextColor="{StaticResource Gray600}" HorizontalOptions="Center" />
+                </StackLayout>
+            </Frame>
+        </Grid>
+
+        <!-- Sync History / Queue -->
+        <CollectionView Grid.Row="2"
+                        ItemsSource="{Binding SyncItems}"
+                        Margin="16,12"
+                        SelectionMode="None">
+            <CollectionView.Header>
+                <Label Text="Sync Queue" FontSize="16" FontAttributes="Bold" Margin="0,0,0,8" />
+            </CollectionView.Header>
+            <CollectionView.EmptyView>
+                <StackLayout VerticalOptions="Center" HorizontalOptions="Center" Padding="20">
+                    <Label Text="All records synced"
+                           FontSize="16"
+                           TextColor="{StaticResource Gray600}"
+                           HorizontalOptions="Center" />
+                </StackLayout>
+            </CollectionView.EmptyView>
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="sync:SyncItemViewModel">
+                    <Frame Margin="0,4" Padding="12" CornerRadius="8" HasShadow="True">
+                        <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
+                            <!-- Status Icon -->
+                            <Label Grid.Column="0"
+                                   Text="{Binding StatusIcon}"
+                                   FontSize="20"
+                                   VerticalOptions="Center" />
+                            <!-- Details -->
+                            <StackLayout Grid.Column="1" VerticalOptions="Center">
+                                <Label Text="{Binding Title}" FontSize="14" FontAttributes="Bold" />
+                                <Label Text="{Binding Subtitle}" FontSize="12" TextColor="{StaticResource Gray600}" />
+                                <Label Text="{Binding TimestampText}" FontSize="10" TextColor="{StaticResource Gray500}" />
+                            </StackLayout>
+                            <!-- Action -->
+                            <Button Grid.Column="2"
+                                    Text="{Binding ActionText}"
+                                    Command="{Binding ActionCommand}"
+                                    IsVisible="{Binding HasAction}"
+                                    FontSize="11"
+                                    Padding="8,4"
+                                    VerticalOptions="Center"
+                                    BackgroundColor="{StaticResource Primary}" />
+                        </Grid>
+                    </Frame>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+
+        <!-- Bottom Actions -->
+        <Grid Grid.Row="3"
+              ColumnDefinitions="*,*"
+              Padding="16,10"
+              ColumnSpacing="12"
+              BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}">
+            <Button Grid.Column="0"
+                    Text="Sync Now"
+                    Command="{Binding SyncNowCommand}"
+                    IsEnabled="{Binding CanSync}"
+                    BackgroundColor="{StaticResource Primary}"
+                    TextColor="White" />
+            <Button Grid.Column="1"
+                    Text="Resolve Conflicts"
+                    Command="{Binding ResolveConflictsCommand}"
+                    IsVisible="{Binding HasConflicts}"
+                    BackgroundColor="Orange"
+                    TextColor="White" />
+        </Grid>
+
+    </Grid>
+
+</ContentPage>

--- a/examples/field-data-collection/Features/Sync/SyncStatusPage.xaml.cs
+++ b/examples/field-data-collection/Features/Sync/SyncStatusPage.xaml.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License 2.0. See LICENSE in the project root.
+
+namespace HonuaFieldCollector.Features.Sync;
+
+public partial class SyncStatusPage : ContentPage
+{
+    public SyncStatusPage(SyncStatusViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is SyncStatusViewModel vm)
+            vm.RefreshCommand.Execute(null);
+    }
+}

--- a/examples/field-data-collection/Features/Sync/SyncStatusViewModel.cs
+++ b/examples/field-data-collection/Features/Sync/SyncStatusViewModel.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License 2.0. See LICENSE in the project root.
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
+
+namespace HonuaFieldCollector.Features.Sync;
+
+/// <summary>
+/// ViewModel for the Sync Center screen. Shows sync queue, status,
+/// pending/conflict counts, and history.
+/// </summary>
+public partial class SyncStatusViewModel : ObservableObject
+{
+    private readonly ISyncService _syncService;
+    private readonly IConflictResolutionService _conflictService;
+    private readonly IConnectivity _connectivity;
+    private readonly ILogger<SyncStatusViewModel> _logger;
+
+    [ObservableProperty] private string _syncStatusTitle = "Ready";
+    [ObservableProperty] private Color _syncStatusColor = Colors.Green;
+    [ObservableProperty] private string _lastSyncText = "Never synced";
+    [ObservableProperty] private bool _isSyncing;
+    [ObservableProperty] private int _pendingCount;
+    [ObservableProperty] private int _conflictCount;
+    [ObservableProperty] private Color _conflictCountColor = Colors.Black;
+    [ObservableProperty] private int _uploadedCount;
+    [ObservableProperty] private bool _hasConflicts;
+    [ObservableProperty] private bool _canSync;
+
+    public ObservableCollection<SyncItemViewModel> SyncItems { get; } = [];
+
+    public SyncStatusViewModel(
+        ISyncService syncService,
+        IConflictResolutionService conflictService,
+        IConnectivity connectivity,
+        ILogger<SyncStatusViewModel> logger)
+    {
+        _syncService = syncService;
+        _conflictService = conflictService;
+        _connectivity = connectivity;
+        _logger = logger;
+
+        _connectivity.ConnectivityChanged += OnConnectivityChanged;
+    }
+
+    [RelayCommand]
+    private async Task RefreshAsync()
+    {
+        try
+        {
+            var status = await _syncService.GetSyncStatusAsync();
+
+            PendingCount = status.PendingOperations;
+            ConflictCount = status.ConflictCount;
+            UploadedCount = status.CompletedOperations;
+            HasConflicts = status.ConflictCount > 0;
+            ConflictCountColor = HasConflicts ? Colors.Red : Colors.Black;
+            CanSync = _connectivity.NetworkAccess == NetworkAccess.Internet && !IsSyncing;
+
+            if (status.LastSyncTime.HasValue)
+                LastSyncText = $"Last sync: {status.LastSyncTime.Value:g}";
+
+            SyncStatusTitle = PendingCount > 0 ? $"{PendingCount} pending" : "Up to date";
+            SyncStatusColor = HasConflicts ? Colors.Orange : (PendingCount > 0 ? Colors.Blue : Colors.Green);
+
+            // Populate queue items
+            SyncItems.Clear();
+            foreach (var op in status.Operations)
+            {
+                SyncItems.Add(new SyncItemViewModel
+                {
+                    Title = op.Title,
+                    Subtitle = op.OperationType,
+                    TimestampText = op.CreatedAt.ToString("g"),
+                    StatusIcon = op.Status switch
+                    {
+                        "pending" => "clock",
+                        "conflict" => "warning",
+                        "uploaded" => "check",
+                        "error" => "error",
+                        _ => "help"
+                    },
+                    HasAction = op.Status == "conflict",
+                    ActionText = op.Status == "conflict" ? "Resolve" : string.Empty,
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to refresh sync status");
+        }
+    }
+
+    [RelayCommand]
+    private async Task SyncNowAsync()
+    {
+        if (IsSyncing) return;
+        IsSyncing = true;
+        SyncStatusTitle = "Syncing...";
+        SyncStatusColor = Colors.Blue;
+
+        try
+        {
+            await _syncService.SyncNowAsync();
+            await RefreshAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Sync failed");
+            SyncStatusTitle = "Sync failed";
+            SyncStatusColor = Colors.Red;
+        }
+        finally
+        {
+            IsSyncing = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task ResolveConflictsAsync()
+    {
+        await Shell.Current.GoToAsync("conflicts");
+    }
+
+    private void OnConnectivityChanged(object? sender, ConnectivityChangedEventArgs e)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            CanSync = e.NetworkAccess == NetworkAccess.Internet && !IsSyncing;
+        });
+    }
+}
+
+/// <summary>
+/// ViewModel for a single sync queue item.
+/// </summary>
+public partial class SyncItemViewModel : ObservableObject
+{
+    [ObservableProperty] private string _title = string.Empty;
+    [ObservableProperty] private string _subtitle = string.Empty;
+    [ObservableProperty] private string _timestampText = string.Empty;
+    [ObservableProperty] private string _statusIcon = string.Empty;
+    [ObservableProperty] private bool _hasAction;
+    [ObservableProperty] private string _actionText = string.Empty;
+
+    [RelayCommand]
+    private async Task ActionAsync()
+    {
+        // Navigate to conflict resolution for this item
+    }
+}

--- a/examples/field-data-collection/HonuaFieldCollector.csproj
+++ b/examples/field-data-collection/HonuaFieldCollector.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-    <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
+    <!-- <TargetFrameworks>$(TargetFrameworks);net10.0-tizen</TargetFrameworks> -->
 
     <OutputType>Exe</OutputType>
     <RootNamespace>HonuaFieldCollector</RootNamespace>

--- a/examples/shared/Honua.Mobile.SharedComponents.csproj
+++ b/examples/shared/Honua.Mobile.SharedComponents.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -26,9 +26,9 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0|AnyCPU'">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <DocumentationFile>bin\Release\net8.0\Honua.Mobile.SharedComponents.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\net10.0\Honua.Mobile.SharedComponents.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/quality/accessibility-checklist.md
+++ b/quality/accessibility-checklist.md
@@ -1,0 +1,65 @@
+# Honua Mobile Accessibility Checklist
+
+This checklist covers MAUI-specific accessibility requirements for the Honua Mobile application.
+Every new or modified UI surface must be validated against these criteria before merge.
+
+Reference: [.NET MAUI Accessibility](https://learn.microsoft.com/dotnet/maui/fundamentals/accessibility)
+
+---
+
+## Content Descriptions
+
+- [ ] All interactive controls (`Button`, `ImageButton`, `Entry`, `Picker`, `Switch`, etc.) have a `SemanticProperties.Description` set
+- [ ] Non-decorative images have a meaningful `ContentDescription` or `SemanticProperties.Description`
+- [ ] Decorative images are explicitly marked with `SemanticProperties.Description=""` so screen readers skip them
+- [ ] Icons that convey meaning have descriptive text alternatives
+
+## Automation Identifiers
+
+- [ ] All tappable elements have an `AutomationId` assigned for UI testing
+- [ ] `AutomationId` values follow a consistent naming convention (e.g., `Page_ElementName_Action`)
+- [ ] No duplicate `AutomationId` values exist within a single page
+
+## Touch Targets
+
+- [ ] Minimum touch target size is 44x44dp (device-independent pixels) for all interactive elements
+- [ ] Tap targets that are visually smaller than 44x44dp use padding or `MinimumHeightRequest`/`MinimumWidthRequest` to meet the threshold
+- [ ] Adjacent tap targets have sufficient spacing to avoid accidental activation
+
+## Color Contrast
+
+- [ ] Normal text (below 18sp / 14sp bold) meets a minimum contrast ratio of 4.5:1 against its background
+- [ ] Large text (18sp+ or 14sp+ bold) meets a minimum contrast ratio of 3:1 against its background
+- [ ] UI components and graphical objects (icons, borders, focus indicators) meet a minimum contrast ratio of 3:1
+- [ ] Information is never conveyed by color alone (e.g., error states use icons or text in addition to red)
+
+## Screen Reader Navigation
+
+- [ ] Logical reading order is maintained; `TabIndex` or layout order matches visual flow
+- [ ] `SemanticProperties.HeadingLevel` is set on page titles and section headers
+- [ ] Grouped controls use `SemanticProperties.Hint` to describe the expected interaction
+- [ ] Dynamic content changes announce updates via `SemanticScreenReader.Announce()`
+- [ ] Modal dialogs and popups trap focus correctly and return focus on dismissal
+
+## Dynamic Type / Font Scaling
+
+- [ ] All text uses scalable units (`sp` or platform default) rather than fixed pixel sizes
+- [ ] Layouts accommodate up to 200% font scaling without content clipping or overlap
+- [ ] `Label.LineBreakMode` is set to `WordWrap` or `TailTruncation` where appropriate
+- [ ] No hardcoded heights on text-containing views that would clip scaled text
+
+## Semantic Properties
+
+- [ ] `SemanticProperties.Description` is set on all controls that need a screen reader label
+- [ ] `SemanticProperties.Hint` is set on controls where the interaction is not obvious (e.g., "Double-tap to open the map area selector")
+- [ ] `SemanticProperties.HeadingLevel` is used for structural headings (`Level1` through `Level6`)
+- [ ] Custom controls implement `ISemanticProvider` or set semantic properties on inner elements
+- [ ] Collection views (`CollectionView`, `ListView`) expose item descriptions via `DataTemplate` semantic bindings
+
+---
+
+## Review Sign-Off
+
+| Reviewer | Date | Notes |
+|----------|------|-------|
+|          |      |       |

--- a/quality/performance-budget.json
+++ b/quality/performance-budget.json
@@ -1,0 +1,24 @@
+{
+  "budgets": {
+    "sdk_package_size_kb": {
+      "warning": 512,
+      "error": 1024,
+      "description": "Honua.Mobile.Offline package size"
+    },
+    "geopackage_init_ms": {
+      "warning": 200,
+      "error": 500,
+      "description": "GeoPackage store initialization time"
+    },
+    "sync_batch_50_ms": {
+      "warning": 5000,
+      "error": 15000,
+      "description": "Sync engine batch of 50 operations"
+    },
+    "feature_query_100_ms": {
+      "warning": 500,
+      "error": 2000,
+      "description": "Feature query returning 100 results"
+    }
+  }
+}

--- a/quality/release-checklist.md
+++ b/quality/release-checklist.md
@@ -1,0 +1,38 @@
+# Honua Mobile Release Checklist
+
+Complete all items before publishing a release. Each gate references an automated or manual
+quality check; link the evidence (CI run URL, review comment, etc.) in the Notes column.
+
+---
+
+## CI and Automated Gates
+
+- [ ] All CI gates pass (build, test, gRPC validation, security)
+- [ ] Performance budgets within thresholds (`quality/performance-budget.json`)
+- [ ] Smoke tests pass (`tests/Honua.Mobile.Smoke.Tests`)
+- [ ] No CodeQL or dependency-audit findings above accepted risk level
+
+## Quality Review
+
+- [ ] Accessibility checklist reviewed for new/changed UI (`quality/accessibility-checklist.md`)
+- [ ] No P1/P2 bugs open in the issue tracker
+- [ ] Manual exploratory testing completed on target platforms (Android, iOS, Windows)
+
+## Documentation and Release Artifacts
+
+- [ ] CHANGELOG updated with user-facing changes
+- [ ] Version number bumped in `Directory.Build.props` / `.csproj` files
+- [ ] Migration notes documented for breaking API changes (if any)
+- [ ] NuGet package metadata reviewed (description, tags, license)
+
+## Platform-Specific Validation
+
+- [ ] Android build and smoke test pass on CI
+- [ ] Windows MAUI build passes on CI
+- [ ] iOS build verified (manual or Mac-hosted agent)
+
+## Final Approval
+
+| Approver | Date | Result |
+|----------|------|--------|
+|          |      |        |

--- a/src/Honua.Mobile.Field/Forms/FormValidation.cs
+++ b/src/Honua.Mobile.Field/Forms/FormValidation.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Collections;
 using System.Text.RegularExpressions;
 using Honua.Mobile.Field.Records;
 
@@ -129,6 +130,7 @@ public sealed class FormValidator
         {
             null => true,
             string text => string.IsNullOrWhiteSpace(text),
+            IEnumerable collection => !collection.Cast<object?>().Any(),
             _ => false,
         };
     }

--- a/src/Honua.Mobile.Field/Forms/FormValidation.cs
+++ b/src/Honua.Mobile.Field/Forms/FormValidation.cs
@@ -7,6 +7,8 @@ namespace Honua.Mobile.Field.Forms;
 
 public sealed class FormValidator
 {
+    private static readonly TimeSpan RegexEvaluationTimeout = TimeSpan.FromMilliseconds(250);
+
     public FormValidationResult Validate(FormDefinition form, FieldRecord record)
     {
         ArgumentNullException.ThrowIfNull(form);
@@ -98,9 +100,9 @@ public sealed class FormValidator
     private static void ValidateRules(ICollection<FormValidationError> errors, FormField field, object rawValue)
     {
         if (!string.IsNullOrWhiteSpace(field.Validation.RegexPattern) &&
-            !Regex.IsMatch(rawValue.ToString() ?? string.Empty, field.Validation.RegexPattern))
+            !IsRegexMatch(rawValue.ToString() ?? string.Empty, field.Validation.RegexPattern!, out var regexErrorMessage))
         {
-            errors.Add(new FormValidationError(field.FieldId, $"{field.Label} does not match the required format."));
+            errors.Add(new FormValidationError(field.FieldId, regexErrorMessage ?? $"{field.Label} does not match the required format."));
         }
 
         if (TryAsDouble(rawValue, out var numericValue))
@@ -140,8 +142,8 @@ public sealed class FormValidator
         switch (value)
         {
             case null:
-                parsed = 0;
-                return true;
+                parsed = default;
+                return false;
             case double d:
                 parsed = d;
                 return true;
@@ -175,6 +177,26 @@ public sealed class FormValidator
         }
 
         return string.Equals(left?.ToString(), right?.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsRegexMatch(string input, string pattern, out string? errorMessage)
+    {
+        errorMessage = null;
+
+        try
+        {
+            return Regex.IsMatch(input, pattern, RegexOptions.None, RegexEvaluationTimeout);
+        }
+        catch (ArgumentException)
+        {
+            errorMessage = "Validation pattern is invalid.";
+            return false;
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            errorMessage = "Validation pattern timed out.";
+            return false;
+        }
     }
 }
 

--- a/src/Honua.Mobile.Field/Records/RecordWorkflow.cs
+++ b/src/Honua.Mobile.Field/Records/RecordWorkflow.cs
@@ -30,6 +30,7 @@ public sealed class RecordWorkflow
         if (targetStatus == RecordStatus.Submitted)
         {
             record.SubmittedAtUtc = now;
+            record.CompletedAtUtc = null;
         }
 
         if (targetStatus is RecordStatus.Approved or RecordStatus.Rejected)

--- a/src/Honua.Mobile.IoT/Honua.Mobile.IoT.csproj
+++ b/src/Honua.Mobile.IoT/Honua.Mobile.IoT.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -52,15 +52,12 @@
 
   <ItemGroup>
     <!-- Core Dependencies -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
 
     <!-- Bluetooth LE Support -->
     <PackageReference Include="Plugin.BLE" Version="3.1.0" />
-
-    <!-- WiFi Network Discovery -->
-    <PackageReference Include="System.Net.NetworkInformation" Version="8.0.0" />
 
     <!-- JSON Serialization -->
     <PackageReference Include="System.Text.Json" Version="9.0.0" />

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageModels.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageModels.cs
@@ -5,6 +5,8 @@ public sealed class GeoPackageSyncStoreOptions
     public required string DatabasePath { get; init; }
 
     public bool AutoCreateDirectory { get; init; } = true;
+
+    public TimeSpan InProgressLeaseTimeout { get; init; } = TimeSpan.FromMinutes(5);
 }
 
 public enum OfflineOperationType

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
@@ -68,6 +68,7 @@ CREATE TABLE IF NOT EXISTS honua_sync_queue (
     payload_json TEXT NOT NULL,
     priority INTEGER NOT NULL,
     created_at_utc TEXT NOT NULL,
+    claimed_at_utc TEXT,
     attempt_count INTEGER NOT NULL DEFAULT 0,
     last_error TEXT,
     status TEXT NOT NULL DEFAULT 'pending'
@@ -101,6 +102,8 @@ VALUES ('honua_map_areas', 'attributes', 'honua_map_areas', 'Downloaded map area
         await using var command = connection.CreateCommand();
         command.CommandText = sql;
         await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+        await EnsureColumnExistsAsync(connection, "honua_sync_queue", "claimed_at_utc", "TEXT", ct).ConfigureAwait(false);
     }
 
     public async Task EnqueueAsync(OfflineEditOperation operation, CancellationToken ct = default)
@@ -112,8 +115,8 @@ VALUES ('honua_map_areas', 'attributes', 'honua_map_areas', 'Downloaded map area
 
         await using var command = connection.CreateCommand();
         command.CommandText = @"
-INSERT INTO honua_sync_queue (operation_id, layer_key, target_collection, operation_type, payload_json, priority, created_at_utc, attempt_count, status)
-VALUES ($operation_id, $layer_key, $target_collection, $operation_type, $payload_json, $priority, $created_at_utc, $attempt_count, 'pending')
+INSERT INTO honua_sync_queue (operation_id, layer_key, target_collection, operation_type, payload_json, priority, created_at_utc, claimed_at_utc, attempt_count, status)
+VALUES ($operation_id, $layer_key, $target_collection, $operation_type, $payload_json, $priority, $created_at_utc, NULL, $attempt_count, 'pending')
 ON CONFLICT(operation_id) DO UPDATE SET
   layer_key = excluded.layer_key,
   target_collection = excluded.target_collection,
@@ -121,6 +124,7 @@ ON CONFLICT(operation_id) DO UPDATE SET
   payload_json = excluded.payload_json,
   priority = excluded.priority,
   created_at_utc = excluded.created_at_utc,
+  claimed_at_utc = NULL,
   attempt_count = excluded.attempt_count,
   status = 'pending',
   last_error = NULL;
@@ -151,7 +155,11 @@ ON CONFLICT(operation_id) DO UPDATE SET
         await ExecuteTransactionCommandAsync(connection, "BEGIN IMMEDIATE;", ct).ConfigureAwait(false);
         try
         {
-            var claimedOperationIds = await ReadPendingOperationIdsAsync(connection, maxCount, ct).ConfigureAwait(false);
+            var leaseTimeout = _options.InProgressLeaseTimeout < TimeSpan.Zero
+                ? TimeSpan.Zero
+                : _options.InProgressLeaseTimeout;
+            var staleClaimCutoffUtc = DateTimeOffset.UtcNow - leaseTimeout;
+            var claimedOperationIds = await ReadPendingOperationIdsAsync(connection, maxCount, staleClaimCutoffUtc, ct).ConfigureAwait(false);
             if (claimedOperationIds.Count == 0)
             {
                 await ExecuteTransactionCommandAsync(connection, "COMMIT;", ct).ConfigureAwait(false);
@@ -163,10 +171,12 @@ ON CONFLICT(operation_id) DO UPDATE SET
                 var idParameters = AddOperationIdParameters(claimCommand, claimedOperationIds);
                 claimCommand.CommandText = $@"
 UPDATE honua_sync_queue
-SET status = 'in_progress'
-WHERE status IN ('pending', 'retry')
+SET status = 'in_progress',
+    claimed_at_utc = $claimed_at_utc
+WHERE status IN ('pending', 'retry', 'in_progress')
   AND operation_id IN ({idParameters});
 ";
+                claimCommand.Parameters.AddWithValue("$claimed_at_utc", DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture));
 
                 await claimCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
             }
@@ -238,6 +248,7 @@ ORDER BY priority ASC, created_at_utc ASC;
         command.CommandText = @"
 UPDATE honua_sync_queue
 SET status = 'pending',
+    claimed_at_utc = NULL,
     last_error = NULL
 WHERE operation_id = $operation_id;
 ";
@@ -255,6 +266,7 @@ WHERE operation_id = $operation_id;
 UPDATE honua_sync_queue
 SET status = $status,
     attempt_count = attempt_count + 1,
+    claimed_at_utc = NULL,
     last_error = $last_error
 WHERE operation_id = $operation_id;
 ";
@@ -370,17 +382,29 @@ ON CONFLICT(area_id) DO UPDATE SET
         await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
 
-    private static async Task<IReadOnlyList<string>> ReadPendingOperationIdsAsync(SqliteConnection connection, int maxCount, CancellationToken ct)
+    private static async Task<IReadOnlyList<string>> ReadPendingOperationIdsAsync(
+        SqliteConnection connection,
+        int maxCount,
+        DateTimeOffset staleClaimCutoffUtc,
+        CancellationToken ct)
     {
         await using var command = connection.CreateCommand();
         command.CommandText = @"
 SELECT operation_id
 FROM honua_sync_queue
 WHERE status IN ('pending', 'retry')
+   OR (
+      status = 'in_progress'
+      AND (
+        claimed_at_utc IS NULL
+        OR claimed_at_utc <= $stale_claim_cutoff_utc
+      )
+   )
 ORDER BY priority ASC, created_at_utc ASC
 LIMIT $limit;
 ";
         command.Parameters.AddWithValue("$limit", maxCount);
+        command.Parameters.AddWithValue("$stale_claim_cutoff_utc", staleClaimCutoffUtc.ToString("O", CultureInfo.InvariantCulture));
 
         var operationIds = new List<string>(capacity: maxCount);
         await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
@@ -421,6 +445,30 @@ LIMIT $limit;
         }
 
         return string.Join(", ", parameterNames);
+    }
+
+    private static async Task EnsureColumnExistsAsync(
+        SqliteConnection connection,
+        string tableName,
+        string columnName,
+        string columnDefinition,
+        CancellationToken ct)
+    {
+        await using var infoCommand = connection.CreateCommand();
+        infoCommand.CommandText = $"PRAGMA table_info({tableName});";
+
+        await using var reader = await infoCommand.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            if (string.Equals(reader.GetString(1), columnName, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+        }
+
+        await using var alterCommand = connection.CreateCommand();
+        alterCommand.CommandText = $"ALTER TABLE {tableName} ADD COLUMN {columnName} {columnDefinition};";
+        await alterCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
 
     private SqliteConnection OpenConnection() => new($"Data Source={_options.DatabasePath}");

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
@@ -148,37 +148,63 @@ ON CONFLICT(operation_id) DO UPDATE SET
         await using var connection = OpenConnection();
         await connection.OpenAsync(ct).ConfigureAwait(false);
 
-        await using var command = connection.CreateCommand();
-        command.CommandText = @"
+        await ExecuteTransactionCommandAsync(connection, "BEGIN IMMEDIATE;", ct).ConfigureAwait(false);
+        try
+        {
+            var claimedOperationIds = await ReadPendingOperationIdsAsync(connection, maxCount, ct).ConfigureAwait(false);
+            if (claimedOperationIds.Count == 0)
+            {
+                await ExecuteTransactionCommandAsync(connection, "COMMIT;", ct).ConfigureAwait(false);
+                return [];
+            }
+
+            await using (var claimCommand = connection.CreateCommand())
+            {
+                var idParameters = AddOperationIdParameters(claimCommand, claimedOperationIds);
+                claimCommand.CommandText = $@"
+UPDATE honua_sync_queue
+SET status = 'in_progress'
+WHERE status IN ('pending', 'retry')
+  AND operation_id IN ({idParameters});
+";
+
+                await claimCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            }
+
+            var items = new List<OfflineEditOperation>(capacity: claimedOperationIds.Count);
+            await using (var command = connection.CreateCommand())
+            {
+                var idParameters = AddOperationIdParameters(command, claimedOperationIds);
+                command.CommandText = $@"
 SELECT operation_id, layer_key, target_collection, operation_type, payload_json, priority, created_at_utc, attempt_count
 FROM honua_sync_queue
-WHERE status IN ('pending', 'retry')
-ORDER BY priority ASC, created_at_utc ASC
-LIMIT $limit;
+WHERE operation_id IN ({idParameters})
+ORDER BY priority ASC, created_at_utc ASC;
 ";
-        command.Parameters.AddWithValue("$limit", maxCount);
 
-        var items = new List<OfflineEditOperation>(capacity: maxCount);
-        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
-        while (await reader.ReadAsync(ct).ConfigureAwait(false))
-        {
-            var operationType = Enum.Parse<OfflineOperationType>(reader.GetString(3), ignoreCase: true);
-            var createdAt = DateTimeOffset.Parse(reader.GetString(6), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+                await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+                while (await reader.ReadAsync(ct).ConfigureAwait(false))
+                {
+                    items.Add(ReadOfflineEditOperation(reader));
+                }
+            }
 
-            items.Add(new OfflineEditOperation
-            {
-                OperationId = reader.GetString(0),
-                LayerKey = reader.GetString(1),
-                TargetCollection = reader.GetString(2),
-                OperationType = operationType,
-                PayloadJson = reader.GetString(4),
-                Priority = reader.GetInt32(5),
-                CreatedAtUtc = createdAt,
-                AttemptCount = reader.GetInt32(7),
-            });
+            await ExecuteTransactionCommandAsync(connection, "COMMIT;", ct).ConfigureAwait(false);
+            return items;
         }
+        catch
+        {
+            try
+            {
+                await ExecuteTransactionCommandAsync(connection, "ROLLBACK;", CancellationToken.None).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Preserve original exception when rollback also fails.
+            }
 
-        return items;
+            throw;
+        }
     }
 
     public async Task<int> CountPendingAsync(CancellationToken ct = default)
@@ -199,6 +225,22 @@ LIMIT $limit;
 
         await using var command = connection.CreateCommand();
         command.CommandText = "DELETE FROM honua_sync_queue WHERE operation_id = $operation_id;";
+        command.Parameters.AddWithValue("$operation_id", operationId);
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    public async Task MarkPendingAsync(string operationId, CancellationToken ct = default)
+    {
+        await using var connection = OpenConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = @"
+UPDATE honua_sync_queue
+SET status = 'pending',
+    last_error = NULL
+WHERE operation_id = $operation_id;
+";
         command.Parameters.AddWithValue("$operation_id", operationId);
         await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
@@ -319,6 +361,66 @@ ON CONFLICT(area_id) DO UPDATE SET
         }
 
         return items;
+    }
+
+    private static async Task ExecuteTransactionCommandAsync(SqliteConnection connection, string sql, CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    private static async Task<IReadOnlyList<string>> ReadPendingOperationIdsAsync(SqliteConnection connection, int maxCount, CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = @"
+SELECT operation_id
+FROM honua_sync_queue
+WHERE status IN ('pending', 'retry')
+ORDER BY priority ASC, created_at_utc ASC
+LIMIT $limit;
+";
+        command.Parameters.AddWithValue("$limit", maxCount);
+
+        var operationIds = new List<string>(capacity: maxCount);
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            operationIds.Add(reader.GetString(0));
+        }
+
+        return operationIds;
+    }
+
+    private static OfflineEditOperation ReadOfflineEditOperation(SqliteDataReader reader)
+    {
+        var operationType = Enum.Parse<OfflineOperationType>(reader.GetString(3), ignoreCase: true);
+        var createdAt = DateTimeOffset.Parse(reader.GetString(6), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+
+        return new OfflineEditOperation
+        {
+            OperationId = reader.GetString(0),
+            LayerKey = reader.GetString(1),
+            TargetCollection = reader.GetString(2),
+            OperationType = operationType,
+            PayloadJson = reader.GetString(4),
+            Priority = reader.GetInt32(5),
+            CreatedAtUtc = createdAt,
+            AttemptCount = reader.GetInt32(7),
+        };
+    }
+
+    private static string AddOperationIdParameters(SqliteCommand command, IReadOnlyList<string> operationIds)
+    {
+        var parameterNames = new string[operationIds.Count];
+        for (var i = 0; i < operationIds.Count; i++)
+        {
+            var parameterName = $"$id_{i}";
+            command.Parameters.AddWithValue(parameterName, operationIds[i]);
+            parameterNames[i] = parameterName;
+        }
+
+        return string.Join(", ", parameterNames);
     }
 
     private SqliteConnection OpenConnection() => new($"Data Source={_options.DatabasePath}");

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
@@ -97,6 +97,17 @@ VALUES ('honua_sync_queue', 'attributes', 'honua_sync_queue', 'Offline edit queu
 
 INSERT OR IGNORE INTO gpkg_contents (table_name, data_type, identifier, description, srs_id)
 VALUES ('honua_map_areas', 'attributes', 'honua_map_areas', 'Downloaded map area package catalog', 4326);
+
+CREATE TABLE IF NOT EXISTS honua_features (
+    layer_key TEXT NOT NULL,
+    object_id INTEGER NOT NULL,
+    feature_json TEXT NOT NULL,
+    updated_at_utc TEXT NOT NULL,
+    PRIMARY KEY (layer_key, object_id)
+);
+
+INSERT OR IGNORE INTO gpkg_contents (table_name, data_type, identifier, description, srs_id)
+VALUES ('honua_features', 'attributes', 'honua_features', 'Replicated feature cache for delta sync', 4326);
 ";
 
         await using var command = connection.CreateCommand();
@@ -373,6 +384,120 @@ ON CONFLICT(area_id) DO UPDATE SET
         }
 
         return items;
+    }
+
+    public async Task UpsertFeatureAsync(string layerKey, string featureJson, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(layerKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(featureJson);
+
+        var objectId = ExtractObjectId(featureJson);
+
+        await using var connection = OpenConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = @"
+INSERT INTO honua_features (layer_key, object_id, feature_json, updated_at_utc)
+VALUES ($layer_key, $object_id, $feature_json, $updated_at_utc)
+ON CONFLICT(layer_key, object_id) DO UPDATE SET
+  feature_json = excluded.feature_json,
+  updated_at_utc = excluded.updated_at_utc;
+";
+
+        command.Parameters.AddWithValue("$layer_key", layerKey);
+        command.Parameters.AddWithValue("$object_id", objectId);
+        command.Parameters.AddWithValue("$feature_json", featureJson);
+        command.Parameters.AddWithValue("$updated_at_utc", DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture));
+
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    public async Task DeleteFeatureAsync(string layerKey, long objectId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(layerKey);
+
+        await using var connection = OpenConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "DELETE FROM honua_features WHERE layer_key = $layer_key AND object_id = $object_id;";
+        command.Parameters.AddWithValue("$layer_key", layerKey);
+        command.Parameters.AddWithValue("$object_id", objectId);
+
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<string>> GetFeaturesAsync(string layerKey, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(layerKey);
+
+        await using var connection = OpenConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT feature_json FROM honua_features WHERE layer_key = $layer_key ORDER BY object_id ASC;";
+        command.Parameters.AddWithValue("$layer_key", layerKey);
+
+        var items = new List<string>();
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            items.Add(reader.GetString(0));
+        }
+
+        return items;
+    }
+
+    private static long ExtractObjectId(string featureJson)
+    {
+        using var doc = JsonDocument.Parse(featureJson);
+        var root = doc.RootElement;
+
+        if (root.TryGetProperty("attributes", out var attributes))
+        {
+            if (attributes.TryGetProperty("OBJECTID", out var oid) && oid.TryGetInt64(out var id))
+            {
+                return id;
+            }
+
+            if (attributes.TryGetProperty("objectid", out oid) && oid.TryGetInt64(out id))
+            {
+                return id;
+            }
+
+            if (attributes.TryGetProperty("ObjectID", out oid) && oid.TryGetInt64(out id))
+            {
+                return id;
+            }
+
+            if (attributes.TryGetProperty("FID", out oid) && oid.TryGetInt64(out id))
+            {
+                return id;
+            }
+        }
+
+        if (root.TryGetProperty("OBJECTID", out var topOid) && topOid.TryGetInt64(out var topId))
+        {
+            return topId;
+        }
+
+        if (root.TryGetProperty("objectid", out topOid) && topOid.TryGetInt64(out topId))
+        {
+            return topId;
+        }
+
+        if (root.TryGetProperty("ObjectID", out topOid) && topOid.TryGetInt64(out topId))
+        {
+            return topId;
+        }
+
+        if (root.TryGetProperty("FID", out topOid) && topOid.TryGetInt64(out topId))
+        {
+            return topId;
+        }
+
+        throw new InvalidOperationException("Feature JSON does not contain a recognizable object ID field (OBJECTID, objectid, ObjectID, or FID).");
     }
 
     private static async Task ExecuteTransactionCommandAsync(SqliteConnection connection, string sql, CancellationToken ct)

--- a/src/Honua.Mobile.Offline/GeoPackage/IGeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/IGeoPackageSyncStore.cs
@@ -12,6 +12,8 @@ public interface IGeoPackageSyncStore
 
     Task MarkSucceededAsync(string operationId, CancellationToken ct = default);
 
+    Task MarkPendingAsync(string operationId, CancellationToken ct = default);
+
     Task MarkFailedAsync(string operationId, string failureReason, bool retryable, CancellationToken ct = default);
 
     Task SetSyncCursorAsync(string cursorKey, string cursorValue, CancellationToken ct = default);

--- a/src/Honua.Mobile.Offline/GeoPackage/IGeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/IGeoPackageSyncStore.cs
@@ -23,4 +23,10 @@ public interface IGeoPackageSyncStore
     Task UpsertMapAreaAsync(MapAreaPackage mapArea, CancellationToken ct = default);
 
     Task<IReadOnlyList<MapAreaPackage>> ListMapAreasAsync(CancellationToken ct = default);
+
+    Task UpsertFeatureAsync(string layerKey, string featureJson, CancellationToken ct = default);
+
+    Task DeleteFeatureAsync(string layerKey, long objectId, CancellationToken ct = default);
+
+    Task<IReadOnlyList<string>> GetFeaturesAsync(string layerKey, CancellationToken ct = default);
 }

--- a/src/Honua.Mobile.Offline/MapAreas/MapAreaContracts.cs
+++ b/src/Honua.Mobile.Offline/MapAreas/MapAreaContracts.cs
@@ -16,6 +16,8 @@ public sealed class MapAreaDownloadRequest
 
     public int MaxZoom { get; init; }
 
+    public long MaxLayerPayloadBytes { get; init; } = 32L * 1024L * 1024L;
+
     public IReadOnlyList<MapLayerDownloadSource> Layers { get; init; } = [];
 }
 

--- a/src/Honua.Mobile.Offline/MapAreas/MapAreaDownloader.cs
+++ b/src/Honua.Mobile.Offline/MapAreas/MapAreaDownloader.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text;
 using Microsoft.Data.Sqlite;
 using Honua.Mobile.Offline.GeoPackage;
 
@@ -24,9 +25,7 @@ public sealed class MapAreaDownloader : IMapAreaDownloader
             throw new InvalidOperationException("At least one map layer source is required.");
         }
 
-        Directory.CreateDirectory(request.OutputDirectory);
-
-        var packagePath = Path.Combine(request.OutputDirectory, $"{request.AreaId}.gpkg");
+        var packagePath = BuildPackagePath(request.OutputDirectory, request.AreaId);
         await using var packageConnection = new SqliteConnection($"Data Source={packagePath}");
         await packageConnection.OpenAsync(ct).ConfigureAwait(false);
 
@@ -163,5 +162,71 @@ ON CONFLICT(layer_key) DO UPDATE SET
             .Replace("{maxLat}", request.BoundingBox.MaxLatitude.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal)
             .Replace("{minZoom}", request.MinZoom.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal)
             .Replace("{maxZoom}", request.MaxZoom.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal);
+    }
+
+    private static string BuildPackagePath(string outputDirectory, string areaId)
+    {
+        if (string.IsNullOrWhiteSpace(outputDirectory))
+        {
+            throw new InvalidOperationException("Output directory is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(areaId))
+        {
+            throw new InvalidOperationException("Area ID is required.");
+        }
+
+        var normalizedOutputDirectory = Path.GetFullPath(outputDirectory);
+        Directory.CreateDirectory(normalizedOutputDirectory);
+
+        var safeAreaId = SanitizeAreaId(areaId);
+        if (string.IsNullOrWhiteSpace(safeAreaId))
+        {
+            throw new InvalidOperationException("Area ID must include at least one valid file-name character.");
+        }
+
+        var packagePath = Path.GetFullPath(Path.Combine(normalizedOutputDirectory, $"{safeAreaId}.gpkg"));
+        if (!IsPathUnderDirectory(packagePath, normalizedOutputDirectory))
+        {
+            throw new InvalidOperationException("Resolved map package path is outside the requested output directory.");
+        }
+
+        return packagePath;
+    }
+
+    private static string SanitizeAreaId(string areaId)
+    {
+        var invalidCharacters = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(areaId.Length);
+
+        foreach (var character in areaId.Trim())
+        {
+            if (character == Path.DirectorySeparatorChar ||
+                character == Path.AltDirectorySeparatorChar ||
+                character == ':' ||
+                character == '.' ||
+                Array.IndexOf(invalidCharacters, character) >= 0)
+            {
+                builder.Append('_');
+                continue;
+            }
+
+            builder.Append(character);
+        }
+
+        return builder.ToString().Trim('.');
+    }
+
+    private static bool IsPathUnderDirectory(string candidatePath, string parentDirectoryPath)
+    {
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        var normalizedParent = Path.EndsInDirectorySeparator(parentDirectoryPath)
+            ? parentDirectoryPath
+            : parentDirectoryPath + Path.DirectorySeparatorChar;
+
+        return candidatePath.StartsWith(normalizedParent, comparison);
     }
 }

--- a/src/Honua.Mobile.Offline/MapAreas/MapAreaDownloader.cs
+++ b/src/Honua.Mobile.Offline/MapAreas/MapAreaDownloader.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text;
+using System.Buffers;
 using Microsoft.Data.Sqlite;
 using Honua.Mobile.Offline.GeoPackage;
 
@@ -25,6 +26,11 @@ public sealed class MapAreaDownloader : IMapAreaDownloader
             throw new InvalidOperationException("At least one map layer source is required.");
         }
 
+        if (request.MaxLayerPayloadBytes <= 0)
+        {
+            throw new InvalidOperationException("Max layer payload bytes must be greater than zero.");
+        }
+
         var packagePath = BuildPackagePath(request.OutputDirectory, request.AreaId);
         await using var packageConnection = new SqliteConnection($"Data Source={packagePath}");
         await packageConnection.OpenAsync(ct).ConfigureAwait(false);
@@ -37,7 +43,7 @@ public sealed class MapAreaDownloader : IMapAreaDownloader
         foreach (var layer in request.Layers.OrderBy(layer => layer.Priority))
         {
             var url = ApplyTemplate(layer.SourceUrl, request);
-            using var response = await _httpClient.GetAsync(url, ct).ConfigureAwait(false);
+            using var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 if (layer.Required)
@@ -48,7 +54,7 @@ public sealed class MapAreaDownloader : IMapAreaDownloader
                 continue;
             }
 
-            var payload = await response.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false);
+            var payload = await ReadBoundedPayloadAsync(response.Content, request.MaxLayerPayloadBytes, layer.LayerKey, ct).ConfigureAwait(false);
             var contentType = layer.ContentType ?? response.Content.Headers.ContentType?.MediaType ?? "application/octet-stream";
 
             await UpsertLayerPayloadAsync(packageConnection, layer, url, payload, contentType, ct).ConfigureAwait(false);
@@ -228,5 +234,50 @@ ON CONFLICT(layer_key) DO UPDATE SET
             : parentDirectoryPath + Path.DirectorySeparatorChar;
 
         return candidatePath.StartsWith(normalizedParent, comparison);
+    }
+
+    private static async Task<byte[]> ReadBoundedPayloadAsync(
+        HttpContent content,
+        long maxBytes,
+        string layerKey,
+        CancellationToken ct)
+    {
+        if (content.Headers.ContentLength is long contentLength && contentLength > maxBytes)
+        {
+            throw new InvalidOperationException(
+                $"Layer '{layerKey}' payload size ({contentLength} bytes) exceeds configured max ({maxBytes} bytes).");
+        }
+
+        await using var sourceStream = await content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        using var memoryStream = new MemoryStream();
+        var buffer = ArrayPool<byte>.Shared.Rent(81920);
+
+        try
+        {
+            long totalRead = 0;
+            while (true)
+            {
+                var read = await sourceStream.ReadAsync(buffer.AsMemory(0, buffer.Length), ct).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                totalRead += read;
+                if (totalRead > maxBytes)
+                {
+                    throw new InvalidOperationException(
+                        $"Layer '{layerKey}' payload size exceeds configured max ({maxBytes} bytes).");
+                }
+
+                memoryStream.Write(buffer, 0, read);
+            }
+
+            return memoryStream.ToArray();
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
     }
 }

--- a/src/Honua.Mobile.Offline/Sync/BackgroundSyncOrchestrator.cs
+++ b/src/Honua.Mobile.Offline/Sync/BackgroundSyncOrchestrator.cs
@@ -87,13 +87,29 @@ public sealed class BackgroundSyncOrchestrator : IAsyncDisposable
     {
         if (_options.RunImmediately)
         {
-            await RunOnceIfOnlineAsync(ct).ConfigureAwait(false);
+            await ExecuteCycleAsync(ct).ConfigureAwait(false);
         }
 
         using var timer = new PeriodicTimer(_options.SyncInterval);
         while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
         {
+            await ExecuteCycleAsync(ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ExecuteCycleAsync(CancellationToken ct)
+    {
+        try
+        {
             await RunOnceIfOnlineAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            // Keep the background loop alive and retry on the next interval.
         }
     }
 }

--- a/src/Honua.Mobile.Offline/Sync/BackgroundSyncOrchestrator.cs
+++ b/src/Honua.Mobile.Offline/Sync/BackgroundSyncOrchestrator.cs
@@ -5,6 +5,8 @@ public sealed class BackgroundSyncOrchestrator : IAsyncDisposable
     private readonly IOfflineSyncRunner _runner;
     private readonly IConnectivityStateProvider _connectivity;
     private readonly BackgroundSyncOrchestratorOptions _options;
+    private readonly DeltaDownloadEngine? _downloadEngine;
+    private readonly string? _downloadServiceId;
     private readonly SemaphoreSlim _runLock = new(1, 1);
 
     private CancellationTokenSource? _cts;
@@ -13,11 +15,15 @@ public sealed class BackgroundSyncOrchestrator : IAsyncDisposable
     public BackgroundSyncOrchestrator(
         IOfflineSyncRunner runner,
         IConnectivityStateProvider connectivity,
-        BackgroundSyncOrchestratorOptions? options = null)
+        BackgroundSyncOrchestratorOptions? options = null,
+        DeltaDownloadEngine? downloadEngine = null,
+        string? downloadServiceId = null)
     {
         _runner = runner ?? throw new ArgumentNullException(nameof(runner));
         _connectivity = connectivity ?? throw new ArgumentNullException(nameof(connectivity));
         _options = options ?? new BackgroundSyncOrchestratorOptions();
+        _downloadEngine = downloadEngine;
+        _downloadServiceId = downloadServiceId;
     }
 
     public bool IsRunning => _loopTask is { IsCompleted: false };
@@ -59,6 +65,8 @@ public sealed class BackgroundSyncOrchestrator : IAsyncDisposable
         }
     }
 
+    public DeltaDownloadResult? LastDownloadResult { get; private set; }
+
     public async Task<SyncRunResult?> RunOnceIfOnlineAsync(CancellationToken ct = default)
     {
         if (!_connectivity.IsOnline)
@@ -69,7 +77,14 @@ public sealed class BackgroundSyncOrchestrator : IAsyncDisposable
         await _runLock.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            return await _runner.SyncAsync(ct).ConfigureAwait(false);
+            var uploadResult = await _runner.SyncAsync(ct).ConfigureAwait(false);
+
+            if (_downloadEngine is not null && !string.IsNullOrWhiteSpace(_downloadServiceId))
+            {
+                LastDownloadResult = await _downloadEngine.DownloadAsync(_downloadServiceId, ct).ConfigureAwait(false);
+            }
+
+            return uploadResult;
         }
         finally
         {

--- a/src/Honua.Mobile.Offline/Sync/DeltaDownloadEngine.cs
+++ b/src/Honua.Mobile.Offline/Sync/DeltaDownloadEngine.cs
@@ -1,0 +1,89 @@
+using System.Globalization;
+using System.Text.Json;
+using Honua.Mobile.Offline.GeoPackage;
+
+namespace Honua.Mobile.Offline.Sync;
+
+public sealed class DeltaDownloadEngine
+{
+    private readonly IGeoPackageSyncStore _store;
+    private readonly IReplicaSyncClient _replicaClient;
+    private readonly DeltaDownloadOptions _options;
+
+    public DeltaDownloadEngine(IGeoPackageSyncStore store, IReplicaSyncClient replicaClient, DeltaDownloadOptions? options = null)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _replicaClient = replicaClient ?? throw new ArgumentNullException(nameof(replicaClient));
+        _options = options ?? new DeltaDownloadOptions();
+    }
+
+    public async Task<DeltaDownloadResult> DownloadAsync(string serviceId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceId);
+
+        await _store.InitializeAsync(ct).ConfigureAwait(false);
+
+        var replicaCursorKey = $"replica:{serviceId}";
+        var replicaId = await _store.GetSyncCursorAsync(replicaCursorKey, ct).ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(replicaId))
+        {
+            var replicaName = _options.ReplicaName ?? $"honua-mobile-{serviceId}";
+            var createResult = await _replicaClient.CreateReplicaAsync(serviceId, replicaName, _options.LayerIds, ct).ConfigureAwait(false);
+            replicaId = createResult.ReplicaId;
+
+            await _store.SetSyncCursorAsync(replicaCursorKey, replicaId, ct).ConfigureAwait(false);
+            await _store.SetSyncCursorAsync($"servergen:{serviceId}", createResult.ServerGen.ToString(CultureInfo.InvariantCulture), ct).ConfigureAwait(false);
+        }
+
+        var extractResult = await _replicaClient.ExtractChangesAsync(serviceId, replicaId, ct).ConfigureAwait(false);
+
+        int totalAdds = 0;
+        int totalUpdates = 0;
+        int totalDeletes = 0;
+
+        foreach (var layerChange in extractResult.LayerChanges)
+        {
+            var layerKey = layerChange.LayerId.ToString(CultureInfo.InvariantCulture);
+
+            if (layerChange.AddFeaturesJson is { Length: > 0 })
+            {
+                foreach (var featureJson in layerChange.AddFeaturesJson)
+                {
+                    await _store.UpsertFeatureAsync(layerKey, featureJson, ct).ConfigureAwait(false);
+                    totalAdds++;
+                }
+            }
+
+            if (layerChange.UpdateFeaturesJson is { Length: > 0 })
+            {
+                foreach (var featureJson in layerChange.UpdateFeaturesJson)
+                {
+                    await _store.UpsertFeatureAsync(layerKey, featureJson, ct).ConfigureAwait(false);
+                    totalUpdates++;
+                }
+            }
+
+            if (layerChange.DeleteIds is { Length: > 0 })
+            {
+                foreach (var objectId in layerChange.DeleteIds)
+                {
+                    await _store.DeleteFeatureAsync(layerKey, objectId, ct).ConfigureAwait(false);
+                    totalDeletes++;
+                }
+            }
+        }
+
+        var syncResult = await _replicaClient.SynchronizeReplicaAsync(serviceId, replicaId, "download", ct).ConfigureAwait(false);
+
+        await _store.SetSyncCursorAsync($"servergen:{serviceId}", syncResult.ServerGen.ToString(CultureInfo.InvariantCulture), ct).ConfigureAwait(false);
+
+        return new DeltaDownloadResult
+        {
+            Adds = totalAdds,
+            Updates = totalUpdates,
+            Deletes = totalDeletes,
+            ServerGen = syncResult.ServerGen,
+        };
+    }
+}

--- a/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
+++ b/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
@@ -194,21 +194,42 @@ public sealed class HonuaApiOfflineOperationUploader : IOfflineOperationUploader
 
     private static UploadResult ParseApplyEditsResponse(JsonElement root)
     {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits response payload is malformed." };
+        }
+
         if (TryReadError(root, out var topLevelCode, out var topLevelMessage))
         {
             return FromErrorCode(topLevelCode, topLevelMessage);
         }
 
         var resultArrays = new[] { "addResults", "updateResults", "deleteResults" };
+        var foundResultArray = false;
+        var foundResultEntry = false;
+
         foreach (var propertyName in resultArrays)
         {
-            if (!root.TryGetProperty(propertyName, out var results) || results.ValueKind != JsonValueKind.Array)
+            if (!root.TryGetProperty(propertyName, out var results))
             {
                 continue;
             }
 
+            foundResultArray = true;
+            if (results.ValueKind != JsonValueKind.Array)
+            {
+                return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits response payload is malformed." };
+            }
+
             foreach (var result in results.EnumerateArray())
             {
+                foundResultEntry = true;
+
+                if (result.ValueKind != JsonValueKind.Object)
+                {
+                    return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits result payload is malformed." };
+                }
+
                 if (result.TryGetProperty("success", out var success) && success.ValueKind == JsonValueKind.True)
                 {
                     continue;
@@ -219,8 +240,23 @@ public sealed class HonuaApiOfflineOperationUploader : IOfflineOperationUploader
                     return FromErrorCode(code, message);
                 }
 
-                return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits result reported failure." };
+                if (result.TryGetProperty("success", out success) && success.ValueKind == JsonValueKind.False)
+                {
+                    return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits result reported failure." };
+                }
+
+                return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits result payload is malformed." };
             }
+        }
+
+        if (!foundResultArray)
+        {
+            return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits response is missing edit result arrays." };
+        }
+
+        if (!foundResultEntry)
+        {
+            return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits response contains no edit results." };
         }
 
         return new UploadResult { Outcome = UploadOutcome.Success };

--- a/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
+++ b/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
@@ -44,6 +44,18 @@ public sealed class HonuaApiOfflineOperationUploader : IOfflineOperationUploader
                 _ => new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = $"Unsupported protocol '{payload.Protocol}'." },
             };
         }
+        catch (JsonException ex)
+        {
+            return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = $"Invalid offline payload: {ex.Message}" };
+        }
+        catch (InvalidOperationException ex)
+        {
+            return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = $"Invalid offline payload: {ex.Message}" };
+        }
+        catch (ArgumentException ex)
+        {
+            return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = $"Invalid offline payload: {ex.Message}" };
+        }
         catch (HonuaMobileApiException ex)
         {
             return FromStatusCode(ex.StatusCode, ex.Message);
@@ -51,6 +63,10 @@ public sealed class HonuaApiOfflineOperationUploader : IOfflineOperationUploader
         catch (HttpRequestException ex)
         {
             return new UploadResult { Outcome = UploadOutcome.RetryableFailure, Message = ex.Message };
+        }
+        catch (TaskCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (TaskCanceledException ex)
         {

--- a/src/Honua.Mobile.Offline/Sync/IReplicaSyncClient.cs
+++ b/src/Honua.Mobile.Offline/Sync/IReplicaSyncClient.cs
@@ -1,0 +1,34 @@
+namespace Honua.Mobile.Offline.Sync;
+
+public interface IReplicaSyncClient
+{
+    Task<CreateReplicaResult> CreateReplicaAsync(string serviceId, string replicaName, int[]? layerIds = null, CancellationToken ct = default);
+
+    Task<ExtractChangesResult> ExtractChangesAsync(string serviceId, string replicaId, CancellationToken ct = default);
+
+    Task<SynchronizeResult> SynchronizeReplicaAsync(string serviceId, string replicaId, string syncDirection = "download", CancellationToken ct = default);
+
+    Task UnRegisterReplicaAsync(string serviceId, string replicaId, CancellationToken ct = default);
+}
+
+public sealed record CreateReplicaResult(string ReplicaId, long ServerGen);
+
+public sealed record SynchronizeResult(string ReplicaId, long ServerGen);
+
+public sealed class ExtractChangesResult
+{
+    public required LayerChangeSet[] LayerChanges { get; init; }
+
+    public long ServerGen { get; init; }
+}
+
+public sealed class LayerChangeSet
+{
+    public int LayerId { get; init; }
+
+    public string[]? AddFeaturesJson { get; init; }
+
+    public string[]? UpdateFeaturesJson { get; init; }
+
+    public long[]? DeleteIds { get; init; }
+}

--- a/src/Honua.Mobile.Offline/Sync/OfflineSyncEngine.cs
+++ b/src/Honua.Mobile.Offline/Sync/OfflineSyncEngine.cs
@@ -72,6 +72,11 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
                 await ReleaseClaimedOperationsAsync(pending, index).ConfigureAwait(false);
                 throw;
             }
+            catch
+            {
+                await ReleaseClaimedOperationsAsync(pending, index).ConfigureAwait(false);
+                throw;
+            }
         }
 
         return new SyncRunResult

--- a/src/Honua.Mobile.Offline/Sync/OfflineSyncEngine.cs
+++ b/src/Honua.Mobile.Offline/Sync/OfflineSyncEngine.cs
@@ -97,18 +97,18 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
                 return ConflictResolutionState.ResolvedState;
 
             case SyncConflictStrategy.ClientWins:
-            {
-                var forced = await _uploader.UploadAsync(operation, forceWrite: true, ct).ConfigureAwait(false);
-                if (forced.Outcome == UploadOutcome.Success)
                 {
-                    await _store.MarkSucceededAsync(operation.OperationId, ct).ConfigureAwait(false);
-                    return ConflictResolutionState.ResolvedState;
-                }
+                    var forced = await _uploader.UploadAsync(operation, forceWrite: true, ct).ConfigureAwait(false);
+                    if (forced.Outcome == UploadOutcome.Success)
+                    {
+                        await _store.MarkSucceededAsync(operation.OperationId, ct).ConfigureAwait(false);
+                        return ConflictResolutionState.ResolvedState;
+                    }
 
-                var reason = forced.Message ?? "conflict retry failed";
-                await _store.MarkFailedAsync(operation.OperationId, reason, retryable: forced.Outcome == UploadOutcome.RetryableFailure, ct).ConfigureAwait(false);
-                return new ConflictResolutionState(false, true, reason);
-            }
+                    var reason = forced.Message ?? "conflict retry failed";
+                    await _store.MarkFailedAsync(operation.OperationId, reason, retryable: forced.Outcome == UploadOutcome.RetryableFailure, ct).ConfigureAwait(false);
+                    return new ConflictResolutionState(false, true, reason);
+                }
 
             case SyncConflictStrategy.ManualReview:
             default:

--- a/src/Honua.Mobile.Offline/Sync/OfflineSyncEngine.cs
+++ b/src/Honua.Mobile.Offline/Sync/OfflineSyncEngine.cs
@@ -23,39 +23,55 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
         var failures = new List<SyncFailure>();
         var success = 0;
 
-        foreach (var operation in pending)
+        for (var index = 0; index < pending.Count; index++)
         {
-            ct.ThrowIfCancellationRequested();
+            var operation = pending[index];
 
-            if (operation.AttemptCount >= _options.MaxAttempts)
+            try
             {
-                await _store.MarkFailedAsync(operation.OperationId, "max attempts reached", retryable: false, ct).ConfigureAwait(false);
-                failures.Add(new SyncFailure(operation.OperationId, "max attempts reached"));
-                continue;
-            }
+                ct.ThrowIfCancellationRequested();
 
-            var uploadResult = await _uploader.UploadAsync(operation, forceWrite: false, ct).ConfigureAwait(false);
-            if (uploadResult.Outcome == UploadOutcome.Success)
-            {
-                await _store.MarkSucceededAsync(operation.OperationId, ct).ConfigureAwait(false);
-                success++;
-                continue;
-            }
-
-            if (uploadResult.Outcome == UploadOutcome.Conflict)
-            {
-                var conflictResolved = await HandleConflictAsync(operation, ct).ConfigureAwait(false);
-                if (conflictResolved)
+                if (operation.AttemptCount >= _options.MaxAttempts)
                 {
+                    await _store.MarkFailedAsync(operation.OperationId, "max attempts reached", retryable: false, ct).ConfigureAwait(false);
+                    failures.Add(new SyncFailure(operation.OperationId, "max attempts reached"));
+                    continue;
+                }
+
+                var uploadResult = await _uploader.UploadAsync(operation, forceWrite: false, ct).ConfigureAwait(false);
+                if (uploadResult.Outcome == UploadOutcome.Success)
+                {
+                    await _store.MarkSucceededAsync(operation.OperationId, ct).ConfigureAwait(false);
                     success++;
                     continue;
                 }
-            }
 
-            var retryable = uploadResult.Outcome == UploadOutcome.RetryableFailure;
-            var reason = uploadResult.Message ?? uploadResult.Outcome.ToString();
-            await _store.MarkFailedAsync(operation.OperationId, reason, retryable, ct).ConfigureAwait(false);
-            failures.Add(new SyncFailure(operation.OperationId, reason));
+                if (uploadResult.Outcome == UploadOutcome.Conflict)
+                {
+                    var conflictResolved = await HandleConflictAsync(operation, ct).ConfigureAwait(false);
+                    if (conflictResolved.Resolved)
+                    {
+                        success++;
+                        continue;
+                    }
+
+                    if (conflictResolved.FailureHandled)
+                    {
+                        failures.Add(new SyncFailure(operation.OperationId, conflictResolved.FailureReason ?? "Conflict resolution failed."));
+                        continue;
+                    }
+                }
+
+                var retryable = uploadResult.Outcome == UploadOutcome.RetryableFailure;
+                var reason = uploadResult.Message ?? uploadResult.Outcome.ToString();
+                await _store.MarkFailedAsync(operation.OperationId, reason, retryable, ct).ConfigureAwait(false);
+                failures.Add(new SyncFailure(operation.OperationId, reason));
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                await ReleaseClaimedOperationsAsync(pending, index).ConfigureAwait(false);
+                throw;
+            }
         }
 
         return new SyncRunResult
@@ -67,13 +83,13 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
         };
     }
 
-    private async Task<bool> HandleConflictAsync(OfflineEditOperation operation, CancellationToken ct)
+    private async Task<ConflictResolutionState> HandleConflictAsync(OfflineEditOperation operation, CancellationToken ct)
     {
         switch (_options.ConflictStrategy)
         {
             case SyncConflictStrategy.ServerWins:
                 await _store.MarkSucceededAsync(operation.OperationId, ct).ConfigureAwait(false);
-                return true;
+                return ConflictResolutionState.ResolvedState;
 
             case SyncConflictStrategy.ClientWins:
             {
@@ -81,18 +97,32 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
                 if (forced.Outcome == UploadOutcome.Success)
                 {
                     await _store.MarkSucceededAsync(operation.OperationId, ct).ConfigureAwait(false);
-                    return true;
+                    return ConflictResolutionState.ResolvedState;
                 }
 
                 var reason = forced.Message ?? "conflict retry failed";
                 await _store.MarkFailedAsync(operation.OperationId, reason, retryable: forced.Outcome == UploadOutcome.RetryableFailure, ct).ConfigureAwait(false);
-                return false;
+                return new ConflictResolutionState(false, true, reason);
             }
 
             case SyncConflictStrategy.ManualReview:
             default:
-                await _store.MarkFailedAsync(operation.OperationId, "conflict requires manual review", retryable: false, ct).ConfigureAwait(false);
-                return false;
+                const string manualReviewReason = "conflict requires manual review";
+                await _store.MarkFailedAsync(operation.OperationId, manualReviewReason, retryable: false, ct).ConfigureAwait(false);
+                return new ConflictResolutionState(false, true, manualReviewReason);
+        }
+    }
+
+    private readonly record struct ConflictResolutionState(bool Resolved, bool FailureHandled, string? FailureReason)
+    {
+        public static readonly ConflictResolutionState ResolvedState = new(true, false, null);
+    }
+
+    private async Task ReleaseClaimedOperationsAsync(IReadOnlyList<OfflineEditOperation> pending, int startIndex)
+    {
+        for (var i = startIndex; i < pending.Count; i++)
+        {
+            await _store.MarkPendingAsync(pending[i].OperationId, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/src/Honua.Mobile.Offline/Sync/ReplicaSyncClient.cs
+++ b/src/Honua.Mobile.Offline/Sync/ReplicaSyncClient.cs
@@ -1,0 +1,185 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace Honua.Mobile.Offline.Sync;
+
+public sealed class ReplicaSyncClient : IReplicaSyncClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly HttpClient _httpClient;
+
+    public ReplicaSyncClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+    public async Task<CreateReplicaResult> CreateReplicaAsync(string serviceId, string replicaName, int[]? layerIds = null, CancellationToken ct = default)
+    {
+        var url = $"rest/services/{serviceId}/FeatureServer/createReplica";
+        var parameters = new Dictionary<string, string>
+        {
+            ["replicaName"] = replicaName,
+            ["syncModel"] = "perLayer",
+            ["f"] = "json",
+        };
+
+        if (layerIds is { Length: > 0 })
+        {
+            parameters["layers"] = string.Join(',', layerIds.Select(id => id.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        using var content = new FormUrlEncodedContent(parameters);
+        using var response = await _httpClient.PostAsync(url, content, ct).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        using var doc = await JsonDocument.ParseAsync(
+            await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false), cancellationToken: ct).ConfigureAwait(false);
+
+        var root = doc.RootElement;
+        ThrowIfError(root);
+
+        var replicaId = root.GetProperty("replicaID").GetString()
+            ?? throw new InvalidOperationException("Server did not return a replicaID.");
+        var serverGen = root.GetProperty("serverGen").GetInt64();
+
+        return new CreateReplicaResult(replicaId, serverGen);
+    }
+
+    public async Task<ExtractChangesResult> ExtractChangesAsync(string serviceId, string replicaId, CancellationToken ct = default)
+    {
+        var url = $"rest/services/{serviceId}/FeatureServer/extractChanges";
+        var parameters = new Dictionary<string, string>
+        {
+            ["replicaID"] = replicaId,
+            ["f"] = "json",
+        };
+
+        using var content = new FormUrlEncodedContent(parameters);
+        using var response = await _httpClient.PostAsync(url, content, ct).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        using var doc = await JsonDocument.ParseAsync(
+            await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false), cancellationToken: ct).ConfigureAwait(false);
+
+        var root = doc.RootElement;
+        ThrowIfError(root);
+
+        var serverGen = root.GetProperty("serverGen").GetInt64();
+        var layerChanges = new List<LayerChangeSet>();
+
+        if (root.TryGetProperty("layerChanges", out var layerChangesElement) && layerChangesElement.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var layerElement in layerChangesElement.EnumerateArray())
+            {
+                layerChanges.Add(ParseLayerChangeSet(layerElement));
+            }
+        }
+
+        return new ExtractChangesResult
+        {
+            LayerChanges = layerChanges.ToArray(),
+            ServerGen = serverGen,
+        };
+    }
+
+    public async Task<SynchronizeResult> SynchronizeReplicaAsync(string serviceId, string replicaId, string syncDirection = "download", CancellationToken ct = default)
+    {
+        var url = $"rest/services/{serviceId}/FeatureServer/synchronizeReplica";
+        var parameters = new Dictionary<string, string>
+        {
+            ["replicaID"] = replicaId,
+            ["syncDirection"] = syncDirection,
+            ["f"] = "json",
+        };
+
+        using var content = new FormUrlEncodedContent(parameters);
+        using var response = await _httpClient.PostAsync(url, content, ct).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        using var doc = await JsonDocument.ParseAsync(
+            await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false), cancellationToken: ct).ConfigureAwait(false);
+
+        var root = doc.RootElement;
+        ThrowIfError(root);
+
+        var serverGen = root.GetProperty("serverGen").GetInt64();
+
+        return new SynchronizeResult(replicaId, serverGen);
+    }
+
+    public async Task UnRegisterReplicaAsync(string serviceId, string replicaId, CancellationToken ct = default)
+    {
+        var url = $"rest/services/{serviceId}/FeatureServer/unRegisterReplica";
+        var parameters = new Dictionary<string, string>
+        {
+            ["replicaID"] = replicaId,
+            ["f"] = "json",
+        };
+
+        using var content = new FormUrlEncodedContent(parameters);
+        using var response = await _httpClient.PostAsync(url, content, ct).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        using var doc = await JsonDocument.ParseAsync(
+            await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false), cancellationToken: ct).ConfigureAwait(false);
+
+        ThrowIfError(doc.RootElement);
+    }
+
+    private static LayerChangeSet ParseLayerChangeSet(JsonElement element)
+    {
+        var layerId = element.GetProperty("id").GetInt32();
+        string[]? adds = null;
+        string[]? updates = null;
+        long[]? deletes = null;
+
+        if (element.TryGetProperty("addFeatures", out var addFeatures) && addFeatures.ValueKind == JsonValueKind.Array)
+        {
+            adds = addFeatures.EnumerateArray()
+                .Select(f => f.GetRawText())
+                .ToArray();
+        }
+
+        if (element.TryGetProperty("updateFeatures", out var updateFeatures) && updateFeatures.ValueKind == JsonValueKind.Array)
+        {
+            updates = updateFeatures.EnumerateArray()
+                .Select(f => f.GetRawText())
+                .ToArray();
+        }
+
+        if (element.TryGetProperty("deleteIds", out var deleteIds) && deleteIds.ValueKind == JsonValueKind.Array)
+        {
+            deletes = deleteIds.EnumerateArray()
+                .Select(d => d.GetInt64())
+                .ToArray();
+        }
+
+        return new LayerChangeSet
+        {
+            LayerId = layerId,
+            AddFeaturesJson = adds,
+            UpdateFeaturesJson = updates,
+            DeleteIds = deletes,
+        };
+    }
+
+    private static void ThrowIfError(JsonElement root)
+    {
+        if (root.TryGetProperty("error", out var error) && error.ValueKind == JsonValueKind.Object)
+        {
+            var message = error.TryGetProperty("message", out var msg) && msg.ValueKind == JsonValueKind.String
+                ? msg.GetString()
+                : "Unknown server error";
+
+            var code = error.TryGetProperty("code", out var codeElement) && codeElement.TryGetInt32(out var parsedCode)
+                ? parsedCode
+                : (int?)null;
+
+            throw new InvalidOperationException($"Replica sync error{(code.HasValue ? $" ({code.Value})" : "")}: {message}");
+        }
+    }
+}

--- a/src/Honua.Mobile.Offline/Sync/SyncContracts.cs
+++ b/src/Honua.Mobile.Offline/Sync/SyncContracts.cs
@@ -67,3 +67,21 @@ public sealed class SyncRunResult
 }
 
 public sealed record SyncFailure(string OperationId, string Reason);
+
+public sealed class DeltaDownloadOptions
+{
+    public string? ReplicaName { get; init; }
+
+    public int[]? LayerIds { get; init; }
+}
+
+public sealed class DeltaDownloadResult
+{
+    public int Adds { get; init; }
+
+    public int Updates { get; init; }
+
+    public int Deletes { get; init; }
+
+    public long ServerGen { get; init; }
+}

--- a/src/Honua.Mobile.Sdk/Grpc/GrpcFeatureTranslator.cs
+++ b/src/Honua.Mobile.Sdk/Grpc/GrpcFeatureTranslator.cs
@@ -276,6 +276,9 @@ public static class GrpcFeatureTranslator
 
     private static Proto.Geometry? ToGeometry(JsonElement source)
     {
+        var hasZ = TryReadBoolean(source, "hasZ");
+        var hasM = TryReadBoolean(source, "hasM");
+
         if (source.TryGetProperty("x", out var xNode) &&
             source.TryGetProperty("y", out var yNode) &&
             xNode.TryGetDouble(out var x) &&
@@ -308,7 +311,7 @@ public static class GrpcFeatureTranslator
             var multipoint = new Proto.MultiPointGeometry();
             foreach (var pointNode in pointsNode.EnumerateArray())
             {
-                if (TryReadPointFromArray(pointNode, out var point))
+                if (TryReadPointFromArray(pointNode, hasZ, hasM, out var point))
                 {
                     multipoint.Points.Add(point);
                 }
@@ -322,7 +325,7 @@ public static class GrpcFeatureTranslator
             var polyline = new Proto.PolylineGeometry();
             foreach (var pathNode in pathsNode.EnumerateArray())
             {
-                var sequence = ToCoordinateSequence(pathNode);
+                var sequence = ToCoordinateSequence(pathNode, hasZ, hasM);
                 if (sequence is not null)
                 {
                     polyline.Paths.Add(sequence);
@@ -337,7 +340,7 @@ public static class GrpcFeatureTranslator
             var polygon = new Proto.PolygonGeometry();
             foreach (var ringNode in ringsNode.EnumerateArray())
             {
-                var sequence = ToCoordinateSequence(ringNode);
+                var sequence = ToCoordinateSequence(ringNode, hasZ, hasM);
                 if (sequence is not null)
                 {
                     polygon.Rings.Add(sequence);
@@ -388,7 +391,7 @@ public static class GrpcFeatureTranslator
         return sequence.Coords.Select(coord => new object?[] { coord.X, coord.Y, coord.Z, coord.M }).Cast<object?>().ToArray();
     }
 
-    private static Proto.CoordinateSequence? ToCoordinateSequence(JsonElement source)
+    private static Proto.CoordinateSequence? ToCoordinateSequence(JsonElement source, bool hasZ, bool hasM)
     {
         if (source.ValueKind != JsonValueKind.Array)
         {
@@ -398,7 +401,7 @@ public static class GrpcFeatureTranslator
         var sequence = new Proto.CoordinateSequence();
         foreach (var node in source.EnumerateArray())
         {
-            if (!TryReadCoordinate(node, out var coord))
+            if (!TryReadCoordinate(node, hasZ, hasM, out var coord))
             {
                 continue;
             }
@@ -409,7 +412,7 @@ public static class GrpcFeatureTranslator
         return sequence;
     }
 
-    private static bool TryReadPointFromArray(JsonElement source, out Proto.PointGeometry point)
+    private static bool TryReadPointFromArray(JsonElement source, bool hasZ, bool hasM, out Proto.PointGeometry point)
     {
         point = new Proto.PointGeometry();
 
@@ -432,20 +435,27 @@ public static class GrpcFeatureTranslator
         point.X = x;
         point.Y = y;
 
-        if (enumerator.MoveNext() && enumerator.Current.TryGetDouble(out var z))
+        if (enumerator.MoveNext() && enumerator.Current.TryGetDouble(out var third))
         {
-            point.Z = z;
-        }
+            if (hasM && !hasZ)
+            {
+                point.M = third;
+            }
+            else
+            {
+                point.Z = third;
+            }
 
-        if (enumerator.MoveNext() && enumerator.Current.TryGetDouble(out var m))
-        {
-            point.M = m;
+            if (hasM && hasZ && enumerator.MoveNext() && enumerator.Current.TryGetDouble(out var m))
+            {
+                point.M = m;
+            }
         }
 
         return true;
     }
 
-    private static bool TryReadCoordinate(JsonElement source, out Proto.Coordinate coordinate)
+    private static bool TryReadCoordinate(JsonElement source, bool hasZ, bool hasM, out Proto.Coordinate coordinate)
     {
         coordinate = new Proto.Coordinate();
 
@@ -468,17 +478,39 @@ public static class GrpcFeatureTranslator
         coordinate.X = x;
         coordinate.Y = y;
 
-        if (enumerator.MoveNext() && enumerator.Current.TryGetDouble(out var z))
+        if (enumerator.MoveNext() && enumerator.Current.TryGetDouble(out var third))
         {
-            coordinate.Z = z;
-        }
+            if (hasM && !hasZ)
+            {
+                coordinate.M = third;
+            }
+            else
+            {
+                coordinate.Z = third;
+            }
 
-        if (enumerator.MoveNext() && enumerator.Current.TryGetDouble(out var m))
-        {
-            coordinate.M = m;
+            if (hasM && hasZ && enumerator.MoveNext() && enumerator.Current.TryGetDouble(out var m))
+            {
+                coordinate.M = m;
+            }
         }
 
         return true;
+    }
+
+    private static bool TryReadBoolean(JsonElement source, string propertyName)
+    {
+        if (!source.TryGetProperty(propertyName, out var node))
+        {
+            return false;
+        }
+
+        return node.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => false,
+        };
     }
 
     private static Dictionary<string, object?>? ToSpatialReference(Proto.SpatialReference? source)

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
@@ -59,28 +59,36 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        IReadOnlyList<JsonDocument>? grpcPages = null;
-
         if (CanUseGrpcForQueries)
         {
-            try
-            {
-                grpcPages = await QueryFeaturesGrpcPagesAsync(request, ct).ConfigureAwait(false);
-            }
-            catch (RpcException) when (_options.AllowRestFallbackOnGrpcFailure)
-            {
-                // Fall through to REST unary query.
-            }
-        }
+            var yieldedGrpcPage = false;
+            await using var grpcEnumerator = QueryFeaturesGrpcPagesAsync(request, ct).GetAsyncEnumerator(ct);
 
-        if (grpcPages is { Count: > 0 })
-        {
-            foreach (var page in grpcPages)
+            while (true)
             {
-                yield return page;
-            }
+                JsonDocument? nextPage = null;
+                try
+                {
+                    if (!await grpcEnumerator.MoveNextAsync().ConfigureAwait(false))
+                    {
+                        if (yieldedGrpcPage)
+                        {
+                            yield break;
+                        }
 
-            yield break;
+                        break;
+                    }
+
+                    nextPage = grpcEnumerator.Current;
+                }
+                catch (RpcException) when (_options.AllowRestFallbackOnGrpcFailure && !yieldedGrpcPage)
+                {
+                    break;
+                }
+
+                yieldedGrpcPage = true;
+                yield return nextPage!;
+            }
         }
 
         yield return await QueryFeaturesRestAsync(request, ct).ConfigureAwait(false);
@@ -183,19 +191,17 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
         return GrpcFeatureTranslator.ToJsonDocument(response);
     }
 
-    private async Task<IReadOnlyList<JsonDocument>> QueryFeaturesGrpcPagesAsync(QueryFeaturesRequest request, CancellationToken ct)
+    private async IAsyncEnumerable<JsonDocument> QueryFeaturesGrpcPagesAsync(
+        QueryFeaturesRequest request,
+        [EnumeratorCancellation] CancellationToken ct)
     {
         var protoRequest = GrpcFeatureTranslator.ToProtoQueryRequest(request);
         var metadata = await BuildGrpcMetadataAsync(ct).ConfigureAwait(false);
-        var call = _grpcClient!.QueryFeaturesStream(protoRequest, metadata, cancellationToken: ct);
-
-        var pages = new List<JsonDocument>();
+        using var call = _grpcClient!.QueryFeaturesStream(protoRequest, metadata, cancellationToken: ct);
         await foreach (var page in call.ResponseStream.ReadAllAsync(ct).ConfigureAwait(false))
         {
-            pages.Add(GrpcFeatureTranslator.ToJsonDocument(page));
+            yield return GrpcFeatureTranslator.ToJsonDocument(page);
         }
-
-        return pages;
     }
 
     private async Task<JsonDocument> ApplyEditsGrpcAsync(ApplyEditsRequest request, CancellationToken ct)
@@ -273,12 +279,20 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
 
     private async ValueTask ApplyHttpAuthenticationAsync(HttpRequestMessage request, CancellationToken ct)
     {
-        if (!string.IsNullOrWhiteSpace(_options.ApiKey))
+        var token = await ResolveBearerTokenAsync(ct).ConfigureAwait(false);
+        var hasApiKey = !string.IsNullOrWhiteSpace(_options.ApiKey);
+        var hasBearerToken = !string.IsNullOrWhiteSpace(token);
+
+        if (hasApiKey || hasBearerToken)
+        {
+            EnsureSecureTransport(ResolveAbsoluteRequestUri(request));
+        }
+
+        if (hasApiKey)
         {
             request.Headers.TryAddWithoutValidation("X-API-Key", _options.ApiKey);
         }
 
-        var token = await ResolveBearerTokenAsync(ct).ConfigureAwait(false);
         if (!string.IsNullOrWhiteSpace(token))
         {
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
@@ -288,16 +302,23 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
     private async Task<Metadata> BuildGrpcMetadataAsync(CancellationToken ct)
     {
         var metadata = new Metadata();
+        var token = await ResolveBearerTokenAsync(ct).ConfigureAwait(false);
+        var hasApiKey = !string.IsNullOrWhiteSpace(_options.ApiKey);
+        var hasBearerToken = !string.IsNullOrWhiteSpace(token);
 
-        if (!string.IsNullOrWhiteSpace(_options.ApiKey))
+        if (hasApiKey || hasBearerToken)
         {
-            metadata.Add("x-api-key", _options.ApiKey);
+            EnsureSecureTransport(_options.GrpcEndpoint ?? _options.BaseUri);
         }
 
-        var token = await ResolveBearerTokenAsync(ct).ConfigureAwait(false);
-        if (!string.IsNullOrWhiteSpace(token))
+        if (hasApiKey)
         {
-            metadata.Add("authorization", $"Bearer {token}");
+            metadata.Add("x-api-key", _options.ApiKey!);
+        }
+
+        if (hasBearerToken)
+        {
+            metadata.Add("authorization", $"Bearer {token!}");
         }
 
         return metadata;
@@ -312,6 +333,41 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
         }
 
         return token;
+    }
+
+    private Uri ResolveAbsoluteRequestUri(HttpRequestMessage request)
+    {
+        if (request.RequestUri is null)
+        {
+            throw new InvalidOperationException("Request URI cannot be null.");
+        }
+
+        if (request.RequestUri.IsAbsoluteUri)
+        {
+            return request.RequestUri;
+        }
+
+        if (_http.BaseAddress is null)
+        {
+            throw new InvalidOperationException("HonuaMobileClient requires an absolute BaseUri.");
+        }
+
+        return new Uri(_http.BaseAddress, request.RequestUri);
+    }
+
+    private void EnsureSecureTransport(Uri targetUri)
+    {
+        if (_options.AllowInsecureTransportForDevelopment)
+        {
+            return;
+        }
+
+        if (!string.Equals(targetUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                "Refusing to send authentication over non-HTTPS transport. " +
+                "Set AllowInsecureTransportForDevelopment=true only for local development.");
+        }
     }
 
     private static Uri BuildUri(string relativePath, IReadOnlyDictionary<string, string?>? query)

--- a/src/Honua.Mobile.Sdk/HonuaMobileClientOptions.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClientOptions.cs
@@ -20,6 +20,8 @@ public sealed class HonuaMobileClientOptions
 
     public Func<CancellationToken, ValueTask<string?>>? AccessTokenProvider { get; init; }
 
+    public bool AllowInsecureTransportForDevelopment { get; init; }
+
     public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(30);
 
     public ProductInfoHeaderValue UserAgent { get; init; } = new("honua-mobile-sdk", "0.1.0");

--- a/templates/honua-fieldcollector/HonuaFieldCollector.csproj
+++ b/templates/honua-fieldcollector/HonuaFieldCollector.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net10.0-android;net10.0-ios;net10.0-windows10.0.19041.0</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>namespace</RootNamespace>
 		<UseMaui>true</UseMaui>

--- a/tests/Honua.Mobile.Field.Tests/FormValidatorTests.cs
+++ b/tests/Honua.Mobile.Field.Tests/FormValidatorTests.cs
@@ -149,4 +149,150 @@ public sealed class FormValidatorTests
         Assert.False(result.IsValid);
         Assert.Contains(result.Errors, error => error.FieldId == "tags");
     }
+
+    [Fact]
+    public void Validate_WhenVisibilityRuleComparesNullToZero_FieldRemainsHidden()
+    {
+        var form = new FormDefinition
+        {
+            FormId = "inspection",
+            Name = "Inspection",
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "main",
+                    Label = "Main",
+                    Fields =
+                    [
+                        new FormField { FieldId = "score", Label = "Score", Type = FormFieldType.Numeric },
+                        new FormField
+                        {
+                            FieldId = "followup",
+                            Label = "Follow-up",
+                            Type = FormFieldType.Text,
+                            Required = true,
+                            VisibilityRule = new FieldVisibilityRule
+                            {
+                                DependsOnFieldId = "score",
+                                Operator = ComparisonOperator.Equals,
+                                MatchValue = 0,
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var record = new FieldRecord
+        {
+            RecordId = "r-null-score",
+            FormId = "inspection",
+            Values =
+            {
+                ["score"] = null,
+            },
+        };
+
+        var validator = new FormValidator();
+        var result = validator.Validate(form, record);
+
+        Assert.True(result.IsValid);
+        Assert.DoesNotContain(result.Errors, error => error.FieldId == "followup");
+    }
+
+    [Fact]
+    public void Validate_WithInvalidRegexPattern_DoesNotThrow()
+    {
+        var form = new FormDefinition
+        {
+            FormId = "inspection",
+            Name = "Inspection",
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "main",
+                    Label = "Main",
+                    Fields =
+                    [
+                        new FormField
+                        {
+                            FieldId = "code",
+                            Label = "Code",
+                            Type = FormFieldType.Text,
+                            Validation = new FieldValidationRule
+                            {
+                                RegexPattern = "(",
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var record = new FieldRecord
+        {
+            RecordId = "r-invalid-regex",
+            FormId = "inspection",
+            Values =
+            {
+                ["code"] = "ABC",
+            },
+        };
+
+        var validator = new FormValidator();
+        var result = validator.Validate(form, record);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, error => error.FieldId == "code");
+    }
+
+    [Fact]
+    public async Task Validate_WithCatastrophicRegexInput_CompletesQuickly()
+    {
+        var form = new FormDefinition
+        {
+            FormId = "inspection",
+            Name = "Inspection",
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "main",
+                    Label = "Main",
+                    Fields =
+                    [
+                        new FormField
+                        {
+                            FieldId = "code",
+                            Label = "Code",
+                            Type = FormFieldType.Text,
+                            Validation = new FieldValidationRule
+                            {
+                                RegexPattern = "^(a+)+$",
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var record = new FieldRecord
+        {
+            RecordId = "r-redos",
+            FormId = "inspection",
+            Values =
+            {
+                ["code"] = new string('a', 4000) + "!",
+            },
+        };
+
+        var validator = new FormValidator();
+        var validationTask = Task.Run(() => validator.Validate(form, record));
+        var result = await validationTask.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, error => error.FieldId == "code");
+    }
 }

--- a/tests/Honua.Mobile.Field.Tests/FormValidatorTests.cs
+++ b/tests/Honua.Mobile.Field.Tests/FormValidatorTests.cs
@@ -105,4 +105,48 @@ public sealed class FormValidatorTests
         Assert.Equal("alpha-beta", record.Values["display"]);
         Assert.Equal(8d, record.Values["total"]);
     }
+
+    [Fact]
+    public void Validate_RequiredMultipleChoiceRejectsEmptyCollection()
+    {
+        var form = new FormDefinition
+        {
+            FormId = "inspection",
+            Name = "Inspection",
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "main",
+                    Label = "Main",
+                    Fields =
+                    [
+                        new FormField
+                        {
+                            FieldId = "tags",
+                            Label = "Tags",
+                            Type = FormFieldType.MultipleChoice,
+                            Required = true,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var record = new FieldRecord
+        {
+            RecordId = "r-empty-tags",
+            FormId = "inspection",
+            Values =
+            {
+                ["tags"] = Array.Empty<string>(),
+            },
+        };
+
+        var validator = new FormValidator();
+        var result = validator.Validate(form, record);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, error => error.FieldId == "tags");
+    }
 }

--- a/tests/Honua.Mobile.Field.Tests/RecordWorkflowTests.cs
+++ b/tests/Honua.Mobile.Field.Tests/RecordWorkflowTests.cs
@@ -67,4 +67,30 @@ public sealed class RecordWorkflowTests
         Assert.Single(duplicates);
         Assert.Equal("r-1", duplicates[0].RecordId);
     }
+
+    [Fact]
+    public void Transition_Resubmission_ClearsCompletedTimestamp()
+    {
+        var createdAt = DateTimeOffset.UtcNow.AddMinutes(-40);
+        var completedAt = createdAt.AddMinutes(20);
+        var resubmittedAt = createdAt.AddMinutes(35);
+
+        var record = new FieldRecord
+        {
+            RecordId = "record-2",
+            FormId = "inspection",
+            CreatedAtUtc = createdAt,
+            Status = RecordStatus.Rejected,
+            SubmittedAtUtc = createdAt.AddMinutes(10),
+            CompletedAtUtc = completedAt,
+        };
+
+        var workflow = new RecordWorkflow();
+        workflow.Transition(record, RecordStatus.Submitted, resubmittedAt);
+
+        Assert.Equal(RecordStatus.Submitted, record.Status);
+        Assert.Equal(resubmittedAt, record.SubmittedAtUtc);
+        Assert.Null(record.CompletedAtUtc);
+        Assert.Null(record.Duration);
+    }
 }

--- a/tests/Honua.Mobile.Offline.Tests/BackgroundSyncOrchestratorTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/BackgroundSyncOrchestratorTests.cs
@@ -38,6 +38,28 @@ public sealed class BackgroundSyncOrchestratorTests
         Assert.True(runner.CallCount >= 1);
     }
 
+    [Fact]
+    public async Task StartAsync_WhenSyncThrows_KeepsLoopRunning()
+    {
+        var runner = new FlakySyncRunner(initialFailures: 1);
+        var connectivity = new ToggleConnectivityProvider { IsOnline = true };
+        await using var orchestrator = new BackgroundSyncOrchestrator(
+            runner,
+            connectivity,
+            new BackgroundSyncOrchestratorOptions
+            {
+                SyncInterval = TimeSpan.FromMilliseconds(25),
+                RunImmediately = true,
+            });
+
+        await orchestrator.StartAsync();
+        await Task.Delay(150);
+        await orchestrator.StopAsync();
+
+        Assert.True(runner.CallCount >= 2);
+        Assert.True(runner.SuccessCount >= 1);
+    }
+
     private sealed class FakeSyncRunner : IOfflineSyncRunner
     {
         public int CallCount { get; private set; }
@@ -57,5 +79,38 @@ public sealed class BackgroundSyncOrchestratorTests
     private sealed class ToggleConnectivityProvider : IConnectivityStateProvider
     {
         public bool IsOnline { get; set; }
+    }
+
+    private sealed class FlakySyncRunner : IOfflineSyncRunner
+    {
+        private int _remainingFailures;
+
+        public FlakySyncRunner(int initialFailures)
+        {
+            _remainingFailures = initialFailures;
+        }
+
+        public int CallCount { get; private set; }
+
+        public int SuccessCount { get; private set; }
+
+        public Task<SyncRunResult> SyncAsync(CancellationToken ct = default)
+        {
+            CallCount++;
+
+            if (_remainingFailures > 0)
+            {
+                _remainingFailures--;
+                throw new InvalidOperationException("transient sync error");
+            }
+
+            SuccessCount++;
+            return Task.FromResult(new SyncRunResult
+            {
+                Loaded = 0,
+                Succeeded = 0,
+                Failed = 0,
+            });
+        }
     }
 }

--- a/tests/Honua.Mobile.Offline.Tests/GeoPackageSyncStoreTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/GeoPackageSyncStoreTests.cs
@@ -73,6 +73,41 @@ public sealed class GeoPackageSyncStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task GetPendingAsync_ReclaimsStaleInProgressOperations()
+    {
+        var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions
+        {
+            DatabasePath = _databasePath,
+            InProgressLeaseTimeout = TimeSpan.FromMilliseconds(150),
+        });
+        await store.InitializeAsync();
+
+        await store.EnqueueAsync(new OfflineEditOperation
+        {
+            OperationId = "stale-op",
+            LayerKey = "assets",
+            TargetCollection = "assets",
+            OperationType = OfflineOperationType.Update,
+            PayloadJson = "{}",
+            Priority = 1,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+        });
+
+        var firstClaim = await store.GetPendingAsync(1);
+        Assert.Single(firstClaim);
+        Assert.Equal("stale-op", firstClaim[0].OperationId);
+
+        var immediateClaim = await store.GetPendingAsync(1);
+        Assert.Empty(immediateClaim);
+
+        await Task.Delay(250);
+
+        var reclaimed = await store.GetPendingAsync(1);
+        Assert.Single(reclaimed);
+        Assert.Equal("stale-op", reclaimed[0].OperationId);
+    }
+
+    [Fact]
     public async Task MapAreas_CanBeUpsertedAndListed()
     {
         var store = CreateStore();

--- a/tests/Honua.Mobile.Offline.Tests/GeoPackageSyncStoreTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/GeoPackageSyncStoreTests.cs
@@ -47,6 +47,32 @@ public sealed class GeoPackageSyncStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task GetPendingAsync_ClaimsRowsToPreventDuplicateProcessing()
+    {
+        var store = CreateStore();
+        await store.InitializeAsync();
+
+        await store.EnqueueAsync(new OfflineEditOperation
+        {
+            OperationId = "op-1",
+            LayerKey = "assets",
+            TargetCollection = "assets",
+            OperationType = OfflineOperationType.Update,
+            PayloadJson = "{}",
+            Priority = 5,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+        });
+
+        var firstClaim = store.GetPendingAsync(1);
+        var secondClaim = store.GetPendingAsync(1);
+        await Task.WhenAll(firstClaim, secondClaim);
+        var firstClaimResult = await firstClaim;
+        var secondClaimResult = await secondClaim;
+
+        Assert.Equal(1, firstClaimResult.Count + secondClaimResult.Count);
+    }
+
+    [Fact]
     public async Task MapAreas_CanBeUpsertedAndListed()
     {
         var store = CreateStore();

--- a/tests/Honua.Mobile.Offline.Tests/HonuaApiOfflineOperationUploaderTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/HonuaApiOfflineOperationUploaderTests.cs
@@ -97,6 +97,61 @@ public sealed class HonuaApiOfflineOperationUploaderTests
         Assert.Equal(UploadOutcome.RetryableFailure, result.Outcome);
     }
 
+    [Fact]
+    public async Task UploadAsync_MalformedDeletePayload_ReturnsFatalFailure()
+    {
+        var requestCount = 0;
+        var uploader = CreateUploader((_, _) =>
+        {
+            requestCount++;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+            };
+        });
+
+        var result = await uploader.UploadAsync(new OfflineEditOperation
+        {
+            LayerKey = "assets",
+            TargetCollection = "assets",
+            OperationType = OfflineOperationType.Delete,
+            PayloadJson = """
+            {
+              "protocol": "FeatureServer",
+              "serviceId": "default",
+              "layerId": 0
+            }
+            """,
+        }, forceWrite: false);
+
+        Assert.Equal(UploadOutcome.FatalFailure, result.Outcome);
+        Assert.Contains("Delete operation requires", result.Message, StringComparison.Ordinal);
+        Assert.Equal(0, requestCount);
+    }
+
+    [Fact]
+    public async Task UploadAsync_WhenCanceled_ThrowsOperationCanceledException()
+    {
+        var uploader = CreateUploader((_, _) => throw new TaskCanceledException("request canceled"));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => uploader.UploadAsync(new OfflineEditOperation
+        {
+            LayerKey = "assets",
+            TargetCollection = "assets",
+            OperationType = OfflineOperationType.Add,
+            PayloadJson = """
+            {
+              "protocol": "FeatureServer",
+              "serviceId": "default",
+              "layerId": 0,
+              "feature": { "attributes": { "asset_id": "A-1" } }
+            }
+            """,
+        }, forceWrite: false, cts.Token));
+    }
+
     private static HonuaApiOfflineOperationUploader CreateUploader(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> responder)
     {
         var client = new HonuaMobileClient(

--- a/tests/Honua.Mobile.Offline.Tests/HonuaApiOfflineOperationUploaderTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/HonuaApiOfflineOperationUploaderTests.cs
@@ -72,6 +72,60 @@ public sealed class HonuaApiOfflineOperationUploaderTests
     }
 
     [Fact]
+    public async Task UploadAsync_FeatureServerEmptyApplyEditsEnvelope_ReturnsFatalFailure()
+    {
+        var uploader = CreateUploader((_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+        });
+
+        var result = await uploader.UploadAsync(new OfflineEditOperation
+        {
+            LayerKey = "assets",
+            TargetCollection = "assets",
+            OperationType = OfflineOperationType.Add,
+            PayloadJson = """
+            {
+              "protocol": "FeatureServer",
+              "serviceId": "default",
+              "layerId": 0,
+              "feature": { "attributes": { "asset_id": "A-1" } }
+            }
+            """,
+        }, forceWrite: false);
+
+        Assert.Equal(UploadOutcome.FatalFailure, result.Outcome);
+        Assert.Contains("missing", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UploadAsync_FeatureServerMalformedApplyEditsEnvelope_ReturnsFatalFailure()
+    {
+        var uploader = CreateUploader((_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"addResults":[{}]}""", Encoding.UTF8, "application/json"),
+        });
+
+        var result = await uploader.UploadAsync(new OfflineEditOperation
+        {
+            LayerKey = "assets",
+            TargetCollection = "assets",
+            OperationType = OfflineOperationType.Add,
+            PayloadJson = """
+            {
+              "protocol": "FeatureServer",
+              "serviceId": "default",
+              "layerId": 0,
+              "feature": { "attributes": { "asset_id": "A-1" } }
+            }
+            """,
+        }, forceWrite: false);
+
+        Assert.Equal(UploadOutcome.FatalFailure, result.Outcome);
+        Assert.Contains("malformed", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task UploadAsync_Http503_ReturnsRetryableFailure()
     {
         var uploader = CreateUploader((_, _) => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)

--- a/tests/Honua.Mobile.Offline.Tests/MapAreaDownloaderTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/MapAreaDownloaderTests.cs
@@ -70,6 +70,62 @@ public sealed class MapAreaDownloaderTests : IDisposable
         Assert.Equal(1, count);
     }
 
+    [Fact]
+    public async Task DownloadAsync_SanitizesAreaId_AndKeepsPackageUnderOutputDirectory()
+    {
+        var storePath = Path.Combine(_rootDirectory, "sync-store.gpkg");
+        var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions { DatabasePath = storePath });
+
+        var httpClient = new HttpClient(new StubHttpMessageHandler((request, _) =>
+        {
+            var payload = Encoding.UTF8.GetBytes($"payload:{request.RequestUri}");
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(payload),
+            });
+        }));
+
+        var outputDirectory = Path.Combine(_rootDirectory, "packages");
+        var downloader = new MapAreaDownloader(httpClient, store);
+        var result = await downloader.DownloadAsync(new MapAreaDownloadRequest
+        {
+            AreaId = "../..//../very/../../unsafe",
+            Name = "Unsafe Name",
+            BoundingBox = new BoundingBox(-158.30, 21.20, -157.60, 21.60),
+            OutputDirectory = outputDirectory,
+            MinZoom = 10,
+            MaxZoom = 15,
+            Layers =
+            [
+                new MapLayerDownloadSource
+                {
+                    LayerKey = "assets",
+                    SourceUrl = "https://tiles.honua.test/data?bbox={minLon},{minLat},{maxLon},{maxLat}&z={minZoom}-{maxZoom}",
+                    Priority = 1,
+                    Required = true,
+                },
+            ],
+        });
+
+        var packagePath = Path.GetFullPath(result.GeoPackagePath);
+        var outputPath = Path.GetFullPath(outputDirectory);
+        var pathComparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        var expectedPrefix = Path.EndsInDirectorySeparator(outputPath)
+            ? outputPath
+            : outputPath + Path.DirectorySeparatorChar;
+
+        if (pathComparison == StringComparison.OrdinalIgnoreCase)
+        {
+            Assert.StartsWith(expectedPrefix.ToUpperInvariant(), packagePath.ToUpperInvariant());
+        }
+        else
+        {
+            Assert.StartsWith(expectedPrefix, packagePath);
+        }
+        Assert.DoesNotContain("..", Path.GetFileNameWithoutExtension(packagePath), StringComparison.Ordinal);
+        Assert.True(File.Exists(packagePath));
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_rootDirectory))

--- a/tests/Honua.Mobile.Offline.Tests/MapAreaDownloaderTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/MapAreaDownloaderTests.cs
@@ -126,6 +126,46 @@ public sealed class MapAreaDownloaderTests : IDisposable
         Assert.True(File.Exists(packagePath));
     }
 
+    [Fact]
+    public async Task DownloadAsync_WhenLayerPayloadExceedsLimit_ThrowsInvalidOperationException()
+    {
+        var storePath = Path.Combine(_rootDirectory, "sync-store.gpkg");
+        var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions { DatabasePath = storePath });
+
+        var oversizedPayload = new byte[4096];
+        var httpClient = new HttpClient(new StubHttpMessageHandler((_, _) =>
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(oversizedPayload),
+            });
+        }));
+
+        var downloader = new MapAreaDownloader(httpClient, store);
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => downloader.DownloadAsync(new MapAreaDownloadRequest
+        {
+            AreaId = "oversized",
+            Name = "Oversized",
+            BoundingBox = new BoundingBox(-158.30, 21.20, -157.60, 21.60),
+            OutputDirectory = Path.Combine(_rootDirectory, "packages"),
+            MinZoom = 10,
+            MaxZoom = 15,
+            MaxLayerPayloadBytes = 1024,
+            Layers =
+            [
+                new MapLayerDownloadSource
+                {
+                    LayerKey = "assets",
+                    SourceUrl = "https://tiles.honua.test/data",
+                    Priority = 1,
+                    Required = true,
+                },
+            ],
+        }));
+
+        Assert.Contains("exceeds configured max", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_rootDirectory))

--- a/tests/Honua.Mobile.Offline.Tests/OfflineSyncEngineTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/OfflineSyncEngineTests.cs
@@ -1,5 +1,6 @@
 using Honua.Mobile.Offline.GeoPackage;
 using Honua.Mobile.Offline.Sync;
+using Microsoft.Data.Sqlite;
 
 namespace Honua.Mobile.Offline.Tests;
 
@@ -67,10 +68,46 @@ public sealed class OfflineSyncEngineTests : IDisposable
 
         var result = await engine.SyncAsync();
         var pending = await store.GetPendingAsync(10);
+        var operationState = await ReadOperationStateAsync("manual-op");
 
         Assert.Equal(0, result.Succeeded);
         Assert.Equal(1, result.Failed);
         Assert.Empty(pending);
+        Assert.NotNull(operationState);
+        Assert.Equal("failed", operationState!.Value.Status);
+        Assert.Equal(1, operationState.Value.AttemptCount);
+    }
+
+    [Fact]
+    public async Task SyncAsync_WhenCanceled_RequeuesClaimedOperationsWithoutIncrementingAttempts()
+    {
+        var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions { DatabasePath = _databasePath });
+        await store.InitializeAsync();
+
+        await store.EnqueueAsync(new OfflineEditOperation
+        {
+            OperationId = "cancel-op",
+            LayerKey = "assets",
+            TargetCollection = "assets",
+            OperationType = OfflineOperationType.Update,
+            PayloadJson = "{}",
+            Priority = 1,
+        });
+
+        var uploader = new BlockingUploader();
+        var engine = new OfflineSyncEngine(store, uploader);
+        using var cts = new CancellationTokenSource();
+
+        var syncTask = engine.SyncAsync(cts.Token);
+        await uploader.Started.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await syncTask);
+
+        var pending = await store.GetPendingAsync(10);
+        Assert.Single(pending);
+        Assert.Equal("cancel-op", pending[0].OperationId);
+        Assert.Equal(0, pending[0].AttemptCount);
     }
 
     public void Dispose()
@@ -102,5 +139,40 @@ public sealed class OfflineSyncEngineTests : IDisposable
     {
         public Task<UploadResult> UploadAsync(OfflineEditOperation operation, bool forceWrite, CancellationToken ct = default)
             => Task.FromResult(new UploadResult { Outcome = UploadOutcome.Conflict, Message = "conflict" });
+    }
+
+    private sealed class BlockingUploader : IOfflineOperationUploader
+    {
+        public TaskCompletionSource<bool> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task<UploadResult> UploadAsync(OfflineEditOperation operation, bool forceWrite, CancellationToken ct = default)
+        {
+            Started.TrySetResult(true);
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+            return new UploadResult { Outcome = UploadOutcome.Success };
+        }
+    }
+
+    private async Task<(int AttemptCount, string Status)?> ReadOperationStateAsync(string operationId)
+    {
+        await using var connection = new SqliteConnection($"Data Source={_databasePath}");
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = @"
+SELECT attempt_count, status
+FROM honua_sync_queue
+WHERE operation_id = $operation_id
+LIMIT 1;
+";
+        command.Parameters.AddWithValue("$operation_id", operationId);
+
+        await using var reader = await command.ExecuteReaderAsync();
+        if (!await reader.ReadAsync())
+        {
+            return null;
+        }
+
+        return (reader.GetInt32(0), reader.GetString(1));
     }
 }

--- a/tests/Honua.Mobile.Offline.Tests/OfflineSyncEngineTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/OfflineSyncEngineTests.cs
@@ -110,6 +110,42 @@ public sealed class OfflineSyncEngineTests : IDisposable
         Assert.Equal(0, pending[0].AttemptCount);
     }
 
+    [Fact]
+    public async Task SyncAsync_WhenUploaderThrows_RequeuesClaimedOperations()
+    {
+        var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions { DatabasePath = _databasePath });
+        await store.InitializeAsync();
+
+        await store.EnqueueAsync(new OfflineEditOperation
+        {
+            OperationId = "throw-op-1",
+            LayerKey = "assets",
+            TargetCollection = "assets",
+            OperationType = OfflineOperationType.Update,
+            PayloadJson = "{}",
+            Priority = 1,
+        });
+
+        await store.EnqueueAsync(new OfflineEditOperation
+        {
+            OperationId = "throw-op-2",
+            LayerKey = "assets",
+            TargetCollection = "assets",
+            OperationType = OfflineOperationType.Update,
+            PayloadJson = "{}",
+            Priority = 2,
+        });
+
+        var engine = new OfflineSyncEngine(store, new ThrowingUploader());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => engine.SyncAsync());
+
+        var pending = await store.GetPendingAsync(10);
+        Assert.Equal(2, pending.Count);
+        Assert.Contains(pending, operation => operation.OperationId == "throw-op-1");
+        Assert.Contains(pending, operation => operation.OperationId == "throw-op-2");
+    }
+
     public void Dispose()
     {
         if (File.Exists(_databasePath))
@@ -151,6 +187,12 @@ public sealed class OfflineSyncEngineTests : IDisposable
             await Task.Delay(Timeout.InfiniteTimeSpan, ct);
             return new UploadResult { Outcome = UploadOutcome.Success };
         }
+    }
+
+    private sealed class ThrowingUploader : IOfflineOperationUploader
+    {
+        public Task<UploadResult> UploadAsync(OfflineEditOperation operation, bool forceWrite, CancellationToken ct = default)
+            => throw new InvalidOperationException("unexpected uploader fault");
     }
 
     private async Task<(int AttemptCount, string Status)?> ReadOperationStateAsync(string operationId)

--- a/tests/Honua.Mobile.Sdk.Tests/GrpcFeatureTranslatorTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/GrpcFeatureTranslatorTests.cs
@@ -144,4 +144,39 @@ public sealed class GrpcFeatureTranslatorTests
         Assert.True(feature.GetProperty("attributes").GetProperty("active").GetBoolean());
         Assert.Equal(-157.8583, feature.GetProperty("geometry").GetProperty("x").GetDouble(), 4);
     }
+
+    [Fact]
+    public void ToProtoApplyEditsRequest_MapsMOnlyCoordinatesWhenHasMTrue()
+    {
+        var request = new ApplyEditsRequest
+        {
+            ServiceId = "default",
+            LayerId = 0,
+            AddsJson = """
+            [
+              {
+                "attributes": { "asset_id": "A-1" },
+                "geometry":
+                {
+                  "hasM": true,
+                  "paths": [
+                    [
+                      [1.0, 2.0, 9.5],
+                      [3.0, 4.0, 8.5]
+                    ]
+                  ]
+                }
+              }
+            ]
+            """,
+        };
+
+        var proto = GrpcFeatureTranslator.ToProtoApplyEditsRequest(request);
+        var firstCoord = proto.Adds[0].Geometry.Polyline.Paths[0].Coords[0];
+
+        Assert.Equal(1.0, firstCoord.X);
+        Assert.Equal(2.0, firstCoord.Y);
+        Assert.Equal(9.5, firstCoord.M);
+        Assert.Equal(0.0, firstCoord.Z);
+    }
 }

--- a/tests/Honua.Mobile.Sdk.Tests/HonuaMobileClientTransportSecurityTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/HonuaMobileClientTransportSecurityTests.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Honua.Mobile.Sdk;
+using Honua.Mobile.Sdk.Models;
+
+namespace Honua.Mobile.Sdk.Tests;
+
+public sealed class HonuaMobileClientTransportSecurityTests
+{
+    [Fact]
+    public async Task QueryFeaturesAsync_WithApiKeyOverHttp_ThrowsAndDoesNotSendRequest()
+    {
+        var handler = new RecordingHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+        }));
+
+        var client = CreateClient(handler, new HonuaMobileClientOptions
+        {
+            BaseUri = new Uri("http://api.honua.test"),
+            ApiKey = "test-key",
+            PreferGrpcForFeatureQueries = false,
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => client.QueryFeaturesAsync(CreateQueryRequest()));
+        Assert.Equal(0, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task QueryFeaturesAsync_WithApiKeyOverHttp_AllowsWhenInsecureDevOverrideEnabled()
+    {
+        var handler = new RecordingHandler((request, _) =>
+        {
+            Assert.True(request.Headers.Contains("X-API-Key"));
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"features\":[]}", Encoding.UTF8, "application/json"),
+            });
+        });
+
+        var client = CreateClient(handler, new HonuaMobileClientOptions
+        {
+            BaseUri = new Uri("http://api.honua.test"),
+            ApiKey = "test-key",
+            AllowInsecureTransportForDevelopment = true,
+            PreferGrpcForFeatureQueries = false,
+        });
+
+        using var result = await client.QueryFeaturesAsync(CreateQueryRequest());
+        Assert.Equal(1, handler.RequestCount);
+        Assert.Equal(JsonValueKind.Array, result.RootElement.GetProperty("features").ValueKind);
+    }
+
+    [Fact]
+    public async Task QueryFeaturesAsync_WithBearerTokenOverHttp_ThrowsAndDoesNotSendRequest()
+    {
+        var handler = new RecordingHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+        }));
+
+        var client = CreateClient(handler, new HonuaMobileClientOptions
+        {
+            BaseUri = new Uri("http://api.honua.test"),
+            AccessTokenProvider = _ => ValueTask.FromResult<string?>("token-from-provider"),
+            PreferGrpcForFeatureQueries = false,
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => client.QueryFeaturesAsync(CreateQueryRequest()));
+        Assert.Equal(0, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task QueryFeaturesAsync_WithGrpcAuthOverHttp_ThrowsAndDoesNotFallBackToRest()
+    {
+        var handler = new RecordingHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+        }));
+
+        var client = CreateClient(handler, new HonuaMobileClientOptions
+        {
+            BaseUri = new Uri("https://api.honua.test"),
+            GrpcEndpoint = new Uri("http://grpc.honua.test"),
+            ApiKey = "test-key",
+            PreferGrpcForFeatureQueries = true,
+            AllowRestFallbackOnGrpcFailure = true,
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => client.QueryFeaturesAsync(CreateQueryRequest()));
+        Assert.Equal(0, handler.RequestCount);
+    }
+
+    private static QueryFeaturesRequest CreateQueryRequest() => new()
+    {
+        ServiceId = "assets",
+        LayerId = 0,
+    };
+
+    private static HonuaMobileClient CreateClient(HttpMessageHandler handler, HonuaMobileClientOptions options)
+    {
+        return new HonuaMobileClient(
+            new HttpClient(handler)
+            {
+                BaseAddress = options.BaseUri,
+            },
+            options);
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _responder;
+
+        public RecordingHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder)
+        {
+            _responder = responder;
+        }
+
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            return _responder(request, cancellationToken);
+        }
+    }
+}

--- a/tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj
+++ b/tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Honua.Mobile.Offline\Honua.Mobile.Offline.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Honua.Mobile.Smoke.Tests/SmokeTests.cs
+++ b/tests/Honua.Mobile.Smoke.Tests/SmokeTests.cs
@@ -1,0 +1,265 @@
+using Honua.Mobile.Offline.GeoPackage;
+using Honua.Mobile.Offline.Sync;
+
+namespace Honua.Mobile.Smoke.Tests;
+
+/// <summary>
+/// Reliability smoke tests that verify critical paths in the Honua Mobile offline stack.
+/// These are intentionally lightweight and run without external dependencies so they can
+/// gate every CI build.
+/// </summary>
+public sealed class SmokeTests : IDisposable
+{
+    private readonly string _databasePath;
+
+    public SmokeTests()
+    {
+        _databasePath = Path.Combine(
+            Path.GetTempPath(),
+            $"honua-smoke-{Guid.NewGuid():N}.gpkg");
+    }
+
+    // ---------------------------------------------------------------
+    // 1. GeoPackage store initializes without error
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task GeoPackageStore_Initializes_WithoutError()
+    {
+        var store = CreateStore();
+
+        await store.InitializeAsync();
+
+        // A second initialization should also succeed (idempotent).
+        await store.InitializeAsync();
+    }
+
+    // ---------------------------------------------------------------
+    // 2. Sync engine handles empty queue gracefully
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task SyncEngine_EmptyQueue_ReturnsZeroCounts()
+    {
+        var store = CreateStore();
+        await store.InitializeAsync();
+
+        var uploader = new NoOpUploader();
+        var engine = new OfflineSyncEngine(store, uploader);
+
+        var result = await engine.SyncAsync();
+
+        Assert.Equal(0, result.Loaded);
+        Assert.Equal(0, result.Succeeded);
+        Assert.Equal(0, result.Failed);
+        Assert.Empty(result.Failures);
+    }
+
+    // ---------------------------------------------------------------
+    // 3. Offline edit operations round-trip
+    //    (enqueue -> get pending -> mark succeeded)
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task OfflineEdit_RoundTrip_EnqueueGetPendingMarkSucceeded()
+    {
+        var store = CreateStore();
+        await store.InitializeAsync();
+
+        var operation = new OfflineEditOperation
+        {
+            OperationId = "smoke-roundtrip-1",
+            LayerKey = "assets",
+            TargetCollection = "assets",
+            OperationType = OfflineOperationType.Add,
+            PayloadJson = "{\"name\":\"hydrant\"}",
+            Priority = 1,
+        };
+
+        await store.EnqueueAsync(operation);
+
+        var pending = await store.GetPendingAsync(10);
+        Assert.Single(pending);
+        Assert.Equal("smoke-roundtrip-1", pending[0].OperationId);
+        Assert.Equal("assets", pending[0].LayerKey);
+        Assert.Equal(OfflineOperationType.Add, pending[0].OperationType);
+
+        await store.MarkSucceededAsync("smoke-roundtrip-1");
+
+        var remaining = await store.CountPendingAsync();
+        Assert.Equal(0, remaining);
+    }
+
+    // ---------------------------------------------------------------
+    // 4. Delta download engine handles missing replica gracefully
+    //    When no replica cursor exists the engine creates one. We
+    //    verify this path with a fake client that returns an empty
+    //    change set.
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task DeltaDownloadEngine_MissingReplica_CreatesAndDownloads()
+    {
+        var store = CreateStore();
+        await store.InitializeAsync();
+
+        var fakeClient = new FakeReplicaSyncClient();
+        var engine = new DeltaDownloadEngine(store, fakeClient);
+
+        var result = await engine.DownloadAsync("service-1");
+
+        Assert.Equal(0, result.Adds);
+        Assert.Equal(0, result.Updates);
+        Assert.Equal(0, result.Deletes);
+
+        // The engine should have persisted the replica cursor.
+        var cursor = await store.GetSyncCursorAsync("replica:service-1");
+        Assert.NotNull(cursor);
+        Assert.Equal(fakeClient.CreatedReplicaId, cursor);
+    }
+
+    // ---------------------------------------------------------------
+    // 5. Background sync orchestrator starts and stops cleanly
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task BackgroundSyncOrchestrator_StartStop_CompletesCleanly()
+    {
+        var runner = new NoOpSyncRunner();
+        var connectivity = new AlwaysOnlineConnectivityStateProvider();
+        await using var orchestrator = new BackgroundSyncOrchestrator(
+            runner,
+            connectivity,
+            new BackgroundSyncOrchestratorOptions
+            {
+                SyncInterval = TimeSpan.FromMilliseconds(50),
+                RunImmediately = true,
+            });
+
+        await orchestrator.StartAsync();
+        Assert.True(orchestrator.IsRunning);
+
+        // Let at least one cycle execute.
+        await Task.Delay(120);
+        await orchestrator.StopAsync();
+
+        Assert.False(orchestrator.IsRunning);
+        Assert.True(runner.CallCount >= 1, "Expected at least one sync cycle to run.");
+    }
+
+    // ---------------------------------------------------------------
+    // 6. Sync cursor persistence round-trips
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task SyncCursor_Persistence_RoundTrips()
+    {
+        var store = CreateStore();
+        await store.InitializeAsync();
+
+        await store.SetSyncCursorAsync("servergen:svc-1", "42");
+        var value = await store.GetSyncCursorAsync("servergen:svc-1");
+        Assert.Equal("42", value);
+
+        // Overwrite and verify the update is persisted.
+        await store.SetSyncCursorAsync("servergen:svc-1", "99");
+        var updated = await store.GetSyncCursorAsync("servergen:svc-1");
+        Assert.Equal("99", updated);
+
+        // A cursor that was never set should return null.
+        var missing = await store.GetSyncCursorAsync("nonexistent-key");
+        Assert.Null(missing);
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    public void Dispose()
+    {
+        if (File.Exists(_databasePath))
+        {
+            File.Delete(_databasePath);
+        }
+    }
+
+    private GeoPackageSyncStore CreateStore()
+    {
+        return new GeoPackageSyncStore(new GeoPackageSyncStoreOptions
+        {
+            DatabasePath = _databasePath,
+        });
+    }
+
+    // -- Fakes -----------------------------------------------------
+
+    private sealed class NoOpUploader : IOfflineOperationUploader
+    {
+        public Task<UploadResult> UploadAsync(
+            OfflineEditOperation operation,
+            bool forceWrite,
+            CancellationToken ct = default)
+        {
+            return Task.FromResult(new UploadResult { Outcome = UploadOutcome.Success });
+        }
+    }
+
+    private sealed class NoOpSyncRunner : IOfflineSyncRunner
+    {
+        public int CallCount { get; private set; }
+
+        public Task<SyncRunResult> SyncAsync(CancellationToken ct = default)
+        {
+            CallCount++;
+            return Task.FromResult(new SyncRunResult
+            {
+                Loaded = 0,
+                Succeeded = 0,
+                Failed = 0,
+            });
+        }
+    }
+
+    private sealed class FakeReplicaSyncClient : IReplicaSyncClient
+    {
+        public string CreatedReplicaId { get; } = Guid.NewGuid().ToString("N");
+
+        public Task<CreateReplicaResult> CreateReplicaAsync(
+            string serviceId,
+            string replicaName,
+            int[]? layerIds = null,
+            CancellationToken ct = default)
+        {
+            return Task.FromResult(new CreateReplicaResult(CreatedReplicaId, ServerGen: 1));
+        }
+
+        public Task<ExtractChangesResult> ExtractChangesAsync(
+            string serviceId,
+            string replicaId,
+            CancellationToken ct = default)
+        {
+            return Task.FromResult(new ExtractChangesResult
+            {
+                LayerChanges = [],
+                ServerGen = 2,
+            });
+        }
+
+        public Task<SynchronizeResult> SynchronizeReplicaAsync(
+            string serviceId,
+            string replicaId,
+            string syncDirection = "download",
+            CancellationToken ct = default)
+        {
+            return Task.FromResult(new SynchronizeResult(replicaId, ServerGen: 2));
+        }
+
+        public Task UnRegisterReplicaAsync(
+            string serviceId,
+            string replicaId,
+            CancellationToken ct = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Completes Phase 0 of the Mobile SDK epic, delivering form schema contracts, reference app screens, bidirectional offline sync, and quality infrastructure.

### Form Schema (Issue #4)
- Remove v2 semantics from phase-0 docs (nothing shipped yet)
- Proto schema extensions (conditional visibility, workflow actions, access control) committed separately in grpc-geospatial-standard and honua-server

### Reference App Shell (Issue #5)
- Scaffold 4 MAUI screens: Map, DataCollection, SyncStatus, Settings
- XAML views with MVVM ViewModels using CommunityToolkit.Mvvm
- AppShell updated with tab navigation and correct xmlns namespace imports

### Offline Sync — Delta Download (Issue #8)
- `IReplicaSyncClient` + `ReplicaSyncClient` for server replication endpoints
- `DeltaDownloadEngine` orchestrates: register replica → extract changes → upsert/delete in GeoPackage → advance cursor
- `IGeoPackageSyncStore` extended with `honua_features` table and feature CRUD
- `BackgroundSyncOrchestrator` runs download after upload
- Bidirectional flow: upload via edit queue + download via delta extraction

### Quality Gates (Issue #21)
- Performance budget config (SDK size, GeoPackage init, sync batch, query timing)
- MAUI accessibility checklist (touch targets, contrast, screen reader, semantic properties)
- Release checklist referencing all quality gate outcomes
- Smoke test project with 6 critical-path tests
- CI workflow updated with quality-gates job

### CI & Infrastructure
- Align mobile projects and templates to net10
- Update MAUI validation matrix
- Fix linux workflow restore and workload usage
- Whitespace fixes for offline sync engine

## Related Issues

Closes #4
Closes #5
Closes #8
Closes #21

## Test plan

- [ ] `dotnet build` passes across all projects
- [ ] `dotnet test` passes (existing + new smoke tests)
- [ ] CI quality-gates job validates performance budgets
- [ ] GeoPackage sync round-trip: enqueue edit → upload → download delta → verify local store
- [ ] AppShell navigation: all 4 tabs render and navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)