### PR TITLE
feat: add map annotation layer SDK

### DIFF
--- a/Honua.Mobile.sln
+++ b/Honua.Mobile.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Mobile.Offline.Tests"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Mobile.Sdk.Tests", "tests\Honua.Mobile.Sdk.Tests\Honua.Mobile.Sdk.Tests.csproj", "{5FC8602D-CF71-4DCC-90CC-276D0407C22C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Mobile.Maui.Tests", "tests\Honua.Mobile.Maui.Tests\Honua.Mobile.Maui.Tests.csproj", "{ABA8CE4F-C7A7-4D79-860E-994506812B33}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -115,6 +117,18 @@ Global
 		{5FC8602D-CF71-4DCC-90CC-276D0407C22C}.Release|x64.Build.0 = Release|Any CPU
 		{5FC8602D-CF71-4DCC-90CC-276D0407C22C}.Release|x86.ActiveCfg = Release|Any CPU
 		{5FC8602D-CF71-4DCC-90CC-276D0407C22C}.Release|x86.Build.0 = Release|Any CPU
+		{ABA8CE4F-C7A7-4D79-860E-994506812B33}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ABA8CE4F-C7A7-4D79-860E-994506812B33}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ABA8CE4F-C7A7-4D79-860E-994506812B33}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ABA8CE4F-C7A7-4D79-860E-994506812B33}.Debug|x64.Build.0 = Debug|Any CPU
+		{ABA8CE4F-C7A7-4D79-860E-994506812B33}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ABA8CE4F-C7A7-4D79-860E-994506812B33}.Debug|x86.Build.0 = Debug|Any CPU
+		{ABA8CE4F-C7A7-4D79-860E-994506812B33}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ABA8CE4F-C7A7-4D79-860E-994506812B33}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ABA8CE4F-C7A7-4D79-860E-994506812B33}.Release|x64.ActiveCfg = Release|Any CPU
+		{ABA8CE4F-C7A7-4D79-860E-994506812B33}.Release|x64.Build.0 = Release|Any CPU
+		{ABA8CE4F-C7A7-4D79-860E-994506812B33}.Release|x86.ActiveCfg = Release|Any CPU
+		{ABA8CE4F-C7A7-4D79-860E-994506812B33}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -127,5 +141,6 @@ Global
 		{EC35CDDC-7AA4-4169-A7BC-C25C05D12FB5} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{34987433-8E8C-49FF-9776-C122ADFD0EFB} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{5FC8602D-CF71-4DCC-90CC-276D0407C22C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{ABA8CE4F-C7A7-4D79-860E-994506812B33} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ tests/
   Honua.Mobile.Sdk.Tests/     HTTP client, transport security, gRPC translation (19 tests)
   Honua.Mobile.Field.Tests/   Validation, calculated fields, workflow (9 tests)
   Honua.Mobile.Offline.Tests/ Sync engine, conflicts, map download, GeoPackage (40 tests)
+  Honua.Mobile.Maui.Tests/    MAUI integration helpers, map annotations (12 tests)
   Honua.Mobile.Smoke.Tests/   End-to-end smoke paths (6 tests)
 proto/
   honua/v1/                   gRPC protocol definitions
@@ -127,8 +128,8 @@ without the MAUI workload.
 ## Status
 
 Production-ready foundation for offline sync, forms, and gRPC transport.
-74 tests across 4 test projects. `dotnet test Honua.Mobile.sln` runs the
-SDK, Field, and Offline suites; run the Smoke test project separately.
+86 tests across 5 test projects. `dotnet test Honua.Mobile.sln` runs the
+SDK, Field, Offline, and MAUI suites; run the Smoke test project separately.
 
 The IoT module (`Honua.Mobile.IoT`) contains interface definitions only --
 no implementation yet.

--- a/src/Honua.Mobile.Maui/Annotations/HonuaAnnotation.cs
+++ b/src/Honua.Mobile.Maui/Annotations/HonuaAnnotation.cs
@@ -1,0 +1,37 @@
+namespace Honua.Mobile.Maui.Annotations;
+
+/// <summary>
+/// Programmatic map annotation that can be rendered by platform-specific map adapters.
+/// </summary>
+public sealed record HonuaAnnotation
+{
+    public required string Id { get; init; }
+
+    public required HonuaAnnotationType Type { get; init; }
+
+    public required IReadOnlyList<HonuaMapCoordinate> Coordinates { get; init; }
+
+    public string? Text { get; init; }
+
+    public HonuaAnnotationStyle Style { get; init; } = HonuaAnnotationStyle.Default;
+
+    public IReadOnlyDictionary<string, object?> Metadata { get; init; } = new Dictionary<string, object?>();
+
+    public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    public DateTimeOffset UpdatedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    public HonuaAnnotationBounds Bounds => HonuaAnnotationBounds.FromCoordinates(Coordinates);
+
+    public HonuaAnnotation WithStyle(HonuaAnnotationStyle style)
+    {
+        ArgumentNullException.ThrowIfNull(style);
+        style.Validate();
+
+        return this with
+        {
+            Style = style,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+    }
+}

--- a/src/Honua.Mobile.Maui/Annotations/HonuaAnnotationBounds.cs
+++ b/src/Honua.Mobile.Maui/Annotations/HonuaAnnotationBounds.cs
@@ -1,0 +1,69 @@
+namespace Honua.Mobile.Maui.Annotations;
+
+/// <summary>
+/// Axis-aligned geographic bounding box for annotation queries.
+/// </summary>
+public readonly record struct HonuaAnnotationBounds
+{
+    public HonuaAnnotationBounds(
+        double minLongitude,
+        double minLatitude,
+        double maxLongitude,
+        double maxLatitude)
+    {
+        if (minLongitude > maxLongitude)
+        {
+            throw new ArgumentException("Minimum longitude must be less than or equal to maximum longitude.");
+        }
+
+        if (minLatitude > maxLatitude)
+        {
+            throw new ArgumentException("Minimum latitude must be less than or equal to maximum latitude.");
+        }
+
+        _ = new HonuaMapCoordinate(minLatitude, minLongitude);
+        _ = new HonuaMapCoordinate(maxLatitude, maxLongitude);
+
+        MinLongitude = minLongitude;
+        MinLatitude = minLatitude;
+        MaxLongitude = maxLongitude;
+        MaxLatitude = maxLatitude;
+    }
+
+    public double MinLongitude { get; }
+
+    public double MinLatitude { get; }
+
+    public double MaxLongitude { get; }
+
+    public double MaxLatitude { get; }
+
+    public bool Contains(HonuaMapCoordinate coordinate) =>
+        coordinate.Longitude >= MinLongitude
+        && coordinate.Longitude <= MaxLongitude
+        && coordinate.Latitude >= MinLatitude
+        && coordinate.Latitude <= MaxLatitude;
+
+    public bool Intersects(HonuaAnnotationBounds other) =>
+        MinLongitude <= other.MaxLongitude
+        && MaxLongitude >= other.MinLongitude
+        && MinLatitude <= other.MaxLatitude
+        && MaxLatitude >= other.MinLatitude;
+
+    public static HonuaAnnotationBounds FromCoordinates(IEnumerable<HonuaMapCoordinate> coordinates)
+    {
+        ArgumentNullException.ThrowIfNull(coordinates);
+
+        var materialized = coordinates as IReadOnlyCollection<HonuaMapCoordinate> ?? coordinates.ToArray();
+        if (materialized.Count == 0)
+        {
+            throw new ArgumentException("At least one coordinate is required.", nameof(coordinates));
+        }
+
+        return new HonuaAnnotationBounds(
+            materialized.Min(coordinate => coordinate.Longitude),
+            materialized.Min(coordinate => coordinate.Latitude),
+            materialized.Max(coordinate => coordinate.Longitude),
+            materialized.Max(coordinate => coordinate.Latitude));
+    }
+}

--- a/src/Honua.Mobile.Maui/Annotations/HonuaAnnotationLayer.cs
+++ b/src/Honua.Mobile.Maui/Annotations/HonuaAnnotationLayer.cs
@@ -1,0 +1,261 @@
+namespace Honua.Mobile.Maui.Annotations;
+
+/// <summary>
+/// In-memory annotation layer that exposes drawing, styling, management, and spatial query APIs.
+/// Platform-specific renderers can bind to the layer's annotation collection.
+/// </summary>
+public sealed class HonuaAnnotationLayer
+{
+    private readonly Dictionary<string, HonuaAnnotation> _annotations = new(StringComparer.Ordinal);
+    private HonuaAnnotationStyle _defaultStyle = HonuaAnnotationStyle.Default;
+
+    public HonuaAnnotationStyle DefaultStyle => _defaultStyle;
+
+    public IReadOnlyList<HonuaAnnotation> Annotations => _annotations.Values.ToArray();
+
+    public HonuaAnnotationLayer SetFillColor(string fillColor)
+    {
+        _defaultStyle = _defaultStyle.SetFillColor(fillColor);
+        return this;
+    }
+
+    public HonuaAnnotationLayer SetStrokeColor(string strokeColor)
+    {
+        _defaultStyle = _defaultStyle.SetStrokeColor(strokeColor);
+        return this;
+    }
+
+    public HonuaAnnotationLayer SetStrokeWidth(double strokeWidth)
+    {
+        _defaultStyle = _defaultStyle.SetStrokeWidth(strokeWidth);
+        return this;
+    }
+
+    public HonuaAnnotationLayer SetOpacity(double opacity)
+    {
+        _defaultStyle = _defaultStyle.SetOpacity(opacity);
+        return this;
+    }
+
+    public HonuaAnnotation DrawPoint(
+        HonuaMapCoordinate coordinate,
+        string? id = null,
+        HonuaAnnotationStyle? style = null,
+        IReadOnlyDictionary<string, object?>? metadata = null)
+    {
+        return AddAnnotation(CreateAnnotation(
+            HonuaAnnotationType.Point,
+            [coordinate],
+            id,
+            text: null,
+            style,
+            metadata));
+    }
+
+    public HonuaAnnotation DrawPolyline(
+        IEnumerable<HonuaMapCoordinate> coordinates,
+        string? id = null,
+        HonuaAnnotationStyle? style = null,
+        IReadOnlyDictionary<string, object?>? metadata = null)
+    {
+        return AddAnnotation(CreateAnnotation(
+            HonuaAnnotationType.Polyline,
+            MaterializeCoordinates(coordinates),
+            id,
+            text: null,
+            style,
+            metadata));
+    }
+
+    public HonuaAnnotation DrawPolygon(
+        IEnumerable<HonuaMapCoordinate> coordinates,
+        string? id = null,
+        HonuaAnnotationStyle? style = null,
+        IReadOnlyDictionary<string, object?>? metadata = null)
+    {
+        return AddAnnotation(CreateAnnotation(
+            HonuaAnnotationType.Polygon,
+            MaterializeCoordinates(coordinates),
+            id,
+            text: null,
+            style,
+            metadata));
+    }
+
+    public HonuaAnnotation DrawText(
+        HonuaMapCoordinate coordinate,
+        string text,
+        string? id = null,
+        HonuaAnnotationStyle? style = null,
+        IReadOnlyDictionary<string, object?>? metadata = null)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            throw new ArgumentException("Text annotations require non-empty text.", nameof(text));
+        }
+
+        return AddAnnotation(CreateAnnotation(
+            HonuaAnnotationType.Text,
+            [coordinate],
+            id,
+            text,
+            style,
+            metadata));
+    }
+
+    public HonuaAnnotation AddAnnotation(HonuaAnnotation annotation)
+    {
+        ArgumentNullException.ThrowIfNull(annotation);
+        ValidateAnnotation(annotation);
+
+        if (_annotations.ContainsKey(annotation.Id))
+        {
+            throw new InvalidOperationException($"Annotation '{annotation.Id}' already exists.");
+        }
+
+        var stored = SnapshotAnnotation(annotation);
+        _annotations.Add(stored.Id, stored);
+        return stored;
+    }
+
+    public HonuaAnnotation UpdateAnnotation(HonuaAnnotation annotation)
+    {
+        ArgumentNullException.ThrowIfNull(annotation);
+        ValidateAnnotation(annotation);
+
+        if (!_annotations.TryGetValue(annotation.Id, out var existing))
+        {
+            throw new KeyNotFoundException($"Annotation '{annotation.Id}' was not found.");
+        }
+
+        var updated = SnapshotAnnotation(annotation) with
+        {
+            CreatedAt = existing.CreatedAt,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _annotations[annotation.Id] = updated;
+        return updated;
+    }
+
+    public HonuaAnnotation UpdateAnnotation(string annotationId, Func<HonuaAnnotation, HonuaAnnotation> update)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(annotationId);
+        ArgumentNullException.ThrowIfNull(update);
+
+        if (!_annotations.TryGetValue(annotationId, out var existing))
+        {
+            throw new KeyNotFoundException($"Annotation '{annotationId}' was not found.");
+        }
+
+        var updated = update(existing);
+        if (!string.Equals(updated.Id, annotationId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Annotation updates cannot change the annotation ID.");
+        }
+
+        return UpdateAnnotation(updated);
+    }
+
+    public bool RemoveAnnotation(string annotationId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(annotationId);
+        return _annotations.Remove(annotationId);
+    }
+
+    public IReadOnlyList<HonuaAnnotation> GetAnnotationsInBounds(HonuaAnnotationBounds bounds)
+    {
+        return _annotations.Values
+            .Where(annotation => annotation.Bounds.Intersects(bounds))
+            .ToArray();
+    }
+
+    public IReadOnlyList<HonuaAnnotation> GetAnnotationsByType(HonuaAnnotationType type)
+    {
+        return _annotations.Values
+            .Where(annotation => annotation.Type == type)
+            .ToArray();
+    }
+
+    public void Clear() => _annotations.Clear();
+
+    private HonuaAnnotation CreateAnnotation(
+        HonuaAnnotationType type,
+        IReadOnlyList<HonuaMapCoordinate> coordinates,
+        string? id,
+        string? text,
+        HonuaAnnotationStyle? style,
+        IReadOnlyDictionary<string, object?>? metadata)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new HonuaAnnotation
+        {
+            Id = string.IsNullOrWhiteSpace(id) ? Guid.NewGuid().ToString("N") : id,
+            Type = type,
+            Coordinates = coordinates,
+            Text = text,
+            Style = style ?? _defaultStyle,
+            Metadata = metadata ?? new Dictionary<string, object?>(),
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    private static IReadOnlyList<HonuaMapCoordinate> MaterializeCoordinates(IEnumerable<HonuaMapCoordinate> coordinates)
+    {
+        ArgumentNullException.ThrowIfNull(coordinates);
+        return coordinates.ToArray();
+    }
+
+    private static HonuaAnnotation SnapshotAnnotation(HonuaAnnotation annotation)
+    {
+        return annotation with
+        {
+            Coordinates = annotation.Coordinates.ToArray(),
+            Metadata = new Dictionary<string, object?>(annotation.Metadata),
+        };
+    }
+
+    private static void ValidateAnnotation(HonuaAnnotation annotation)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(annotation.Id);
+        ArgumentNullException.ThrowIfNull(annotation.Coordinates);
+        annotation.Style.Validate();
+
+        switch (annotation.Type)
+        {
+            case HonuaAnnotationType.Point:
+                RequireCoordinateCount(annotation, 1, exact: true);
+                break;
+            case HonuaAnnotationType.Text:
+                RequireCoordinateCount(annotation, 1, exact: true);
+                if (string.IsNullOrWhiteSpace(annotation.Text))
+                {
+                    throw new ArgumentException("Text annotations require non-empty text.", nameof(annotation));
+                }
+                break;
+            case HonuaAnnotationType.Polyline:
+                RequireCoordinateCount(annotation, 2, exact: false);
+                break;
+            case HonuaAnnotationType.Polygon:
+                RequireCoordinateCount(annotation, 3, exact: false);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(annotation), annotation.Type, "Unsupported annotation type.");
+        }
+    }
+
+    private static void RequireCoordinateCount(HonuaAnnotation annotation, int count, bool exact)
+    {
+        var actual = annotation.Coordinates.Count;
+        if (exact && actual != count)
+        {
+            throw new ArgumentException($"Annotation type {annotation.Type} requires exactly {count} coordinate(s).", nameof(annotation));
+        }
+
+        if (!exact && actual < count)
+        {
+            throw new ArgumentException($"Annotation type {annotation.Type} requires at least {count} coordinate(s).", nameof(annotation));
+        }
+    }
+}

--- a/src/Honua.Mobile.Maui/Annotations/HonuaAnnotationStyle.cs
+++ b/src/Honua.Mobile.Maui/Annotations/HonuaAnnotationStyle.cs
@@ -1,0 +1,87 @@
+namespace Honua.Mobile.Maui.Annotations;
+
+/// <summary>
+/// Visual styling shared by annotation primitives.
+/// </summary>
+public sealed record HonuaAnnotationStyle
+{
+    public string? FillColor { get; init; }
+
+    public string StrokeColor { get; init; } = "#2A7FDB";
+
+    public double StrokeWidth { get; init; } = 2;
+
+    public double Opacity { get; init; } = 1;
+
+    public string TextColor { get; init; } = "#1A1A1A";
+
+    public double TextSize { get; init; } = 14;
+
+    public static HonuaAnnotationStyle Default { get; } = new();
+
+    public HonuaAnnotationStyle SetFillColor(string fillColor)
+    {
+        ValidateColor(fillColor, nameof(fillColor));
+        return this with { FillColor = fillColor };
+    }
+
+    public HonuaAnnotationStyle SetStrokeColor(string strokeColor)
+    {
+        ValidateColor(strokeColor, nameof(strokeColor));
+        return this with { StrokeColor = strokeColor };
+    }
+
+    public HonuaAnnotationStyle SetStrokeWidth(double strokeWidth)
+    {
+        if (strokeWidth <= 0 || double.IsNaN(strokeWidth) || double.IsInfinity(strokeWidth))
+        {
+            throw new ArgumentOutOfRangeException(nameof(strokeWidth), "Stroke width must be greater than zero.");
+        }
+
+        return this with { StrokeWidth = strokeWidth };
+    }
+
+    public HonuaAnnotationStyle SetOpacity(double opacity)
+    {
+        if (opacity is < 0 or > 1 || double.IsNaN(opacity) || double.IsInfinity(opacity))
+        {
+            throw new ArgumentOutOfRangeException(nameof(opacity), "Opacity must be between 0 and 1.");
+        }
+
+        return this with { Opacity = opacity };
+    }
+
+    public void Validate()
+    {
+        ValidateColor(StrokeColor, nameof(StrokeColor));
+        ValidateColor(TextColor, nameof(TextColor));
+
+        if (!string.IsNullOrWhiteSpace(FillColor))
+        {
+            ValidateColor(FillColor, nameof(FillColor));
+        }
+
+        if (StrokeWidth <= 0 || double.IsNaN(StrokeWidth) || double.IsInfinity(StrokeWidth))
+        {
+            throw new ArgumentOutOfRangeException(nameof(StrokeWidth), "Stroke width must be greater than zero.");
+        }
+
+        if (Opacity is < 0 or > 1 || double.IsNaN(Opacity) || double.IsInfinity(Opacity))
+        {
+            throw new ArgumentOutOfRangeException(nameof(Opacity), "Opacity must be between 0 and 1.");
+        }
+
+        if (TextSize <= 0 || double.IsNaN(TextSize) || double.IsInfinity(TextSize))
+        {
+            throw new ArgumentOutOfRangeException(nameof(TextSize), "Text size must be greater than zero.");
+        }
+    }
+
+    private static void ValidateColor(string color, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(color))
+        {
+            throw new ArgumentException("Color values cannot be empty.", parameterName);
+        }
+    }
+}

--- a/src/Honua.Mobile.Maui/Annotations/HonuaAnnotationType.cs
+++ b/src/Honua.Mobile.Maui/Annotations/HonuaAnnotationType.cs
@@ -1,0 +1,12 @@
+namespace Honua.Mobile.Maui.Annotations;
+
+/// <summary>
+/// Supported map annotation primitives for programmatic markup.
+/// </summary>
+public enum HonuaAnnotationType
+{
+    Point,
+    Polyline,
+    Polygon,
+    Text,
+}

--- a/src/Honua.Mobile.Maui/Annotations/HonuaMapCoordinate.cs
+++ b/src/Honua.Mobile.Maui/Annotations/HonuaMapCoordinate.cs
@@ -1,0 +1,27 @@
+namespace Honua.Mobile.Maui.Annotations;
+
+/// <summary>
+/// Geographic coordinate in WGS84 latitude/longitude order.
+/// </summary>
+public readonly record struct HonuaMapCoordinate
+{
+    public HonuaMapCoordinate(double latitude, double longitude)
+    {
+        if (double.IsNaN(latitude) || double.IsInfinity(latitude) || latitude is < -90 or > 90)
+        {
+            throw new ArgumentOutOfRangeException(nameof(latitude), "Latitude must be between -90 and 90 degrees.");
+        }
+
+        if (double.IsNaN(longitude) || double.IsInfinity(longitude) || longitude is < -180 or > 180)
+        {
+            throw new ArgumentOutOfRangeException(nameof(longitude), "Longitude must be between -180 and 180 degrees.");
+        }
+
+        Latitude = latitude;
+        Longitude = longitude;
+    }
+
+    public double Latitude { get; }
+
+    public double Longitude { get; }
+}

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Honua.Mobile.Field.Forms;
 using Honua.Mobile.Field.Records;
+using Honua.Mobile.Maui.Annotations;
 using Honua.Mobile.Offline.GeoPackage;
 using Honua.Mobile.Offline.MapAreas;
 using Honua.Mobile.Offline.Sync;
@@ -148,6 +149,19 @@ public static class HonuaMobileServiceCollectionExtensions
             return new MapAreaDownloader(httpClient, store);
         });
 
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the client-side map annotation layer used by platform map renderers.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaMapAnnotations(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddTransient<HonuaAnnotationLayer>();
         return services;
     }
 }

--- a/tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj
+++ b/tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Honua.Mobile.Maui\Honua.Mobile.Maui.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Honua.Mobile.Maui.Tests/HonuaAnnotationLayerTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaAnnotationLayerTests.cs
@@ -1,0 +1,184 @@
+using Honua.Mobile.Maui;
+using Honua.Mobile.Maui.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Mobile.Maui.Tests;
+
+public sealed class HonuaAnnotationLayerTests
+{
+    [Fact]
+    public void DrawPoint_AppliesDefaultStyleAndStoresAnnotation()
+    {
+        var layer = new HonuaAnnotationLayer()
+            .SetFillColor("#FF0000")
+            .SetStrokeColor("#00FF00")
+            .SetStrokeWidth(4)
+            .SetOpacity(0.5);
+
+        var annotation = layer.DrawPoint(new HonuaMapCoordinate(21.3069, -157.8583), id: "poi-1");
+
+        Assert.Equal("poi-1", annotation.Id);
+        Assert.Equal(HonuaAnnotationType.Point, annotation.Type);
+        Assert.Equal("#FF0000", annotation.Style.FillColor);
+        Assert.Equal("#00FF00", annotation.Style.StrokeColor);
+        Assert.Equal(4, annotation.Style.StrokeWidth);
+        Assert.Equal(0.5, annotation.Style.Opacity);
+        Assert.Single(layer.Annotations);
+    }
+
+    [Fact]
+    public void DrawPolyline_RequiresAtLeastTwoCoordinates()
+    {
+        var layer = new HonuaAnnotationLayer();
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            layer.DrawPolyline([new HonuaMapCoordinate(21.30, -157.85)]));
+
+        Assert.Contains("at least 2", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DrawPolygon_RequiresAtLeastThreeCoordinates()
+    {
+        var layer = new HonuaAnnotationLayer();
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            layer.DrawPolygon(
+            [
+                new HonuaMapCoordinate(21.30, -157.85),
+                new HonuaMapCoordinate(21.31, -157.86),
+            ]));
+
+        Assert.Contains("at least 3", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DrawText_RequiresText()
+    {
+        var layer = new HonuaAnnotationLayer();
+
+        Assert.Throws<ArgumentException>(() =>
+            layer.DrawText(new HonuaMapCoordinate(21.30, -157.85), " "));
+    }
+
+    [Fact]
+    public void AddAnnotation_RejectsDuplicateIds()
+    {
+        var layer = new HonuaAnnotationLayer();
+        layer.DrawPoint(new HonuaMapCoordinate(21.30, -157.85), id: "duplicate");
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            layer.DrawText(new HonuaMapCoordinate(21.31, -157.86), "note", id: "duplicate"));
+
+        Assert.Contains("already exists", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void UpdateAnnotation_ReplacesAnnotationAndPreservesCreatedAt()
+    {
+        var layer = new HonuaAnnotationLayer();
+        var original = layer.DrawText(new HonuaMapCoordinate(21.30, -157.85), "before", id: "label");
+
+        var updated = layer.UpdateAnnotation("label", annotation => annotation with
+        {
+            Text = "after",
+            Style = annotation.Style.SetOpacity(0.25),
+        });
+
+        Assert.Equal("after", updated.Text);
+        Assert.Equal(0.25, updated.Style.Opacity);
+        Assert.Equal(original.CreatedAt, updated.CreatedAt);
+        Assert.True(updated.UpdatedAt >= original.UpdatedAt);
+        Assert.Equal("after", layer.Annotations.Single().Text);
+    }
+
+    [Fact]
+    public void RemoveAnnotation_RemovesById()
+    {
+        var layer = new HonuaAnnotationLayer();
+        layer.DrawPoint(new HonuaMapCoordinate(21.30, -157.85), id: "poi");
+
+        Assert.True(layer.RemoveAnnotation("poi"));
+        Assert.False(layer.RemoveAnnotation("poi"));
+        Assert.Empty(layer.Annotations);
+    }
+
+    [Fact]
+    public void GetAnnotationsInBounds_ReturnsIntersectingAnnotations()
+    {
+        var layer = new HonuaAnnotationLayer();
+        var inside = layer.DrawPoint(new HonuaMapCoordinate(21.3069, -157.8583), id: "inside");
+        layer.DrawPoint(new HonuaMapCoordinate(20.75, -156.45), id: "outside");
+        var crossing = layer.DrawPolyline(
+        [
+            new HonuaMapCoordinate(21.20, -158.00),
+            new HonuaMapCoordinate(21.50, -157.70),
+        ], id: "crossing");
+
+        var matches = layer.GetAnnotationsInBounds(new HonuaAnnotationBounds(-157.90, 21.25, -157.80, 21.35));
+
+        Assert.Equal(["crossing", "inside"], matches.Select(annotation => annotation.Id).Order().ToArray());
+        Assert.Contains(inside, matches);
+        Assert.Contains(crossing, matches);
+    }
+
+    [Fact]
+    public void DrawPolyline_CopiesMutableCoordinateCollections()
+    {
+        var coordinates = new List<HonuaMapCoordinate>
+        {
+            new(21.20, -158.00),
+            new(21.50, -157.70),
+        };
+        var layer = new HonuaAnnotationLayer();
+
+        var annotation = layer.DrawPolyline(coordinates, id: "route");
+        coordinates.Clear();
+
+        Assert.Equal(2, annotation.Coordinates.Count);
+        Assert.Equal(2, layer.Annotations.Single().Coordinates.Count);
+        var matches = layer.GetAnnotationsInBounds(new HonuaAnnotationBounds(-158.10, 21.10, -157.60, 21.60));
+        Assert.Single(matches);
+    }
+
+    [Fact]
+    public void GetAnnotationsByType_FiltersByAnnotationType()
+    {
+        var layer = new HonuaAnnotationLayer();
+        layer.DrawPoint(new HonuaMapCoordinate(21.30, -157.85), id: "point");
+        layer.DrawText(new HonuaMapCoordinate(21.30, -157.85), "label", id: "label");
+        layer.DrawPolygon(
+        [
+            new HonuaMapCoordinate(21.30, -157.85),
+            new HonuaMapCoordinate(21.31, -157.85),
+            new HonuaMapCoordinate(21.31, -157.84),
+        ], id: "polygon");
+
+        var textAnnotations = layer.GetAnnotationsByType(HonuaAnnotationType.Text);
+
+        Assert.Single(textAnnotations);
+        Assert.Equal("label", textAnnotations[0].Id);
+    }
+
+    [Fact]
+    public void SetOpacity_RejectsOutOfRangeValues()
+    {
+        var layer = new HonuaAnnotationLayer();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => layer.SetOpacity(-0.1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => layer.SetOpacity(1.1));
+    }
+
+    [Fact]
+    public void AddHonuaMapAnnotations_RegistersTransientAnnotationLayer()
+    {
+        var services = new ServiceCollection()
+            .AddHonuaMapAnnotations()
+            .BuildServiceProvider();
+
+        var first = services.GetRequiredService<HonuaAnnotationLayer>();
+        var second = services.GetRequiredService<HonuaAnnotationLayer>();
+
+        Assert.NotSame(first, second);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a core `HonuaAnnotationLayer` API for drawing points, polylines, polygons, and text annotations.
- Adds annotation styling, bounds queries, type filters, update/remove operations, and DI registration via `AddHonuaMapAnnotations()`.
- Adds `Honua.Mobile.Maui.Tests` coverage and updates README test counts.

Refs #13.

## Validation
- `dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj`
- `dotnet test Honua.Mobile.sln --no-restore`
- `dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj`