### PR TITLE
feat: add routing client SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ dynamic forms, and background sync.
 
 | Package | Purpose |
 |---------|---------|
-| **Honua.Mobile.Sdk** | Transport, auth, gRPC-first client with REST fallback |
+| **Honua.Mobile.Sdk** | Transport, auth, gRPC-first client, REST fallback, routing SDK |
 | **Honua.Mobile.Field** | Dynamic forms, validation, calculated fields, record workflow |
 | **Honua.Mobile.Offline** | GeoPackage storage, sync queue, map area download, conflict resolution |
 | **Honua.Mobile.Maui** | MAUI service registration and DI extensions |
@@ -30,6 +30,7 @@ builder.Services
         ApiKey = "<your-api-key>",
         PreferGrpcForFeatureQueries = true,
     })
+    .AddHonuaRouting()
     .AddHonuaApiOfflineUploader()
     .AddHonuaMobileFieldCollection()
     .AddHonuaGeoPackageOfflineSync(
@@ -92,6 +93,27 @@ await foreach (var page in client.QueryFeaturesStreamAsync(request))
 Transport security enforced -- API keys and bearer tokens are never sent over HTTP
 unless `AllowInsecureTransportForDevelopment` is explicitly set.
 
+## Routing
+
+Experimental GeoServices-compatible NAServer client for directions, service
+areas, closest facility, and route optimization:
+
+```csharp
+var route = await client.Routing.GetDirectionsAsync(
+    RoutingLocation.FromLatitudeLongitude(21.3069, -157.8583, "Start"),
+    RoutingLocation.FromLatitudeLongitude(21.2810, -157.8037, "Finish"));
+
+var optimized = await client.Routing.Route()
+    .From(currentLocation)
+    .Via(jobSite)
+    .To(depot)
+    .WithTraffic()
+    .AvoidTolls()
+    .ExecuteAsync();
+
+var reachable = await client.Routing.GetServiceAreaAsync(depot, TimeSpan.FromMinutes(30));
+```
+
 ## Repository Structure
 
 ```
@@ -104,7 +126,7 @@ src/
 apps/
   Honua.Mobile.App/           Reference MAUI application
 tests/
-  Honua.Mobile.Sdk.Tests/     HTTP client, transport security, gRPC translation (19 tests)
+  Honua.Mobile.Sdk.Tests/     HTTP client, transport security, gRPC translation, routing (26 tests)
   Honua.Mobile.Field.Tests/   Validation, calculated fields, workflow (9 tests)
   Honua.Mobile.Offline.Tests/ Sync engine, conflicts, map download, GeoPackage (40 tests)
   Honua.Mobile.Maui.Tests/    MAUI integration helpers, map annotations (12 tests)
@@ -128,7 +150,7 @@ without the MAUI workload.
 ## Status
 
 Production-ready foundation for offline sync, forms, and gRPC transport.
-86 tests across 5 test projects. `dotnet test Honua.Mobile.sln` runs the
+93 tests across 5 test projects. `dotnet test Honua.Mobile.sln` runs the
 SDK, Field, Offline, and MAUI suites; run the Smoke test project separately.
 
 The IoT module (`Honua.Mobile.IoT`) contains interface definitions only --

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Honua.Mobile.Offline.GeoPackage;
 using Honua.Mobile.Offline.MapAreas;
 using Honua.Mobile.Offline.Sync;
 using Honua.Mobile.Sdk;
+using Honua.Mobile.Sdk.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -51,6 +52,20 @@ public static class HonuaMobileServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddSingleton<IOfflineOperationUploader, HonuaApiOfflineOperationUploader>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers <see cref="HonuaRoutingClient"/> from the configured <see cref="HonuaMobileClient"/>.
+    /// Requires <see cref="AddHonuaMobileSdk"/> to be called first.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaRouting(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton(sp => sp.GetRequiredService<HonuaMobileClient>().Routing);
         return services;
     }
 

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
@@ -6,6 +6,7 @@ using Grpc.Core;
 using Grpc.Net.Client;
 using Honua.Mobile.Sdk.Grpc;
 using Honua.Mobile.Sdk.Models;
+using Honua.Mobile.Sdk.Routing;
 using Proto = Honua.Server.Features.Grpc.Proto;
 
 namespace Honua.Mobile.Sdk;
@@ -43,7 +44,14 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
             _grpcChannel = GrpcChannel.ForAddress(grpcAddress);
             _grpcClient = new Proto.FeatureService.FeatureServiceClient(_grpcChannel);
         }
+
+        Routing = new HonuaRoutingClient(this, options);
     }
+
+    /// <summary>
+    /// Routing and network-analysis client for directions, service areas, closest facility, and route optimization.
+    /// </summary>
+    public HonuaRoutingClient Routing { get; }
 
     /// <summary>
     /// Queries features from a feature service layer, preferring gRPC when available.
@@ -336,7 +344,7 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
         return SendJsonAsync(HttpMethod.Post, path, query: null, new FormUrlEncodedContent(body), ct);
     }
 
-    private async Task<JsonDocument> SendJsonAsync(
+    internal async Task<JsonDocument> SendJsonAsync(
         HttpMethod method,
         string relativePath,
         IReadOnlyDictionary<string, string?>? query,

--- a/src/Honua.Mobile.Sdk/HonuaMobileClientOptions.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClientOptions.cs
@@ -62,4 +62,24 @@ public sealed class HonuaMobileClientOptions
     /// User-Agent product header sent with every request. Defaults to <c>honua-mobile-sdk/0.1.0</c>.
     /// </summary>
     public ProductInfoHeaderValue UserAgent { get; init; } = new("honua-mobile-sdk", "0.1.0");
+
+    /// <summary>
+    /// GeoServices-compatible NAServer service id used by routing APIs.
+    /// </summary>
+    public string RoutingServiceId { get; init; } = "Routing";
+
+    /// <summary>
+    /// NAServer route layer name used for directions and route optimization.
+    /// </summary>
+    public string RoutingRouteLayerName { get; init; } = "Route";
+
+    /// <summary>
+    /// NAServer service-area layer name used for isochrone requests.
+    /// </summary>
+    public string RoutingServiceAreaLayerName { get; init; } = "ServiceArea";
+
+    /// <summary>
+    /// NAServer closest-facility layer name used for nearest-facility requests.
+    /// </summary>
+    public string RoutingClosestFacilityLayerName { get; init; } = "ClosestFacility";
 }

--- a/src/Honua.Mobile.Sdk/Routing/HonuaRoutingClient.cs
+++ b/src/Honua.Mobile.Sdk/Routing/HonuaRoutingClient.cs
@@ -1,0 +1,706 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace Honua.Mobile.Sdk.Routing;
+
+/// <summary>
+/// Client for Honua routing and network-analysis operations.
+/// </summary>
+public sealed class HonuaRoutingClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new();
+
+    private readonly HonuaMobileClient _client;
+    private readonly HonuaMobileClientOptions _options;
+
+    internal HonuaRoutingClient(HonuaMobileClient client, HonuaMobileClientOptions options)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <summary>
+    /// Creates a fluent directions builder.
+    /// </summary>
+    public RouteDirectionsBuilder Route() => new(this);
+
+    /// <summary>
+    /// Gets directions from an origin to a destination with optional waypoints.
+    /// </summary>
+    public Task<RouteResult> GetDirectionsAsync(
+        RoutingLocation origin,
+        RoutingLocation destination,
+        IReadOnlyList<RoutingLocation>? waypoints = null,
+        RouteSolveOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(origin);
+        ArgumentNullException.ThrowIfNull(destination);
+
+        return GetDirectionsAsync(
+            new RouteDirectionsRequest
+            {
+                Origin = origin,
+                Destination = destination,
+                Waypoints = waypoints,
+                Options = options ?? new RouteSolveOptions(),
+            },
+            ct);
+    }
+
+    /// <summary>
+    /// Gets directions from the current location resolved by <paramref name="locationProvider"/>.
+    /// </summary>
+    public async Task<RouteResult> GetDirectionsFromCurrentLocationAsync(
+        IRoutingLocationProvider locationProvider,
+        RoutingLocation destination,
+        IReadOnlyList<RoutingLocation>? waypoints = null,
+        RouteSolveOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(locationProvider);
+        ArgumentNullException.ThrowIfNull(destination);
+
+        var origin = await locationProvider.GetCurrentLocationAsync(ct).ConfigureAwait(false);
+        return await GetDirectionsAsync(origin, destination, waypoints, options, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Gets directions from an origin to a destination with optional waypoints.
+    /// </summary>
+    public async Task<RouteResult> GetDirectionsAsync(RouteDirectionsRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Origin);
+        ArgumentNullException.ThrowIfNull(request.Destination);
+
+        var stops = new List<RoutingLocation> { request.Origin };
+        if (request.Waypoints is { Count: > 0 })
+        {
+            stops.AddRange(request.Waypoints);
+        }
+
+        stops.Add(request.Destination);
+        ValidateLocations(stops, minCount: 2, nameof(request));
+
+        var options = request.Options ?? new RouteSolveOptions();
+        var form = CreateRouteSolveForm(options);
+        form["stops"] = SerializeFeatureSet(stops);
+        form["findBestSequence"] = "false";
+
+        using var response = await _client.SendJsonAsync(
+            HttpMethod.Post,
+            BuildNasPath(options.ServiceId, options.RouteLayerName, "solve", _options.RoutingRouteLayerName),
+            query: null,
+            new FormUrlEncodedContent(WithoutNullValues(form)),
+            ct).ConfigureAwait(false);
+
+        return RoutingResultParser.ParseRoute(response);
+    }
+
+    /// <summary>
+    /// Gets the service area reachable from <paramref name="center"/> within <paramref name="travelTime"/>.
+    /// </summary>
+    public Task<ServiceAreaResult> GetServiceAreaAsync(
+        RoutingLocation center,
+        TimeSpan travelTime,
+        ServiceAreaOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(center);
+
+        return GetServiceAreaAsync(
+            new ServiceAreaRequest
+            {
+                Center = center,
+                TravelTime = travelTime,
+                Options = options ?? new ServiceAreaOptions(),
+            },
+            ct);
+    }
+
+    /// <summary>
+    /// Gets a service area / isochrone polygon around a center location.
+    /// </summary>
+    public async Task<ServiceAreaResult> GetServiceAreaAsync(ServiceAreaRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Center);
+
+        if (request.TravelTime <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(request), "Travel time must be greater than zero.");
+        }
+
+        ValidateLocations(new[] { request.Center }, minCount: 1, nameof(request));
+
+        var options = request.Options ?? new ServiceAreaOptions();
+        var form = new Dictionary<string, string?>
+        {
+            ["f"] = options.ResponseFormat,
+            ["facilities"] = SerializeFeatureSet(new[] { request.Center }),
+            ["defaultBreaks"] = request.TravelTime.TotalMinutes.ToString("0.###", CultureInfo.InvariantCulture),
+            ["travelDirection"] = options.TravelDirection,
+            ["outputPolygons"] = options.OutputPolygons,
+            ["mergeSimilarPolygonRanges"] = options.MergeSimilarPolygonRanges ? "true" : "false",
+            ["travelMode"] = options.TravelMode,
+            ["startTime"] = FormatStartTime(options.StartTime),
+        };
+        AddAdditionalParameters(form, options.AdditionalParameters);
+
+        using var response = await _client.SendJsonAsync(
+            HttpMethod.Post,
+            BuildNasPath(options.ServiceId, options.ServiceAreaLayerName, "solveServiceArea", _options.RoutingServiceAreaLayerName),
+            query: null,
+            new FormUrlEncodedContent(WithoutNullValues(form)),
+            ct).ConfigureAwait(false);
+
+        return RoutingResultParser.ParseServiceArea(response);
+    }
+
+    /// <summary>
+    /// Finds the closest facilities for one or more incident locations.
+    /// </summary>
+    public Task<ClosestFacilityResult> FindClosestFacilityAsync(
+        IReadOnlyList<RoutingLocation> incidents,
+        IReadOnlyList<RoutingLocation> facilities,
+        ClosestFacilityOptions? options = null,
+        CancellationToken ct = default)
+    {
+        return FindClosestFacilityAsync(
+            new ClosestFacilityRequest
+            {
+                Incidents = incidents,
+                Facilities = facilities,
+                Options = options ?? new ClosestFacilityOptions(),
+            },
+            ct);
+    }
+
+    /// <summary>
+    /// Finds the closest facilities for one or more incident locations.
+    /// </summary>
+    public async Task<ClosestFacilityResult> FindClosestFacilityAsync(ClosestFacilityRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Incidents);
+        ArgumentNullException.ThrowIfNull(request.Facilities);
+
+        ValidateLocations(request.Incidents, minCount: 1, nameof(request.Incidents));
+        ValidateLocations(request.Facilities, minCount: 1, nameof(request.Facilities));
+
+        var options = request.Options ?? new ClosestFacilityOptions();
+        var form = new Dictionary<string, string?>
+        {
+            ["f"] = options.ResponseFormat,
+            ["incidents"] = SerializeFeatureSet(request.Incidents),
+            ["facilities"] = SerializeFeatureSet(request.Facilities),
+            ["defaultTargetFacilityCount"] = options.TargetFacilityCount?.ToString(CultureInfo.InvariantCulture),
+            ["travelDirection"] = options.TravelDirection,
+            ["returnDirections"] = options.ReturnDirections ? "true" : "false",
+            ["returnRoutes"] = options.ReturnRoutes ? "true" : "false",
+            ["travelMode"] = options.TravelMode,
+            ["startTime"] = FormatStartTime(options.StartTime),
+        };
+        AddAdditionalParameters(form, options.AdditionalParameters);
+
+        using var response = await _client.SendJsonAsync(
+            HttpMethod.Post,
+            BuildNasPath(
+                options.ServiceId,
+                options.ClosestFacilityLayerName,
+                "solveClosestFacility",
+                _options.RoutingClosestFacilityLayerName),
+            query: null,
+            new FormUrlEncodedContent(WithoutNullValues(form)),
+            ct).ConfigureAwait(false);
+
+        return RoutingResultParser.ParseClosestFacility(response);
+    }
+
+    /// <summary>
+    /// Optimizes the order of route stops using NAServer best-sequence routing.
+    /// </summary>
+    public Task<RouteResult> OptimizeRouteAsync(
+        IReadOnlyList<RoutingLocation> stops,
+        RouteOptimizationOptions? options = null,
+        CancellationToken ct = default)
+    {
+        return OptimizeRouteAsync(
+            new RouteOptimizationRequest
+            {
+                Stops = stops,
+                Options = options ?? new RouteOptimizationOptions(),
+            },
+            ct);
+    }
+
+    /// <summary>
+    /// Optimizes the order of route stops using NAServer best-sequence routing.
+    /// </summary>
+    public async Task<RouteResult> OptimizeRouteAsync(RouteOptimizationRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Stops);
+        ValidateLocations(request.Stops, minCount: 2, nameof(request.Stops));
+
+        var options = request.Options ?? new RouteOptimizationOptions();
+        var form = CreateRouteOptimizationForm(options);
+        form["stops"] = SerializeFeatureSet(request.Stops);
+
+        using var response = await _client.SendJsonAsync(
+            HttpMethod.Post,
+            BuildNasPath(options.ServiceId, options.RouteLayerName, "solve", _options.RoutingRouteLayerName),
+            query: null,
+            new FormUrlEncodedContent(WithoutNullValues(form)),
+            ct).ConfigureAwait(false);
+
+        return RoutingResultParser.ParseRoute(response);
+    }
+
+    private Dictionary<string, string?> CreateRouteSolveForm(RouteSolveOptions options)
+    {
+        var form = new Dictionary<string, string?>
+        {
+            ["f"] = options.ResponseFormat,
+            ["returnDirections"] = options.ReturnDirections ? "true" : "false",
+            ["returnRoutes"] = options.ReturnRoutes ? "true" : "false",
+            ["useTraffic"] = options.UseTraffic ? "true" : null,
+            ["avoidTolls"] = options.AvoidTolls ? "true" : null,
+            ["avoidHighways"] = options.AvoidHighways ? "true" : null,
+            ["travelMode"] = options.TravelMode,
+            ["startTime"] = FormatStartTime(options.StartTime),
+            ["directionsLengthUnits"] = options.DirectionsLengthUnits,
+            ["outputLines"] = options.OutputLines,
+        };
+        AddAdditionalParameters(form, options.AdditionalParameters);
+        return form;
+    }
+
+    private Dictionary<string, string?> CreateRouteOptimizationForm(RouteOptimizationOptions options)
+    {
+        var form = new Dictionary<string, string?>
+        {
+            ["f"] = options.ResponseFormat,
+            ["returnDirections"] = options.ReturnDirections ? "true" : "false",
+            ["returnRoutes"] = options.ReturnRoutes ? "true" : "false",
+            ["findBestSequence"] = "true",
+            ["preserveFirstStop"] = options.PreserveFirstStop ? "true" : "false",
+            ["preserveLastStop"] = options.PreserveLastStop ? "true" : "false",
+            ["useTraffic"] = options.UseTraffic ? "true" : null,
+            ["avoidTolls"] = options.AvoidTolls ? "true" : null,
+            ["avoidHighways"] = options.AvoidHighways ? "true" : null,
+            ["travelMode"] = options.TravelMode,
+            ["startTime"] = FormatStartTime(options.StartTime),
+            ["directionsLengthUnits"] = options.DirectionsLengthUnits,
+            ["outputLines"] = options.OutputLines,
+        };
+        AddAdditionalParameters(form, options.AdditionalParameters);
+        return form;
+    }
+
+    private string BuildNasPath(string? serviceId, string? layerName, string operation, string defaultLayerName)
+    {
+        var resolvedServiceId = string.IsNullOrWhiteSpace(serviceId) ? _options.RoutingServiceId : serviceId;
+        var resolvedLayerName = string.IsNullOrWhiteSpace(layerName) ? defaultLayerName : layerName;
+
+        return $"/rest/services/{Uri.EscapeDataString(resolvedServiceId)}/NAServer/{Uri.EscapeDataString(resolvedLayerName)}/{operation}";
+    }
+
+    private static string SerializeFeatureSet(IReadOnlyList<RoutingLocation> locations)
+    {
+        var features = locations.Select(location =>
+        {
+            var attributes = new Dictionary<string, object?>();
+            if (!string.IsNullOrWhiteSpace(location.Id))
+            {
+                attributes["Id"] = location.Id;
+            }
+
+            if (!string.IsNullOrWhiteSpace(location.Name))
+            {
+                attributes["Name"] = location.Name;
+            }
+
+            if (location.Attributes is not null)
+            {
+                foreach (var attribute in location.Attributes)
+                {
+                    attributes[attribute.Key] = attribute.Value;
+                }
+            }
+
+            var feature = new Dictionary<string, object?>
+            {
+                ["geometry"] = new Dictionary<string, object?>
+                {
+                    ["x"] = location.Coordinate.Longitude,
+                    ["y"] = location.Coordinate.Latitude,
+                    ["spatialReference"] = new Dictionary<string, object?> { ["wkid"] = 4326 },
+                },
+            };
+
+            if (attributes.Count > 0)
+            {
+                feature["attributes"] = attributes;
+            }
+
+            return feature;
+        }).ToArray();
+
+        var featureSet = new Dictionary<string, object?>
+        {
+            ["features"] = features,
+            ["spatialReference"] = new Dictionary<string, object?> { ["wkid"] = 4326 },
+        };
+
+        return JsonSerializer.Serialize(featureSet, JsonOptions);
+    }
+
+    private static void ValidateLocations(IReadOnlyList<RoutingLocation> locations, int minCount, string parameterName)
+    {
+        if (locations.Count < minCount)
+        {
+            throw new ArgumentException($"At least {minCount} routing location(s) are required.", parameterName);
+        }
+
+        foreach (var location in locations)
+        {
+            ArgumentNullException.ThrowIfNull(location);
+            if (!double.IsFinite(location.Coordinate.Longitude) || !double.IsFinite(location.Coordinate.Latitude))
+            {
+                throw new ArgumentOutOfRangeException(parameterName, "Routing coordinates must be finite numbers.");
+            }
+
+            if (location.Coordinate.Latitude is < -90 or > 90)
+            {
+                throw new ArgumentOutOfRangeException(parameterName, "Routing latitude must be between -90 and 90.");
+            }
+
+            if (location.Coordinate.Longitude is < -180 or > 180)
+            {
+                throw new ArgumentOutOfRangeException(parameterName, "Routing longitude must be between -180 and 180.");
+            }
+        }
+    }
+
+    private static void AddAdditionalParameters(Dictionary<string, string?> form, IReadOnlyDictionary<string, string?>? additionalParameters)
+    {
+        if (additionalParameters is null)
+        {
+            return;
+        }
+
+        foreach (var parameter in additionalParameters)
+        {
+            form[parameter.Key] = parameter.Value;
+        }
+    }
+
+    private static string? FormatStartTime(DateTimeOffset? startTime)
+        => startTime?.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
+
+    private static Dictionary<string, string> WithoutNullValues(Dictionary<string, string?> values)
+        => values.Where(pair => !string.IsNullOrWhiteSpace(pair.Value))
+            .ToDictionary(pair => pair.Key, pair => pair.Value!, StringComparer.Ordinal);
+}
+
+/// <summary>
+/// Fluent builder for common directions requests.
+/// </summary>
+public sealed class RouteDirectionsBuilder
+{
+    private readonly HonuaRoutingClient _client;
+    private readonly List<RoutingLocation> _waypoints = new();
+    private RoutingLocation? _origin;
+    private RoutingLocation? _destination;
+    private RouteSolveOptions _options = new();
+
+    internal RouteDirectionsBuilder(HonuaRoutingClient client)
+    {
+        _client = client;
+    }
+
+    public RouteDirectionsBuilder From(RoutingLocation origin)
+    {
+        _origin = origin ?? throw new ArgumentNullException(nameof(origin));
+        return this;
+    }
+
+    public async Task<RouteDirectionsBuilder> FromCurrentLocationAsync(IRoutingLocationProvider locationProvider, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(locationProvider);
+        _origin = await locationProvider.GetCurrentLocationAsync(ct).ConfigureAwait(false);
+        return this;
+    }
+
+    public RouteDirectionsBuilder To(RoutingLocation destination)
+    {
+        _destination = destination ?? throw new ArgumentNullException(nameof(destination));
+        return this;
+    }
+
+    public RouteDirectionsBuilder Via(RoutingLocation waypoint)
+    {
+        _waypoints.Add(waypoint ?? throw new ArgumentNullException(nameof(waypoint)));
+        return this;
+    }
+
+    public RouteDirectionsBuilder WithTraffic()
+    {
+        _options = CopyOptions(useTraffic: true);
+        return this;
+    }
+
+    public RouteDirectionsBuilder AvoidTolls()
+    {
+        _options = CopyOptions(avoidTolls: true);
+        return this;
+    }
+
+    public RouteDirectionsBuilder AvoidHighways()
+    {
+        _options = CopyOptions(avoidHighways: true);
+        return this;
+    }
+
+    public RouteDirectionsBuilder WithTravelMode(string travelMode)
+    {
+        if (string.IsNullOrWhiteSpace(travelMode))
+        {
+            throw new ArgumentException("Travel mode cannot be empty.", nameof(travelMode));
+        }
+
+        _options = CopyOptions(travelMode: travelMode);
+        return this;
+    }
+
+    public RouteDirectionsBuilder WithOptions(RouteSolveOptions options)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        return this;
+    }
+
+    public Task<RouteResult> ExecuteAsync(CancellationToken ct = default)
+    {
+        if (_origin is null)
+        {
+            throw new InvalidOperationException("Route origin has not been set.");
+        }
+
+        if (_destination is null)
+        {
+            throw new InvalidOperationException("Route destination has not been set.");
+        }
+
+        return _client.GetDirectionsAsync(_origin, _destination, _waypoints, _options, ct);
+    }
+
+    private RouteSolveOptions CopyOptions(
+        bool? useTraffic = null,
+        bool? avoidTolls = null,
+        bool? avoidHighways = null,
+        string? travelMode = null)
+        => new()
+        {
+            ServiceId = _options.ServiceId,
+            RouteLayerName = _options.RouteLayerName,
+            ResponseFormat = _options.ResponseFormat,
+            ReturnDirections = _options.ReturnDirections,
+            ReturnRoutes = _options.ReturnRoutes,
+            UseTraffic = useTraffic ?? _options.UseTraffic,
+            AvoidTolls = avoidTolls ?? _options.AvoidTolls,
+            AvoidHighways = avoidHighways ?? _options.AvoidHighways,
+            TravelMode = travelMode ?? _options.TravelMode,
+            StartTime = _options.StartTime,
+            DirectionsLengthUnits = _options.DirectionsLengthUnits,
+            OutputLines = _options.OutputLines,
+            AdditionalParameters = _options.AdditionalParameters,
+        };
+}
+
+internal static class RoutingResultParser
+{
+    public static RouteResult ParseRoute(JsonDocument document)
+    {
+        var directions = ParseDirections(document.RootElement);
+        var routes = ParseRouteSummaries(document.RootElement);
+        if (routes.Count == 0)
+        {
+            routes = ParseDirectionSummaries(document.RootElement);
+        }
+
+        return new RouteResult(document.RootElement.Clone(), routes, directions);
+    }
+
+    public static ServiceAreaResult ParseServiceArea(JsonDocument document)
+        => new(document.RootElement.Clone());
+
+    public static ClosestFacilityResult ParseClosestFacility(JsonDocument document)
+    {
+        var routes = ParseRouteSummaries(document.RootElement);
+        if (routes.Count == 0)
+        {
+            routes = ParseDirectionSummaries(document.RootElement);
+        }
+
+        return new ClosestFacilityResult(document.RootElement.Clone(), routes, ParseDirections(document.RootElement));
+    }
+
+    private static IReadOnlyList<RouteDirectionStep> ParseDirections(JsonElement root)
+    {
+        var steps = new List<RouteDirectionStep>();
+        if (!TryGetProperty(root, "directions", out var directions))
+        {
+            return steps;
+        }
+
+        foreach (var directionSet in EnumerateObjectOrArray(directions))
+        {
+            if (!TryGetProperty(directionSet, "features", out var features))
+            {
+                continue;
+            }
+
+            foreach (var feature in EnumerateObjectOrArray(features))
+            {
+                if (!TryGetProperty(feature, "attributes", out var attributes))
+                {
+                    continue;
+                }
+
+                steps.Add(new RouteDirectionStep(
+                    ReadString(attributes, "text", "Text", "maneuverText", "driveInstruction"),
+                    ReadDouble(attributes, "length", "Length", "distance", "Distance"),
+                    ReadMinutes(attributes, "time", "Time", "minutes", "Minutes"),
+                    ReadString(attributes, "maneuverType", "ManeuverType", "type")));
+            }
+        }
+
+        return steps;
+    }
+
+    private static IReadOnlyList<RouteSummary> ParseRouteSummaries(JsonElement root)
+    {
+        var summaries = new List<RouteSummary>();
+        if (!TryGetProperty(root, "routes", out var routes) || !TryGetProperty(routes, "features", out var features))
+        {
+            return summaries;
+        }
+
+        foreach (var feature in EnumerateObjectOrArray(features))
+        {
+            if (!TryGetProperty(feature, "attributes", out var attributes))
+            {
+                continue;
+            }
+
+            summaries.Add(new RouteSummary(
+                ReadString(attributes, "Name", "name", "RouteName"),
+                ReadDouble(attributes, "Total_Length", "totalLength", "TotalDistance", "totalDistance"),
+                ReadMinutes(attributes, "Total_Time", "totalTime", "Total_TravelTime", "travelTime")));
+        }
+
+        return summaries;
+    }
+
+    private static IReadOnlyList<RouteSummary> ParseDirectionSummaries(JsonElement root)
+    {
+        var summaries = new List<RouteSummary>();
+        if (!TryGetProperty(root, "directions", out var directions))
+        {
+            return summaries;
+        }
+
+        foreach (var directionSet in EnumerateObjectOrArray(directions))
+        {
+            if (!TryGetProperty(directionSet, "summary", out var summary))
+            {
+                continue;
+            }
+
+            summaries.Add(new RouteSummary(
+                ReadString(summary, "routeName", "RouteName", "Name"),
+                ReadDouble(summary, "totalLength", "Total_Length", "totalDistance"),
+                ReadMinutes(summary, "totalTime", "Total_Time", "travelTime")));
+        }
+
+        return summaries;
+    }
+
+    private static IEnumerable<JsonElement> EnumerateObjectOrArray(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in element.EnumerateArray())
+            {
+                yield return item;
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Object)
+        {
+            yield return element;
+        }
+    }
+
+    private static string? ReadString(JsonElement element, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (TryGetProperty(element, name, out var value) && value.ValueKind == JsonValueKind.String)
+            {
+                return value.GetString();
+            }
+        }
+
+        return null;
+    }
+
+    private static double? ReadDouble(JsonElement element, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (!TryGetProperty(element, name, out var value))
+            {
+                continue;
+            }
+
+            if (value.ValueKind == JsonValueKind.Number && value.TryGetDouble(out var number))
+            {
+                return number;
+            }
+
+            if (value.ValueKind == JsonValueKind.String &&
+                double.TryParse(value.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out number))
+            {
+                return number;
+            }
+        }
+
+        return null;
+    }
+
+    private static TimeSpan? ReadMinutes(JsonElement element, params string[] names)
+    {
+        var value = ReadDouble(element, names);
+        return value is null ? null : TimeSpan.FromMinutes(value.Value);
+    }
+
+    private static bool TryGetProperty(JsonElement element, string name, out JsonElement value)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = property.Value;
+                    return true;
+                }
+            }
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/src/Honua.Mobile.Sdk/Routing/RoutingModels.cs
+++ b/src/Honua.Mobile.Sdk/Routing/RoutingModels.cs
@@ -1,0 +1,345 @@
+using System.Text.Json;
+
+namespace Honua.Mobile.Sdk.Routing;
+
+/// <summary>
+/// WGS84 coordinate used by routing operations. Longitude maps to X and latitude maps to Y.
+/// </summary>
+public readonly record struct RoutingCoordinate(double Longitude, double Latitude)
+{
+    /// <summary>
+    /// Creates a coordinate from latitude/longitude ordered values, which is common for GPS APIs.
+    /// </summary>
+    public static RoutingCoordinate FromLatitudeLongitude(double latitude, double longitude) => new(longitude, latitude);
+}
+
+/// <summary>
+/// Point input for route stops, facilities, incidents, and service-area centers.
+/// </summary>
+public sealed class RoutingLocation
+{
+    /// <summary>
+    /// WGS84 point coordinate.
+    /// </summary>
+    public required RoutingCoordinate Coordinate { get; init; }
+
+    /// <summary>
+    /// Optional display name sent as the route stop/facility name.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// Optional stable caller identifier.
+    /// </summary>
+    public string? Id { get; init; }
+
+    /// <summary>
+    /// Additional attributes included with the network-analysis feature.
+    /// </summary>
+    public IReadOnlyDictionary<string, object?>? Attributes { get; init; }
+
+    /// <summary>
+    /// Creates a location from longitude/latitude ordered values.
+    /// </summary>
+    public static RoutingLocation FromLongitudeLatitude(double longitude, double latitude, string? name = null) => new()
+    {
+        Coordinate = new RoutingCoordinate(longitude, latitude),
+        Name = name,
+    };
+
+    /// <summary>
+    /// Creates a location from latitude/longitude ordered values, which is common for GPS APIs.
+    /// </summary>
+    public static RoutingLocation FromLatitudeLongitude(double latitude, double longitude, string? name = null) => new()
+    {
+        Coordinate = RoutingCoordinate.FromLatitudeLongitude(latitude, longitude),
+        Name = name,
+    };
+}
+
+/// <summary>
+/// Supplies the current device location to routing builders or callers.
+/// Platform packages can implement this with MAUI/Android/iOS GPS APIs.
+/// </summary>
+public interface IRoutingLocationProvider
+{
+    /// <summary>
+    /// Resolves the current device location.
+    /// </summary>
+    ValueTask<RoutingLocation> GetCurrentLocationAsync(CancellationToken ct = default);
+}
+
+/// <summary>
+/// Options shared by route solve and route optimization requests.
+/// </summary>
+public sealed class RouteSolveOptions
+{
+    /// <summary>
+    /// Override for the NAServer service id. Defaults to <see cref="HonuaMobileClientOptions.RoutingServiceId"/>.
+    /// </summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>
+    /// Override for the route layer name. Defaults to <see cref="HonuaMobileClientOptions.RoutingRouteLayerName"/>.
+    /// </summary>
+    public string? RouteLayerName { get; init; }
+
+    /// <summary>
+    /// REST response format. Defaults to JSON.
+    /// </summary>
+    public string ResponseFormat { get; init; } = "json";
+
+    /// <summary>
+    /// Requests turn-by-turn directions in the response.
+    /// </summary>
+    public bool ReturnDirections { get; init; } = true;
+
+    /// <summary>
+    /// Requests route geometry in the response.
+    /// </summary>
+    public bool ReturnRoutes { get; init; } = true;
+
+    /// <summary>
+    /// Requests traffic-aware routing when the server/network supports it.
+    /// </summary>
+    public bool UseTraffic { get; init; }
+
+    /// <summary>
+    /// Requests toll-road restrictions when the server/network supports them.
+    /// </summary>
+    public bool AvoidTolls { get; init; }
+
+    /// <summary>
+    /// Requests highway restrictions when the server/network supports them.
+    /// </summary>
+    public bool AvoidHighways { get; init; }
+
+    /// <summary>
+    /// Optional server travel mode name or JSON travel-mode payload.
+    /// </summary>
+    public string? TravelMode { get; init; }
+
+    /// <summary>
+    /// Optional route start time.
+    /// </summary>
+    public DateTimeOffset? StartTime { get; init; }
+
+    /// <summary>
+    /// Direction length units sent to GeoServices-compatible NAServer endpoints.
+    /// </summary>
+    public string DirectionsLengthUnits { get; init; } = "esriMeters";
+
+    /// <summary>
+    /// Route line shape type sent to GeoServices-compatible NAServer endpoints.
+    /// </summary>
+    public string OutputLines { get; init; } = "esriNAOutputLineTrueShape";
+
+    /// <summary>
+    /// Additional raw NAServer form parameters for server-specific routing extensions.
+    /// </summary>
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Directions request for point-to-point and multi-stop routing.
+/// </summary>
+public sealed class RouteDirectionsRequest
+{
+    public required RoutingLocation Origin { get; init; }
+
+    public required RoutingLocation Destination { get; init; }
+
+    public IReadOnlyList<RoutingLocation>? Waypoints { get; init; }
+
+    public RouteSolveOptions Options { get; init; } = new();
+}
+
+/// <summary>
+/// Options for optimized multi-stop route requests.
+/// </summary>
+public sealed class RouteOptimizationOptions
+{
+    public string? ServiceId { get; init; }
+
+    public string? RouteLayerName { get; init; }
+
+    public string ResponseFormat { get; init; } = "json";
+
+    public bool ReturnDirections { get; init; } = true;
+
+    public bool ReturnRoutes { get; init; } = true;
+
+    public bool UseTraffic { get; init; }
+
+    public bool AvoidTolls { get; init; }
+
+    public bool AvoidHighways { get; init; }
+
+    public string? TravelMode { get; init; }
+
+    public DateTimeOffset? StartTime { get; init; }
+
+    public bool PreserveFirstStop { get; init; } = true;
+
+    public bool PreserveLastStop { get; init; } = true;
+
+    public string DirectionsLengthUnits { get; init; } = "esriMeters";
+
+    public string OutputLines { get; init; } = "esriNAOutputLineTrueShape";
+
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Optimizes a sequence of stops using NAServer route solving with best-sequence enabled.
+/// </summary>
+public sealed class RouteOptimizationRequest
+{
+    public required IReadOnlyList<RoutingLocation> Stops { get; init; }
+
+    public RouteOptimizationOptions Options { get; init; } = new();
+}
+
+/// <summary>
+/// Options for service-area / isochrone requests.
+/// </summary>
+public sealed class ServiceAreaOptions
+{
+    public string? ServiceId { get; init; }
+
+    public string? ServiceAreaLayerName { get; init; }
+
+    public string ResponseFormat { get; init; } = "json";
+
+    public string TravelDirection { get; init; } = "esriNATravelDirectionFromFacility";
+
+    public string OutputPolygons { get; init; } = "esriNAOutputPolygonSimplified";
+
+    public bool MergeSimilarPolygonRanges { get; init; } = true;
+
+    public string? TravelMode { get; init; }
+
+    public DateTimeOffset? StartTime { get; init; }
+
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Service-area / isochrone request centered on one location.
+/// </summary>
+public sealed class ServiceAreaRequest
+{
+    public required RoutingLocation Center { get; init; }
+
+    public required TimeSpan TravelTime { get; init; }
+
+    public ServiceAreaOptions Options { get; init; } = new();
+}
+
+/// <summary>
+/// Options for closest-facility network-analysis requests.
+/// </summary>
+public sealed class ClosestFacilityOptions
+{
+    public string? ServiceId { get; init; }
+
+    public string? ClosestFacilityLayerName { get; init; }
+
+    public string ResponseFormat { get; init; } = "json";
+
+    public int? TargetFacilityCount { get; init; }
+
+    public string TravelDirection { get; init; } = "esriNATravelDirectionToFacility";
+
+    public bool ReturnDirections { get; init; } = true;
+
+    public bool ReturnRoutes { get; init; } = true;
+
+    public string? TravelMode { get; init; }
+
+    public DateTimeOffset? StartTime { get; init; }
+
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Finds the nearest facilities for one or more incident locations.
+/// </summary>
+public sealed class ClosestFacilityRequest
+{
+    public required IReadOnlyList<RoutingLocation> Incidents { get; init; }
+
+    public required IReadOnlyList<RoutingLocation> Facilities { get; init; }
+
+    public ClosestFacilityOptions Options { get; init; } = new();
+}
+
+/// <summary>
+/// Summary information parsed from a routing response when present.
+/// </summary>
+public sealed record RouteSummary(string? Name, double? TotalDistance, TimeSpan? TotalTime);
+
+/// <summary>
+/// Turn-by-turn instruction parsed from a routing response when present.
+/// </summary>
+public sealed record RouteDirectionStep(string? Text, double? Distance, TimeSpan? Time, string? ManeuverType);
+
+/// <summary>
+/// Result returned from directions and optimized-route requests.
+/// </summary>
+public sealed class RouteResult
+{
+    internal RouteResult(JsonElement rawResponse, IReadOnlyList<RouteSummary> routes, IReadOnlyList<RouteDirectionStep> directions)
+    {
+        RawResponse = rawResponse;
+        Routes = routes;
+        Directions = directions;
+    }
+
+    /// <summary>
+    /// Raw server response, cloned from the response document.
+    /// </summary>
+    public JsonElement RawResponse { get; }
+
+    /// <summary>
+    /// Parsed route summaries, when the response uses GeoServices-compatible route features or direction summaries.
+    /// </summary>
+    public IReadOnlyList<RouteSummary> Routes { get; }
+
+    /// <summary>
+    /// Parsed turn-by-turn directions, when available.
+    /// </summary>
+    public IReadOnlyList<RouteDirectionStep> Directions { get; }
+}
+
+/// <summary>
+/// Result returned from service-area requests.
+/// </summary>
+public sealed class ServiceAreaResult
+{
+    internal ServiceAreaResult(JsonElement rawResponse)
+    {
+        RawResponse = rawResponse;
+    }
+
+    public JsonElement RawResponse { get; }
+}
+
+/// <summary>
+/// Result returned from closest-facility requests.
+/// </summary>
+public sealed class ClosestFacilityResult
+{
+    internal ClosestFacilityResult(JsonElement rawResponse, IReadOnlyList<RouteSummary> routes, IReadOnlyList<RouteDirectionStep> directions)
+    {
+        RawResponse = rawResponse;
+        Routes = routes;
+        Directions = directions;
+    }
+
+    public JsonElement RawResponse { get; }
+
+    public IReadOnlyList<RouteSummary> Routes { get; }
+
+    public IReadOnlyList<RouteDirectionStep> Directions { get; }
+}

--- a/tests/Honua.Mobile.Sdk.Tests/HonuaRoutingClientTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/HonuaRoutingClientTests.cs
@@ -1,0 +1,267 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Honua.Mobile.Sdk;
+using Honua.Mobile.Sdk.Routing;
+
+namespace Honua.Mobile.Sdk.Tests;
+
+public sealed class HonuaRoutingClientTests
+{
+    [Fact]
+    public async Task GetDirectionsAsync_SendsNasServerSolvePayloadAndParsesDirections()
+    {
+        Dictionary<string, string>? form = null;
+        HttpMethod? method = null;
+        Uri? uri = null;
+        var handler = new RecordingHandler(async (request, ct) =>
+        {
+            method = request.Method;
+            uri = request.RequestUri;
+            form = await ReadFormAsync(request, ct);
+            return JsonResponse("""
+            {
+              "routes": {
+                "features": [
+                  { "attributes": { "Name": "Route 1", "Total_Length": 10.5, "Total_Time": 25 } }
+                ]
+              },
+              "directions": [
+                {
+                  "features": [
+                    { "attributes": { "text": "Head east", "length": 0.1, "time": 1.2, "maneuverType": "esriDMTDepart" } }
+                  ]
+                }
+              ]
+            }
+            """);
+        });
+        var client = CreateClient(handler);
+
+        var result = await client.Routing.GetDirectionsAsync(
+            RoutingLocation.FromLongitudeLatitude(-157.8583, 21.3069, "Start"),
+            RoutingLocation.FromLongitudeLatitude(-157.8037, 21.2810, "Finish"),
+            new[] { RoutingLocation.FromLongitudeLatitude(-157.84, 21.29, "Waypoint") });
+
+        Assert.Equal(HttpMethod.Post, method);
+        Assert.Equal("https://api.honua.test/rest/services/Routing/NAServer/Route/solve", uri?.ToString());
+        Assert.NotNull(form);
+        Assert.Equal("json", form["f"]);
+        Assert.Equal("true", form["returnDirections"]);
+        Assert.Equal("false", form["findBestSequence"]);
+
+        using var stops = JsonDocument.Parse(form["stops"]);
+        var features = stops.RootElement.GetProperty("features").EnumerateArray().ToArray();
+        Assert.Equal(3, features.Length);
+        Assert.Equal("Start", features[0].GetProperty("attributes").GetProperty("Name").GetString());
+        Assert.Equal(-157.8583, features[0].GetProperty("geometry").GetProperty("x").GetDouble(), precision: 4);
+
+        Assert.Single(result.Routes);
+        Assert.Equal("Route 1", result.Routes[0].Name);
+        Assert.Single(result.Directions);
+        Assert.Equal("Head east", result.Directions[0].Text);
+        Assert.Equal(TimeSpan.FromMinutes(1.2), result.Directions[0].Time);
+    }
+
+    [Fact]
+    public async Task OptimizeRouteAsync_SendsBestSequenceParameters()
+    {
+        Dictionary<string, string>? form = null;
+        var handler = new RecordingHandler(async (request, ct) =>
+        {
+            form = await ReadFormAsync(request, ct);
+            return JsonResponse("{}");
+        });
+        var client = CreateClient(handler);
+
+        await client.Routing.OptimizeRouteAsync(
+            new[]
+            {
+                RoutingLocation.FromLongitudeLatitude(-157.86, 21.30, "A"),
+                RoutingLocation.FromLongitudeLatitude(-157.84, 21.31, "B"),
+                RoutingLocation.FromLongitudeLatitude(-157.82, 21.32, "C"),
+            },
+            new RouteOptimizationOptions
+            {
+                PreserveFirstStop = true,
+                PreserveLastStop = false,
+            });
+
+        Assert.NotNull(form);
+        Assert.Equal("true", form["findBestSequence"]);
+        Assert.Equal("true", form["preserveFirstStop"]);
+        Assert.Equal("false", form["preserveLastStop"]);
+    }
+
+    [Fact]
+    public async Task GetServiceAreaAsync_SendsTravelTimeBreak()
+    {
+        Dictionary<string, string>? form = null;
+        Uri? uri = null;
+        var handler = new RecordingHandler(async (request, ct) =>
+        {
+            uri = request.RequestUri;
+            form = await ReadFormAsync(request, ct);
+            return JsonResponse("{}");
+        });
+        var client = CreateClient(handler);
+
+        await client.Routing.GetServiceAreaAsync(
+            RoutingLocation.FromLongitudeLatitude(-157.8583, 21.3069, "Depot"),
+            TimeSpan.FromMinutes(30));
+
+        Assert.Equal("https://api.honua.test/rest/services/Routing/NAServer/ServiceArea/solveServiceArea", uri?.ToString());
+        Assert.NotNull(form);
+        Assert.Equal("30", form["defaultBreaks"]);
+        Assert.Equal("esriNATravelDirectionFromFacility", form["travelDirection"]);
+        using var facilities = JsonDocument.Parse(form["facilities"]);
+        Assert.Equal("Depot", facilities.RootElement.GetProperty("features")[0].GetProperty("attributes").GetProperty("Name").GetString());
+    }
+
+    [Fact]
+    public async Task FindClosestFacilityAsync_SendsIncidentAndFacilityFeatureSets()
+    {
+        Dictionary<string, string>? form = null;
+        Uri? uri = null;
+        var handler = new RecordingHandler(async (request, ct) =>
+        {
+            uri = request.RequestUri;
+            form = await ReadFormAsync(request, ct);
+            return JsonResponse("{}");
+        });
+        var client = CreateClient(handler);
+
+        await client.Routing.FindClosestFacilityAsync(
+            new[] { RoutingLocation.FromLongitudeLatitude(-157.85, 21.30, "Incident") },
+            new[]
+            {
+                RoutingLocation.FromLongitudeLatitude(-157.80, 21.28, "Facility A"),
+                RoutingLocation.FromLongitudeLatitude(-157.82, 21.31, "Facility B"),
+            },
+            new ClosestFacilityOptions { TargetFacilityCount = 1 });
+
+        Assert.Equal("https://api.honua.test/rest/services/Routing/NAServer/ClosestFacility/solveClosestFacility", uri?.ToString());
+        Assert.NotNull(form);
+        Assert.Equal("1", form["defaultTargetFacilityCount"]);
+        using var incidents = JsonDocument.Parse(form["incidents"]);
+        using var facilities = JsonDocument.Parse(form["facilities"]);
+        Assert.Single(incidents.RootElement.GetProperty("features").EnumerateArray());
+        Assert.Equal(2, facilities.RootElement.GetProperty("features").EnumerateArray().Count());
+    }
+
+    [Fact]
+    public async Task FindClosestFacilityAsync_UsesDirectionSummaryWhenRoutesAreOmitted()
+    {
+        var handler = new RecordingHandler((_, _) => Task.FromResult(JsonResponse("""
+        {
+          "directions": [
+            {
+              "summary": { "routeName": "Incident - Facility A", "totalLength": 2.5, "totalTime": 8 }
+            }
+          ]
+        }
+        """)));
+        var client = CreateClient(handler);
+
+        var result = await client.Routing.FindClosestFacilityAsync(
+            new[] { RoutingLocation.FromLongitudeLatitude(-157.85, 21.30, "Incident") },
+            new[] { RoutingLocation.FromLongitudeLatitude(-157.80, 21.28, "Facility A") },
+            new ClosestFacilityOptions { ReturnRoutes = false });
+
+        Assert.Single(result.Routes);
+        Assert.Equal("Incident - Facility A", result.Routes[0].Name);
+        Assert.Equal(2.5, result.Routes[0].TotalDistance);
+        Assert.Equal(TimeSpan.FromMinutes(8), result.Routes[0].TotalTime);
+    }
+
+    [Fact]
+    public async Task RouteBuilder_AppliesTrafficAndRestrictions()
+    {
+        Dictionary<string, string>? form = null;
+        var handler = new RecordingHandler(async (request, ct) =>
+        {
+            form = await ReadFormAsync(request, ct);
+            return JsonResponse("{}");
+        });
+        var client = CreateClient(handler);
+
+        await client.Routing.Route()
+            .From(RoutingLocation.FromLongitudeLatitude(-157.8583, 21.3069))
+            .Via(RoutingLocation.FromLongitudeLatitude(-157.84, 21.29))
+            .To(RoutingLocation.FromLongitudeLatitude(-157.8037, 21.2810))
+            .WithTraffic()
+            .AvoidTolls()
+            .ExecuteAsync();
+
+        Assert.NotNull(form);
+        Assert.Equal("true", form["useTraffic"]);
+        Assert.Equal("true", form["avoidTolls"]);
+        using var stops = JsonDocument.Parse(form["stops"]);
+        Assert.Equal(3, stops.RootElement.GetProperty("features").EnumerateArray().Count());
+    }
+
+    [Fact]
+    public async Task RoutingCall_WithApiKeyOverHttp_ThrowsAndDoesNotSendRequest()
+    {
+        var handler = new RecordingHandler((_, _) => Task.FromResult(JsonResponse("{}")));
+        var client = CreateClient(handler, new HonuaMobileClientOptions
+        {
+            BaseUri = new Uri("http://api.honua.test"),
+            ApiKey = "test-key",
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => client.Routing.GetDirectionsAsync(
+            RoutingLocation.FromLongitudeLatitude(-157.8583, 21.3069),
+            RoutingLocation.FromLongitudeLatitude(-157.8037, 21.2810)));
+        Assert.Equal(0, handler.RequestCount);
+    }
+
+    private static HonuaMobileClient CreateClient(
+        HttpMessageHandler handler,
+        HonuaMobileClientOptions? options = null)
+    {
+        options ??= new HonuaMobileClientOptions
+        {
+            BaseUri = new Uri("https://api.honua.test"),
+            RoutingServiceId = "Routing",
+        };
+
+        return new HonuaMobileClient(new HttpClient(handler), options);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(json, Encoding.UTF8, "application/json"),
+    };
+
+    private static async Task<Dictionary<string, string>> ReadFormAsync(HttpRequestMessage request, CancellationToken ct)
+    {
+        var body = await request.Content!.ReadAsStringAsync(ct);
+        return body.Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => part.Split('=', 2))
+            .ToDictionary(
+                pair => Decode(pair[0]),
+                pair => pair.Length == 2 ? Decode(pair[1]) : string.Empty,
+                StringComparer.Ordinal);
+    }
+
+    private static string Decode(string value) => Uri.UnescapeDataString(value.Replace("+", " "));
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _responder;
+
+        public RecordingHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder)
+        {
+            _responder = responder;
+        }
+
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            return _responder(request, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add HonuaRoutingClient for directions, service areas, closest facility, and route optimization
- expose typed routing request/result models, current-location provider abstraction, and a fluent route builder
- register routing through MAUI DI and document the experimental routing APIs

## Validation
- dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --no-restore
- dotnet test Honua.Mobile.sln --no-restore
- dotnet format Honua.Mobile.sln --verify-no-changes --no-restore
- git diff --check

Closes #15