### PR TITLE
fix: review findings and keep Android advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             CHANGED_FILES=$(git diff --name-only ${{ github.event.before }}..${{ github.sha }})
           fi
 
-          SRC_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^(src/|proto/|quality/)' || true)
+          SRC_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^(src/|apps/|proto/|quality/)' || true)
           TEST_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^tests/' || true)
 
           if [ -n "$SRC_CHANGED" ]; then
@@ -134,6 +134,7 @@ jobs:
           dotnet restore tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj
           dotnet restore tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj
           dotnet restore tests/Honua.Mobile.Field.Tests/Honua.Mobile.Field.Tests.csproj
+          dotnet restore tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj
 
       - name: Create Test Results Directory
         run: mkdir -p ./TestResults
@@ -145,6 +146,8 @@ jobs:
           dotnet build tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj \
             --no-restore --configuration Release
           dotnet build tests/Honua.Mobile.Field.Tests/Honua.Mobile.Field.Tests.csproj \
+            --no-restore --configuration Release
+          dotnet build tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj \
             --no-restore --configuration Release
 
       - name: Run SDK Tests
@@ -174,6 +177,15 @@ jobs:
             --results-directory ./TestResults \
             --collect:"XPlat Code Coverage"
 
+      - name: Run MAUI Component Tests
+        run: |
+          dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj \
+            --no-build --no-restore --configuration Release \
+            --logger "trx;LogFileName=maui-tests.trx" \
+            --logger "console;verbosity=minimal" \
+            --results-directory ./TestResults \
+            --collect:"XPlat Code Coverage"
+
       - name: Upload Test Results
         uses: actions/upload-artifact@v7
         if: always()
@@ -187,6 +199,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, changes]
     if: needs.changes.outputs.src_changed == 'true'
+    continue-on-error: true
     permissions:
       contents: read
     steps:
@@ -204,23 +217,40 @@ jobs:
           java-version: '17'
 
       - name: Install MAUI workload
-        run: dotnet workload install maui-android
+        run: |
+          dotnet workload install maui-android \
+            || echo "::warning::MAUI Android workload install failed; Android checks are advisory and do not block merge"
 
       - name: Restore
         run: |
-          dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj -p:TargetFramework=net10.0-android
+          status=0
+          dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj -p:TargetFramework=net10.0-android || status=$?
+          dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj -p:TargetFramework=net10.0-android || status=$?
+
+          if [ "$status" -ne 0 ]; then
+            echo "::warning::Android restore failed; Android checks are advisory and do not block merge"
+          fi
 
       - name: Build MAUI Components
         run: |
           dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
-            --configuration Release
+            --configuration Release \
+            || echo "::warning::MAUI component build failed in Android job; Android checks are advisory and do not block merge"
 
-      - name: Build Reference App (Android)
+      - name: Build Android Apps
         run: |
+          status=0
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
-            --framework net10.0-android \
-            || echo "::warning::Android build failed - may require Android SDK setup"
+            --framework net10.0-android || status=$?
+
+          dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
+            --configuration Release \
+            --framework net10.0-android || status=$?
+
+          if [ "$status" -ne 0 ]; then
+            echo "::warning::Android app build failed; Android checks are advisory and do not block merge"
+          fi
 
   maui-windows:
     name: MAUI Windows Build
@@ -465,7 +495,7 @@ jobs:
           windows_result="${{ needs.maui-windows.result }}"
 
           if [[ "$android_result" == "failure" ]]; then
-            echo "⚠️ Android build failed (may require SDK configuration)"
+            echo "⚠️ Android build failed, but it is advisory and does not block merge"
           fi
 
           if [[ "$windows_result" == "failure" ]]; then

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       pull-requests: write
       issues: read
+      statuses: write
     steps:
       - name: Check PR Requirements
         uses: actions/github-script@v8
@@ -167,6 +168,19 @@ jobs:
                 body: comment
               });
             }
+
+            const statusState = issues.length > 0 ? 'failure' : 'success';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: statusState,
+              context: 'Validate Mobile SDK PR',
+              description: issues.length > 0
+                ? `Mobile SDK PR validation failed: ${issues.length} critical issue(s)`
+                : 'Mobile SDK PR validation passed',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });
 
             // Fail if critical issues found
             if (issues.length > 0) {

--- a/Honua.Mobile.sln
+++ b/Honua.Mobile.sln
@@ -23,6 +23,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Mobile.Sdk.Tests", "t
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Mobile.Maui.Tests", "tests\Honua.Mobile.Maui.Tests\Honua.Mobile.Maui.Tests.csproj", "{ABA8CE4F-C7A7-4D79-860E-994506812B33}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Mobile.Smoke.Tests", "tests\Honua.Mobile.Smoke.Tests\Honua.Mobile.Smoke.Tests.csproj", "{2DEE74CC-D0FB-458C-8980-1A9E54FADE0B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -129,6 +131,18 @@ Global
 		{ABA8CE4F-C7A7-4D79-860E-994506812B33}.Release|x64.Build.0 = Release|Any CPU
 		{ABA8CE4F-C7A7-4D79-860E-994506812B33}.Release|x86.ActiveCfg = Release|Any CPU
 		{ABA8CE4F-C7A7-4D79-860E-994506812B33}.Release|x86.Build.0 = Release|Any CPU
+		{2DEE74CC-D0FB-458C-8980-1A9E54FADE0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2DEE74CC-D0FB-458C-8980-1A9E54FADE0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2DEE74CC-D0FB-458C-8980-1A9E54FADE0B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2DEE74CC-D0FB-458C-8980-1A9E54FADE0B}.Debug|x64.Build.0 = Debug|Any CPU
+		{2DEE74CC-D0FB-458C-8980-1A9E54FADE0B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2DEE74CC-D0FB-458C-8980-1A9E54FADE0B}.Debug|x86.Build.0 = Debug|Any CPU
+		{2DEE74CC-D0FB-458C-8980-1A9E54FADE0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2DEE74CC-D0FB-458C-8980-1A9E54FADE0B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2DEE74CC-D0FB-458C-8980-1A9E54FADE0B}.Release|x64.ActiveCfg = Release|Any CPU
+		{2DEE74CC-D0FB-458C-8980-1A9E54FADE0B}.Release|x64.Build.0 = Release|Any CPU
+		{2DEE74CC-D0FB-458C-8980-1A9E54FADE0B}.Release|x86.ActiveCfg = Release|Any CPU
+		{2DEE74CC-D0FB-458C-8980-1A9E54FADE0B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -142,5 +156,6 @@ Global
 		{34987433-8E8C-49FF-9776-C122ADFD0EFB} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{5FC8602D-CF71-4DCC-90CC-276D0407C22C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{ABA8CE4F-C7A7-4D79-860E-994506812B33} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{2DEE74CC-D0FB-458C-8980-1A9E54FADE0B} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/apps/Honua.Mobile.FieldCollection/Services/Features/GeoPackageFeatureService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Features/GeoPackageFeatureService.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.RegularExpressions;
 using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services.Storage;
 using CoreModels = Honua.Mobile.FieldCollection.Models;
@@ -13,6 +16,10 @@ namespace Honua.Mobile.FieldCollection.Services.Features;
 /// </summary>
 public class GeoPackageFeatureService : IFeatureService
 {
+    private static readonly Regex WherePredicateRegex = new(
+        @"^\s*(?<field>[A-Za-z_][A-Za-z0-9_]*)\s*(?<op>==|!=|<>|>=|<=|=|>|<)\s*(?<value>.+?)\s*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private readonly GeoPackageStorageService _storage;
     private readonly ISyncService _syncService;
 
@@ -72,7 +79,9 @@ public class GeoPackageFeatureService : IFeatureService
                 {
                     Bounds = ConvertToBoundingBox(query.SpatialFilter),
                     Relationship = ConvertToSpatialRelationship(query.SpatialFilter.Relationship),
-                    MaxResults = query.MaxResults
+                    MaxResults = string.IsNullOrWhiteSpace(query.WhereClause) && query.OrderBy?.Any() != true
+                        ? query.MaxResults
+                        : null
                 };
             }
 
@@ -96,7 +105,7 @@ public class GeoPackageFeatureService : IFeatureService
 
             return features;
         }
-        catch (Exception)
+        catch (Exception ex) when (ex is not NotSupportedException and not ArgumentException)
         {
             return new List<Feature>();
         }
@@ -321,9 +330,31 @@ public class GeoPackageFeatureService : IFeatureService
                 point.Longitude + buffer, point.Latitude + buffer);
         }
 
-        // For other geometry types, would extract actual bounds
-        // For now, return a default large bounds
-        return StorageBoundingBox.FromCoordinates(-180, -90, 180, 90);
+        if (spatialFilter.Geometry is CoreModels.LineString line && line.Coordinates.Count > 0)
+        {
+            return ConvertPointsToBoundingBox(line.Coordinates);
+        }
+
+        if (spatialFilter.Geometry is CoreModels.Polygon polygon)
+        {
+            var points = polygon.Coordinates.SelectMany(ring => ring).ToList();
+            if (points.Count > 0)
+            {
+                return ConvertPointsToBoundingBox(points);
+            }
+        }
+
+        throw new NotSupportedException("Spatial filters require a point, line, or polygon with coordinates.");
+    }
+
+    private static StorageBoundingBox ConvertPointsToBoundingBox(IEnumerable<CoreModels.Point> points)
+    {
+        var pointList = points.ToList();
+        return StorageBoundingBox.FromCoordinates(
+            pointList.Min(point => point.Longitude),
+            pointList.Min(point => point.Latitude),
+            pointList.Max(point => point.Longitude),
+            pointList.Max(point => point.Latitude));
     }
 
     private static StorageSpatialRelationship ConvertToSpatialRelationship(CoreModels.SpatialRelationship relationship)
@@ -342,9 +373,15 @@ public class GeoPackageFeatureService : IFeatureService
 
     private static List<Feature> ApplyWhereClause(List<Feature> features, string whereClause)
     {
-        // Simple implementation - in a real system would parse SQL WHERE clause
-        // For now, just return all features
-        return features;
+        var predicates = ParseWhereClause(whereClause);
+        if (predicates.Count == 0)
+        {
+            return features;
+        }
+
+        return features
+            .Where(feature => predicates.All(predicate => MatchesWherePredicate(feature, predicate)))
+            .ToList();
     }
 
     private static List<Feature> ApplyOrderBy(List<Feature> features, List<OrderByClause> orderBy)
@@ -370,6 +407,285 @@ public class GeoPackageFeatureService : IFeatureService
         return feature.Attributes.TryGetValue(fieldName, out var value) ? value : null;
     }
 
+    private static IReadOnlyList<WherePredicate> ParseWhereClause(string whereClause)
+    {
+        var trimmed = whereClause.Trim();
+        if (trimmed.Length == 0 ||
+            string.Equals(trimmed, "1=1", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(trimmed, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            return [];
+        }
+
+        var parts = SplitWhereClause(trimmed);
+        var predicates = new List<WherePredicate>(parts.Count);
+
+        foreach (var part in parts)
+        {
+            var match = WherePredicateRegex.Match(part);
+            if (!match.Success)
+            {
+                throw new NotSupportedException($"Unsupported where clause predicate: '{part}'.");
+            }
+
+            predicates.Add(new WherePredicate(
+                match.Groups["field"].Value,
+                match.Groups["op"].Value,
+                ParseLiteral(match.Groups["value"].Value)));
+        }
+
+        return predicates;
+    }
+
+    private static IReadOnlyList<string> SplitWhereClause(string whereClause)
+    {
+        var parts = new List<string>();
+        var startIndex = 0;
+        var inSingleQuote = false;
+        var inDoubleQuote = false;
+
+        for (var index = 0; index < whereClause.Length; index++)
+        {
+            var character = whereClause[index];
+
+            if (character == '\'' && !inDoubleQuote)
+            {
+                if (inSingleQuote && index + 1 < whereClause.Length && whereClause[index + 1] == '\'')
+                {
+                    index++;
+                    continue;
+                }
+
+                inSingleQuote = !inSingleQuote;
+                continue;
+            }
+
+            if (character == '"' && !inSingleQuote)
+            {
+                if (inDoubleQuote && index + 1 < whereClause.Length && whereClause[index + 1] == '"')
+                {
+                    index++;
+                    continue;
+                }
+
+                inDoubleQuote = !inDoubleQuote;
+                continue;
+            }
+
+            if (!inSingleQuote && !inDoubleQuote && IsAndSeparator(whereClause, index))
+            {
+                parts.Add(whereClause[startIndex..index].Trim());
+                index += 2;
+                startIndex = index + 1;
+            }
+        }
+
+        parts.Add(whereClause[startIndex..].Trim());
+        return parts;
+    }
+
+    private static bool IsAndSeparator(string value, int index)
+    {
+        return index > 0 &&
+            index + 3 < value.Length &&
+            char.IsWhiteSpace(value[index - 1]) &&
+            char.IsWhiteSpace(value[index + 3]) &&
+            string.Compare(value, index, "AND", 0, 3, ignoreCase: true, CultureInfo.InvariantCulture) == 0;
+    }
+
+    private static object? ParseLiteral(string literal)
+    {
+        var trimmed = literal.Trim();
+
+        if (string.Equals(trimmed, "NULL", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        if (string.Equals(trimmed, "TRUE", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (string.Equals(trimmed, "FALSE", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (trimmed.Length >= 2 && trimmed[0] == '\'' && trimmed[^1] == '\'')
+        {
+            return trimmed[1..^1].Replace("''", "'", StringComparison.Ordinal);
+        }
+
+        if (trimmed.Length >= 2 && trimmed[0] == '"' && trimmed[^1] == '"')
+        {
+            return trimmed[1..^1].Replace("\"\"", "\"", StringComparison.Ordinal);
+        }
+
+        if (double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var numericValue))
+        {
+            return numericValue;
+        }
+
+        return trimmed;
+    }
+
+    private static bool MatchesWherePredicate(Feature feature, WherePredicate predicate)
+    {
+        if (!feature.Attributes.TryGetValue(predicate.FieldName, out var rawValue))
+        {
+            return predicate.Value is null && (predicate.Operator is "=" or "==");
+        }
+
+        var fieldValue = NormalizeAttributeValue(rawValue);
+
+        return predicate.Operator switch
+        {
+            "=" or "==" => ValuesEqual(fieldValue, predicate.Value),
+            "!=" or "<>" => !ValuesEqual(fieldValue, predicate.Value),
+            ">" => CompareValues(fieldValue, predicate.Value) > 0,
+            ">=" => CompareValues(fieldValue, predicate.Value) >= 0,
+            "<" => CompareValues(fieldValue, predicate.Value) < 0,
+            "<=" => CompareValues(fieldValue, predicate.Value) <= 0,
+            _ => false
+        };
+    }
+
+    private static object? NormalizeAttributeValue(object? value)
+    {
+        if (value is JsonElement element)
+        {
+            return element.ValueKind switch
+            {
+                JsonValueKind.String => element.GetString(),
+                JsonValueKind.Number when element.TryGetDouble(out var number) => number,
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                JsonValueKind.Null or JsonValueKind.Undefined => null,
+                _ => element.ToString()
+            };
+        }
+
+        return value;
+    }
+
+    private static bool ValuesEqual(object? left, object? right)
+    {
+        if (left is null || right is null)
+        {
+            return left is null && right is null;
+        }
+
+        if (TryGetDouble(left, out var leftNumber) && TryGetDouble(right, out var rightNumber))
+        {
+            return Math.Abs(leftNumber - rightNumber) < double.Epsilon;
+        }
+
+        if (TryGetBoolean(left, out var leftBoolean) && TryGetBoolean(right, out var rightBoolean))
+        {
+            return leftBoolean == rightBoolean;
+        }
+
+        if (TryGetDateTimeOffset(left, out var leftDate) && TryGetDateTimeOffset(right, out var rightDate))
+        {
+            return leftDate == rightDate;
+        }
+
+        return string.Equals(
+            Convert.ToString(left, CultureInfo.InvariantCulture),
+            Convert.ToString(right, CultureInfo.InvariantCulture),
+            StringComparison.Ordinal);
+    }
+
+    private static int CompareValues(object? left, object? right)
+    {
+        if (left is null || right is null)
+        {
+            return left is null && right is null ? 0 : left is null ? -1 : 1;
+        }
+
+        if (TryGetDouble(left, out var leftNumber) && TryGetDouble(right, out var rightNumber))
+        {
+            return leftNumber.CompareTo(rightNumber);
+        }
+
+        if (TryGetDateTimeOffset(left, out var leftDate) && TryGetDateTimeOffset(right, out var rightDate))
+        {
+            return leftDate.CompareTo(rightDate);
+        }
+
+        return string.Compare(
+            Convert.ToString(left, CultureInfo.InvariantCulture),
+            Convert.ToString(right, CultureInfo.InvariantCulture),
+            StringComparison.Ordinal);
+    }
+
+    private static bool TryGetDouble(object? value, out double number)
+    {
+        switch (value)
+        {
+            case double doubleValue:
+                number = doubleValue;
+                return true;
+            case float floatValue:
+                number = floatValue;
+                return true;
+            case decimal decimalValue:
+                number = (double)decimalValue;
+                return true;
+            case int intValue:
+                number = intValue;
+                return true;
+            case long longValue:
+                number = longValue;
+                return true;
+            case string stringValue:
+                return double.TryParse(stringValue, NumberStyles.Float, CultureInfo.InvariantCulture, out number);
+            default:
+                number = 0;
+                return false;
+        }
+    }
+
+    private static bool TryGetBoolean(object? value, out bool result)
+    {
+        if (value is bool booleanValue)
+        {
+            result = booleanValue;
+            return true;
+        }
+
+        if (value is string stringValue && bool.TryParse(stringValue, out result))
+        {
+            return true;
+        }
+
+        result = false;
+        return false;
+    }
+
+    private static bool TryGetDateTimeOffset(object? value, out DateTimeOffset result)
+    {
+        switch (value)
+        {
+            case DateTime dateTimeValue:
+                result = dateTimeValue;
+                return true;
+            case DateTimeOffset dateTimeOffsetValue:
+                result = dateTimeOffsetValue;
+                return true;
+            case string stringValue:
+                return DateTimeOffset.TryParse(
+                    stringValue,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind,
+                    out result);
+            default:
+                result = default;
+                return false;
+        }
+    }
+
     private static double EstimateLayerSize(List<Feature> features)
     {
         // Rough estimate: assume 1KB per feature on average
@@ -377,6 +693,8 @@ public class GeoPackageFeatureService : IFeatureService
     }
 
     #endregion
+
+    private sealed record WherePredicate(string FieldName, string Operator, object? Value);
 }
 
 /// <summary>

--- a/apps/Honua.Mobile.FieldCollection/Services/Storage/DatabaseService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Storage/DatabaseService.cs
@@ -135,6 +135,7 @@ public class DatabaseService : IDisposable
         try
         {
             // Close existing connections
+            _syncService?.Dispose();
             _storageService?.Dispose();
             _syncService = null;
             _storageService = null;
@@ -172,6 +173,7 @@ public class DatabaseService : IDisposable
 
     public void Dispose()
     {
+        _syncService?.Dispose();
         _storageService?.Dispose();
         _initLock?.Dispose();
         GC.SuppressFinalize(this);

--- a/apps/Honua.Mobile.FieldCollection/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Storage/GeoPackageStorageService.cs
@@ -6,6 +6,7 @@ using Honua.Mobile.FieldCollection.Services.Storage.Models;
 using ChangeOperation = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeOperation;
 using CoreModels = Honua.Mobile.FieldCollection.Models;
 using StorageSyncStatus = Honua.Mobile.FieldCollection.Services.Storage.Models.SyncStatus;
+using NtsEnvelope = NetTopologySuite.Geometries.Envelope;
 using NtsGeometry = NetTopologySuite.Geometries.Geometry;
 
 namespace Honua.Mobile.FieldCollection.Services.Storage;
@@ -116,11 +117,93 @@ public class GeoPackageStorageService : IDisposable
     private async Task CreateChangeTrackingTables()
     {
         // Honua change tracking for delta sync
-        await _connection.CreateTableAsync<LocalFeature>();
+        await EnsureLocalFeaturesTableAsync();
         await _connection.CreateTableAsync<ChangeRecord>();
         await _connection.CreateTableAsync<SyncSession>();
         await _connection.CreateTableAsync<ConflictRecord>();
         await _connection.CreateTableAsync<LayerMetadata>();
+    }
+
+    private async Task EnsureLocalFeaturesTableAsync()
+    {
+        var hasTable = await _connection.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'local_features'");
+
+        if (hasTable == 0)
+        {
+            await CreateLocalFeaturesTableAsync("local_features");
+        }
+        else if (!await LocalFeaturesTableUsesStorageKeyAsync())
+        {
+            await MigrateLocalFeaturesTableAsync();
+        }
+
+        await _connection.ExecuteAsync("CREATE INDEX IF NOT EXISTS idx_local_features_id_layer_id ON local_features(id, layer_id)");
+        await _connection.ExecuteAsync("CREATE INDEX IF NOT EXISTS idx_local_features_layer_id ON local_features(layer_id)");
+        await _connection.ExecuteAsync("CREATE INDEX IF NOT EXISTS idx_local_features_modified_at ON local_features(modified_at)");
+        await _connection.ExecuteAsync("CREATE INDEX IF NOT EXISTS idx_local_features_sync_status ON local_features(sync_status)");
+    }
+
+    private async Task<bool> LocalFeaturesTableUsesStorageKeyAsync()
+    {
+        var columns = await _connection.QueryAsync<TableColumnInfo>("PRAGMA table_info(local_features)");
+        return columns.Any(column =>
+            string.Equals(column.Name, "storage_key", StringComparison.OrdinalIgnoreCase) &&
+            column.PrimaryKey > 0);
+    }
+
+    private async Task MigrateLocalFeaturesTableAsync()
+    {
+        const string migrationTable = "local_features_migration";
+
+        await _connection.ExecuteAsync("BEGIN IMMEDIATE");
+        try
+        {
+            await _connection.ExecuteAsync($"DROP TABLE IF EXISTS {migrationTable}");
+            await CreateLocalFeaturesTableAsync(migrationTable);
+            await _connection.ExecuteAsync($@"
+                INSERT OR REPLACE INTO {migrationTable}
+                    (storage_key, id, layer_id, geometry, attributes, created_at, modified_at, version, sync_status, server_version, conflict_resolution)
+                SELECT
+                    CAST(layer_id AS TEXT) || ':' || id,
+                    id,
+                    layer_id,
+                    geometry,
+                    attributes,
+                    created_at,
+                    modified_at,
+                    version,
+                    sync_status,
+                    server_version,
+                    conflict_resolution
+                FROM local_features");
+            await _connection.ExecuteAsync("DROP TABLE local_features");
+            await _connection.ExecuteAsync($"ALTER TABLE {migrationTable} RENAME TO local_features");
+            await _connection.ExecuteAsync("COMMIT");
+        }
+        catch
+        {
+            await _connection.ExecuteAsync("ROLLBACK");
+            throw;
+        }
+    }
+
+    private Task CreateLocalFeaturesTableAsync(string tableName)
+    {
+        return _connection.ExecuteAsync($@"
+            CREATE TABLE IF NOT EXISTS {tableName} (
+                storage_key TEXT NOT NULL PRIMARY KEY,
+                id TEXT NOT NULL,
+                layer_id INTEGER NOT NULL,
+                geometry BLOB,
+                attributes TEXT,
+                created_at DATETIME NOT NULL,
+                modified_at DATETIME NOT NULL,
+                version INTEGER NOT NULL,
+                sync_status INTEGER NOT NULL,
+                server_version INTEGER,
+                conflict_resolution TEXT
+            )");
     }
 
     private async Task CreateSpatialIndexes()
@@ -173,7 +256,7 @@ public class GeoPackageStorageService : IDisposable
             if (spatialQuery != null)
             {
                 localFeatures = localFeatures
-                    .Where(feature => IntersectsBounds(feature, spatialQuery.Bounds))
+                    .Where(feature => MatchesSpatialQuery(feature, spatialQuery))
                     .ToList();
 
                 if (spatialQuery.MaxResults.HasValue)
@@ -289,6 +372,7 @@ public class GeoPackageStorageService : IDisposable
         var geometry = ConvertToNtsGeometry(feature.Geometry);
         var localFeature = new LocalFeature
         {
+            StorageKey = BuildStorageKey(feature.LayerId, feature.Id),
             Id = feature.Id,
             LayerId = feature.LayerId,
             Geometry = geometry != null ? _wkbWriter.Write(geometry) : null,
@@ -371,20 +455,31 @@ public class GeoPackageStorageService : IDisposable
 
     #region Spatial Queries
 
-    private bool IntersectsBounds(LocalFeature feature, BoundingBox bounds)
+    private bool MatchesSpatialQuery(LocalFeature feature, SpatialQuery spatialQuery)
     {
-        if (feature.Geometry == null)
+        if (feature.Geometry == null || !spatialQuery.Bounds.IsValid)
         {
             return false;
         }
 
         var geometry = _wkbReader.Read(feature.Geometry);
-        var envelope = geometry.EnvelopeInternal;
+        var bounds = spatialQuery.Bounds;
+        var queryGeometry = geometry.Factory.ToGeometry(new NtsEnvelope(
+            bounds.MinX,
+            bounds.MaxX,
+            bounds.MinY,
+            bounds.MaxY));
 
-        return envelope.MinX <= bounds.MaxX
-            && envelope.MaxX >= bounds.MinX
-            && envelope.MinY <= bounds.MaxY
-            && envelope.MaxY >= bounds.MinY;
+        return spatialQuery.Relationship switch
+        {
+            SpatialRelationship.Intersects => geometry.Intersects(queryGeometry),
+            SpatialRelationship.Contains => geometry.Contains(queryGeometry),
+            SpatialRelationship.Within => geometry.Within(queryGeometry),
+            SpatialRelationship.Overlaps => geometry.Overlaps(queryGeometry),
+            SpatialRelationship.Touches => geometry.Touches(queryGeometry),
+            SpatialRelationship.Crosses => geometry.Crosses(queryGeometry),
+            _ => geometry.Intersects(queryGeometry)
+        };
     }
 
     #endregion
@@ -551,6 +646,11 @@ public class GeoPackageStorageService : IDisposable
         throw new NotSupportedException($"Geometry type {ntsGeometry.GeometryType} not supported");
     }
 
+    private static string BuildStorageKey(int layerId, string featureId)
+    {
+        return $"{layerId}:{featureId}";
+    }
+
     #endregion
 
     #region Storage Statistics
@@ -601,4 +701,13 @@ public class StorageStatistics
     public int PendingChanges { get; set; }
     public double DatabaseSizeMb { get; set; }
     public DateTime LastCompaction { get; set; }
+}
+
+internal sealed class TableColumnInfo
+{
+    [Column("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [Column("pk")]
+    public int PrimaryKey { get; set; }
 }

--- a/apps/Honua.Mobile.FieldCollection/Services/Storage/Models/StorageModels.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Storage/Models/StorageModels.cs
@@ -10,7 +10,11 @@ namespace Honua.Mobile.FieldCollection.Services.Storage.Models;
 public class LocalFeature
 {
     [PrimaryKey]
+    [Column("storage_key")]
+    public string StorageKey { get; set; } = string.Empty;
+
     [Column("id")]
+    [Indexed]
     public string Id { get; set; } = string.Empty;
 
     [Column("layer_id")]

--- a/apps/Honua.Mobile.FieldCollection/Services/Sync/GeoPackageSyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Sync/GeoPackageSyncService.cs
@@ -11,16 +11,28 @@ using StorageSyncSessionStatus = Honua.Mobile.FieldCollection.Services.Storage.M
 namespace Honua.Mobile.FieldCollection.Services.Sync;
 
 /// <summary>
+/// Uploads local field collection changes to the remote sync service.
+/// </summary>
+public interface IFieldCollectionChangeUploader
+{
+    Task<bool> UploadChangeAsync(StorageChangeRecord change, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
 /// Real implementation of sync service with GeoPackage-based delta sync
 /// Implements last-write-wins conflict resolution with manual merge support
 /// </summary>
-public partial class GeoPackageSyncService : ObservableObject, ISyncService
+public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDisposable
 {
     private readonly GeoPackageStorageService _storage;
     private readonly IAuthenticationService _authService;
     private readonly IConnectivityService _connectivityService;
+    private readonly IFieldCollectionChangeUploader _changeUploader;
     private readonly SemaphoreSlim _syncLock = new(1, 1);
+    private readonly CancellationTokenSource _pendingChangesCancellation = new();
+    private readonly Task _pendingChangesTask;
     private CancellationTokenSource? _syncCancellation;
+    private bool _disposed;
 
     [ObservableProperty]
     private bool isSyncing;
@@ -43,29 +55,47 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService
     public GeoPackageSyncService(
         GeoPackageStorageService storage,
         IAuthenticationService authService,
-        IConnectivityService connectivityService)
+        IConnectivityService connectivityService,
+        IFieldCollectionChangeUploader? changeUploader = null)
     {
         _storage = storage;
         _authService = authService;
         _connectivityService = connectivityService;
+        _changeUploader = changeUploader ?? new UnconfiguredFieldCollectionChangeUploader();
 
         // Update pending changes count periodically
-        _ = Task.Run(UpdatePendingChangesAsync);
+        _pendingChangesTask = Task.Run(() => UpdatePendingChangesAsync(_pendingChangesCancellation.Token));
     }
 
-    private async Task UpdatePendingChangesAsync()
+    private async Task UpdatePendingChangesAsync(CancellationToken cancellationToken)
     {
-        while (true)
+        while (!cancellationToken.IsCancellationRequested)
         {
             try
             {
                 var changes = await _storage.GetPendingChangesAsync();
                 PendingChangesCount = changes.Count;
-                await Task.Delay(5000); // Update every 5 seconds
             }
-            catch
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                // Ignore errors in background task
+                break;
+            }
+            catch (ObjectDisposedException) when (_disposed)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error updating pending changes count: {ex.Message}");
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                break;
             }
         }
     }
@@ -102,14 +132,14 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService
                 // Phase 1: Pull changes from server
                 Status = SyncStatus.PullingChanges;
                 SyncMessage = "Downloading changes from server...";
-                var pullResult = await PullChangesInternalAsync(session, _syncCancellation.Token);
+                await PullChangesInternalAsync(session, _syncCancellation.Token);
 
                 SyncProgress = 0.5;
 
                 // Phase 2: Push local changes
                 Status = SyncStatus.PushingChanges;
                 SyncMessage = "Uploading changes to server...";
-                var pushResult = await PushChangesInternalAsync(session, _syncCancellation.Token);
+                await PushChangesInternalAsync(session, _syncCancellation.Token);
 
                 SyncProgress = 0.8;
 
@@ -168,6 +198,8 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService
             Status = SyncStatus.Idle;
             SyncProgress = 0;
             SyncMessage = null;
+            _syncCancellation?.Dispose();
+            _syncCancellation = null;
             _syncLock.Release();
         }
     }
@@ -197,7 +229,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService
             IsSyncing = true;
             Status = SyncStatus.PullingChanges;
 
-            var result = await PullChangesInternalAsync(session, _syncCancellation.Token);
+            await PullChangesInternalAsync(session, _syncCancellation.Token);
             await CompleteSyncSessionAsync(session, StorageSyncSessionStatus.Completed);
 
             LastSyncTime = DateTime.UtcNow;
@@ -221,6 +253,8 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService
         {
             IsSyncing = false;
             Status = SyncStatus.Idle;
+            _syncCancellation?.Dispose();
+            _syncCancellation = null;
             _syncLock.Release();
         }
     }
@@ -317,6 +351,8 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService
         {
             IsSyncing = false;
             Status = SyncStatus.Idle;
+            _syncCancellation?.Dispose();
+            _syncCancellation = null;
             _syncLock.Release();
         }
     }
@@ -332,8 +368,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                // In a real implementation, this would send to server via gRPC
-                var success = await SendChangeToServerAsync(change);
+                var success = await _changeUploader.UploadChangeAsync(change, cancellationToken);
 
                 if (success)
                 {
@@ -364,11 +399,11 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService
 
     #region Conflict Resolution
 
-    public async Task<IEnumerable<ConflictInfo>> GetConflictsAsync()
+    public Task<IEnumerable<ConflictInfo>> GetConflictsAsync()
     {
         // In a real implementation, query ConflictRecord table
         // For now, return empty list
-        return new List<ConflictInfo>();
+        return Task.FromResult<IEnumerable<ConflictInfo>>(new List<ConflictInfo>());
     }
 
     public async Task<bool> ResolveConflictAsync(string conflictId, ConflictResolution resolution)
@@ -436,10 +471,10 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService
         }
     }
 
-    private async Task CreateConflictRecordAsync(ServerChange serverChange, Feature localFeature, StorageSyncSession session)
+    private Task CreateConflictRecordAsync(ServerChange serverChange, Feature localFeature, StorageSyncSession session)
     {
         // Implementation would create a ConflictRecord in storage
-        await Task.CompletedTask;
+        return Task.CompletedTask;
     }
 
     #endregion
@@ -463,7 +498,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService
         return session;
     }
 
-    private async Task CompleteSyncSessionAsync(StorageSyncSession session, StorageSyncSessionStatus status, string? errorMessage = null)
+    private Task CompleteSyncSessionAsync(StorageSyncSession session, StorageSyncSessionStatus status, string? errorMessage = null)
     {
         session.EndTime = DateTime.UtcNow;
         session.Status = status;
@@ -471,21 +506,23 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService
 
         // Update in database
         // await _storage.UpdateSyncSessionAsync(session);
+        return Task.CompletedTask;
     }
 
     #endregion
 
     #region Helper Methods
 
-    private async Task<bool> CanSyncAsync()
+    private Task<bool> CanSyncAsync()
     {
-        return _connectivityService.IsConnected && _authService.IsAuthenticated;
+        return Task.FromResult(_connectivityService.IsConnected && _authService.IsAuthenticated);
     }
 
-    public async Task CancelSyncAsync()
+    public Task CancelSyncAsync()
     {
         _syncCancellation?.Cancel();
         Status = SyncStatus.Cancelled;
+        return Task.CompletedTask;
     }
 
     private async Task<List<ServerChange>> GetServerChangesAsync(long sinceGeneration)
@@ -493,13 +530,6 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService
         // Mock implementation - would call actual gRPC service
         await Task.Delay(100);
         return new List<ServerChange>();
-    }
-
-    private async Task<bool> SendChangeToServerAsync(StorageChangeRecord change)
-    {
-        // Mock implementation - would call actual gRPC service
-        await Task.Delay(50);
-        return true;
     }
 
     private async Task<long> GetLatestServerGenerationAsync()
@@ -517,6 +547,47 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService
     }
 
     #endregion
+
+    #region IDisposable
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _pendingChangesCancellation.Cancel();
+        _syncCancellation?.Cancel();
+
+        try
+        {
+            _pendingChangesTask.Wait(TimeSpan.FromSeconds(1));
+        }
+        catch (AggregateException)
+        {
+            // Background status refresh has been cancelled; preserve disposal flow.
+        }
+        finally
+        {
+            _pendingChangesCancellation.Dispose();
+            _syncCancellation?.Dispose();
+            _syncLock.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    #endregion
+}
+
+internal sealed class UnconfiguredFieldCollectionChangeUploader : IFieldCollectionChangeUploader
+{
+    public Task<bool> UploadChangeAsync(StorageChangeRecord change, CancellationToken cancellationToken = default)
+    {
+        throw new InvalidOperationException(
+            "Field collection change upload is not configured. Pending local changes were left unsynced.");
+    }
 }
 
 /// <summary>

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
@@ -632,5 +632,13 @@ LIMIT $limit;
         await alterCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
 
-    private SqliteConnection OpenConnection() => new($"Data Source={_options.DatabasePath}");
+    private SqliteConnection OpenConnection()
+    {
+        var builder = new SqliteConnectionStringBuilder
+        {
+            DataSource = _options.DatabasePath,
+        };
+
+        return new SqliteConnection(builder.ToString());
+    }
 }

--- a/src/Honua.Mobile.Offline/MapAreas/MapAreaDownloader.cs
+++ b/src/Honua.Mobile.Offline/MapAreas/MapAreaDownloader.cs
@@ -44,7 +44,7 @@ public sealed class MapAreaDownloader : IMapAreaDownloader
         }
 
         var packagePath = BuildPackagePath(request.OutputDirectory, request.AreaId);
-        await using var packageConnection = new SqliteConnection($"Data Source={packagePath}");
+        await using var packageConnection = OpenSqliteConnection(packagePath);
         await packageConnection.OpenAsync(ct).ConfigureAwait(false);
 
         await EnsureGeoPackageTablesAsync(packageConnection, ct).ConfigureAwait(false);
@@ -169,6 +169,16 @@ ON CONFLICT(layer_key) DO UPDATE SET
         cmd.Parameters.AddWithValue("$downloaded_at_utc", DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture));
 
         await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    private static SqliteConnection OpenSqliteConnection(string databasePath)
+    {
+        var builder = new SqliteConnectionStringBuilder
+        {
+            DataSource = databasePath,
+        };
+
+        return new SqliteConnection(builder.ToString());
     }
 
     private static string ApplyTemplate(string sourceUrl, MapAreaDownloadRequest request)

--- a/tests/Honua.Mobile.Offline.Tests/GeoPackageSyncStoreTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/GeoPackageSyncStoreTests.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using Honua.Mobile.Offline.GeoPackage;
+using Microsoft.Data.Sqlite;
 
 namespace Honua.Mobile.Offline.Tests;
 
@@ -78,7 +80,7 @@ public sealed class GeoPackageSyncStoreTests : IDisposable
         var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions
         {
             DatabasePath = _databasePath,
-            InProgressLeaseTimeout = TimeSpan.FromMilliseconds(150),
+            InProgressLeaseTimeout = TimeSpan.FromMinutes(5),
         });
         await store.InitializeAsync();
 
@@ -100,7 +102,7 @@ public sealed class GeoPackageSyncStoreTests : IDisposable
         var immediateClaim = await store.GetPendingAsync(1);
         Assert.Empty(immediateClaim);
 
-        await Task.Delay(250);
+        await SetClaimedAtUtcAsync("stale-op", DateTimeOffset.UtcNow.AddMinutes(-10));
 
         var reclaimed = await store.GetPendingAsync(1);
         Assert.Single(reclaimed);
@@ -130,6 +132,35 @@ public sealed class GeoPackageSyncStoreTests : IDisposable
         Assert.Equal(10, mapAreas[0].MinZoom);
     }
 
+    [Fact]
+    public async Task InitializeAsync_HandlesDatabasePathsWithConnectionStringCharacters()
+    {
+        var databasePath = Path.Combine(Path.GetTempPath(), $"honua-mobile-{Guid.NewGuid():N};Mode=Memory.gpkg");
+
+        try
+        {
+            var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions
+            {
+                DatabasePath = databasePath,
+            });
+
+            await store.InitializeAsync();
+            await store.SetSyncCursorAsync("replica", "cursor-1");
+
+            var cursor = await store.GetSyncCursorAsync("replica");
+
+            Assert.Equal("cursor-1", cursor);
+            Assert.True(File.Exists(databasePath));
+        }
+        finally
+        {
+            if (File.Exists(databasePath))
+            {
+                File.Delete(databasePath);
+            }
+        }
+    }
+
     public void Dispose()
     {
         if (File.Exists(_databasePath))
@@ -144,5 +175,27 @@ public sealed class GeoPackageSyncStoreTests : IDisposable
         {
             DatabasePath = _databasePath,
         });
+    }
+
+    private async Task SetClaimedAtUtcAsync(string operationId, DateTimeOffset claimedAtUtc)
+    {
+        var builder = new SqliteConnectionStringBuilder
+        {
+            DataSource = _databasePath,
+        };
+
+        await using var connection = new SqliteConnection(builder.ToString());
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = @"
+UPDATE honua_sync_queue
+SET claimed_at_utc = $claimed_at_utc
+WHERE operation_id = $operation_id;
+";
+        command.Parameters.AddWithValue("$claimed_at_utc", claimedAtUtc.ToString("O", CultureInfo.InvariantCulture));
+        command.Parameters.AddWithValue("$operation_id", operationId);
+
+        await command.ExecuteNonQueryAsync();
     }
 }

--- a/tests/Honua.Mobile.Offline.Tests/MapAreaDownloaderTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/MapAreaDownloaderTests.cs
@@ -60,7 +60,7 @@ public sealed class MapAreaDownloaderTests : IDisposable
         Assert.Single(areas);
         Assert.Equal("oahu-urban", areas[0].AreaId);
 
-        await using var packageConnection = new SqliteConnection($"Data Source={result.GeoPackagePath}");
+        await using var packageConnection = OpenSqliteConnection(result.GeoPackagePath);
         await packageConnection.OpenAsync();
 
         await using var cmd = packageConnection.CreateCommand();
@@ -127,6 +127,55 @@ public sealed class MapAreaDownloaderTests : IDisposable
     }
 
     [Fact]
+    public async Task DownloadAsync_HandlesAreaIdsWithConnectionStringCharacters()
+    {
+        var storePath = Path.Combine(_rootDirectory, "sync-store.gpkg");
+        var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions { DatabasePath = storePath });
+
+        var httpClient = new HttpClient(new StubHttpMessageHandler((request, _) =>
+        {
+            var payload = Encoding.UTF8.GetBytes($"payload:{request.RequestUri}");
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(payload),
+            });
+        }));
+
+        var downloader = new MapAreaDownloader(httpClient, store);
+        var result = await downloader.DownloadAsync(new MapAreaDownloadRequest
+        {
+            AreaId = "oahu;Mode=Memory",
+            Name = "Oahu",
+            BoundingBox = new BoundingBox(-158.30, 21.20, -157.60, 21.60),
+            OutputDirectory = Path.Combine(_rootDirectory, "packages"),
+            MinZoom = 10,
+            MaxZoom = 15,
+            Layers =
+            [
+                new MapLayerDownloadSource
+                {
+                    LayerKey = "assets",
+                    SourceUrl = "https://tiles.honua.test/data",
+                    Priority = 1,
+                    Required = true,
+                },
+            ],
+        });
+
+        Assert.Contains(";Mode=Memory", Path.GetFileNameWithoutExtension(result.GeoPackagePath), StringComparison.Ordinal);
+        Assert.True(File.Exists(result.GeoPackagePath));
+
+        await using var packageConnection = OpenSqliteConnection(result.GeoPackagePath);
+        await packageConnection.OpenAsync();
+
+        await using var cmd = packageConnection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM honua_layer_payloads;";
+        var count = (long)(await cmd.ExecuteScalarAsync() ?? 0L);
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
     public async Task DownloadAsync_WhenLayerPayloadExceedsLimit_ThrowsInvalidOperationException()
     {
         var storePath = Path.Combine(_rootDirectory, "sync-store.gpkg");
@@ -172,6 +221,16 @@ public sealed class MapAreaDownloaderTests : IDisposable
         {
             Directory.Delete(_rootDirectory, recursive: true);
         }
+    }
+
+    private static SqliteConnection OpenSqliteConnection(string databasePath)
+    {
+        var builder = new SqliteConnectionStringBuilder
+        {
+            DataSource = databasePath,
+        };
+
+        return new SqliteConnection(builder.ToString());
     }
 
     private sealed class StubHttpMessageHandler : HttpMessageHandler


### PR DESCRIPTION
## Summary
- prevent FieldCollection offline changes from being marked synced without a configured uploader
- make local feature storage layer-aware and migrate existing local feature tables to a synthetic storage key
- honor spatial relationships and simple where clauses in FieldCollection queries
- harden SQLite connection strings for GeoPackage paths with connection-string characters
- expand CI/test coverage while keeping Android app builds advisory and non-blocking

## Platform Impact
- Android app builds now run in the advisory MAUI Android job, including FieldCollection, but do not block merge.
- Windows MAUI remains a required platform build when source/app changes are detected.

## Offline Impact
- Pending local FieldCollection edits remain pending unless a configured uploader successfully uploads them.
- GeoPackage feature storage now keys features by layer and feature id to avoid cross-layer overwrite.
- SQLite package paths are built with SqliteConnectionStringBuilder so path characters like semicolons are treated as filename data.

## Testing
- dotnet test Honua.Mobile.sln --configuration Release
- dotnet format Honua.Mobile.sln --verify-no-changes --no-restore
- dotnet build src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj --no-restore --configuration Release /p:TreatWarningsAsErrors=true
- dotnet build src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj --no-restore --configuration Release /p:TreatWarningsAsErrors=true
- dotnet build src/Honua.Mobile.Field/Honua.Mobile.Field.csproj --no-restore --configuration Release /p:TreatWarningsAsErrors=true

Android app build was attempted locally and is blocked by missing Android SDK (XA5300), which is why CI now treats Android as advisory.