### PR TITLE
feat: add embeddable map web component

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ permissions: {}
 
 env:
   DOTNET_VERSION: '10.0.x'  # Current repo targets net10
+  NODE_VERSION: '24.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_NOLOGO: true
 
@@ -70,6 +71,11 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: Cache NuGet packages
         uses: actions/cache@v5
         with:
@@ -83,6 +89,7 @@ jobs:
           dotnet restore src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj
           dotnet restore src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj
           dotnet restore src/Honua.Mobile.Field/Honua.Mobile.Field.csproj
+          npm ci --prefix src/Honua.Embed
 
       - name: Build Core Libraries (warnings as errors)
         id: build
@@ -96,6 +103,8 @@ jobs:
 
           dotnet build src/Honua.Mobile.Field/Honua.Mobile.Field.csproj \
             --no-restore --configuration Release /p:TreatWarningsAsErrors=true
+
+          npm run build --prefix src/Honua.Embed
 
       - name: Format Check
         run: |
@@ -121,6 +130,11 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: Cache NuGet packages
         uses: actions/cache@v5
         with:
@@ -135,6 +149,7 @@ jobs:
           dotnet restore tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj
           dotnet restore tests/Honua.Mobile.Field.Tests/Honua.Mobile.Field.Tests.csproj
           dotnet restore tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj
+          npm ci --prefix src/Honua.Embed
 
       - name: Create Test Results Directory
         run: mkdir -p ./TestResults
@@ -185,6 +200,9 @@ jobs:
             --logger "console;verbosity=minimal" \
             --results-directory ./TestResults \
             --collect:"XPlat Code Coverage"
+
+      - name: Run Embed Component Tests
+        run: npm test --prefix src/Honua.Embed
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v7

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ obj/
 *.suo
 TestResults/
 artifacts/
+node_modules/
+dist/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ dynamic forms, and background sync.
 | **Honua.Mobile.Field** | Dynamic forms, validation, calculated fields, record workflow |
 | **Honua.Mobile.Offline** | GeoPackage storage, sync queue, map area download, conflict resolution |
 | **Honua.Mobile.Maui** | MAUI service registration and DI extensions |
+| **@honua/embed** | Framework-agnostic `<honua-map>` web component for ISV embeds |
 
 ## Quick Start
 
@@ -118,6 +119,8 @@ var reachable = await client.Routing.GetServiceAreaAsync(depot, TimeSpan.FromMin
 
 ```
 src/
+  Honua.Embed/                Embeddable map web component package
+    tests/                    Web component DOM behavior tests (9 tests)
   Honua.Mobile.Sdk/           Core mobile client
   Honua.Mobile.Field/         Field collection components
   Honua.Mobile.Offline/       GeoPackage sync engine
@@ -128,7 +131,7 @@ apps/
 tests/
   Honua.Mobile.Sdk.Tests/     HTTP client, transport security, gRPC translation, routing (26 tests)
   Honua.Mobile.Field.Tests/   Validation, calculated fields, workflow (9 tests)
-  Honua.Mobile.Offline.Tests/ Sync engine, conflicts, map download, GeoPackage (40 tests)
+  Honua.Mobile.Offline.Tests/ Sync engine, conflicts, map download, GeoPackage (42 tests)
   Honua.Mobile.Maui.Tests/    MAUI integration helpers, map annotations (12 tests)
   Honua.Mobile.Smoke.Tests/   End-to-end smoke paths (6 tests)
 proto/
@@ -141,6 +144,9 @@ proto/
 dotnet build Honua.Mobile.sln
 dotnet test Honua.Mobile.sln
 dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj
+npm ci --prefix src/Honua.Embed
+npm run build --prefix src/Honua.Embed
+npm test --prefix src/Honua.Embed
 ```
 
 Building Android targets requires a configured Android SDK. The library projects
@@ -150,8 +156,8 @@ without the MAUI workload.
 ## Status
 
 Production-ready foundation for offline sync, forms, and gRPC transport.
-93 tests across 5 test projects. `dotnet test Honua.Mobile.sln` runs the
-SDK, Field, Offline, and MAUI suites; run the Smoke test project separately.
+.NET test coverage across SDK, Field, Offline, MAUI, and Smoke projects, plus
+DOM tests for the embeddable map package.
 
 The IoT module (`Honua.Mobile.IoT`) contains interface definitions only --
 no implementation yet.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -6,6 +6,7 @@ In-depth guides for building with the Honua Mobile SDK.
 |-------|-------------|
 | [Advanced Features](advanced-features.md) | Power-user capabilities including AR, IoT, and AI-assisted workflows |
 | [Camera Integration](camera-integration.md) | Photo and video capture, AI face blurring, and media management |
+| [Embeddable Map](embeddable-map.md) | Framework-agnostic `<honua-map>` web component for ISV integrations |
 | [Migration Guide](migration-guide.md) | Migrating from other field collection platforms to Honua |
 | [Offline Sync](offline-sync.md) | GeoPackage storage, sync engine configuration, and conflict resolution |
 | [Performance](performance.md) | Optimizing startup time, memory usage, and sync throughput |

--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -1,0 +1,39 @@
+# Embeddable Map Component
+
+`@honua/embed` provides a framework-agnostic `<honua-map>` custom element for ISV and SaaS integrations.
+
+```html
+<script type="module">
+  import '@honua/embed';
+</script>
+
+<honua-map
+  service-url="https://services.honua.example/FeatureServer"
+  layer-ids="assets,work-orders"
+  center="21.3069,-157.8583"
+  zoom="12"
+  interactive
+  search
+  identify>
+</honua-map>
+```
+
+The component is white-label by default: it does not render Honua branding unless an integrator provides their own attribution. Host applications can style it with CSS custom properties without leaking styles into the map internals.
+
+## Integration Events
+
+```js
+const map = document.querySelector('honua-map');
+
+map.addEventListener('honua-map-search', (event) => {
+  console.log(event.detail.query);
+});
+
+map.addEventListener('honua-map-identify', (event) => {
+  console.log(event.detail.x, event.detail.y);
+});
+```
+
+## First Slice Scope
+
+This initial package establishes the web component API, Shadow DOM encapsulation, declarative attributes, theme hooks, accessible controls, and test coverage. Follow-on work can add a production map renderer, feature loading, generated embed snippets, analytics, and framework-specific wrappers.

--- a/examples/embed-basic/README.md
+++ b/examples/embed-basic/README.md
@@ -1,0 +1,11 @@
+# Basic Embed Example
+
+From the repository root, build the web component package before opening the example:
+
+```bash
+npm ci --prefix src/Honua.Embed
+npm run build --prefix src/Honua.Embed
+python3 -m http.server 8080
+```
+
+Then open `http://localhost:8080/examples/embed-basic/`.

--- a/examples/embed-basic/index.html
+++ b/examples/embed-basic/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Honua Embed Example</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 32px;
+        color: #13212c;
+        background: #f6f8fa;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      main {
+        max-width: 960px;
+        margin: 0 auto;
+      }
+
+      honua-map {
+        height: 520px;
+        --honua-map-accent: #1f7a8c;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <honua-map
+        service-url="https://services.honua.example/FeatureServer"
+        layer-ids="assets,work-orders"
+        center="21.3069,-157.8583"
+        zoom="12"
+        basemap="streets"
+        interactive
+        search
+        identify
+        attribution="Example city GIS">
+      </honua-map>
+    </main>
+    <script type="module" src="../../src/Honua.Embed/dist/index.js"></script>
+  </body>
+</html>

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -1,0 +1,70 @@
+# @honua/embed
+
+Framework-agnostic web component for embedding Honua map views in SaaS and ISV applications.
+
+## Install
+
+```bash
+npm install @honua/embed
+```
+
+## Use
+
+```html
+<script type="module">
+  import '@honua/embed';
+</script>
+
+<honua-map
+  service-url="https://services.honua.example/FeatureServer"
+  layer-ids="assets,work-orders"
+  center="21.3069,-157.8583"
+  zoom="12"
+  basemap="streets"
+  interactive
+  search
+  identify
+  attribution="City GIS">
+</honua-map>
+```
+
+## Attributes
+
+| Attribute | Purpose |
+| --- | --- |
+| `service-url` | Honua service or FeatureServer base URL. |
+| `layer-ids` | Comma-separated layer identifiers. |
+| `api-key` | API key for integrations. It is available in `element.config` but never rendered. |
+| `center` | Initial latitude/longitude pair, for example `21.3069,-157.8583`. |
+| `zoom` | Initial zoom level, clamped from `0` to `24`. |
+| `bbox` | Initial bounds as `minLon,minLat,maxLon,maxLat`. |
+| `basemap` | `streets`, `satellite`, `dark`, or an integration-defined style id. |
+| `interactive` | Enables keyboard focus and zoom controls. |
+| `search` | Shows the search control and emits `honua-map-search`. |
+| `identify` | Enables click/identify events and emits `honua-map-identify`. |
+| `attribution` | Optional attribution text. No Honua branding is shown by default. |
+| `theme` | `light` or `dark`. |
+
+## Events
+
+| Event | Detail |
+| --- | --- |
+| `honua-map-ready` | Current `HonuaMapConfig`. |
+| `honua-map-config-change` | Current `HonuaMapConfig`. |
+| `honua-map-search` | `{ query, config }`. |
+| `honua-map-identify` | `{ x, y, config }`. |
+
+## Styling
+
+The component uses Shadow DOM and exposes CSS custom properties:
+
+```css
+honua-map {
+  --honua-map-accent: #1f7a8c;
+  --honua-map-surface: #ffffff;
+  --honua-map-border: rgba(19, 33, 44, 0.16);
+  --honua-map-font-family: Inter, sans-serif;
+}
+```
+
+This first slice provides the embeddable API, accessibility shell, theming, and integration events. A future slice can connect the visual surface to a full map renderer and Honua feature/query endpoints.

--- a/src/Honua.Embed/package-lock.json
+++ b/src/Honua.Embed/package-lock.json
@@ -1,0 +1,1405 @@
+{
+  "name": "@honua/embed",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@honua/embed",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "happy-dom": "^20.0.10",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.15"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/src/Honua.Embed/package.json
+++ b/src/Honua.Embed/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@honua/embed",
+  "version": "0.1.0",
+  "description": "Framework-agnostic Honua embeddable map web component.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "keywords": [
+    "honua",
+    "map",
+    "web-component",
+    "gis"
+  ],
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "happy-dom": "^20.0.10",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.15"
+  }
+}

--- a/src/Honua.Embed/src/index.ts
+++ b/src/Honua.Embed/src/index.ts
@@ -1,0 +1,579 @@
+export interface HonuaMapCoordinate {
+  latitude: number;
+  longitude: number;
+}
+
+export interface HonuaMapBounds {
+  minLongitude: number;
+  minLatitude: number;
+  maxLongitude: number;
+  maxLatitude: number;
+}
+
+export interface HonuaMapConfig {
+  serviceUrl: string | null;
+  layerIds: string[];
+  apiKey: string | null;
+  center: HonuaMapCoordinate | null;
+  zoom: number;
+  bounds: HonuaMapBounds | null;
+  basemap: string;
+  interactive: boolean;
+  search: boolean;
+  identify: boolean;
+  attribution: string | null;
+  theme: 'light' | 'dark';
+}
+
+export interface HonuaMapIdentifyDetail {
+  x: number;
+  y: number;
+  config: HonuaMapConfig;
+}
+
+export interface HonuaMapSearchDetail {
+  query: string;
+  config: HonuaMapConfig;
+}
+
+const DEFAULT_ZOOM = 10;
+const ELEMENT_NAME = 'honua-map';
+
+const template = document.createElement('template');
+template.innerHTML = `
+  <style>
+    :host {
+      --honua-map-background: #f4f7f9;
+      --honua-map-foreground: #13212c;
+      --honua-map-muted: #566774;
+      --honua-map-accent: #1f7a8c;
+      --honua-map-surface: #ffffff;
+      --honua-map-border: rgba(19, 33, 44, 0.16);
+      --honua-map-control-size: 36px;
+      --honua-map-font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      display: block;
+      min-height: 280px;
+      color: var(--honua-map-foreground);
+      font-family: var(--honua-map-font-family);
+    }
+
+    :host([theme="dark"]) {
+      --honua-map-background: #101820;
+      --honua-map-foreground: #eef5f7;
+      --honua-map-muted: #a9b8bf;
+      --honua-map-accent: #4fb4c8;
+      --honua-map-surface: #15232d;
+      --honua-map-border: rgba(238, 245, 247, 0.2);
+    }
+
+    .map {
+      position: relative;
+      min-height: inherit;
+      height: 100%;
+      overflow: hidden;
+      background: var(--honua-map-background);
+      border: 1px solid var(--honua-map-border);
+      border-radius: 8px;
+      box-sizing: border-box;
+    }
+
+    .map:focus-visible {
+      outline: 3px solid color-mix(in srgb, var(--honua-map-accent) 60%, transparent);
+      outline-offset: 2px;
+    }
+
+    .surface {
+      position: absolute;
+      inset: 0;
+      background-color: #dfe9ea;
+      background-image:
+        linear-gradient(rgba(31, 122, 140, 0.16) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(31, 122, 140, 0.16) 1px, transparent 1px),
+        radial-gradient(circle at 42% 48%, rgba(82, 145, 108, 0.24), transparent 28%),
+        radial-gradient(circle at 62% 36%, rgba(64, 129, 161, 0.18), transparent 24%);
+      background-size: 48px 48px, 48px 48px, 100% 100%, 100% 100%;
+    }
+
+    .surface[data-basemap="dark"] {
+      background-color: #14212b;
+      background-image:
+        linear-gradient(rgba(79, 180, 200, 0.2) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(79, 180, 200, 0.2) 1px, transparent 1px),
+        radial-gradient(circle at 40% 44%, rgba(76, 143, 113, 0.24), transparent 30%),
+        radial-gradient(circle at 66% 38%, rgba(81, 121, 176, 0.18), transparent 22%);
+    }
+
+    .surface[data-basemap="satellite"] {
+      background-color: #48644d;
+      background-image:
+        radial-gradient(circle at 24% 26%, rgba(96, 133, 75, 0.82), transparent 20%),
+        radial-gradient(circle at 72% 62%, rgba(52, 90, 105, 0.66), transparent 24%),
+        linear-gradient(145deg, rgba(25, 39, 28, 0.45), rgba(88, 116, 72, 0.3));
+    }
+
+    .surface[data-basemap="streets"] {
+      background-image:
+        linear-gradient(35deg, transparent 47%, rgba(255, 255, 255, 0.78) 48%, rgba(255, 255, 255, 0.78) 52%, transparent 53%),
+        linear-gradient(110deg, transparent 47%, rgba(255, 255, 255, 0.62) 48%, rgba(255, 255, 255, 0.62) 52%, transparent 53%),
+        linear-gradient(rgba(31, 122, 140, 0.12) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(31, 122, 140, 0.12) 1px, transparent 1px);
+      background-size: 100% 100%, 100% 100%, 48px 48px, 48px 48px;
+    }
+
+    .toolbar,
+    .layers,
+    .meta,
+    .controls,
+    .popup {
+      position: absolute;
+      z-index: 1;
+    }
+
+    .toolbar {
+      top: 12px;
+      left: 12px;
+      right: 12px;
+      display: none;
+    }
+
+    :host([search]:not([search="false"]):not([search="0"]):not([search="no"])) .toolbar {
+      display: block;
+    }
+
+    .search {
+      display: flex;
+      max-width: 440px;
+      background: var(--honua-map-surface);
+      border: 1px solid var(--honua-map-border);
+      border-radius: 8px;
+      box-shadow: 0 10px 28px rgba(19, 33, 44, 0.14);
+    }
+
+    input {
+      min-width: 0;
+      flex: 1;
+      height: 38px;
+      padding: 0 12px;
+      color: var(--honua-map-foreground);
+      background: transparent;
+      border: 0;
+      font: inherit;
+      outline: 0;
+    }
+
+    button {
+      width: var(--honua-map-control-size);
+      height: var(--honua-map-control-size);
+      color: var(--honua-map-foreground);
+      background: var(--honua-map-surface);
+      border: 1px solid var(--honua-map-border);
+      border-radius: 6px;
+      font: inherit;
+      font-size: 18px;
+      line-height: 1;
+      cursor: pointer;
+    }
+
+    button:hover {
+      border-color: var(--honua-map-accent);
+    }
+
+    svg {
+      width: 18px;
+      height: 18px;
+      stroke: currentColor;
+      stroke-width: 2;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      fill: none;
+      pointer-events: none;
+    }
+
+    .search button {
+      height: 38px;
+      border-width: 0 0 0 1px;
+      border-radius: 0 8px 8px 0;
+    }
+
+    .controls {
+      right: 12px;
+      top: 12px;
+      display: none;
+      gap: 6px;
+      flex-direction: column;
+    }
+
+    :host([interactive]:not([interactive="false"]):not([interactive="0"]):not([interactive="no"])) .controls {
+      display: flex;
+    }
+
+    :host([search]:not([search="false"]):not([search="0"]):not([search="no"])) .controls {
+      top: 62px;
+    }
+
+    .layers {
+      left: 12px;
+      bottom: 12px;
+      display: flex;
+      max-width: calc(100% - 24px);
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .layer {
+      max-width: 180px;
+      overflow: hidden;
+      padding: 4px 8px;
+      color: var(--honua-map-foreground);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      background: color-mix(in srgb, var(--honua-map-surface) 88%, transparent);
+      border: 1px solid var(--honua-map-border);
+      border-radius: 999px;
+      font-size: 12px;
+    }
+
+    .meta {
+      right: 12px;
+      bottom: 12px;
+      max-width: min(420px, calc(100% - 24px));
+      color: var(--honua-map-muted);
+      font-size: 12px;
+      text-align: right;
+    }
+
+    .marker {
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: 18px;
+      height: 18px;
+      transform: translate(-50%, -50%) rotate(45deg);
+      background: var(--honua-map-accent);
+      border: 2px solid var(--honua-map-surface);
+      border-radius: 50% 50% 50% 0;
+      box-shadow: 0 3px 10px rgba(19, 33, 44, 0.3);
+    }
+
+    .popup {
+      display: none;
+      min-width: 160px;
+      padding: 8px 10px;
+      color: var(--honua-map-foreground);
+      background: var(--honua-map-surface);
+      border: 1px solid var(--honua-map-border);
+      border-radius: 8px;
+      box-shadow: 0 14px 30px rgba(19, 33, 44, 0.16);
+      font-size: 13px;
+      pointer-events: none;
+    }
+
+    .popup[data-open="true"] {
+      display: block;
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+    }
+  </style>
+  <section class="map" role="application" aria-label="Embedded map">
+    <div class="surface"></div>
+    <div class="marker" aria-hidden="true"></div>
+    <form class="toolbar" part="toolbar">
+      <div class="search">
+        <label class="sr-only" for="honua-map-search">Search</label>
+        <input id="honua-map-search" name="search" type="search" autocomplete="off" placeholder="Search">
+        <button type="submit" aria-label="Search">
+          <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+            <circle cx="11" cy="11" r="7"></circle>
+            <path d="m20 20-3.5-3.5"></path>
+          </svg>
+        </button>
+      </div>
+    </form>
+    <div class="controls" part="controls">
+      <button type="button" data-action="zoom-in" aria-label="Zoom in">+</button>
+      <button type="button" data-action="zoom-out" aria-label="Zoom out">&minus;</button>
+    </div>
+    <div class="layers" part="layers"></div>
+    <output class="popup" part="popup"></output>
+    <div class="meta" part="attribution"></div>
+  </section>
+`;
+
+export class HonuaMapElement extends HTMLElement {
+  static get observedAttributes(): string[] {
+    return [
+      'service-url',
+      'layer-ids',
+      'api-key',
+      'center',
+      'zoom',
+      'bbox',
+      'basemap',
+      'interactive',
+      'search',
+      'identify',
+      'attribution',
+      'theme',
+    ];
+  }
+
+  readonly #root: ShadowRoot;
+  #readyDispatched = false;
+
+  constructor() {
+    super();
+    this.#root = this.attachShadow({ mode: 'open' });
+    this.#root.append(template.content.cloneNode(true));
+  }
+
+  get config(): HonuaMapConfig {
+    return readConfig(this);
+  }
+
+  connectedCallback(): void {
+    this.#upgradeProperty('center');
+    this.#upgradeProperty('zoom');
+    this.#render();
+    this.#bindEvents();
+
+    if (!this.#readyDispatched) {
+      this.#readyDispatched = true;
+      this.dispatchEvent(new CustomEvent('honua-map-ready', {
+        bubbles: true,
+        composed: true,
+        detail: this.config,
+      }));
+    }
+  }
+
+  attributeChangedCallback(): void {
+    this.#render();
+    this.dispatchEvent(new CustomEvent('honua-map-config-change', {
+      bubbles: true,
+      composed: true,
+      detail: this.config,
+    }));
+  }
+
+  setView(center: HonuaMapCoordinate, zoom = this.config.zoom): void {
+    this.setAttribute('center', `${center.latitude},${center.longitude}`);
+    this.setAttribute('zoom', String(clampZoom(zoom)));
+  }
+
+  refresh(): void {
+    this.#render();
+  }
+
+  identifyAt(x: number, y: number): void {
+    if (!this.config.identify) {
+      return;
+    }
+
+    const popup = this.#query<HTMLOutputElement>('.popup');
+    popup.style.left = `${Math.max(8, x)}px`;
+    popup.style.top = `${Math.max(8, y)}px`;
+    popup.dataset.open = 'true';
+    popup.value = `x ${Math.round(x)}, y ${Math.round(y)}`;
+
+    this.dispatchEvent(new CustomEvent<HonuaMapIdentifyDetail>('honua-map-identify', {
+      bubbles: true,
+      composed: true,
+      detail: { x, y, config: this.config },
+    }));
+  }
+
+  #bindEvents(): void {
+    this.#query<HTMLFormElement>('.toolbar').onsubmit = (event) => {
+      event.preventDefault();
+      if (!this.config.search) {
+        return;
+      }
+
+      const input = this.#query<HTMLInputElement>('input[type="search"]');
+      const query = input.value.trim();
+      if (query.length === 0) {
+        return;
+      }
+
+      this.dispatchEvent(new CustomEvent<HonuaMapSearchDetail>('honua-map-search', {
+        bubbles: true,
+        composed: true,
+        detail: { query, config: this.config },
+      }));
+    };
+
+    this.#query<HTMLElement>('.surface').onclick = (event) => {
+      const rect = this.#query<HTMLElement>('.map').getBoundingClientRect();
+      this.identifyAt(event.clientX - rect.left, event.clientY - rect.top);
+    };
+
+    this.#query<HTMLElement>('.controls').onclick = (event) => {
+      if (!this.config.interactive) {
+        return;
+      }
+
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+
+      if (target.dataset.action === 'zoom-in') {
+        this.setAttribute('zoom', String(clampZoom(this.config.zoom + 1)));
+      }
+
+      if (target.dataset.action === 'zoom-out') {
+        this.setAttribute('zoom', String(clampZoom(this.config.zoom - 1)));
+      }
+    };
+
+    this.#query<HTMLElement>('.map').onkeydown = (event) => {
+      if (!this.config.interactive) {
+        return;
+      }
+
+      if (event.key === '+' || event.key === '=') {
+        event.preventDefault();
+        this.setAttribute('zoom', String(clampZoom(this.config.zoom + 1)));
+      }
+
+      if (event.key === '-' || event.key === '_') {
+        event.preventDefault();
+        this.setAttribute('zoom', String(clampZoom(this.config.zoom - 1)));
+      }
+    };
+  }
+
+  #render(): void {
+    const config = this.config;
+    const map = this.#query<HTMLElement>('.map');
+    const surface = this.#query<HTMLElement>('.surface');
+    const layers = this.#query<HTMLElement>('.layers');
+    const meta = this.#query<HTMLElement>('.meta');
+
+    map.tabIndex = config.interactive ? 0 : -1;
+    surface.dataset.basemap = config.basemap;
+    layers.replaceChildren(...config.layerIds.map((layerId) => {
+      const chip = document.createElement('span');
+      chip.className = 'layer';
+      chip.setAttribute('part', 'layer');
+      chip.textContent = layerId;
+      return chip;
+    }));
+    meta.textContent = config.attribution ?? '';
+  }
+
+  #query<T extends Element>(selector: string): T {
+    const element = this.#root.querySelector<T>(selector);
+    if (!element) {
+      throw new Error(`Missing Honua embed element: ${selector}`);
+    }
+
+    return element;
+  }
+
+  #upgradeProperty(propertyName: string): void {
+    if (!Object.prototype.hasOwnProperty.call(this, propertyName)) {
+      return;
+    }
+
+    const value = (this as unknown as Record<string, unknown>)[propertyName];
+    delete (this as unknown as Record<string, unknown>)[propertyName];
+    (this as unknown as Record<string, unknown>)[propertyName] = value;
+  }
+}
+
+export function defineHonuaMapElement(name = ELEMENT_NAME): CustomElementConstructor {
+  const existing = customElements.get(name);
+  if (existing) {
+    return existing;
+  }
+
+  customElements.define(name, HonuaMapElement);
+  return HonuaMapElement;
+}
+
+function readConfig(element: HTMLElement): HonuaMapConfig {
+  return {
+    serviceUrl: emptyToNull(element.getAttribute('service-url')),
+    layerIds: splitList(element.getAttribute('layer-ids')),
+    apiKey: emptyToNull(element.getAttribute('api-key')),
+    center: parseCoordinate(element.getAttribute('center')),
+    zoom: clampZoom(parseNumber(element.getAttribute('zoom')) ?? DEFAULT_ZOOM),
+    bounds: parseBounds(element.getAttribute('bbox')),
+    basemap: element.getAttribute('basemap')?.trim() || 'streets',
+    interactive: parseBooleanAttribute(element, 'interactive'),
+    search: parseBooleanAttribute(element, 'search'),
+    identify: parseBooleanAttribute(element, 'identify'),
+    attribution: emptyToNull(element.getAttribute('attribution')),
+    theme: element.getAttribute('theme') === 'dark' ? 'dark' : 'light',
+  };
+}
+
+function emptyToNull(value: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function splitList(value: string | null): string[] {
+  return value
+    ?.split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0) ?? [];
+}
+
+function parseCoordinate(value: string | null): HonuaMapCoordinate | null {
+  const [latitude, longitude] = splitList(value).map(Number);
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    return null;
+  }
+
+  return { latitude, longitude };
+}
+
+function parseBounds(value: string | null): HonuaMapBounds | null {
+  const [minLongitude, minLatitude, maxLongitude, maxLatitude] = splitList(value).map(Number);
+  if (![minLongitude, minLatitude, maxLongitude, maxLatitude].every(Number.isFinite)) {
+    return null;
+  }
+
+  return { minLongitude, minLatitude, maxLongitude, maxLatitude };
+}
+
+function parseNumber(value: string | null): number | null {
+  if (value === null) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseBooleanAttribute(element: HTMLElement, name: string): boolean {
+  if (!element.hasAttribute(name)) {
+    return false;
+  }
+
+  const value = element.getAttribute(name);
+  return value === '' || value === null || !['false', '0', 'no'].includes(value.toLowerCase());
+}
+
+function clampZoom(value: number): number {
+  return Math.max(0, Math.min(24, Math.round(value)));
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'honua-map': HonuaMapElement;
+  }
+}
+
+if (typeof customElements !== 'undefined') {
+  defineHonuaMapElement();
+}

--- a/src/Honua.Embed/tests/honua-map.test.ts
+++ b/src/Honua.Embed/tests/honua-map.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineHonuaMapElement, HonuaMapElement } from '../src/index';
+
+describe('honua-map', () => {
+  beforeEach(() => {
+    defineHonuaMapElement();
+    document.body.replaceChildren();
+  });
+
+  it('defines the custom element idempotently', () => {
+    const first = defineHonuaMapElement();
+    const second = defineHonuaMapElement();
+
+    expect(first).toBe(HonuaMapElement);
+    expect(second).toBe(HonuaMapElement);
+    expect(customElements.get('honua-map')).toBe(HonuaMapElement);
+  });
+
+  it('parses declarative attributes into map config', () => {
+    const element = document.createElement('honua-map');
+    element.setAttribute('service-url', 'https://services.honua.test/FeatureServer');
+    element.setAttribute('layer-ids', 'parcels, roads, zoning');
+    element.setAttribute('api-key', 'secret-key');
+    element.setAttribute('center', '21.3069,-157.8583');
+    element.setAttribute('zoom', '13');
+    element.setAttribute('bbox', '-158.3,21.2,-157.6,21.6');
+    element.setAttribute('basemap', 'satellite');
+    element.setAttribute('interactive', '');
+    element.setAttribute('search', '');
+    element.setAttribute('identify', '');
+    element.setAttribute('attribution', 'City GIS');
+
+    document.body.append(element);
+
+    expect(element.config).toMatchObject({
+      serviceUrl: 'https://services.honua.test/FeatureServer',
+      layerIds: ['parcels', 'roads', 'zoning'],
+      apiKey: 'secret-key',
+      center: { latitude: 21.3069, longitude: -157.8583 },
+      zoom: 13,
+      bounds: {
+        minLongitude: -158.3,
+        minLatitude: 21.2,
+        maxLongitude: -157.6,
+        maxLatitude: 21.6,
+      },
+      basemap: 'satellite',
+      interactive: true,
+      search: true,
+      identify: true,
+      attribution: 'City GIS',
+    });
+  });
+
+  it('treats false boolean attribute values as disabled', () => {
+    const element = document.createElement('honua-map');
+    element.setAttribute('interactive', 'false');
+    element.setAttribute('search', '0');
+    element.setAttribute('identify', 'no');
+
+    document.body.append(element);
+
+    expect(element.config).toMatchObject({
+      interactive: false,
+      search: false,
+      identify: false,
+    });
+    expect(element.shadowRoot!.querySelector<HTMLElement>('.map')!.tabIndex).toBe(-1);
+  });
+
+  it('renders layer chips and omits api keys from the shadow DOM', () => {
+    const element = document.createElement('honua-map');
+    element.setAttribute('layer-ids', 'assets, work-orders');
+    element.setAttribute('api-key', 'do-not-render');
+
+    document.body.append(element);
+
+    const layerText = [...element.shadowRoot!.querySelectorAll('.layer')]
+      .map((node) => node.textContent);
+
+    expect(layerText).toEqual(['assets', 'work-orders']);
+    expect(element.shadowRoot!.textContent).not.toContain('do-not-render');
+  });
+
+  it('dispatches search events from the optional search control', () => {
+    const element = document.createElement('honua-map');
+    element.setAttribute('search', '');
+    document.body.append(element);
+    const listener = vi.fn();
+    element.addEventListener('honua-map-search', listener);
+
+    const input = element.shadowRoot!.querySelector<HTMLInputElement>('input[type="search"]')!;
+    const form = element.shadowRoot!.querySelector<HTMLFormElement>('form')!;
+    input.value = 'hydrants';
+    form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }));
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail.query).toBe('hydrants');
+  });
+
+  it('keeps disabled controls inert even when events are dispatched programmatically', () => {
+    const element = document.createElement('honua-map');
+    element.setAttribute('zoom', '10');
+    element.setAttribute('search', 'false');
+    document.body.append(element);
+    const listener = vi.fn();
+    element.addEventListener('honua-map-search', listener);
+
+    const input = element.shadowRoot!.querySelector<HTMLInputElement>('input[type="search"]')!;
+    const form = element.shadowRoot!.querySelector<HTMLFormElement>('form')!;
+    const zoomIn = element.shadowRoot!.querySelector<HTMLButtonElement>('[data-action="zoom-in"]')!;
+    input.value = 'hydrants';
+    form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }));
+    zoomIn.click();
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(element.config.zoom).toBe(10);
+  });
+
+  it('dispatches identify events only when identify is enabled', () => {
+    const element = document.createElement('honua-map');
+    document.body.append(element);
+    const listener = vi.fn();
+    element.addEventListener('honua-map-identify', listener);
+
+    element.identifyAt(12, 34);
+    expect(listener).not.toHaveBeenCalled();
+
+    element.setAttribute('identify', '');
+    element.identifyAt(12, 34);
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail).toMatchObject({ x: 12, y: 34 });
+    expect(element.shadowRoot!.querySelector<HTMLOutputElement>('.popup')!.dataset.open).toBe('true');
+  });
+
+  it('updates view through the public API and keyboard zoom controls', () => {
+    const element = document.createElement('honua-map');
+    element.setAttribute('interactive', '');
+    document.body.append(element);
+
+    element.setView({ latitude: 20.75, longitude: -156.45 }, 9);
+    expect(element.getAttribute('center')).toBe('20.75,-156.45');
+    expect(element.getAttribute('zoom')).toBe('9');
+
+    const map = element.shadowRoot!.querySelector<HTMLElement>('.map')!;
+    map.dispatchEvent(new KeyboardEvent('keydown', { key: '+', bubbles: true }));
+    expect(element.config.zoom).toBe(10);
+  });
+
+  it('does not show Honua branding by default', () => {
+    const element = document.createElement('honua-map');
+    document.body.append(element);
+
+    const visibleText = [
+      ...element.shadowRoot!.querySelectorAll('.layer, .meta, .popup'),
+    ].map((node) => node.textContent).join(' ');
+
+    expect(visibleText.toLowerCase()).not.toContain('honua');
+  });
+});

--- a/src/Honua.Embed/tsconfig.json
+++ b/src/Honua.Embed/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["DOM", "ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/src/Honua.Embed/vitest.config.ts
+++ b/src/Honua.Embed/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- Add the `@honua/embed` package with a framework-agnostic `<honua-map>` custom element, Shadow DOM encapsulation, declarative attributes, theming hooks, and integration events.
- Add DOM behavior tests, package docs, an embeddable-map guide, and a basic static example.
- Wire the package build and tests into CI with Node 24 while leaving Android advisory behavior unchanged.

## Scope
Related to #10.

This lands the web component foundation for the broader embeddable map ticket. Server-backed analytics, CDN publishing, iframe fallback service, admin builder, and framework wrapper packages remain follow-on work.

## Testing
- `npm run build --prefix src/Honua.Embed`
- `npm test --prefix src/Honua.Embed` (9 tests)
- Built-package import smoke test with happy-dom
- `dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --configuration Release`
- `dotnet test tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj --configuration Release`
- `dotnet test tests/Honua.Mobile.Field.Tests/Honua.Mobile.Field.Tests.csproj --configuration Release`
- `dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --configuration Release`
- `dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --configuration Release`
- `dotnet format` verification for Sdk, Offline, and Field projects
- `git diff --check`

## Breaking Changes
None.