### PR TITLE
feat(sdk): add scene metadata client

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ dynamic forms, and background sync.
 
 | Package | Purpose |
 |---------|---------|
-| **Honua.Mobile.Sdk** | Transport, auth, gRPC-first client, REST fallback, routing SDK |
+| **Honua.Mobile.Sdk** | Transport, auth, gRPC-first client, REST fallback, routing and scene metadata SDK |
 | **Honua.Mobile.Field** | Dynamic forms, validation, calculated fields, record workflow |
 | **Honua.Mobile.Offline** | GeoPackage storage, sync queue, map area download, conflict resolution |
 | **Honua.Mobile.Maui** | MAUI service registration and DI extensions |
@@ -32,6 +32,7 @@ builder.Services
         PreferGrpcForFeatureQueries = true,
     })
     .AddHonuaRouting()
+    .AddHonuaScenes()
     .AddHonuaApiOfflineUploader()
     .AddHonuaMobileFieldCollection()
     .AddHonuaGeoPackageOfflineSync(
@@ -115,12 +116,31 @@ var optimized = await client.Routing.Route()
 var reachable = await client.Routing.GetServiceAreaAsync(depot, TimeSpan.FromMinutes(30));
 ```
 
+## 3D Scene Metadata
+
+Scene discovery resolves server-managed 3D Tiles and terrain URLs before a
+renderer loads them:
+
+```csharp
+using Honua.Mobile.Sdk.Scenes;
+
+var scene = await client.Scenes.ResolveSceneAsync(
+    "downtown-honolulu",
+    new HonuaSceneResolveRequest
+    {
+        RequiredCapabilities = new[] { HonuaSceneCapabilities.ThreeDimensionalTiles },
+    });
+
+var tilesetUrl = scene.TilesetUrl;
+var terrainUrl = scene.TerrainUrl;
+```
+
 ## Repository Structure
 
 ```
 src/
   Honua.Embed/                Embeddable map web component package
-    tests/                    Web component DOM behavior tests (14 tests)
+    tests/                    Web component DOM behavior tests (17 tests)
   Honua.Mobile.Sdk/           Core mobile client
   Honua.Mobile.Field/         Field collection components
   Honua.Mobile.Offline/       GeoPackage sync engine
@@ -129,7 +149,7 @@ src/
 apps/
   Honua.Mobile.App/           Reference MAUI application
 tests/
-  Honua.Mobile.Sdk.Tests/     HTTP client, transport security, gRPC translation, routing (26 tests)
+  Honua.Mobile.Sdk.Tests/     HTTP client, transport security, gRPC translation, routing, scenes (35 tests)
   Honua.Mobile.Field.Tests/   Validation, calculated fields, workflow (9 tests)
   Honua.Mobile.Offline.Tests/ Sync engine, conflicts, map download, GeoPackage (42 tests)
   Honua.Mobile.Maui.Tests/    MAUI integration helpers, map annotations (12 tests)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ src/
 apps/
   Honua.Mobile.App/           Reference MAUI application
 tests/
-  Honua.Mobile.Sdk.Tests/     HTTP client, transport security, gRPC translation, routing, scenes (35 tests)
+  Honua.Mobile.Sdk.Tests/     HTTP client, transport security, gRPC translation, routing, scenes (36 tests)
   Honua.Mobile.Field.Tests/   Validation, calculated fields, workflow (9 tests)
   Honua.Mobile.Offline.Tests/ Sync engine, conflicts, map download, GeoPackage (42 tests)
   Honua.Mobile.Maui.Tests/    MAUI integration helpers, map annotations (12 tests)

--- a/docs/guides/3d-scene-embed.md
+++ b/docs/guides/3d-scene-embed.md
@@ -18,6 +18,32 @@
 
 CesiumJS is Apache-2.0 open source. The component does not require Cesium ion for external or Honua-hosted 3D Tiles URLs. Integrators can pass `ion-token` only when they choose to use Cesium ion assets or services.
 
+## SDK Discovery
+
+Mobile and web hosts can resolve scene metadata through `HonuaSceneService` before assigning URLs to the renderer.
+
+```csharp
+using Honua.Mobile.Sdk.Scenes;
+
+var scene = await client.Scenes.ResolveSceneAsync(
+    "downtown-honolulu",
+    new HonuaSceneResolveRequest
+    {
+        RequiredCapabilities = new[] { HonuaSceneCapabilities.ThreeDimensionalTiles },
+    });
+```
+
+```js
+const element = document.querySelector('honua-scene');
+const resolvedScene = await fetch('/scene-config/downtown-honolulu').then((response) => response.json());
+
+element.setAttribute('tileset-url', resolvedScene.tilesetUrl);
+
+if (resolvedScene.terrainUrl) {
+  element.setAttribute('terrain-url', resolvedScene.terrainUrl);
+}
+```
+
 ## Events
 
 ```js
@@ -42,4 +68,4 @@ The package build copies Cesium `Assets`, `Workers`, `ThirdParty`, and `Widgets`
 
 ## Current Scope
 
-This first slice proves client-side 3D Tiles loading and scene events. Honua-hosted scene registry, terrain tiles, elevation APIs, 3D Tiles generation, and I3S compatibility are tracked in the linked server backlog.
+This first slice proves client-side 3D Tiles loading, scene events, and typed SDK scene discovery. Honua-hosted scene registry, terrain tiles, elevation APIs, 3D Tiles generation, and I3S compatibility are tracked in the linked server backlog.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -4,7 +4,7 @@ In-depth guides for building with the Honua Mobile SDK.
 
 | Guide | Description |
 |-------|-------------|
-| [3D Scene Embed](3d-scene-embed.md) | CesiumJS-backed `<honua-scene>` component for 3D Tiles |
+| [3D Scene Embed](3d-scene-embed.md) | Scene metadata discovery and CesiumJS-backed `<honua-scene>` rendering |
 | [Advanced Features](advanced-features.md) | Power-user capabilities including AR, IoT, and AI-assisted workflows |
 | [Camera Integration](camera-integration.md) | Photo and video capture, AI face blurring, and media management |
 | [Embeddable Map](embeddable-map.md) | Framework-agnostic `<honua-map>` web component for ISV integrations |

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Honua.Mobile.Offline.MapAreas;
 using Honua.Mobile.Offline.Sync;
 using Honua.Mobile.Sdk;
 using Honua.Mobile.Sdk.Routing;
+using Honua.Mobile.Sdk.Scenes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -66,6 +67,20 @@ public static class HonuaMobileServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddSingleton(sp => sp.GetRequiredService<HonuaMobileClient>().Routing);
+        return services;
+    }
+
+    /// <summary>
+    /// Registers <see cref="IHonuaSceneService"/> from the configured <see cref="HonuaMobileClient"/>.
+    /// Requires <see cref="AddHonuaMobileSdk"/> to be called first.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaScenes(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<IHonuaSceneService>(sp => sp.GetRequiredService<HonuaMobileClient>().Scenes);
         return services;
     }
 

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
@@ -7,6 +7,7 @@ using Grpc.Net.Client;
 using Honua.Mobile.Sdk.Grpc;
 using Honua.Mobile.Sdk.Models;
 using Honua.Mobile.Sdk.Routing;
+using Honua.Mobile.Sdk.Scenes;
 using Proto = Honua.Server.Features.Grpc.Proto;
 
 namespace Honua.Mobile.Sdk;
@@ -46,12 +47,18 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
         }
 
         Routing = new HonuaRoutingClient(this, options);
+        Scenes = new HonuaSceneService(this, options);
     }
 
     /// <summary>
     /// Routing and network-analysis client for directions, service areas, closest facility, and route optimization.
     /// </summary>
     public HonuaRoutingClient Routing { get; }
+
+    /// <summary>
+    /// Scene metadata discovery client for 3D Tiles, terrain, and related render-ready endpoints.
+    /// </summary>
+    public HonuaSceneService Scenes { get; }
 
     /// <summary>
     /// Queries features from a feature service layer, preferring gRPC when available.
@@ -366,7 +373,14 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
                 raw);
         }
 
-        return JsonDocument.Parse(string.IsNullOrWhiteSpace(raw) ? "{}" : raw);
+        try
+        {
+            return JsonDocument.Parse(string.IsNullOrWhiteSpace(raw) ? "{}" : raw);
+        }
+        catch (JsonException ex)
+        {
+            throw new HonuaMobileApiException("Honua mobile request returned invalid JSON.", ex);
+        }
     }
 
     private async ValueTask ApplyHttpAuthenticationAsync(HttpRequestMessage request, CancellationToken ct)

--- a/src/Honua.Mobile.Sdk/HonuaMobileClientOptions.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClientOptions.cs
@@ -82,4 +82,9 @@ public sealed class HonuaMobileClientOptions
     /// NAServer closest-facility layer name used for nearest-facility requests.
     /// </summary>
     public string RoutingClosestFacilityLayerName { get; init; } = "ClosestFacility";
+
+    /// <summary>
+    /// Base REST path for Honua scene metadata discovery endpoints.
+    /// </summary>
+    public string SceneApiPath { get; init; } = "/api/scenes";
 }

--- a/src/Honua.Mobile.Sdk/Scenes/HonuaSceneService.cs
+++ b/src/Honua.Mobile.Sdk/Scenes/HonuaSceneService.cs
@@ -1,0 +1,735 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace Honua.Mobile.Sdk.Scenes;
+
+/// <summary>
+/// Client for Honua scene metadata discovery and render endpoint resolution.
+/// </summary>
+public sealed class HonuaSceneService : IHonuaSceneService
+{
+    private readonly HonuaMobileClient _client;
+    private readonly HonuaMobileClientOptions _options;
+
+    internal HonuaSceneService(HonuaMobileClient client, HonuaMobileClientOptions options)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<HonuaSceneSummary>> ListScenesAsync(
+        HonuaSceneListRequest? request = null,
+        CancellationToken ct = default)
+    {
+        request ??= new HonuaSceneListRequest();
+        var query = new Dictionary<string, string?>
+        {
+            ["f"] = request.ResponseFormat,
+            ["capabilities"] = JoinCsv(request.Capabilities),
+            ["includeDisabled"] = request.IncludeDisabled?.ToString().ToLowerInvariant(),
+        };
+        AddAdditionalParameters(query, request.AdditionalParameters);
+
+        using var response = await _client.SendJsonAsync(
+            HttpMethod.Get,
+            ScenePath(),
+            query,
+            content: null,
+            ct).ConfigureAwait(false);
+
+        return HonuaSceneJsonParser.ParseSceneList(response);
+    }
+
+    /// <inheritdoc />
+    public async Task<HonuaSceneMetadata> GetSceneAsync(string sceneId, CancellationToken ct = default)
+    {
+        var resolvedSceneId = RequireSceneId(sceneId);
+        using var response = await _client.SendJsonAsync(
+            HttpMethod.Get,
+            ScenePath(resolvedSceneId),
+            new Dictionary<string, string?> { ["f"] = "json" },
+            content: null,
+            ct).ConfigureAwait(false);
+
+        return HonuaSceneJsonParser.ParseSceneMetadata(response);
+    }
+
+    /// <inheritdoc />
+    public async Task<HonuaSceneResolution> ResolveSceneAsync(
+        string sceneId,
+        HonuaSceneResolveRequest? request = null,
+        CancellationToken ct = default)
+    {
+        var resolvedSceneId = RequireSceneId(sceneId);
+        request ??= new HonuaSceneResolveRequest();
+        var query = new Dictionary<string, string?>
+        {
+            ["f"] = request.ResponseFormat,
+            ["capabilities"] = JoinCsv(request.RequiredCapabilities),
+            ["includeTerrain"] = request.IncludeTerrain.ToString().ToLowerInvariant(),
+        };
+        AddAdditionalParameters(query, request.AdditionalParameters);
+
+        using var response = await _client.SendJsonAsync(
+            HttpMethod.Get,
+            ScenePath(resolvedSceneId, "resolve"),
+            query,
+            content: null,
+            ct).ConfigureAwait(false);
+
+        var resolution = HonuaSceneJsonParser.ParseSceneResolution(response, resolvedSceneId);
+        EnsureCapabilities(resolution.SceneId, resolution.Capabilities, request.RequiredCapabilities);
+        return resolution;
+    }
+
+    private string ScenePath(params string[] segments)
+    {
+        var basePath = string.IsNullOrWhiteSpace(_options.SceneApiPath)
+            ? "/api/scenes"
+            : _options.SceneApiPath;
+
+        var path = basePath.StartsWith("/", StringComparison.Ordinal) ? basePath : $"/{basePath}";
+        path = path.TrimEnd('/');
+
+        foreach (var segment in segments.Where(segment => !string.IsNullOrWhiteSpace(segment)))
+        {
+            path += $"/{Uri.EscapeDataString(segment)}";
+        }
+
+        return path;
+    }
+
+    private static string RequireSceneId(string sceneId)
+    {
+        if (string.IsNullOrWhiteSpace(sceneId))
+        {
+            throw new ArgumentException("Scene id is required.", nameof(sceneId));
+        }
+
+        return sceneId.Trim();
+    }
+
+    private static void EnsureCapabilities(
+        string sceneId,
+        IReadOnlyList<string> availableCapabilities,
+        IReadOnlyList<string>? requiredCapabilities)
+    {
+        if (requiredCapabilities is not { Count: > 0 })
+        {
+            return;
+        }
+
+        var available = new HashSet<string>(availableCapabilities, StringComparer.OrdinalIgnoreCase);
+        var missing = requiredCapabilities
+            .Where(capability => !string.IsNullOrWhiteSpace(capability))
+            .Where(capability => !available.Contains(capability))
+            .ToArray();
+
+        if (missing.Length > 0)
+        {
+            throw new HonuaMobileApiException(
+                $"Scene '{sceneId}' does not expose required capability: {string.Join(", ", missing)}.");
+        }
+    }
+
+    private static string? JoinCsv(IReadOnlyList<string>? values)
+        => values is { Count: > 0 }
+            ? string.Join(',', values.Where(value => !string.IsNullOrWhiteSpace(value)))
+            : null;
+
+    private static void AddAdditionalParameters(
+        IDictionary<string, string?> query,
+        IReadOnlyDictionary<string, string?>? additionalParameters)
+    {
+        if (additionalParameters is null)
+        {
+            return;
+        }
+
+        foreach (var (key, value) in additionalParameters)
+        {
+            if (!string.IsNullOrWhiteSpace(key))
+            {
+                query[key] = value;
+            }
+        }
+    }
+}
+
+internal static class HonuaSceneJsonParser
+{
+    public static IReadOnlyList<HonuaSceneSummary> ParseSceneList(JsonDocument document)
+    {
+        try
+        {
+            var items = EnumerateSceneItems(document.RootElement).ToArray();
+            return items.Select(ParseSceneSummary).ToArray();
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or JsonException or FormatException)
+        {
+            throw Malformed(ex);
+        }
+    }
+
+    public static HonuaSceneMetadata ParseSceneMetadata(JsonDocument document)
+    {
+        try
+        {
+            return ParseSceneMetadata(document.RootElement);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or JsonException or FormatException)
+        {
+            throw Malformed(ex);
+        }
+    }
+
+    public static HonuaSceneResolution ParseSceneResolution(JsonDocument document, string fallbackSceneId)
+    {
+        try
+        {
+            var root = document.RootElement;
+            var sceneId = GetString(root, "sceneId", "id") ?? fallbackSceneId;
+            var tileset = ParseEndpoint(root, HonuaSceneCapabilities.ThreeDimensionalTiles, "tileset", "tilesetUrl");
+            var terrain = ParseEndpoint(root, HonuaSceneCapabilities.Terrain, "terrain", "terrainUrl");
+            var endpoints = ParseEndpointArray(root)
+                .Concat(
+                    new[] { tileset, terrain }
+                        .Where(endpoint => endpoint is not null)
+                        .Cast<HonuaSceneEndpoint>())
+                .DistinctBy(endpoint => $"{endpoint.Kind}\n{endpoint.Url}")
+                .ToArray();
+            var capabilities = ParseCapabilities(root, endpoints);
+
+            return new HonuaSceneResolution
+            {
+                SceneId = sceneId,
+                TilesetUrl = tileset?.Url ?? GetUri(root, "tilesetUrl"),
+                TerrainUrl = terrain?.Url ?? GetUri(root, "terrainUrl"),
+                Endpoints = endpoints,
+                Capabilities = capabilities,
+                Auth = ParseAuth(root),
+                ExpiresAt = GetDateTimeOffset(root, "expiresAt", "expiration", "validUntil"),
+                RawResponse = root.Clone(),
+            };
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or JsonException or FormatException)
+        {
+            throw Malformed(ex);
+        }
+    }
+
+    private static HonuaSceneSummary ParseSceneSummary(JsonElement element)
+    {
+        var id = GetString(element, "id", "sceneId")
+            ?? throw new InvalidOperationException("Scene item is missing an id.");
+        var tileset = ParseEndpoint(element, HonuaSceneCapabilities.ThreeDimensionalTiles, "tileset", "tilesetUrl");
+        var terrain = ParseEndpoint(element, HonuaSceneCapabilities.Terrain, "terrain", "terrainUrl");
+        var endpoints = new[] { tileset, terrain }.Where(endpoint => endpoint is not null).Cast<HonuaSceneEndpoint>().ToArray();
+
+        return new HonuaSceneSummary
+        {
+            Id = id,
+            Name = GetString(element, "name", "title") ?? id,
+            Description = GetString(element, "description"),
+            Bounds = ParseBounds(element),
+            Capabilities = ParseCapabilities(element, endpoints),
+            Attribution = ParseAttribution(element),
+            Auth = ParseAuth(element),
+            UpdatedAt = GetDateTimeOffset(element, "updatedAt", "modifiedAt", "lastModified"),
+            RawResponse = element.Clone(),
+        };
+    }
+
+    private static HonuaSceneMetadata ParseSceneMetadata(JsonElement element)
+    {
+        var id = GetString(element, "id", "sceneId")
+            ?? throw new InvalidOperationException("Scene metadata is missing an id.");
+        var tileset = ParseEndpoint(element, HonuaSceneCapabilities.ThreeDimensionalTiles, "tileset", "tilesetUrl");
+        var terrain = ParseEndpoint(element, HonuaSceneCapabilities.Terrain, "terrain", "terrainUrl");
+        var endpoints = new[] { tileset, terrain }
+            .Where(endpoint => endpoint is not null)
+            .Cast<HonuaSceneEndpoint>()
+            .ToArray();
+
+        return new HonuaSceneMetadata
+        {
+            Id = id,
+            Name = GetString(element, "name", "title") ?? id,
+            Description = GetString(element, "description"),
+            Tileset = tileset,
+            Terrain = terrain,
+            Center = ParseCoordinate(element, "center"),
+            Bounds = ParseBounds(element),
+            Capabilities = ParseCapabilities(element, endpoints),
+            Attribution = ParseAttribution(element),
+            Auth = ParseAuth(element),
+            Links = ParseLinks(element),
+            UpdatedAt = GetDateTimeOffset(element, "updatedAt", "modifiedAt", "lastModified"),
+            RawResponse = element.Clone(),
+        };
+    }
+
+    private static IEnumerable<JsonElement> EnumerateSceneItems(JsonElement root)
+    {
+        if (root.ValueKind == JsonValueKind.Array)
+        {
+            return root.EnumerateArray();
+        }
+
+        foreach (var propertyName in new[] { "scenes", "items", "features" })
+        {
+            if (TryGetProperty(root, propertyName, out var items) && items.ValueKind == JsonValueKind.Array)
+            {
+                return items.EnumerateArray();
+            }
+        }
+
+        throw new InvalidOperationException("Scene list response must contain a scenes array.");
+    }
+
+    private static HonuaSceneEndpoint? ParseEndpoint(
+        JsonElement root,
+        string defaultKind,
+        string objectPropertyName,
+        string urlPropertyName)
+    {
+        if (TryGetProperty(root, objectPropertyName, out var endpoint) && endpoint.ValueKind == JsonValueKind.Object)
+        {
+            return ParseEndpointObject(endpoint, defaultKind);
+        }
+
+        if (TryGetProperty(root, "endpoints", out var endpoints) &&
+            endpoints.ValueKind == JsonValueKind.Object &&
+            TryGetProperty(endpoints, objectPropertyName, out endpoint) &&
+            endpoint.ValueKind == JsonValueKind.Object)
+        {
+            return ParseEndpointObject(endpoint, defaultKind);
+        }
+
+        var url = GetUri(root, urlPropertyName);
+        if (url is null)
+        {
+            return null;
+        }
+
+        return new HonuaSceneEndpoint
+        {
+            Kind = defaultKind,
+            Url = url,
+            MediaType = defaultKind == HonuaSceneCapabilities.ThreeDimensionalTiles
+                ? "application/json"
+                : null,
+            Format = defaultKind,
+            RequiresAuthentication = ParseAuth(root).RequiresAuthentication,
+        };
+    }
+
+    private static HonuaSceneEndpoint ParseEndpointObject(JsonElement endpoint, string defaultKind)
+    {
+        var url = GetUri(endpoint, "url", "href")
+            ?? throw new InvalidOperationException($"Scene endpoint '{defaultKind}' is missing a url.");
+
+        return new HonuaSceneEndpoint
+        {
+            Kind = GetString(endpoint, "kind", "type") ?? defaultKind,
+            Url = url,
+            MediaType = GetString(endpoint, "mediaType", "contentType"),
+            Format = GetString(endpoint, "format") ?? defaultKind,
+            RequiresAuthentication = GetBool(endpoint, "requiresAuthentication", "requiresAuth") ?? false,
+            Headers = ParseHeaders(endpoint),
+        };
+    }
+
+    private static IReadOnlyList<HonuaSceneEndpoint> ParseEndpointArray(JsonElement root)
+    {
+        if (!TryGetProperty(root, "endpoints", out var endpoints) || endpoints.ValueKind != JsonValueKind.Array)
+        {
+            return Array.Empty<HonuaSceneEndpoint>();
+        }
+
+        return endpoints.EnumerateArray()
+            .Where(endpoint => endpoint.ValueKind == JsonValueKind.Object)
+            .Select(endpoint => ParseEndpointObject(endpoint, GetString(endpoint, "kind", "type") ?? "resource"))
+            .ToArray();
+    }
+
+    private static IReadOnlyDictionary<string, string> ParseHeaders(JsonElement endpoint)
+    {
+        if (!TryGetProperty(endpoint, "headers", out var headers) || headers.ValueKind != JsonValueKind.Object)
+        {
+            return new Dictionary<string, string>();
+        }
+
+        return headers.EnumerateObject()
+            .Where(property => property.Value.ValueKind == JsonValueKind.String)
+            .ToDictionary(property => property.Name, property => property.Value.GetString() ?? string.Empty, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static IReadOnlyList<string> ParseCapabilities(JsonElement root, IReadOnlyList<HonuaSceneEndpoint> endpoints)
+    {
+        var capabilities = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (TryGetProperty(root, "capabilities", out var value))
+        {
+            if (value.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in value.EnumerateArray().Where(item => item.ValueKind == JsonValueKind.String))
+                {
+                    AddCapability(capabilities, item.GetString());
+                }
+            }
+            else if (value.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var property in value.EnumerateObject())
+                {
+                    if (property.Value.ValueKind != JsonValueKind.False)
+                    {
+                        AddCapability(capabilities, property.Name);
+                    }
+                }
+            }
+            else if (value.ValueKind == JsonValueKind.String)
+            {
+                foreach (var capability in SplitCsv(value.GetString()))
+                {
+                    AddCapability(capabilities, capability);
+                }
+            }
+        }
+
+        foreach (var endpoint in endpoints)
+        {
+            AddCapability(capabilities, endpoint.Kind);
+            AddCapability(capabilities, endpoint.Format);
+        }
+
+        return capabilities.Order(StringComparer.OrdinalIgnoreCase).ToArray();
+    }
+
+    private static IReadOnlyList<string> ParseAttribution(JsonElement root)
+    {
+        foreach (var propertyName in new[] { "attribution", "attributions" })
+        {
+            if (!TryGetProperty(root, propertyName, out var value))
+            {
+                continue;
+            }
+
+            if (value.ValueKind == JsonValueKind.String)
+            {
+                return new[] { value.GetString() ?? string.Empty };
+            }
+
+            if (value.ValueKind == JsonValueKind.Array)
+            {
+                return value.EnumerateArray()
+                    .Where(item => item.ValueKind == JsonValueKind.String)
+                    .Select(item => item.GetString() ?? string.Empty)
+                    .Where(item => !string.IsNullOrWhiteSpace(item))
+                    .ToArray();
+            }
+        }
+
+        return Array.Empty<string>();
+    }
+
+    private static HonuaSceneAuthRequirements ParseAuth(JsonElement root)
+    {
+        var auth = TryGetProperty(root, "auth", out var authElement) && authElement.ValueKind == JsonValueKind.Object
+            ? authElement
+            : root;
+
+        var isPublic = GetBool(auth, "public", "isPublic");
+        var requiresAuthentication =
+            GetBool(auth, "requiresAuthentication", "requiresAuth", "required") ??
+            GetBool(root, "requiresAuthentication", "requiresAuth") ??
+            (isPublic.HasValue ? !isPublic.Value : false);
+
+        return new HonuaSceneAuthRequirements
+        {
+            RequiresAuthentication = requiresAuthentication,
+            Schemes = GetStringArray(auth, "schemes", "methods"),
+            Policy = GetString(auth, "policy", "policyId"),
+        };
+    }
+
+    private static HonuaSceneBounds? ParseBounds(JsonElement root)
+    {
+        if (TryGetProperty(root, "bounds", out var bounds) && bounds.ValueKind == JsonValueKind.Object)
+        {
+            var minLongitude = GetDouble(bounds, "minLongitude", "west", "xmin");
+            var minLatitude = GetDouble(bounds, "minLatitude", "south", "ymin");
+            var maxLongitude = GetDouble(bounds, "maxLongitude", "east", "xmax");
+            var maxLatitude = GetDouble(bounds, "maxLatitude", "north", "ymax");
+
+            if (minLongitude.HasValue && minLatitude.HasValue && maxLongitude.HasValue && maxLatitude.HasValue)
+            {
+                return new HonuaSceneBounds
+                {
+                    MinLongitude = minLongitude.Value,
+                    MinLatitude = minLatitude.Value,
+                    MaxLongitude = maxLongitude.Value,
+                    MaxLatitude = maxLatitude.Value,
+                    MinHeight = GetDouble(bounds, "minHeight", "zmin"),
+                    MaxHeight = GetDouble(bounds, "maxHeight", "zmax"),
+                };
+            }
+        }
+
+        if (!TryGetProperty(root, "bbox", out var bbox) || bbox.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var values = bbox.EnumerateArray()
+            .Where(item => item.ValueKind == JsonValueKind.Number)
+            .Select(item => item.GetDouble())
+            .ToArray();
+
+        return values.Length switch
+        {
+            >= 6 => new HonuaSceneBounds
+            {
+                MinLongitude = values[0],
+                MinLatitude = values[1],
+                MinHeight = values[2],
+                MaxLongitude = values[3],
+                MaxLatitude = values[4],
+                MaxHeight = values[5],
+            },
+            >= 4 => new HonuaSceneBounds
+            {
+                MinLongitude = values[0],
+                MinLatitude = values[1],
+                MaxLongitude = values[2],
+                MaxLatitude = values[3],
+            },
+            _ => null,
+        };
+    }
+
+    private static HonuaSceneCoordinate? ParseCoordinate(JsonElement root, string propertyName)
+    {
+        if (!TryGetProperty(root, propertyName, out var coordinate))
+        {
+            return null;
+        }
+
+        if (coordinate.ValueKind == JsonValueKind.Object)
+        {
+            var latitude = GetDouble(coordinate, "latitude", "lat", "y");
+            var longitude = GetDouble(coordinate, "longitude", "lon", "lng", "x");
+            if (latitude.HasValue && longitude.HasValue)
+            {
+                return new HonuaSceneCoordinate
+                {
+                    Latitude = latitude.Value,
+                    Longitude = longitude.Value,
+                    Height = GetDouble(coordinate, "height", "z"),
+                };
+            }
+        }
+
+        if (coordinate.ValueKind == JsonValueKind.Array)
+        {
+            var values = coordinate.EnumerateArray()
+                .Where(item => item.ValueKind == JsonValueKind.Number)
+                .Select(item => item.GetDouble())
+                .ToArray();
+
+            if (values.Length >= 2)
+            {
+                return new HonuaSceneCoordinate
+                {
+                    Longitude = values[0],
+                    Latitude = values[1],
+                    Height = values.Length >= 3 ? values[2] : null,
+                };
+            }
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyList<HonuaSceneLink> ParseLinks(JsonElement root)
+    {
+        if (!TryGetProperty(root, "links", out var links) || links.ValueKind != JsonValueKind.Array)
+        {
+            return Array.Empty<HonuaSceneLink>();
+        }
+
+        return links.EnumerateArray()
+            .Where(link => link.ValueKind == JsonValueKind.Object)
+            .Select(link =>
+            {
+                var rel = GetString(link, "rel") ?? "related";
+                var href = GetUri(link, "href", "url")
+                    ?? throw new InvalidOperationException("Scene link is missing an href.");
+
+                return new HonuaSceneLink
+                {
+                    Rel = rel,
+                    Href = href,
+                    Type = GetString(link, "type", "mediaType"),
+                    Title = GetString(link, "title"),
+                };
+            })
+            .ToArray();
+    }
+
+    private static string? GetString(JsonElement element, params string[] propertyNames)
+    {
+        foreach (var propertyName in propertyNames)
+        {
+            if (TryGetProperty(element, propertyName, out var value) && value.ValueKind == JsonValueKind.String)
+            {
+                var text = value.GetString();
+                return string.IsNullOrWhiteSpace(text) ? null : text;
+            }
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyList<string> GetStringArray(JsonElement element, params string[] propertyNames)
+    {
+        foreach (var propertyName in propertyNames)
+        {
+            if (!TryGetProperty(element, propertyName, out var value))
+            {
+                continue;
+            }
+
+            if (value.ValueKind == JsonValueKind.Array)
+            {
+                return value.EnumerateArray()
+                    .Where(item => item.ValueKind == JsonValueKind.String)
+                    .Select(item => item.GetString() ?? string.Empty)
+                    .Where(item => !string.IsNullOrWhiteSpace(item))
+                    .ToArray();
+            }
+
+            if (value.ValueKind == JsonValueKind.String)
+            {
+                return SplitCsv(value.GetString()).ToArray();
+            }
+        }
+
+        return Array.Empty<string>();
+    }
+
+    private static Uri? GetUri(JsonElement element, params string[] propertyNames)
+    {
+        var value = GetString(element, propertyNames);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out var uri)
+            ? uri
+            : throw new FormatException($"Invalid scene URL: {value}");
+    }
+
+    private static bool? GetBool(JsonElement element, params string[] propertyNames)
+    {
+        foreach (var propertyName in propertyNames)
+        {
+            if (!TryGetProperty(element, propertyName, out var value))
+            {
+                continue;
+            }
+
+            if (value.ValueKind is JsonValueKind.True or JsonValueKind.False)
+            {
+                return value.GetBoolean();
+            }
+
+            if (value.ValueKind == JsonValueKind.String && bool.TryParse(value.GetString(), out var parsed))
+            {
+                return parsed;
+            }
+        }
+
+        return null;
+    }
+
+    private static double? GetDouble(JsonElement element, params string[] propertyNames)
+    {
+        foreach (var propertyName in propertyNames)
+        {
+            if (!TryGetProperty(element, propertyName, out var value))
+            {
+                continue;
+            }
+
+            if (value.ValueKind == JsonValueKind.Number)
+            {
+                return value.GetDouble();
+            }
+
+            if (value.ValueKind == JsonValueKind.String &&
+                double.TryParse(value.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed))
+            {
+                return parsed;
+            }
+        }
+
+        return null;
+    }
+
+    private static DateTimeOffset? GetDateTimeOffset(JsonElement element, params string[] propertyNames)
+    {
+        foreach (var propertyName in propertyNames)
+        {
+            if (TryGetProperty(element, propertyName, out var value) &&
+                value.ValueKind == JsonValueKind.String &&
+                DateTimeOffset.TryParse(value.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var parsed))
+            {
+                return parsed;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement value)
+    {
+        if (element.ValueKind == JsonValueKind.Object && element.TryGetProperty(propertyName, out value))
+        {
+            return true;
+        }
+
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = property.Value;
+                    return true;
+                }
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static IEnumerable<string> SplitCsv(string? value)
+        => string.IsNullOrWhiteSpace(value)
+            ? Array.Empty<string>()
+            : value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private static void AddCapability(ISet<string> capabilities, string? capability)
+    {
+        if (!string.IsNullOrWhiteSpace(capability))
+        {
+            capabilities.Add(capability);
+        }
+    }
+
+    private static HonuaMobileApiException Malformed(Exception ex)
+        => new("Honua scene response was malformed.", ex);
+}

--- a/src/Honua.Mobile.Sdk/Scenes/HonuaSceneService.cs
+++ b/src/Honua.Mobile.Sdk/Scenes/HonuaSceneService.cs
@@ -204,8 +204,8 @@ internal static class HonuaSceneJsonParser
             return new HonuaSceneResolution
             {
                 SceneId = sceneId,
-                TilesetUrl = tileset?.Url ?? GetUri(root, "tilesetUrl"),
-                TerrainUrl = terrain?.Url ?? GetUri(root, "terrainUrl"),
+                TilesetUrl = GetUri(root, "tilesetUrl") ?? tileset?.Url ?? FindEndpointUrl(endpoints, HonuaSceneCapabilities.ThreeDimensionalTiles),
+                TerrainUrl = GetUri(root, "terrainUrl") ?? terrain?.Url ?? FindEndpointUrl(endpoints, HonuaSceneCapabilities.Terrain),
                 Endpoints = endpoints,
                 Capabilities = capabilities,
                 Auth = ParseAuth(root),
@@ -294,9 +294,11 @@ internal static class HonuaSceneJsonParser
         string objectPropertyName,
         string urlPropertyName)
     {
+        var inheritedRequiresAuthentication = ParseAuth(root).RequiresAuthentication;
+
         if (TryGetProperty(root, objectPropertyName, out var endpoint) && endpoint.ValueKind == JsonValueKind.Object)
         {
-            return ParseEndpointObject(endpoint, defaultKind);
+            return ParseEndpointObject(endpoint, defaultKind, inheritedRequiresAuthentication);
         }
 
         if (TryGetProperty(root, "endpoints", out var endpoints) &&
@@ -304,7 +306,7 @@ internal static class HonuaSceneJsonParser
             TryGetProperty(endpoints, objectPropertyName, out endpoint) &&
             endpoint.ValueKind == JsonValueKind.Object)
         {
-            return ParseEndpointObject(endpoint, defaultKind);
+            return ParseEndpointObject(endpoint, defaultKind, inheritedRequiresAuthentication);
         }
 
         var url = GetUri(root, urlPropertyName);
@@ -325,7 +327,10 @@ internal static class HonuaSceneJsonParser
         };
     }
 
-    private static HonuaSceneEndpoint ParseEndpointObject(JsonElement endpoint, string defaultKind)
+    private static HonuaSceneEndpoint ParseEndpointObject(
+        JsonElement endpoint,
+        string defaultKind,
+        bool inheritedRequiresAuthentication)
     {
         var url = GetUri(endpoint, "url", "href")
             ?? throw new InvalidOperationException($"Scene endpoint '{defaultKind}' is missing a url.");
@@ -336,7 +341,7 @@ internal static class HonuaSceneJsonParser
             Url = url,
             MediaType = GetString(endpoint, "mediaType", "contentType"),
             Format = GetString(endpoint, "format") ?? defaultKind,
-            RequiresAuthentication = GetBool(endpoint, "requiresAuthentication", "requiresAuth") ?? false,
+            RequiresAuthentication = GetBool(endpoint, "requiresAuthentication", "requiresAuth") ?? inheritedRequiresAuthentication,
             Headers = ParseHeaders(endpoint),
         };
     }
@@ -348,11 +353,20 @@ internal static class HonuaSceneJsonParser
             return Array.Empty<HonuaSceneEndpoint>();
         }
 
+        var inheritedRequiresAuthentication = ParseAuth(root).RequiresAuthentication;
         return endpoints.EnumerateArray()
             .Where(endpoint => endpoint.ValueKind == JsonValueKind.Object)
-            .Select(endpoint => ParseEndpointObject(endpoint, GetString(endpoint, "kind", "type") ?? "resource"))
+            .Select(endpoint => ParseEndpointObject(
+                endpoint,
+                GetString(endpoint, "kind", "type") ?? "resource",
+                inheritedRequiresAuthentication))
             .ToArray();
     }
+
+    private static Uri? FindEndpointUrl(IReadOnlyList<HonuaSceneEndpoint> endpoints, string kind)
+        => endpoints.FirstOrDefault(endpoint =>
+            string.Equals(endpoint.Kind, kind, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(endpoint.Format, kind, StringComparison.OrdinalIgnoreCase))?.Url;
 
     private static IReadOnlyDictionary<string, string> ParseHeaders(JsonElement endpoint)
     {

--- a/src/Honua.Mobile.Sdk/Scenes/SceneModels.cs
+++ b/src/Honua.Mobile.Sdk/Scenes/SceneModels.cs
@@ -1,0 +1,424 @@
+using System.Text.Json;
+
+namespace Honua.Mobile.Sdk.Scenes;
+
+/// <summary>
+/// Well-known scene capability identifiers advertised by Honua scene metadata.
+/// </summary>
+public static class HonuaSceneCapabilities
+{
+    /// <summary>
+    /// Scene exposes an OGC 3D Tiles / Cesium-compatible tileset endpoint.
+    /// </summary>
+    public const string ThreeDimensionalTiles = "3d-tiles";
+
+    /// <summary>
+    /// Scene exposes a terrain provider endpoint.
+    /// </summary>
+    public const string Terrain = "terrain";
+
+    /// <summary>
+    /// Scene exposes an elevation query or profile endpoint.
+    /// </summary>
+    public const string ElevationProfile = "elevation-profile";
+
+    /// <summary>
+    /// Scene exposes an Esri I3S-compatible scene layer endpoint.
+    /// </summary>
+    public const string I3s = "i3s";
+}
+
+/// <summary>
+/// Client contract for discovering Honua 3D scene metadata and render-ready endpoint URLs.
+/// </summary>
+public interface IHonuaSceneService
+{
+    /// <summary>
+    /// Lists scenes visible to the current SDK credentials.
+    /// </summary>
+    Task<IReadOnlyList<HonuaSceneSummary>> ListScenesAsync(
+        HonuaSceneListRequest? request = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets metadata for a single scene.
+    /// </summary>
+    Task<HonuaSceneMetadata> GetSceneAsync(string sceneId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolves a scene into client-ready URLs for renderers such as CesiumJS or <c>&lt;honua-scene&gt;</c>.
+    /// </summary>
+    Task<HonuaSceneResolution> ResolveSceneAsync(
+        string sceneId,
+        HonuaSceneResolveRequest? request = null,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Filters used when listing scenes from the server.
+/// </summary>
+public sealed class HonuaSceneListRequest
+{
+    /// <summary>
+    /// Optional capabilities required by the caller, for example <see cref="HonuaSceneCapabilities.ThreeDimensionalTiles"/>.
+    /// </summary>
+    public IReadOnlyList<string>? Capabilities { get; init; }
+
+    /// <summary>
+    /// When set, asks the server whether disabled scenes should be included in the list.
+    /// </summary>
+    public bool? IncludeDisabled { get; init; }
+
+    /// <summary>
+    /// REST response format. Defaults to JSON.
+    /// </summary>
+    public string ResponseFormat { get; init; } = "json";
+
+    /// <summary>
+    /// Additional raw query parameters for server-specific scene registry extensions.
+    /// </summary>
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Options used when resolving render-ready scene endpoints.
+/// </summary>
+public sealed class HonuaSceneResolveRequest
+{
+    /// <summary>
+    /// Capabilities the resolved scene must expose before it is returned to the caller.
+    /// </summary>
+    public IReadOnlyList<string>? RequiredCapabilities { get; init; }
+
+    /// <summary>
+    /// Requests terrain endpoint metadata when the scene has terrain. Defaults to <see langword="true"/>.
+    /// </summary>
+    public bool IncludeTerrain { get; init; } = true;
+
+    /// <summary>
+    /// REST response format. Defaults to JSON.
+    /// </summary>
+    public string ResponseFormat { get; init; } = "json";
+
+    /// <summary>
+    /// Additional raw query parameters for server-specific resolution extensions.
+    /// </summary>
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Summary metadata for a scene in a catalog list response.
+/// </summary>
+public sealed class HonuaSceneSummary
+{
+    /// <summary>
+    /// Stable scene identifier used by SDK calls.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Human-readable display name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Optional scene description.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Spatial bounds for the scene when advertised by the server.
+    /// </summary>
+    public HonuaSceneBounds? Bounds { get; init; }
+
+    /// <summary>
+    /// Capabilities available for this scene, such as <c>3d-tiles</c> or <c>terrain</c>.
+    /// </summary>
+    public IReadOnlyList<string> Capabilities { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Attribution lines callers should display with rendered scene content.
+    /// </summary>
+    public IReadOnlyList<string> Attribution { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Authentication requirements advertised for the scene.
+    /// </summary>
+    public HonuaSceneAuthRequirements Auth { get; init; } = HonuaSceneAuthRequirements.None;
+
+    /// <summary>
+    /// Server update timestamp when included in metadata.
+    /// </summary>
+    public DateTimeOffset? UpdatedAt { get; init; }
+
+    /// <summary>
+    /// Raw JSON object for callers that need server-specific metadata not modeled by the SDK yet.
+    /// </summary>
+    public JsonElement RawResponse { get; init; }
+}
+
+/// <summary>
+/// Detailed metadata for a single scene.
+/// </summary>
+public sealed class HonuaSceneMetadata
+{
+    /// <summary>
+    /// Stable scene identifier used by SDK calls.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Human-readable display name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Optional scene description.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Primary 3D Tiles endpoint, when the scene exposes one.
+    /// </summary>
+    public HonuaSceneEndpoint? Tileset { get; init; }
+
+    /// <summary>
+    /// Terrain endpoint, when the scene exposes one.
+    /// </summary>
+    public HonuaSceneEndpoint? Terrain { get; init; }
+
+    /// <summary>
+    /// Suggested initial camera center for renderers.
+    /// </summary>
+    public HonuaSceneCoordinate? Center { get; init; }
+
+    /// <summary>
+    /// Spatial bounds for the scene when advertised by the server.
+    /// </summary>
+    public HonuaSceneBounds? Bounds { get; init; }
+
+    /// <summary>
+    /// Capabilities available for this scene, such as <c>3d-tiles</c> or <c>terrain</c>.
+    /// </summary>
+    public IReadOnlyList<string> Capabilities { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Attribution lines callers should display with rendered scene content.
+    /// </summary>
+    public IReadOnlyList<string> Attribution { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Authentication requirements advertised for the scene.
+    /// </summary>
+    public HonuaSceneAuthRequirements Auth { get; init; } = HonuaSceneAuthRequirements.None;
+
+    /// <summary>
+    /// Related metadata or endpoint links advertised by the server.
+    /// </summary>
+    public IReadOnlyList<HonuaSceneLink> Links { get; init; } = Array.Empty<HonuaSceneLink>();
+
+    /// <summary>
+    /// Server update timestamp when included in metadata.
+    /// </summary>
+    public DateTimeOffset? UpdatedAt { get; init; }
+
+    /// <summary>
+    /// Raw JSON object for callers that need server-specific metadata not modeled by the SDK yet.
+    /// </summary>
+    public JsonElement RawResponse { get; init; }
+}
+
+/// <summary>
+/// Render-ready scene URLs resolved by the server for a specific client request.
+/// </summary>
+public sealed class HonuaSceneResolution
+{
+    /// <summary>
+    /// Stable scene identifier used by SDK calls.
+    /// </summary>
+    public required string SceneId { get; init; }
+
+    /// <summary>
+    /// 3D Tiles tileset URL for CesiumJS clients.
+    /// </summary>
+    public Uri? TilesetUrl { get; init; }
+
+    /// <summary>
+    /// Terrain provider URL for CesiumJS clients.
+    /// </summary>
+    public Uri? TerrainUrl { get; init; }
+
+    /// <summary>
+    /// Expanded endpoint metadata for the resolved scene.
+    /// </summary>
+    public IReadOnlyList<HonuaSceneEndpoint> Endpoints { get; init; } = Array.Empty<HonuaSceneEndpoint>();
+
+    /// <summary>
+    /// Capabilities available in this resolution response.
+    /// </summary>
+    public IReadOnlyList<string> Capabilities { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Authentication requirements advertised for the resolved endpoints.
+    /// </summary>
+    public HonuaSceneAuthRequirements Auth { get; init; } = HonuaSceneAuthRequirements.None;
+
+    /// <summary>
+    /// Optional server-issued expiry for signed render URLs.
+    /// </summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    /// <summary>
+    /// Raw JSON object for callers that need server-specific metadata not modeled by the SDK yet.
+    /// </summary>
+    public JsonElement RawResponse { get; init; }
+}
+
+/// <summary>
+/// URL and format metadata for a scene resource such as a 3D Tiles root or terrain provider.
+/// </summary>
+public sealed class HonuaSceneEndpoint
+{
+    /// <summary>
+    /// Endpoint kind, for example <c>3d-tiles</c>, <c>terrain</c>, or <c>i3s</c>.
+    /// </summary>
+    public required string Kind { get; init; }
+
+    /// <summary>
+    /// Absolute or server-relative endpoint URL.
+    /// </summary>
+    public required Uri Url { get; init; }
+
+    /// <summary>
+    /// Media type returned by the endpoint when known.
+    /// </summary>
+    public string? MediaType { get; init; }
+
+    /// <summary>
+    /// Format identifier advertised by the endpoint, such as <c>3d-tiles</c> or <c>quantized-mesh</c>.
+    /// </summary>
+    public string? Format { get; init; }
+
+    /// <summary>
+    /// Whether the endpoint requires authentication beyond public URL access.
+    /// </summary>
+    public bool RequiresAuthentication { get; init; }
+
+    /// <summary>
+    /// Server-supplied request headers for clients that support custom resource headers.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Headers { get; init; } = new Dictionary<string, string>();
+}
+
+/// <summary>
+/// Authentication requirements for a scene or endpoint.
+/// </summary>
+public sealed class HonuaSceneAuthRequirements
+{
+    /// <summary>
+    /// Represents a public scene that does not require extra authentication.
+    /// </summary>
+    public static HonuaSceneAuthRequirements None { get; } = new()
+    {
+        RequiresAuthentication = false,
+        Schemes = Array.Empty<string>(),
+    };
+
+    /// <summary>
+    /// Whether callers must authenticate to access scene metadata or assets.
+    /// </summary>
+    public bool RequiresAuthentication { get; init; }
+
+    /// <summary>
+    /// Authentication schemes accepted by the server, such as <c>Bearer</c> or <c>ApiKey</c>.
+    /// </summary>
+    public IReadOnlyList<string> Schemes { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Optional access policy name or identifier.
+    /// </summary>
+    public string? Policy { get; init; }
+}
+
+/// <summary>
+/// WGS84 scene coordinate used for suggested camera centers.
+/// </summary>
+public sealed class HonuaSceneCoordinate
+{
+    /// <summary>
+    /// Latitude in decimal degrees.
+    /// </summary>
+    public required double Latitude { get; init; }
+
+    /// <summary>
+    /// Longitude in decimal degrees.
+    /// </summary>
+    public required double Longitude { get; init; }
+
+    /// <summary>
+    /// Optional height above the ellipsoid, in meters.
+    /// </summary>
+    public double? Height { get; init; }
+}
+
+/// <summary>
+/// Spatial extent of a scene in WGS84 degrees, optionally including height range.
+/// </summary>
+public sealed class HonuaSceneBounds
+{
+    /// <summary>
+    /// Western longitude bound.
+    /// </summary>
+    public required double MinLongitude { get; init; }
+
+    /// <summary>
+    /// Southern latitude bound.
+    /// </summary>
+    public required double MinLatitude { get; init; }
+
+    /// <summary>
+    /// Eastern longitude bound.
+    /// </summary>
+    public required double MaxLongitude { get; init; }
+
+    /// <summary>
+    /// Northern latitude bound.
+    /// </summary>
+    public required double MaxLatitude { get; init; }
+
+    /// <summary>
+    /// Optional minimum height in meters.
+    /// </summary>
+    public double? MinHeight { get; init; }
+
+    /// <summary>
+    /// Optional maximum height in meters.
+    /// </summary>
+    public double? MaxHeight { get; init; }
+}
+
+/// <summary>
+/// Related link advertised by scene metadata.
+/// </summary>
+public sealed class HonuaSceneLink
+{
+    /// <summary>
+    /// Link relation type.
+    /// </summary>
+    public required string Rel { get; init; }
+
+    /// <summary>
+    /// Link URL.
+    /// </summary>
+    public required Uri Href { get; init; }
+
+    /// <summary>
+    /// Media type for the target resource.
+    /// </summary>
+    public string? Type { get; init; }
+
+    /// <summary>
+    /// Human-readable link title.
+    /// </summary>
+    public string? Title { get; init; }
+}

--- a/tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/list-scenes.json
+++ b/tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/list-scenes.json
@@ -1,0 +1,20 @@
+{
+  "scenes": [
+    {
+      "id": "downtown-honolulu",
+      "name": "Downtown Honolulu",
+      "description": "Photogrammetry and terrain sample for Honolulu urban planning.",
+      "tilesetUrl": "https://api.honua.test/api/scenes/downtown-honolulu/tileset.json",
+      "terrainUrl": "https://api.honua.test/api/scenes/downtown-honolulu/terrain",
+      "bbox": [-157.875, 21.290, -157.835, 21.325],
+      "capabilities": ["3d-tiles", "terrain"],
+      "attribution": ["City and County of Honolulu"],
+      "auth": {
+        "requiresAuthentication": true,
+        "schemes": ["Bearer", "ApiKey"],
+        "policy": "project-members"
+      },
+      "updatedAt": "2026-04-28T00:00:00Z"
+    }
+  ]
+}

--- a/tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/malformed-scene.json
+++ b/tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/malformed-scene.json
@@ -1,0 +1,4 @@
+{
+  "name": "Missing identifier",
+  "capabilities": ["3d-tiles"]
+}

--- a/tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/resolve-array-only-scene.json
+++ b/tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/resolve-array-only-scene.json
@@ -1,0 +1,19 @@
+{
+  "sceneId": "array-only",
+  "auth": {
+    "requiresAuthentication": true,
+    "schemes": ["Bearer"]
+  },
+  "endpoints": [
+    {
+      "kind": "3d-tiles",
+      "url": "https://api.honua.test/api/scenes/array-only/tileset.json",
+      "format": "3d-tiles"
+    },
+    {
+      "kind": "terrain",
+      "url": "https://api.honua.test/api/scenes/array-only/terrain",
+      "format": "quantized-mesh"
+    }
+  ]
+}

--- a/tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/resolve-scene.json
+++ b/tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/resolve-scene.json
@@ -1,0 +1,29 @@
+{
+  "sceneId": "downtown-honolulu",
+  "tilesetUrl": "https://api.honua.test/api/scenes/downtown-honolulu/tileset.json?sig=test",
+  "terrainUrl": "https://api.honua.test/api/scenes/downtown-honolulu/terrain?sig=test",
+  "capabilities": ["3d-tiles", "terrain"],
+  "auth": {
+    "requiresAuthentication": true,
+    "schemes": ["Bearer", "ApiKey"]
+  },
+  "expiresAt": "2026-04-28T02:00:00Z",
+  "endpoints": [
+    {
+      "kind": "3d-tiles",
+      "url": "https://api.honua.test/api/scenes/downtown-honolulu/tileset.json?sig=test",
+      "format": "3d-tiles",
+      "mediaType": "application/json",
+      "requiresAuthentication": true,
+      "headers": {
+        "X-Honua-Scene": "downtown-honolulu"
+      }
+    },
+    {
+      "kind": "terrain",
+      "url": "https://api.honua.test/api/scenes/downtown-honolulu/terrain?sig=test",
+      "format": "quantized-mesh",
+      "requiresAuthentication": true
+    }
+  ]
+}

--- a/tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/scene-metadata.json
+++ b/tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/scene-metadata.json
@@ -1,0 +1,39 @@
+{
+  "id": "downtown-honolulu",
+  "name": "Downtown Honolulu",
+  "description": "Photogrammetry and terrain sample for Honolulu urban planning.",
+  "center": {
+    "latitude": 21.3069,
+    "longitude": -157.8583,
+    "height": 1200
+  },
+  "bounds": {
+    "west": -157.875,
+    "south": 21.290,
+    "east": -157.835,
+    "north": 21.325
+  },
+  "tileset": {
+    "url": "https://api.honua.test/api/scenes/downtown-honolulu/tileset.json",
+    "format": "3d-tiles",
+    "mediaType": "application/json",
+    "requiresAuthentication": true
+  },
+  "terrain": {
+    "url": "https://api.honua.test/api/scenes/downtown-honolulu/terrain",
+    "format": "quantized-mesh",
+    "requiresAuthentication": true
+  },
+  "capabilities": {
+    "3d-tiles": true,
+    "terrain": true
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://api.honua.test/api/scenes/downtown-honolulu",
+      "type": "application/json",
+      "title": "Scene metadata"
+    }
+  ]
+}

--- a/tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/unsupported-scene.json
+++ b/tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/unsupported-scene.json
@@ -1,0 +1,5 @@
+{
+  "sceneId": "terrain-only",
+  "terrainUrl": "https://api.honua.test/api/scenes/terrain-only/terrain",
+  "capabilities": ["terrain"]
+}

--- a/tests/Honua.Mobile.Sdk.Tests/HonuaSceneServiceTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/HonuaSceneServiceTests.cs
@@ -1,0 +1,235 @@
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Honua.Mobile.Sdk;
+using Honua.Mobile.Sdk.Scenes;
+
+namespace Honua.Mobile.Sdk.Tests;
+
+public sealed class HonuaSceneServiceTests
+{
+    [Fact]
+    public async Task ListScenesAsync_ParsesSceneCatalogFixture()
+    {
+        Uri? uri = null;
+        var handler = new RecordingHandler((request, _) =>
+        {
+            uri = request.RequestUri;
+            return Task.FromResult(JsonResponse(ReadFixture("list-scenes.json")));
+        });
+        var client = CreateClient(handler);
+
+        var scenes = await client.Scenes.ListScenesAsync(new HonuaSceneListRequest
+        {
+            Capabilities = new[] { HonuaSceneCapabilities.ThreeDimensionalTiles },
+        });
+
+        Assert.Equal("https://api.honua.test/api/scenes?f=json&capabilities=3d-tiles", uri?.ToString());
+        var scene = Assert.Single(scenes);
+        Assert.Equal("downtown-honolulu", scene.Id);
+        Assert.Equal("Downtown Honolulu", scene.Name);
+        Assert.Contains(HonuaSceneCapabilities.ThreeDimensionalTiles, scene.Capabilities);
+        Assert.Contains(HonuaSceneCapabilities.Terrain, scene.Capabilities);
+        Assert.True(scene.Auth.RequiresAuthentication);
+        Assert.Equal(-157.875, scene.Bounds!.MinLongitude, precision: 3);
+        Assert.Equal(21.325, scene.Bounds.MaxLatitude, precision: 3);
+    }
+
+    [Fact]
+    public async Task GetSceneAsync_ParsesEndpointMetadata()
+    {
+        var handler = new RecordingHandler((_, _) =>
+        {
+            return Task.FromResult(JsonResponse(ReadFixture("scene-metadata.json")));
+        });
+        var client = CreateClient(handler);
+
+        var scene = await client.Scenes.GetSceneAsync("downtown-honolulu");
+
+        Assert.Equal("downtown-honolulu", scene.Id);
+        Assert.Equal(new Uri("https://api.honua.test/api/scenes/downtown-honolulu/tileset.json"), scene.Tileset!.Url);
+        Assert.Equal("quantized-mesh", scene.Terrain!.Format);
+        Assert.Equal(21.3069, scene.Center!.Latitude, precision: 4);
+        Assert.Single(scene.Links);
+    }
+
+    [Fact]
+    public async Task ResolveSceneAsync_ReturnsClientReadyUrls()
+    {
+        Uri? uri = null;
+        var handler = new RecordingHandler((request, _) =>
+        {
+            uri = request.RequestUri;
+            return Task.FromResult(JsonResponse(ReadFixture("resolve-scene.json")));
+        });
+        var client = CreateClient(handler);
+
+        var resolution = await client.Scenes.ResolveSceneAsync(
+            "downtown-honolulu",
+            new HonuaSceneResolveRequest
+            {
+                RequiredCapabilities = new[] { HonuaSceneCapabilities.ThreeDimensionalTiles },
+            });
+
+        Assert.Equal("https://api.honua.test/api/scenes/downtown-honolulu/resolve?f=json&capabilities=3d-tiles&includeTerrain=true", uri?.ToString());
+        Assert.Equal("downtown-honolulu", resolution.SceneId);
+        Assert.Equal(new Uri("https://api.honua.test/api/scenes/downtown-honolulu/tileset.json?sig=test"), resolution.TilesetUrl);
+        Assert.Equal(new Uri("https://api.honua.test/api/scenes/downtown-honolulu/terrain?sig=test"), resolution.TerrainUrl);
+        Assert.True(resolution.Auth.RequiresAuthentication);
+        Assert.Equal(2, resolution.Endpoints.Count);
+        Assert.Equal("downtown-honolulu", resolution.Endpoints[0].Headers["X-Honua-Scene"]);
+    }
+
+    [Fact]
+    public async Task ResolveSceneAsync_WithSdkCredentials_SendsAuthHeaders()
+    {
+        string? apiKey = null;
+        string? authorization = null;
+        var handler = new RecordingHandler((request, _) =>
+        {
+            if (request.Headers.TryGetValues("X-API-Key", out var values))
+            {
+                apiKey = values.First();
+            }
+
+            authorization = request.Headers.Authorization?.ToString();
+            return Task.FromResult(JsonResponse(ReadFixture("resolve-scene.json")));
+        });
+        var client = CreateClient(handler, new HonuaMobileClientOptions
+        {
+            BaseUri = new Uri("https://api.honua.test"),
+            ApiKey = "scene-api-key",
+            BearerToken = "scene-bearer-token",
+            PreferGrpcForFeatureQueries = false,
+            PreferGrpcForFeatureEdits = false,
+        });
+
+        await client.Scenes.ResolveSceneAsync("downtown-honolulu");
+
+        Assert.Equal("scene-api-key", apiKey);
+        Assert.Equal("Bearer scene-bearer-token", authorization);
+    }
+
+    [Fact]
+    public async Task GetSceneAsync_NotFound_ThrowsApiException()
+    {
+        var handler = new RecordingHandler((_, _) =>
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent("""{"title":"Scene not found"}""", Encoding.UTF8, "application/problem+json"),
+            });
+        });
+        var client = CreateClient(handler);
+
+        var ex = await Assert.ThrowsAsync<HonuaMobileApiException>(() => client.Scenes.GetSceneAsync("missing"));
+
+        Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
+        Assert.Contains("404", ex.Message);
+    }
+
+    [Fact]
+    public async Task ResolveSceneAsync_Unauthorized_ThrowsApiException()
+    {
+        var handler = new RecordingHandler((_, _) =>
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent("""{"title":"Authentication required"}""", Encoding.UTF8, "application/problem+json"),
+            });
+        });
+        var client = CreateClient(handler);
+
+        var ex = await Assert.ThrowsAsync<HonuaMobileApiException>(() => client.Scenes.ResolveSceneAsync("protected"));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, ex.StatusCode);
+        Assert.NotNull(ex.ResponseBody);
+        Assert.Contains("Authentication required", ex.ResponseBody);
+    }
+
+    [Fact]
+    public async Task ResolveSceneAsync_MissingRequiredCapability_ThrowsApiException()
+    {
+        var handler = new RecordingHandler((_, _) =>
+        {
+            return Task.FromResult(JsonResponse(ReadFixture("unsupported-scene.json")));
+        });
+        var client = CreateClient(handler);
+
+        var ex = await Assert.ThrowsAsync<HonuaMobileApiException>(() => client.Scenes.ResolveSceneAsync(
+            "terrain-only",
+            new HonuaSceneResolveRequest
+            {
+                RequiredCapabilities = new[] { HonuaSceneCapabilities.ThreeDimensionalTiles },
+            }));
+
+        Assert.Contains("3d-tiles", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetSceneAsync_MalformedResponse_ThrowsApiException()
+    {
+        var handler = new RecordingHandler((_, _) =>
+        {
+            return Task.FromResult(JsonResponse(ReadFixture("malformed-scene.json")));
+        });
+        var client = CreateClient(handler);
+
+        var ex = await Assert.ThrowsAsync<HonuaMobileApiException>(() => client.Scenes.GetSceneAsync("bad"));
+
+        Assert.Contains("malformed", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ListScenesAsync_InvalidJson_ThrowsApiException()
+    {
+        var handler = new RecordingHandler((_, _) =>
+        {
+            return Task.FromResult(JsonResponse("not-json"));
+        });
+        var client = CreateClient(handler);
+
+        var ex = await Assert.ThrowsAsync<HonuaMobileApiException>(() => client.Scenes.ListScenesAsync());
+
+        Assert.Contains("invalid JSON", ex.Message);
+    }
+
+    private static HonuaMobileClient CreateClient(
+        HttpMessageHandler handler,
+        HonuaMobileClientOptions? options = null)
+    {
+        options ??= new HonuaMobileClientOptions
+        {
+            BaseUri = new Uri("https://api.honua.test"),
+            PreferGrpcForFeatureQueries = false,
+            PreferGrpcForFeatureEdits = false,
+        };
+
+        return new HonuaMobileClient(new HttpClient(handler), options);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(json, Encoding.UTF8, "application/json"),
+    };
+
+    private static string ReadFixture(string name, [CallerFilePath] string sourceFile = "")
+    {
+        var testDirectory = Path.GetDirectoryName(sourceFile)
+            ?? throw new InvalidOperationException("Unable to resolve test directory.");
+        return File.ReadAllText(Path.Combine(testDirectory, "Fixtures", "Scenes", name));
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _responder;
+
+        public RecordingHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder)
+        {
+            _responder = responder;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => _responder(request, cancellationToken);
+    }
+}

--- a/tests/Honua.Mobile.Sdk.Tests/HonuaSceneServiceTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/HonuaSceneServiceTests.cs
@@ -81,6 +81,27 @@ public sealed class HonuaSceneServiceTests
     }
 
     [Fact]
+    public async Task ResolveSceneAsync_WithEndpointArrayOnly_PopulatesUrlsAndInheritedAuth()
+    {
+        var handler = new RecordingHandler((_, _) =>
+        {
+            return Task.FromResult(JsonResponse(ReadFixture("resolve-array-only-scene.json")));
+        });
+        var client = CreateClient(handler);
+
+        var resolution = await client.Scenes.ResolveSceneAsync(
+            "array-only",
+            new HonuaSceneResolveRequest
+            {
+                RequiredCapabilities = new[] { HonuaSceneCapabilities.ThreeDimensionalTiles },
+            });
+
+        Assert.Equal(new Uri("https://api.honua.test/api/scenes/array-only/tileset.json"), resolution.TilesetUrl);
+        Assert.Equal(new Uri("https://api.honua.test/api/scenes/array-only/terrain"), resolution.TerrainUrl);
+        Assert.All(resolution.Endpoints, endpoint => Assert.True(endpoint.RequiresAuthentication));
+    }
+
+    [Fact]
     public async Task ResolveSceneAsync_WithSdkCredentials_SendsAuthHeaders()
     {
         string? apiKey = null;


### PR DESCRIPTION
## Summary
- Add `HonuaSceneService` / `IHonuaSceneService` with typed scene metadata, endpoint, bounds, auth, and resolution models
- Expose `client.Scenes` plus MAUI DI registration through `AddHonuaScenes()`
- Parse fixture-backed scene list, detail, and resolve responses with SDK auth/error handling
- Document resolving scene URLs before rendering with `<honua-scene>`

Closes #32

## Testing
- dotnet build src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj --no-restore --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --no-restore --configuration Release
- dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj --no-restore --configuration Release
- dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --no-restore --configuration Release
- dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --no-restore --configuration Release
- dotnet format src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj --no-restore --verify-no-changes --verbosity diagnostic
- dotnet format src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj --no-restore --verify-no-changes --verbosity diagnostic
- git diff --check

## Platform Impact
- SDK and MAUI service-registration changes only; no native renderer changes.
- Android build remains advisory through the existing CI Gate policy.

## Breaking Changes
None.