### PR TITLE
docs(scene): define protected 3D auth handoff

### DIFF
--- a/docs/guides/3d-scene-embed.md
+++ b/docs/guides/3d-scene-embed.md
@@ -71,3 +71,8 @@ The package build copies Cesium `Assets`, `Workers`, `ThirdParty`, and `Widgets`
 This first slice proves client-side 3D Tiles loading, scene events, and typed SDK scene discovery. Honua-hosted scene registry, terrain tiles, elevation APIs, 3D Tiles generation, and I3S compatibility are tracked in the linked server backlog.
 
 Use the [mobile 3D and AR dependency matrix](mobile-3d-ar-dependency-matrix.md) before starting native AR/VR or offline 3D work. It captures the required server tickets, SDK tickets, platform risks, offline constraints, and edition gates for each client capability.
+
+For protected Honua-hosted scenes, resolve renderer-safe signed URLs through
+`HonuaSceneService` before assigning `tileset-url` or `terrain-url`. Do not pass
+bearer tokens, API keys, or arbitrary request headers into `<honua-scene>`
+attributes. See [Protected 3D Scene Auth](protected-3d-scene-auth.md).

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -13,5 +13,6 @@ In-depth guides for building with the Honua Mobile SDK.
 | [Offline 3D Scene Packages](offline-3d-scene-packages.md) | Package manifest, cache, expiry, and platform policy for offline 3D scenes |
 | [Offline Sync](offline-sync.md) | GeoPackage storage, sync engine configuration, and conflict resolution |
 | [Performance](performance.md) | Optimizing startup time, memory usage, and sync throughput |
+| [Protected 3D Scene Auth](protected-3d-scene-auth.md) | Signed URL, proxy, header, CORS, cache, and revocation policy for protected scene assets |
 | [Security](security.md) | Authentication, transport security, and secure storage best practices |
 | [Troubleshooting](troubleshooting.md) | Common issues and solutions for development and production |

--- a/docs/guides/mobile-3d-ar-dependency-matrix.md
+++ b/docs/guides/mobile-3d-ar-dependency-matrix.md
@@ -36,7 +36,7 @@ The 3D and AR path should move in this order:
 | 6 | honua-io/honua-server#839 and honua-io/honua-server#840 terrain and elevation | Adds the surface and query data needed for field context and profiles. |
 | 7 | honua-io/honua-server#841 and honua-io/honua-server#842 3D features and generation | Produces Honua-owned operational 3D data instead of only hosted external assets. |
 | 8 | #36 offline 3D cache packaging policy | Defines whether 3D scenes can be trusted in disconnected field workflows. |
-| 9 | #37 protected 3D tiles auth handoff | Decides how private scene assets are safely loaded by browsers, WebViews, and native hosts. |
+| 9 | #37 protected 3D tiles auth handoff | Defines how private scene assets are safely loaded by browsers, WebViews, and native hosts. |
 | 10 | #38 native scene anchoring requirements | Narrows ARKit, ARCore, WebXR, and MAUI requirements before #23 implementation. |
 | 11 | #23 AR/VR field workflow enablement | Starts native AR/VR only after scene data, auth, offline, and platform risks are explicit. |
 
@@ -79,9 +79,12 @@ Open decisions are tracked as follow-up tickets:
 
 | Ticket | Question |
 |--------|----------|
-| #37 | Should protected tilesets use signed URLs, short-lived scene tokens, proxying, request-header injection, or a hybrid model? |
 | #38 | Which AR anchoring strategy and first prototype platform should #23 use? |
 
 The offline 3D package model from #36 is captured in
 [Offline 3D Scene Packages](offline-3d-scene-packages.md), with implementation
 follow-ups in #40, #41, and #42.
+
+The protected scene auth handoff from #37 is captured in
+[Protected 3D Scene Auth](protected-3d-scene-auth.md), with implementation
+follow-ups in #44 and honua-io/honua-server#849.

--- a/docs/guides/protected-3d-scene-auth.md
+++ b/docs/guides/protected-3d-scene-auth.md
@@ -1,0 +1,157 @@
+# Protected 3D Scene Auth Handoff
+
+Protected 3D Tiles and terrain assets need a renderer-safe auth handoff because
+scene renderers fetch many nested resources after the entry `tileset.json` or
+terrain provider URL is loaded. Browser and WebView renderers cannot rely on the
+same request-header hooks as native HTTP clients, and credentials must not be
+leaked into markup or logs.
+
+## Recommendation
+
+Use a hybrid strategy:
+
+1. Public scenes use public HTTPS URLs with deterministic `ETag` and
+   `Cache-Control` headers.
+2. Protected browser and WebView scenes use short-lived signed URLs or a signed
+   asset prefix returned by `HonuaSceneService.ResolveSceneAsync`.
+3. Native runtimes may use request headers only when the client explicitly
+   declares that nested renderer asset requests support headers.
+4. A first-party proxy is a fallback for strict tenant policy, audit, or
+   revocation requirements, not the default path.
+
+Do not pass bearer tokens, API keys, refresh tokens, or arbitrary auth headers
+to `<honua-scene>` attributes. The renderer receives only URLs that are safe to
+render, plus non-secret expiry/cache metadata for host UI decisions.
+
+## Strategy Comparison
+
+| Strategy | Browser/WebView fit | Native fit | Pros | Risks | Recommendation |
+|----------|---------------------|------------|------|-------|----------------|
+| Public URL | High | High | Simple, cacheable, works with Cesium nested fetches | Only valid for public scenes | Use for public scenes. |
+| Short-lived signed URL or signed asset prefix | High | High | Works with nested renderer fetches, CDN-compatible, no bearer token in markup | URL sharing until expiry; refresh required | Default for protected scenes. |
+| First-party proxy URL | Medium | Medium | Central audit, fast revocation, hides origin storage layout | Higher server cost, latency, CDN complexity | Fallback for strict policy or tenants that cannot use signed URLs. |
+| Request-header injection | Low | Medium | Avoids URL bearer material and can use normal SDK auth | Browser/Cesium nested fetch support is inconsistent; easy to leak headers into client code | Native-only opt-in, never browser default. |
+| Cookie-only session | Low | Low | Familiar web auth model | Third-party cookie blocking, WebView differences, CSRF and origin complexity | Avoid for embeddable scene assets. |
+
+## Access Envelope
+
+The scene resolve API should return an access envelope for each protected
+endpoint. #44 tracks mobile SDK contracts for this shape, and
+honua-io/honua-server#849 tracks server support.
+
+```json
+{
+  "sceneId": "downtown-honolulu",
+  "tilesetUrl": "https://cdn.honua.example/scenes/downtown/tileset.json?sig=...",
+  "terrainUrl": "https://cdn.honua.example/scenes/downtown/terrain?sig=...",
+  "expiresAt": "2026-04-28T18:30:00Z",
+  "auth": {
+    "requiresAuthentication": true,
+    "schemes": ["SignedUrl"],
+    "policy": "scene-render-protected"
+  },
+  "access": {
+    "mode": "signed-url",
+    "refreshAfterUtc": "2026-04-28T18:20:00Z",
+    "expiresAtUtc": "2026-04-28T18:30:00Z",
+    "corsMode": "registered-origins",
+    "cache": {
+      "public": false,
+      "maxAgeSeconds": 300,
+      "staleWhileRevalidateSeconds": 60
+    },
+    "customHeadersAllowed": false,
+    "revocationKey": "scene-rev-42"
+  }
+}
+```
+
+Required access fields:
+
+| Field | Requirement |
+|-------|-------------|
+| `mode` | One of `public`, `signed-url`, `proxy`, or `headers`. |
+| `expiresAtUtc` | Hard stop for using signed/proxy access. |
+| `refreshAfterUtc` | Host should resolve the scene again before this time. |
+| `corsMode` | Server CORS behavior, such as `public`, `registered-origins`, or `same-origin`. |
+| `cache` | Client-visible cache policy for renderer and host decisions. |
+| `customHeadersAllowed` | `true` only for native/header-capable runtimes. |
+| `revocationKey` | Server revision or policy key that invalidates previously issued access. |
+
+## Runtime Guidance
+
+### Browser and WebView
+
+- Resolve the scene through the SDK or host backend.
+- Pass only `tileset-url` and `terrain-url` values from the resolved response to
+  `<honua-scene>`.
+- Refresh the scene before `refreshAfterUtc` during long sessions.
+- Treat `expiresAtUtc` as a hard stop and unload protected assets after expiry.
+- Do not put bearer tokens, API keys, or header JSON into DOM attributes.
+- Prefer signed URL query strings or signed path prefixes over cookies.
+
+### MAUI
+
+- Use `HonuaSceneService` as the shared access resolver.
+- Prefer the same signed URL path as browser/WebView so MAUI WebView and native
+  renderers behave consistently.
+- Store refresh credentials in platform secure storage, not in renderer markup
+  or package manifests.
+- Clear resolved URLs on sign-out, account switch, tenant switch, or access
+  revocation.
+
+### Native SDKs
+
+- Use signed URLs by default for parity with browser rendering.
+- Use header mode only when the renderer owns every nested asset request and can
+  attach headers consistently.
+- Keep bearer/API-key auth in SDK transport code and never expose it as scene
+  metadata intended for rendering.
+
+## CORS, Cache, And CDN Rules
+
+Protected scene assets should use these defaults:
+
+- `Access-Control-Allow-Origin` must be restricted to registered app/embed
+  origins for browser access; use `Vary: Origin` when origin-specific.
+- Allow `GET`, `HEAD`, and `OPTIONS` for scene assets.
+- Expose only non-secret headers needed by renderers and host code, such as
+  `ETag`, `Cache-Control`, `Content-Length`, and `Content-Type`.
+- Public scenes may use shared CDN caching with deterministic `ETag`.
+- Protected signed URLs may use short CDN TTLs that do not exceed
+  `expiresAtUtc`.
+- Do not cache protected signed URL responses in a shared cache unless the
+  signature scopes the asset, scene revision, tenant, and expiry.
+
+## Expiry, Refresh, And Revocation
+
+Access expiry is separate from offline package use:
+
+- Online render URLs expire at `expiresAtUtc`.
+- Hosts should refresh at `refreshAfterUtc` to avoid mid-session renderer
+  failures.
+- Server revocation should invalidate access by scene revision, tenant, user, or
+  key rotation.
+- Offline packages follow [Offline 3D Scene Packages](offline-3d-scene-packages.md)
+  and must not treat online signed URL expiry as the offline use grant.
+
+## Security Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Signed URL copied from logs or browser devtools | Keep TTL short, scope URL to tenant/scene/revision, avoid bearer material in URL, and scrub logs. |
+| Protected assets cached beyond authorization | Bound CDN/browser max age by `expiresAtUtc` and purge on revocation where supported. |
+| Header instructions exposed to browser code | Use signed URLs for browser/WebView; reserve header mode for native-only clients. |
+| Cross-origin embed leaks access | Restrict CORS to registered origins and use `Vary: Origin`. |
+| Mid-session expiry breaks rendering | Return `refreshAfterUtc` and let hosts re-resolve before expiry. |
+| Offline package outlives entitlement | Enforce `offlineUseExpiresAtUtc` from the offline package manifest. |
+
+## Implementation Follow-Ups
+
+| Ticket | Scope |
+|--------|-------|
+| #44 | Add SDK scene access-envelope models and parsing for render-safe access metadata. |
+| honua-io/honua-server#849 | Add server scene access envelopes with signed URL/proxy/header modes. |
+| honua-io/honua-server#837 | Apply auth, CORS, and cache behavior while serving hosted 3D Tiles assets. |
+| honua-io/honua-server#844 | Expose public/protected scene access configuration in the scene registry. |
+

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -43,6 +43,11 @@ private static string GetSecureApiKey()
 }
 ```
 
+Protected 3D scene assets need a separate renderer handoff because scene
+renderers fetch nested tiles, terrain, textures, and binary payloads after the
+initial SDK request. Use [Protected 3D Scene Auth](protected-3d-scene-auth.md)
+for signed URL, proxy, CORS, cache, and revocation guidance.
+
 ### Secure API Key Storage
 
 Implement secure key management:


### PR DESCRIPTION
## Summary
- add the Protected 3D Scene Auth guide with the recommended signed URL / proxy / header hybrid strategy
- document access-envelope fields, browser/WebView, MAUI, native, CORS, cache, expiry, revocation, and security guidance
- link the guide from the docs index, 3D Scene Embed, Security guide, and dependency matrix
- create follow-ups #44 and honua-io/honua-server#849; linked server #837/#844 via comments

Closes #37

## Platform impact
Docs-only. Captures browser/WebView, MAUI, and native runtime guidance without changing runtime code.

## Offline impact
Docs-only. Clarifies that online signed URL expiry is separate from offline package grants from #36.

## Validation
- git diff --check
