### PR TITLE
feat(sdk): add scene access envelope contracts

### DIFF
--- a/docs/guides/protected-3d-scene-auth.md
+++ b/docs/guides/protected-3d-scene-auth.md
@@ -90,6 +90,19 @@ Required access fields:
 - Do not put bearer tokens, API keys, or header JSON into DOM attributes.
 - Prefer signed URL query strings or signed path prefixes over cookies.
 
+```csharp
+var resolvedScene = await client.Scenes.ResolveSceneAsync("downtown-honolulu");
+
+if (resolvedScene.Access is { IsBrowserSafe: false })
+{
+    throw new InvalidOperationException("Scene access requires a native renderer.");
+}
+
+// Host apps pass only renderer-safe URLs to the web component.
+var tilesetUrl = resolvedScene.TilesetUrl;
+var terrainUrl = resolvedScene.TerrainUrl;
+```
+
 ### MAUI
 
 - Use `HonuaSceneService` as the shared access resolver.
@@ -154,4 +167,3 @@ Access expiry is separate from offline package use:
 | honua-io/honua-server#849 | Add server scene access envelopes with signed URL/proxy/header modes. |
 | honua-io/honua-server#837 | Apply auth, CORS, and cache behavior while serving hosted 3D Tiles assets. |
 | honua-io/honua-server#844 | Expose public/protected scene access configuration in the scene registry. |
-

--- a/src/Honua.Mobile.Sdk/Scenes/HonuaSceneService.cs
+++ b/src/Honua.Mobile.Sdk/Scenes/HonuaSceneService.cs
@@ -190,9 +190,10 @@ internal static class HonuaSceneJsonParser
         {
             var root = document.RootElement;
             var sceneId = GetString(root, "sceneId", "id") ?? fallbackSceneId;
-            var tileset = ParseEndpoint(root, HonuaSceneCapabilities.ThreeDimensionalTiles, "tileset", "tilesetUrl");
-            var terrain = ParseEndpoint(root, HonuaSceneCapabilities.Terrain, "terrain", "terrainUrl");
-            var endpoints = ParseEndpointArray(root)
+            var access = ParseAccessEnvelope(root);
+            var tileset = ParseEndpoint(root, HonuaSceneCapabilities.ThreeDimensionalTiles, "tileset", "tilesetUrl", access);
+            var terrain = ParseEndpoint(root, HonuaSceneCapabilities.Terrain, "terrain", "terrainUrl", access);
+            var endpoints = ParseEndpointArray(root, access)
                 .Concat(
                     new[] { tileset, terrain }
                         .Where(endpoint => endpoint is not null)
@@ -210,6 +211,7 @@ internal static class HonuaSceneJsonParser
                 Capabilities = capabilities,
                 Auth = ParseAuth(root),
                 ExpiresAt = GetDateTimeOffset(root, "expiresAt", "expiration", "validUntil"),
+                Access = access,
                 RawResponse = root.Clone(),
             };
         }
@@ -223,8 +225,9 @@ internal static class HonuaSceneJsonParser
     {
         var id = GetString(element, "id", "sceneId")
             ?? throw new InvalidOperationException("Scene item is missing an id.");
-        var tileset = ParseEndpoint(element, HonuaSceneCapabilities.ThreeDimensionalTiles, "tileset", "tilesetUrl");
-        var terrain = ParseEndpoint(element, HonuaSceneCapabilities.Terrain, "terrain", "terrainUrl");
+        var access = ParseAccessEnvelope(element);
+        var tileset = ParseEndpoint(element, HonuaSceneCapabilities.ThreeDimensionalTiles, "tileset", "tilesetUrl", access);
+        var terrain = ParseEndpoint(element, HonuaSceneCapabilities.Terrain, "terrain", "terrainUrl", access);
         var endpoints = new[] { tileset, terrain }.Where(endpoint => endpoint is not null).Cast<HonuaSceneEndpoint>().ToArray();
 
         return new HonuaSceneSummary
@@ -245,8 +248,9 @@ internal static class HonuaSceneJsonParser
     {
         var id = GetString(element, "id", "sceneId")
             ?? throw new InvalidOperationException("Scene metadata is missing an id.");
-        var tileset = ParseEndpoint(element, HonuaSceneCapabilities.ThreeDimensionalTiles, "tileset", "tilesetUrl");
-        var terrain = ParseEndpoint(element, HonuaSceneCapabilities.Terrain, "terrain", "terrainUrl");
+        var access = ParseAccessEnvelope(element);
+        var tileset = ParseEndpoint(element, HonuaSceneCapabilities.ThreeDimensionalTiles, "tileset", "tilesetUrl", access);
+        var terrain = ParseEndpoint(element, HonuaSceneCapabilities.Terrain, "terrain", "terrainUrl", access);
         var endpoints = new[] { tileset, terrain }
             .Where(endpoint => endpoint is not null)
             .Cast<HonuaSceneEndpoint>()
@@ -292,13 +296,14 @@ internal static class HonuaSceneJsonParser
         JsonElement root,
         string defaultKind,
         string objectPropertyName,
-        string urlPropertyName)
+        string urlPropertyName,
+        HonuaSceneAccessEnvelope? inheritedAccess)
     {
         var inheritedRequiresAuthentication = ParseAuth(root).RequiresAuthentication;
 
         if (TryGetProperty(root, objectPropertyName, out var endpoint) && endpoint.ValueKind == JsonValueKind.Object)
         {
-            return ParseEndpointObject(endpoint, defaultKind, inheritedRequiresAuthentication);
+            return ParseEndpointObject(endpoint, defaultKind, inheritedRequiresAuthentication, inheritedAccess);
         }
 
         if (TryGetProperty(root, "endpoints", out var endpoints) &&
@@ -306,7 +311,7 @@ internal static class HonuaSceneJsonParser
             TryGetProperty(endpoints, objectPropertyName, out endpoint) &&
             endpoint.ValueKind == JsonValueKind.Object)
         {
-            return ParseEndpointObject(endpoint, defaultKind, inheritedRequiresAuthentication);
+            return ParseEndpointObject(endpoint, defaultKind, inheritedRequiresAuthentication, inheritedAccess);
         }
 
         var url = GetUri(root, urlPropertyName);
@@ -324,16 +329,19 @@ internal static class HonuaSceneJsonParser
                 : null,
             Format = defaultKind,
             RequiresAuthentication = ParseAuth(root).RequiresAuthentication,
+            Access = inheritedAccess,
         };
     }
 
     private static HonuaSceneEndpoint ParseEndpointObject(
         JsonElement endpoint,
         string defaultKind,
-        bool inheritedRequiresAuthentication)
+        bool inheritedRequiresAuthentication,
+        HonuaSceneAccessEnvelope? inheritedAccess)
     {
         var url = GetUri(endpoint, "url", "href")
             ?? throw new InvalidOperationException($"Scene endpoint '{defaultKind}' is missing a url.");
+        var access = ParseAccessEnvelope(endpoint) ?? inheritedAccess;
 
         return new HonuaSceneEndpoint
         {
@@ -343,10 +351,13 @@ internal static class HonuaSceneJsonParser
             Format = GetString(endpoint, "format") ?? defaultKind,
             RequiresAuthentication = GetBool(endpoint, "requiresAuthentication", "requiresAuth") ?? inheritedRequiresAuthentication,
             Headers = ParseHeaders(endpoint),
+            Access = access,
         };
     }
 
-    private static IReadOnlyList<HonuaSceneEndpoint> ParseEndpointArray(JsonElement root)
+    private static IReadOnlyList<HonuaSceneEndpoint> ParseEndpointArray(
+        JsonElement root,
+        HonuaSceneAccessEnvelope? inheritedAccess)
     {
         if (!TryGetProperty(root, "endpoints", out var endpoints) || endpoints.ValueKind != JsonValueKind.Array)
         {
@@ -359,7 +370,8 @@ internal static class HonuaSceneJsonParser
             .Select(endpoint => ParseEndpointObject(
                 endpoint,
                 GetString(endpoint, "kind", "type") ?? "resource",
-                inheritedRequiresAuthentication))
+                inheritedRequiresAuthentication,
+                inheritedAccess))
             .ToArray();
     }
 
@@ -465,6 +477,53 @@ internal static class HonuaSceneJsonParser
             RequiresAuthentication = requiresAuthentication,
             Schemes = GetStringArray(auth, "schemes", "methods"),
             Policy = GetString(auth, "policy", "policyId"),
+        };
+    }
+
+    private static HonuaSceneAccessEnvelope? ParseAccessEnvelope(JsonElement root)
+    {
+        var hasAccessObject =
+            TryGetProperty(root, "access", out var accessElement) &&
+            accessElement.ValueKind == JsonValueKind.Object;
+        var access = hasAccessObject ? accessElement : root;
+        var rawMode = GetString(access, "mode", "accessMode", "type") ?? GetString(root, "accessMode");
+
+        if (string.IsNullOrWhiteSpace(rawMode) && !hasAccessObject)
+        {
+            return null;
+        }
+
+        var mode = NormalizeAccessMode(rawMode ?? "unknown");
+        var expiresAt =
+            GetDateTimeOffset(access, "expiresAtUtc", "expiresAt", "expiration", "validUntil") ??
+            (hasAccessObject ? GetDateTimeOffset(root, "expiresAt", "expiration", "validUntil") : null);
+
+        return new HonuaSceneAccessEnvelope
+        {
+            Mode = mode,
+            RefreshAfter = GetDateTimeOffset(access, "refreshAfterUtc", "refreshAfter", "refreshAt"),
+            ExpiresAt = expiresAt,
+            CorsMode = GetString(access, "corsMode", "cors"),
+            Cache = ParseAccessCachePolicy(access),
+            CustomHeadersAllowed = GetBool(access, "customHeadersAllowed", "headersAllowed", "allowCustomHeaders") ??
+                string.Equals(mode, HonuaSceneAccessModes.Headers, StringComparison.OrdinalIgnoreCase),
+            RevocationKey = GetString(access, "revocationKey", "revision", "serverRevision"),
+        };
+    }
+
+    private static HonuaSceneAccessCachePolicy ParseAccessCachePolicy(JsonElement access)
+    {
+        if (!TryGetProperty(access, "cache", out var cache) || cache.ValueKind != JsonValueKind.Object)
+        {
+            return HonuaSceneAccessCachePolicy.Empty;
+        }
+
+        return new HonuaSceneAccessCachePolicy
+        {
+            Public = GetBool(cache, "public", "shared"),
+            MaxAgeSeconds = GetInt(cache, "maxAgeSeconds", "maxAge"),
+            StaleWhileRevalidateSeconds = GetInt(cache, "staleWhileRevalidateSeconds", "staleWhileRevalidate"),
+            NoStore = GetBool(cache, "noStore", "no-store") ?? false,
         };
     }
 
@@ -693,6 +752,30 @@ internal static class HonuaSceneJsonParser
         return null;
     }
 
+    private static int? GetInt(JsonElement element, params string[] propertyNames)
+    {
+        foreach (var propertyName in propertyNames)
+        {
+            if (!TryGetProperty(element, propertyName, out var value))
+            {
+                continue;
+            }
+
+            if (value.ValueKind == JsonValueKind.Number && value.TryGetInt32(out var number))
+            {
+                return number;
+            }
+
+            if (value.ValueKind == JsonValueKind.String &&
+                int.TryParse(value.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                return parsed;
+            }
+        }
+
+        return null;
+    }
+
     private static DateTimeOffset? GetDateTimeOffset(JsonElement element, params string[] propertyNames)
     {
         foreach (var propertyName in propertyNames)
@@ -742,6 +825,19 @@ internal static class HonuaSceneJsonParser
         {
             capabilities.Add(capability);
         }
+    }
+
+    private static string NormalizeAccessMode(string value)
+    {
+        var mode = value.Trim().Replace('_', '-').ToLowerInvariant();
+        return mode switch
+        {
+            "signedurl" or "signed-url" => HonuaSceneAccessModes.SignedUrl,
+            "header" or "headers" => HonuaSceneAccessModes.Headers,
+            "proxy" => HonuaSceneAccessModes.Proxy,
+            "public" => HonuaSceneAccessModes.Public,
+            _ => mode,
+        };
     }
 
     private static HonuaMobileApiException Malformed(Exception ex)

--- a/src/Honua.Mobile.Sdk/Scenes/HonuaSceneService.cs
+++ b/src/Honua.Mobile.Sdk/Scenes/HonuaSceneService.cs
@@ -486,7 +486,9 @@ internal static class HonuaSceneJsonParser
             TryGetProperty(root, "access", out var accessElement) &&
             accessElement.ValueKind == JsonValueKind.Object;
         var access = hasAccessObject ? accessElement : root;
-        var rawMode = GetString(access, "mode", "accessMode", "type") ?? GetString(root, "accessMode");
+        var rawMode = hasAccessObject
+            ? GetString(access, "mode", "accessMode", "type")
+            : GetString(access, "mode", "accessMode") ?? GetString(root, "accessMode");
 
         if (string.IsNullOrWhiteSpace(rawMode) && !hasAccessObject)
         {

--- a/src/Honua.Mobile.Sdk/Scenes/SceneModels.cs
+++ b/src/Honua.Mobile.Sdk/Scenes/SceneModels.cs
@@ -269,6 +269,11 @@ public sealed class HonuaSceneResolution
     public DateTimeOffset? ExpiresAt { get; init; }
 
     /// <summary>
+    /// Renderer-safe access envelope describing how resolved scene URLs may be used.
+    /// </summary>
+    public HonuaSceneAccessEnvelope? Access { get; init; }
+
+    /// <summary>
     /// Raw JSON object for callers that need server-specific metadata not modeled by the SDK yet.
     /// </summary>
     public JsonElement RawResponse { get; init; }
@@ -308,6 +313,141 @@ public sealed class HonuaSceneEndpoint
     /// Server-supplied request headers for clients that support custom resource headers.
     /// </summary>
     public IReadOnlyDictionary<string, string> Headers { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Access envelope for this endpoint. When <see langword="null"/>, use the parent scene resolution access envelope.
+    /// </summary>
+    public HonuaSceneAccessEnvelope? Access { get; init; }
+}
+
+/// <summary>
+/// Well-known access modes for scene render endpoints.
+/// </summary>
+public static class HonuaSceneAccessModes
+{
+    /// <summary>
+    /// Public URL that does not require extra renderer authentication.
+    /// </summary>
+    public const string Public = "public";
+
+    /// <summary>
+    /// Short-lived signed URL or signed asset prefix.
+    /// </summary>
+    public const string SignedUrl = "signed-url";
+
+    /// <summary>
+    /// First-party proxy URL used to serve protected scene assets.
+    /// </summary>
+    public const string Proxy = "proxy";
+
+    /// <summary>
+    /// Native-only mode where every nested renderer request can attach custom headers.
+    /// </summary>
+    public const string Headers = "headers";
+
+    /// <summary>
+    /// Returns whether <paramref name="mode"/> is a mode understood by this SDK version.
+    /// </summary>
+    public static bool IsSupported(string? mode)
+        => string.Equals(mode, Public, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(mode, SignedUrl, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(mode, Proxy, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(mode, Headers, StringComparison.OrdinalIgnoreCase);
+}
+
+/// <summary>
+/// Renderer-safe access metadata for resolved scene URLs.
+/// </summary>
+public sealed class HonuaSceneAccessEnvelope
+{
+    /// <summary>
+    /// Access mode. Known values are in <see cref="HonuaSceneAccessModes"/>.
+    /// </summary>
+    public required string Mode { get; init; }
+
+    /// <summary>
+    /// Time when the host should refresh scene access before a long render session reaches hard expiry.
+    /// </summary>
+    public DateTimeOffset? RefreshAfter { get; init; }
+
+    /// <summary>
+    /// Hard expiry for using the resolved renderer URLs.
+    /// </summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    /// <summary>
+    /// CORS policy descriptor advertised by the server, such as <c>public</c> or <c>registered-origins</c>.
+    /// </summary>
+    public string? CorsMode { get; init; }
+
+    /// <summary>
+    /// Renderer cache policy for this access envelope.
+    /// </summary>
+    public HonuaSceneAccessCachePolicy Cache { get; init; } = HonuaSceneAccessCachePolicy.Empty;
+
+    /// <summary>
+    /// Whether custom request headers are allowed for clients that own all nested renderer requests.
+    /// </summary>
+    public bool CustomHeadersAllowed { get; init; }
+
+    /// <summary>
+    /// Server revision or policy key used to revoke previously issued access.
+    /// </summary>
+    public string? RevocationKey { get; init; }
+
+    /// <summary>
+    /// Whether this SDK version understands the advertised mode.
+    /// </summary>
+    public bool IsSupportedMode => HonuaSceneAccessModes.IsSupported(Mode);
+
+    /// <summary>
+    /// Whether the access envelope can be passed to browser or WebView renderers without custom headers.
+    /// </summary>
+    public bool IsBrowserSafe =>
+        string.Equals(Mode, HonuaSceneAccessModes.Public, StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(Mode, HonuaSceneAccessModes.SignedUrl, StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(Mode, HonuaSceneAccessModes.Proxy, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns whether the access envelope is expired at <paramref name="utcNow"/>.
+    /// </summary>
+    public bool IsExpired(DateTimeOffset utcNow) => ExpiresAt.HasValue && utcNow >= ExpiresAt.Value;
+
+    /// <summary>
+    /// Returns whether callers should refresh access at <paramref name="utcNow"/>.
+    /// </summary>
+    public bool ShouldRefresh(DateTimeOffset utcNow) => RefreshAfter.HasValue && utcNow >= RefreshAfter.Value;
+}
+
+/// <summary>
+/// Cache policy advertised for a resolved scene access envelope.
+/// </summary>
+public sealed class HonuaSceneAccessCachePolicy
+{
+    /// <summary>
+    /// Empty cache policy used when the server omits cache metadata.
+    /// </summary>
+    public static HonuaSceneAccessCachePolicy Empty { get; } = new();
+
+    /// <summary>
+    /// Whether responses can be stored in a shared/public cache.
+    /// </summary>
+    public bool? Public { get; init; }
+
+    /// <summary>
+    /// Maximum cache lifetime in seconds.
+    /// </summary>
+    public int? MaxAgeSeconds { get; init; }
+
+    /// <summary>
+    /// Stale-while-revalidate cache lifetime in seconds.
+    /// </summary>
+    public int? StaleWhileRevalidateSeconds { get; init; }
+
+    /// <summary>
+    /// Whether renderers and host apps should avoid persistent storage for these responses.
+    /// </summary>
+    public bool NoStore { get; init; }
 }
 
 /// <summary>

--- a/tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/resolve-access-scene.json
+++ b/tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/resolve-access-scene.json
@@ -1,0 +1,39 @@
+{
+  "sceneId": "protected-downtown",
+  "tilesetUrl": "https://cdn.honua.test/scenes/protected-downtown/tileset.json?sig=render",
+  "terrainUrl": "https://cdn.honua.test/scenes/protected-downtown/terrain?sig=render",
+  "capabilities": ["3d-tiles", "terrain"],
+  "auth": {
+    "requiresAuthentication": true,
+    "schemes": ["SignedUrl"],
+    "policy": "scene-render-protected"
+  },
+  "expiresAt": "2026-04-28T18:30:00Z",
+  "access": {
+    "mode": "signed-url",
+    "refreshAfterUtc": "2026-04-28T18:20:00Z",
+    "expiresAtUtc": "2026-04-28T18:30:00Z",
+    "corsMode": "registered-origins",
+    "cache": {
+      "public": false,
+      "maxAgeSeconds": 300,
+      "staleWhileRevalidateSeconds": 60
+    },
+    "customHeadersAllowed": false,
+    "revocationKey": "scene-rev-42"
+  },
+  "endpoints": [
+    {
+      "kind": "3d-tiles",
+      "url": "https://cdn.honua.test/scenes/protected-downtown/tileset.json?sig=render",
+      "format": "3d-tiles",
+      "requiresAuthentication": true
+    },
+    {
+      "kind": "terrain",
+      "url": "https://cdn.honua.test/scenes/protected-downtown/terrain?sig=render",
+      "format": "quantized-mesh",
+      "requiresAuthentication": true
+    }
+  ]
+}

--- a/tests/Honua.Mobile.Sdk.Tests/HonuaSceneServiceTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/HonuaSceneServiceTests.cs
@@ -81,6 +81,136 @@ public sealed class HonuaSceneServiceTests
     }
 
     [Fact]
+    public async Task ResolveSceneAsync_ParsesSignedUrlAccessEnvelope()
+    {
+        var handler = new RecordingHandler((_, _) =>
+        {
+            return Task.FromResult(JsonResponse(ReadFixture("resolve-access-scene.json")));
+        });
+        var client = CreateClient(handler);
+
+        var resolution = await client.Scenes.ResolveSceneAsync("protected-downtown");
+
+        Assert.Equal(new DateTimeOffset(2026, 4, 28, 18, 30, 0, TimeSpan.Zero), resolution.ExpiresAt);
+        var access = resolution.Access;
+        Assert.NotNull(access);
+        Assert.Equal(HonuaSceneAccessModes.SignedUrl, access.Mode);
+        Assert.True(access.IsSupportedMode);
+        Assert.True(access.IsBrowserSafe);
+        Assert.False(access.CustomHeadersAllowed);
+        Assert.Equal("registered-origins", access.CorsMode);
+        Assert.Equal("scene-rev-42", access.RevocationKey);
+        Assert.Equal(300, access.Cache.MaxAgeSeconds);
+        Assert.Equal(60, access.Cache.StaleWhileRevalidateSeconds);
+        Assert.False(access.Cache.Public);
+        Assert.True(access.ShouldRefresh(new DateTimeOffset(2026, 4, 28, 18, 21, 0, TimeSpan.Zero)));
+        Assert.False(access.IsExpired(new DateTimeOffset(2026, 4, 28, 18, 21, 0, TimeSpan.Zero)));
+        Assert.All(resolution.Endpoints, endpoint => Assert.Same(access, endpoint.Access));
+    }
+
+    [Theory]
+    [InlineData("public", true, true, false)]
+    [InlineData("signedUrl", true, true, false)]
+    [InlineData("proxy", true, true, false)]
+    [InlineData("headers", false, true, true)]
+    [InlineData("device-cert", false, false, false)]
+    public async Task ResolveSceneAsync_ParsesAccessModeMetadata(
+        string mode,
+        bool browserSafe,
+        bool supported,
+        bool customHeadersAllowed)
+    {
+        var handler = new RecordingHandler((_, _) =>
+        {
+            return Task.FromResult(JsonResponse(AccessModeFixture(mode, customHeadersAllowed)));
+        });
+        var client = CreateClient(handler);
+
+        var resolution = await client.Scenes.ResolveSceneAsync("mode-test");
+
+        var access = resolution.Access;
+        Assert.NotNull(access);
+        Assert.Equal(browserSafe, access.IsBrowserSafe);
+        Assert.Equal(supported, access.IsSupportedMode);
+        Assert.Equal(customHeadersAllowed, access.CustomHeadersAllowed);
+    }
+
+    [Fact]
+    public async Task ResolveSceneAsync_EndpointAccessOverridesRootForNativeHeaders()
+    {
+        var handler = new RecordingHandler((_, _) =>
+        {
+            return Task.FromResult(JsonResponse("""
+                {
+                  "sceneId": "native-header-scene",
+                  "access": {
+                    "mode": "signed-url",
+                    "expiresAtUtc": "2026-04-28T18:30:00Z"
+                  },
+                  "endpoints": [
+                    {
+                      "kind": "3d-tiles",
+                      "url": "https://api.honua.test/api/scenes/native-header-scene/tileset.json",
+                      "format": "3d-tiles",
+                      "requiresAuthentication": true,
+                      "headers": {
+                        "X-Honua-Scene": "native-header-scene"
+                      },
+                      "access": {
+                        "mode": "headers",
+                        "customHeadersAllowed": true,
+                        "corsMode": "native-only"
+                      }
+                    }
+                  ]
+                }
+                """));
+        });
+        var client = CreateClient(handler);
+
+        var resolution = await client.Scenes.ResolveSceneAsync("native-header-scene");
+
+        Assert.Equal(HonuaSceneAccessModes.SignedUrl, resolution.Access!.Mode);
+        var endpoint = Assert.Single(resolution.Endpoints);
+        var endpointAccess = endpoint.Access;
+        Assert.NotNull(endpointAccess);
+        Assert.Equal(HonuaSceneAccessModes.Headers, endpointAccess.Mode);
+        Assert.True(endpointAccess.CustomHeadersAllowed);
+        Assert.False(endpointAccess.IsBrowserSafe);
+        Assert.Equal("native-only", endpointAccess.CorsMode);
+        Assert.Equal("native-header-scene", endpoint.Headers["X-Honua-Scene"]);
+    }
+
+    [Fact]
+    public async Task ResolveSceneAsync_ExpiredAccessEnvelope_ReportsExpiredAndRefreshDue()
+    {
+        var handler = new RecordingHandler((_, _) =>
+        {
+            return Task.FromResult(JsonResponse("""
+                {
+                  "sceneId": "expired-access",
+                  "tilesetUrl": "https://cdn.honua.test/scenes/expired/tileset.json?sig=old",
+                  "capabilities": ["3d-tiles"],
+                  "access": {
+                    "mode": "signed-url",
+                    "refreshAfterUtc": "2026-04-28T16:55:00Z",
+                    "expiresAtUtc": "2026-04-28T17:00:00Z"
+                  }
+                }
+                """));
+        });
+        var client = CreateClient(handler);
+
+        var resolution = await client.Scenes.ResolveSceneAsync("expired-access");
+
+        var access = resolution.Access;
+        Assert.NotNull(access);
+        var now = new DateTimeOffset(2026, 4, 28, 17, 1, 0, TimeSpan.Zero);
+        Assert.True(access.ShouldRefresh(now));
+        Assert.True(access.IsExpired(now));
+    }
+
+    [Fact]
     public async Task ResolveSceneAsync_WithEndpointArrayOnly_PopulatesUrlsAndInheritedAuth()
     {
         var handler = new RecordingHandler((_, _) =>
@@ -233,6 +363,22 @@ public sealed class HonuaSceneServiceTests
     {
         Content = new StringContent(json, Encoding.UTF8, "application/json"),
     };
+
+    private static string AccessModeFixture(string mode, bool customHeadersAllowed)
+    {
+        var headers = customHeadersAllowed.ToString().ToLowerInvariant();
+        return $$"""
+            {
+              "sceneId": "mode-test",
+              "tilesetUrl": "https://cdn.honua.test/scenes/mode-test/tileset.json",
+              "capabilities": ["3d-tiles"],
+              "access": {
+                "mode": "{{mode}}",
+                "customHeadersAllowed": {{headers}}
+              }
+            }
+            """;
+    }
 
     private static string ReadFixture(string name, [CallerFilePath] string sourceFile = "")
     {

--- a/tests/Honua.Mobile.Sdk.Tests/HonuaSceneServiceTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/HonuaSceneServiceTests.cs
@@ -136,6 +136,40 @@ public sealed class HonuaSceneServiceTests
     }
 
     [Fact]
+    public async Task ResolveSceneAsync_EndpointTypeDoesNotOverrideInheritedAccess()
+    {
+        var handler = new RecordingHandler((_, _) =>
+        {
+            return Task.FromResult(JsonResponse("""
+                {
+                  "sceneId": "endpoint-type-inheritance",
+                  "access": {
+                    "mode": "signed-url",
+                    "expiresAtUtc": "2026-04-28T18:30:00Z"
+                  },
+                  "endpoints": [
+                    {
+                      "type": "3d-tiles",
+                      "url": "https://api.honua.test/api/scenes/endpoint-type-inheritance/tileset.json",
+                      "format": "3d-tiles",
+                      "requiresAuthentication": true
+                    }
+                  ]
+                }
+                """));
+        });
+        var client = CreateClient(handler);
+
+        var resolution = await client.Scenes.ResolveSceneAsync("endpoint-type-inheritance");
+
+        Assert.Equal(HonuaSceneAccessModes.SignedUrl, resolution.Access!.Mode);
+        var endpoint = Assert.Single(resolution.Endpoints);
+        Assert.Equal(HonuaSceneCapabilities.ThreeDimensionalTiles, endpoint.Kind);
+        Assert.Same(resolution.Access, endpoint.Access);
+        Assert.True(endpoint.Access!.IsBrowserSafe);
+    }
+
+    [Fact]
     public async Task ResolveSceneAsync_EndpointAccessOverridesRootForNativeHeaders()
     {
         var handler = new RecordingHandler((_, _) =>


### PR DESCRIPTION
## Summary
- add typed scene access envelope and cache policy models for public, signed URL, proxy, header, and unsupported access modes
- parse top-level and endpoint-level access metadata from scene resolution responses while preserving existing `TilesetUrl`, `TerrainUrl`, and `ExpiresAt` behavior
- add tests for signed URL, public, proxy, native header, expired, and unsupported access modes
- update protected 3D scene auth docs with SDK usage that passes only renderer-safe URLs to `<honua-scene>`

Closes #44

## Platform impact
SDK contract change only. Browser/WebView hosts can check `IsBrowserSafe`; native hosts can detect header mode through endpoint access metadata.

## Offline impact
No offline cache behavior changes. Access expiry remains separate from offline package grants defined in #36.

## Validation
- dotnet build src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj --no-restore --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --no-restore --configuration Release
- dotnet format src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj --no-restore --verify-no-changes --verbosity diagnostic
- dotnet format tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --no-restore --verify-no-changes --verbosity diagnostic
- git diff --check
