### PR TITLE
feat(maui): add offline scene package downloader

### DIFF
--- a/docs/guides/offline-3d-scene-packages.md
+++ b/docs/guides/offline-3d-scene-packages.md
@@ -158,6 +158,13 @@ Download behavior:
 Optional assets may fail without invalidating the package, but the local catalog
 must record the missing keys so the renderer can avoid silent cache misses.
 
+The .NET/MAUI runtime service for #41 is `IHonuaScenePackageDownloader`, backed
+by `ScenePackageDownloader` in `Honua.Mobile.Offline.ScenePackages`. MAUI hosts
+register it with `AddHonuaScenePackageDownload()` after
+`AddHonuaGeoPackageOfflineSync(...)`. Downloaded packages are cataloged as
+`ScenePackageRecord` rows, including package footprint bytes and
+`MissingOptionalAssetKeys` for renderer fallback decisions.
+
 ## Invalidation And Expiry
 
 Package state is derived from manifest fields and local validation:

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Honua.Mobile.Field.Records;
 using Honua.Mobile.Maui.Annotations;
 using Honua.Mobile.Offline.GeoPackage;
 using Honua.Mobile.Offline.MapAreas;
+using Honua.Mobile.Offline.ScenePackages;
 using Honua.Mobile.Offline.Sync;
 using Honua.Mobile.Sdk;
 using Honua.Mobile.Sdk.Routing;
@@ -177,6 +178,28 @@ public static class HonuaMobileServiceCollectionExtensions
             var httpClient = factory.CreateClient("HonuaMapArea");
             var store = sp.GetRequiredService<IGeoPackageSyncStore>();
             return new MapAreaDownloader(httpClient, store);
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers <see cref="IHonuaScenePackageDownloader"/> for downloading immutable offline 3D scene packages.
+    /// Requires <see cref="AddHonuaGeoPackageOfflineSync"/> to be called first.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaScenePackageDownload(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddHttpClient("HonuaScenePackage");
+        services.AddSingleton<IHonuaScenePackageDownloader>(sp =>
+        {
+            var factory = sp.GetRequiredService<IHttpClientFactory>();
+            var httpClient = factory.CreateClient("HonuaScenePackage");
+            var store = sp.GetRequiredService<IGeoPackageSyncStore>();
+            return new ScenePackageDownloader(httpClient, store);
         });
 
         return services;

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageModels.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageModels.cs
@@ -1,3 +1,5 @@
+using Honua.Mobile.Sdk.Scenes;
+
 namespace Honua.Mobile.Offline.GeoPackage;
 
 /// <summary>
@@ -126,6 +128,102 @@ public sealed class MapAreaPackage
 
     /// <summary>
     /// UTC timestamp of the last update to this map area package.
+    /// </summary>
+    public DateTimeOffset UpdatedAtUtc { get; init; } = DateTimeOffset.UtcNow;
+}
+
+/// <summary>
+/// Metadata for a downloaded immutable offline 3D scene package.
+/// </summary>
+public sealed class ScenePackageRecord
+{
+    /// <summary>
+    /// Stable package identifier from the scene package manifest.
+    /// </summary>
+    public required string PackageId { get; init; }
+
+    /// <summary>
+    /// Scene identifier rendered by this offline package.
+    /// </summary>
+    public required string SceneId { get; init; }
+
+    /// <summary>
+    /// Human-readable package name.
+    /// </summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>
+    /// Required product edition for package use.
+    /// </summary>
+    public required string EditionGate { get; init; }
+
+    /// <summary>
+    /// Server scene revision represented by this package.
+    /// </summary>
+    public required string ServerRevision { get; init; }
+
+    /// <summary>
+    /// WGS84 package extent.
+    /// </summary>
+    public HonuaSceneBounds? Extent { get; init; }
+
+    /// <summary>
+    /// Directory containing package-local scene assets.
+    /// </summary>
+    public required string PackageDirectory { get; init; }
+
+    /// <summary>
+    /// File path to the downloaded manifest JSON.
+    /// </summary>
+    public required string ManifestPath { get; init; }
+
+    /// <summary>
+    /// Derived validation state for the local package.
+    /// </summary>
+    public HonuaScenePackageState State { get; init; }
+
+    /// <summary>
+    /// Server-declared expected package size in bytes.
+    /// </summary>
+    public long DeclaredBytes { get; init; }
+
+    /// <summary>
+    /// Bytes stored on disk for downloaded assets.
+    /// </summary>
+    public long DownloadedBytes { get; init; }
+
+    /// <summary>
+    /// Number of required manifest assets.
+    /// </summary>
+    public int RequiredAssetCount { get; init; }
+
+    /// <summary>
+    /// Number of assets downloaded by this client.
+    /// </summary>
+    public int DownloadedAssetCount { get; init; }
+
+    /// <summary>
+    /// Optional manifest asset keys that were not downloaded.
+    /// </summary>
+    public IReadOnlyList<string> MissingOptionalAssetKeys { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Time after which the package should surface stale state.
+    /// </summary>
+    public DateTimeOffset? StaleAfterUtc { get; init; }
+
+    /// <summary>
+    /// Time after which protected offline package content must not render without revalidation.
+    /// </summary>
+    public DateTimeOffset? OfflineUseExpiresAtUtc { get; init; }
+
+    /// <summary>
+    /// Expiry for download or refresh credentials.
+    /// </summary>
+    public DateTimeOffset? AuthExpiresAtUtc { get; init; }
+
+    /// <summary>
+    /// Last catalog update timestamp.
     /// </summary>
     public DateTimeOffset UpdatedAtUtc { get; init; } = DateTimeOffset.UtcNow;
 }

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Honua.Mobile.Sdk.Scenes;
 using Microsoft.Data.Sqlite;
 
 namespace Honua.Mobile.Offline.GeoPackage;
@@ -104,11 +105,35 @@ CREATE TABLE IF NOT EXISTS honua_map_areas (
     updated_at_utc TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS honua_scene_packages (
+    package_id TEXT PRIMARY KEY,
+    scene_id TEXT NOT NULL,
+    display_name TEXT,
+    edition_gate TEXT NOT NULL,
+    server_revision TEXT NOT NULL,
+    extent_json TEXT,
+    package_directory TEXT NOT NULL,
+    manifest_path TEXT NOT NULL,
+    state TEXT NOT NULL,
+    declared_bytes INTEGER NOT NULL,
+    downloaded_bytes INTEGER NOT NULL,
+    required_asset_count INTEGER NOT NULL,
+    downloaded_asset_count INTEGER NOT NULL,
+    missing_optional_asset_keys_json TEXT NOT NULL DEFAULT '[]',
+    stale_after_utc TEXT,
+    offline_use_expires_at_utc TEXT,
+    auth_expires_at_utc TEXT,
+    updated_at_utc TEXT NOT NULL
+);
+
 INSERT OR IGNORE INTO gpkg_contents (table_name, data_type, identifier, description, srs_id)
 VALUES ('honua_sync_queue', 'attributes', 'honua_sync_queue', 'Offline edit queue for Honua mobile sync', 4326);
 
 INSERT OR IGNORE INTO gpkg_contents (table_name, data_type, identifier, description, srs_id)
 VALUES ('honua_map_areas', 'attributes', 'honua_map_areas', 'Downloaded map area package catalog', 4326);
+
+INSERT OR IGNORE INTO gpkg_contents (table_name, data_type, identifier, description, srs_id)
+VALUES ('honua_scene_packages', 'attributes', 'honua_scene_packages', 'Downloaded immutable 3D scene package catalog', 4326);
 
 CREATE TABLE IF NOT EXISTS honua_features (
     layer_key TEXT NOT NULL,
@@ -127,6 +152,12 @@ VALUES ('honua_features', 'attributes', 'honua_features', 'Replicated feature ca
         await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
 
         await EnsureColumnExistsAsync(connection, "honua_sync_queue", "claimed_at_utc", "TEXT", ct).ConfigureAwait(false);
+        await EnsureColumnExistsAsync(
+            connection,
+            "honua_scene_packages",
+            "missing_optional_asset_keys_json",
+            "TEXT NOT NULL DEFAULT '[]'",
+            ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -409,6 +440,157 @@ ON CONFLICT(area_id) DO UPDATE SET
     }
 
     /// <inheritdoc />
+    public async Task UpsertScenePackageAsync(ScenePackageRecord scenePackage, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(scenePackage);
+
+        await using var connection = OpenConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+
+        var extent = scenePackage.Extent is null
+            ? null
+            : JsonSerializer.Serialize(scenePackage.Extent);
+        var missingOptionalAssetKeysJson = JsonSerializer.Serialize(scenePackage.MissingOptionalAssetKeys);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = @"
+INSERT INTO honua_scene_packages (
+  package_id,
+  scene_id,
+  display_name,
+  edition_gate,
+  server_revision,
+  extent_json,
+  package_directory,
+  manifest_path,
+  state,
+  declared_bytes,
+  downloaded_bytes,
+  required_asset_count,
+  downloaded_asset_count,
+  missing_optional_asset_keys_json,
+  stale_after_utc,
+  offline_use_expires_at_utc,
+  auth_expires_at_utc,
+  updated_at_utc)
+VALUES (
+  $package_id,
+  $scene_id,
+  $display_name,
+  $edition_gate,
+  $server_revision,
+  $extent_json,
+  $package_directory,
+  $manifest_path,
+  $state,
+  $declared_bytes,
+  $downloaded_bytes,
+  $required_asset_count,
+  $downloaded_asset_count,
+  $missing_optional_asset_keys_json,
+  $stale_after_utc,
+  $offline_use_expires_at_utc,
+  $auth_expires_at_utc,
+  $updated_at_utc)
+ON CONFLICT(package_id) DO UPDATE SET
+  scene_id = excluded.scene_id,
+  display_name = excluded.display_name,
+  edition_gate = excluded.edition_gate,
+  server_revision = excluded.server_revision,
+  extent_json = excluded.extent_json,
+  package_directory = excluded.package_directory,
+  manifest_path = excluded.manifest_path,
+  state = excluded.state,
+  declared_bytes = excluded.declared_bytes,
+  downloaded_bytes = excluded.downloaded_bytes,
+  required_asset_count = excluded.required_asset_count,
+  downloaded_asset_count = excluded.downloaded_asset_count,
+  missing_optional_asset_keys_json = excluded.missing_optional_asset_keys_json,
+  stale_after_utc = excluded.stale_after_utc,
+  offline_use_expires_at_utc = excluded.offline_use_expires_at_utc,
+  auth_expires_at_utc = excluded.auth_expires_at_utc,
+  updated_at_utc = excluded.updated_at_utc;
+";
+
+        command.Parameters.AddWithValue("$package_id", scenePackage.PackageId);
+        command.Parameters.AddWithValue("$scene_id", scenePackage.SceneId);
+        command.Parameters.AddWithValue("$display_name", ToDbValue(scenePackage.DisplayName));
+        command.Parameters.AddWithValue("$edition_gate", scenePackage.EditionGate);
+        command.Parameters.AddWithValue("$server_revision", scenePackage.ServerRevision);
+        command.Parameters.AddWithValue("$extent_json", ToDbValue(extent));
+        command.Parameters.AddWithValue("$package_directory", scenePackage.PackageDirectory);
+        command.Parameters.AddWithValue("$manifest_path", scenePackage.ManifestPath);
+        command.Parameters.AddWithValue("$state", scenePackage.State.ToString().ToLowerInvariant());
+        command.Parameters.AddWithValue("$declared_bytes", scenePackage.DeclaredBytes);
+        command.Parameters.AddWithValue("$downloaded_bytes", scenePackage.DownloadedBytes);
+        command.Parameters.AddWithValue("$required_asset_count", scenePackage.RequiredAssetCount);
+        command.Parameters.AddWithValue("$downloaded_asset_count", scenePackage.DownloadedAssetCount);
+        command.Parameters.AddWithValue("$missing_optional_asset_keys_json", missingOptionalAssetKeysJson);
+        command.Parameters.AddWithValue("$stale_after_utc", ToDbValue(scenePackage.StaleAfterUtc));
+        command.Parameters.AddWithValue("$offline_use_expires_at_utc", ToDbValue(scenePackage.OfflineUseExpiresAtUtc));
+        command.Parameters.AddWithValue("$auth_expires_at_utc", ToDbValue(scenePackage.AuthExpiresAtUtc));
+        command.Parameters.AddWithValue("$updated_at_utc", scenePackage.UpdatedAtUtc.ToString("O", CultureInfo.InvariantCulture));
+
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ScenePackageRecord>> ListScenePackagesAsync(CancellationToken ct = default)
+    {
+        await using var connection = OpenConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = @"
+SELECT
+  package_id,
+  scene_id,
+  display_name,
+  edition_gate,
+  server_revision,
+  extent_json,
+  package_directory,
+  manifest_path,
+  state,
+  declared_bytes,
+  downloaded_bytes,
+  required_asset_count,
+  downloaded_asset_count,
+  missing_optional_asset_keys_json,
+  stale_after_utc,
+  offline_use_expires_at_utc,
+  auth_expires_at_utc,
+  updated_at_utc
+FROM honua_scene_packages
+ORDER BY scene_id ASC, package_id ASC;
+";
+
+        var items = new List<ScenePackageRecord>();
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            items.Add(ReadScenePackageRecord(reader));
+        }
+
+        return items;
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteScenePackageAsync(string packageId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+
+        await using var connection = OpenConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "DELETE FROM honua_scene_packages WHERE package_id = $package_id;";
+        command.Parameters.AddWithValue("$package_id", packageId);
+
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
     public async Task UpsertFeatureAsync(string layerKey, string featureJson, CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(layerKey);
@@ -583,6 +765,53 @@ LIMIT $limit;
             AttemptCount = reader.GetInt32(7),
         };
     }
+
+    private static ScenePackageRecord ReadScenePackageRecord(SqliteDataReader reader)
+    {
+        var extentJson = reader.IsDBNull(5) ? null : reader.GetString(5);
+        var extent = string.IsNullOrWhiteSpace(extentJson)
+            ? null
+            : JsonSerializer.Deserialize<HonuaSceneBounds>(extentJson)
+                ?? throw new InvalidOperationException("Invalid extent payload in honua_scene_packages.");
+
+        return new ScenePackageRecord
+        {
+            PackageId = reader.GetString(0),
+            SceneId = reader.GetString(1),
+            DisplayName = reader.IsDBNull(2) ? null : reader.GetString(2),
+            EditionGate = reader.GetString(3),
+            ServerRevision = reader.GetString(4),
+            Extent = extent,
+            PackageDirectory = reader.GetString(6),
+            ManifestPath = reader.GetString(7),
+            State = Enum.Parse<HonuaScenePackageState>(reader.GetString(8), ignoreCase: true),
+            DeclaredBytes = reader.GetInt64(9),
+            DownloadedBytes = reader.GetInt64(10),
+            RequiredAssetCount = reader.GetInt32(11),
+            DownloadedAssetCount = reader.GetInt32(12),
+            MissingOptionalAssetKeys = ReadStringArrayJson(reader.GetString(13)),
+            StaleAfterUtc = ReadNullableDateTimeOffset(reader, 14),
+            OfflineUseExpiresAtUtc = ReadNullableDateTimeOffset(reader, 15),
+            AuthExpiresAtUtc = ReadNullableDateTimeOffset(reader, 16),
+            UpdatedAtUtc = DateTimeOffset.Parse(reader.GetString(17), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
+        };
+    }
+
+    private static IReadOnlyList<string> ReadStringArrayJson(string json)
+        => JsonSerializer.Deserialize<List<string>>(json) ?? [];
+
+    private static DateTimeOffset? ReadNullableDateTimeOffset(SqliteDataReader reader, int ordinal)
+        => reader.IsDBNull(ordinal)
+            ? null
+            : DateTimeOffset.Parse(reader.GetString(ordinal), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+
+    private static object ToDbValue(string? value)
+        => string.IsNullOrWhiteSpace(value) ? DBNull.Value : value;
+
+    private static object ToDbValue(DateTimeOffset? value)
+        => value.HasValue
+            ? value.Value.ToString("O", CultureInfo.InvariantCulture)
+            : DBNull.Value;
 
     private static string AddOperationIdParameters(SqliteCommand command, IReadOnlyList<string> operationIds)
     {

--- a/src/Honua.Mobile.Offline/GeoPackage/IGeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/IGeoPackageSyncStore.cs
@@ -89,6 +89,27 @@ public interface IGeoPackageSyncStore
     Task<IReadOnlyList<MapAreaPackage>> ListMapAreasAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// Inserts or updates a downloaded immutable scene package record.
+    /// </summary>
+    /// <param name="scenePackage">The scene package metadata to persist.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task UpsertScenePackageAsync(ScenePackageRecord scenePackage, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists all downloaded scene packages ordered by scene and package ID.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>All stored scene package records.</returns>
+    Task<IReadOnlyList<ScenePackageRecord>> ListScenePackagesAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes scene package metadata from the catalog.
+    /// </summary>
+    /// <param name="packageId">The package ID to remove.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task DeleteScenePackageAsync(string packageId, CancellationToken ct = default);
+
+    /// <summary>
     /// Inserts or updates a replicated feature in the local cache.
     /// The object ID is extracted from the JSON payload.
     /// </summary>

--- a/src/Honua.Mobile.Offline/ScenePackages/ScenePackageDownloadContracts.cs
+++ b/src/Honua.Mobile.Offline/ScenePackages/ScenePackageDownloadContracts.cs
@@ -1,0 +1,118 @@
+using Honua.Mobile.Offline.GeoPackage;
+using Honua.Mobile.Sdk.Scenes;
+
+namespace Honua.Mobile.Offline.ScenePackages;
+
+/// <summary>
+/// Parameters for downloading an immutable offline 3D scene package.
+/// </summary>
+public sealed class ScenePackageDownloadRequest
+{
+    /// <summary>
+    /// Manifest describing the package assets to download.
+    /// </summary>
+    public required HonuaScenePackageManifest Manifest { get; init; }
+
+    /// <summary>
+    /// Base URI used to resolve package-local manifest asset paths.
+    /// </summary>
+    public required Uri AssetBaseUri { get; init; }
+
+    /// <summary>
+    /// Directory where the ready package directory and staging directory are created.
+    /// </summary>
+    public required string OutputDirectory { get; init; }
+
+    /// <summary>
+    /// Progress callback invoked as assets are downloaded.
+    /// </summary>
+    public IProgress<ScenePackageDownloadProgress>? Progress { get; init; }
+
+    /// <summary>
+    /// When <see langword="true"/>, partial package staging files are deleted after a failed download.
+    /// Defaults to <see langword="true"/>.
+    /// </summary>
+    public bool CleanupPartialPackageOnFailure { get; init; } = true;
+
+    /// <summary>
+    /// Optional clock override for deterministic tests.
+    /// </summary>
+    public DateTimeOffset? UtcNow { get; init; }
+}
+
+/// <summary>
+/// Progress information for a scene package download.
+/// </summary>
+public sealed class ScenePackageDownloadProgress
+{
+    /// <summary>
+    /// Asset key currently being downloaded.
+    /// </summary>
+    public required string AssetKey { get; init; }
+
+    /// <summary>
+    /// Number of assets fully downloaded so far.
+    /// </summary>
+    public int CompletedAssetCount { get; init; }
+
+    /// <summary>
+    /// Total assets listed in the manifest.
+    /// </summary>
+    public int TotalAssetCount { get; init; }
+
+    /// <summary>
+    /// Bytes downloaded during this operation.
+    /// </summary>
+    public long DownloadedBytes { get; init; }
+
+    /// <summary>
+    /// Declared package byte budget, when advertised by the manifest.
+    /// </summary>
+    public long? DeclaredBytes { get; init; }
+}
+
+/// <summary>
+/// Result of downloading an offline 3D scene package.
+/// </summary>
+public sealed class ScenePackageDownloadResult
+{
+    /// <summary>
+    /// Ready package directory containing package-local scene assets.
+    /// </summary>
+    public required string PackageDirectory { get; init; }
+
+    /// <summary>
+    /// File path to the downloaded manifest JSON.
+    /// </summary>
+    public required string ManifestPath { get; init; }
+
+    /// <summary>
+    /// Number of assets downloaded by this operation.
+    /// </summary>
+    public int DownloadedAssetCount { get; init; }
+
+    /// <summary>
+    /// Bytes downloaded by this operation.
+    /// </summary>
+    public long DownloadedBytes { get; init; }
+
+    /// <summary>
+    /// Catalog record persisted in the offline store.
+    /// </summary>
+    public required ScenePackageRecord CatalogRecord { get; init; }
+}
+
+/// <summary>
+/// Downloads immutable offline 3D scene package assets and registers the local package catalog entry.
+/// </summary>
+public interface IHonuaScenePackageDownloader
+{
+    /// <summary>
+    /// Downloads all manifest assets into a ready package directory and registers package metadata.
+    /// </summary>
+    /// <param name="request">Package download request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<ScenePackageDownloadResult> DownloadAsync(
+        ScenePackageDownloadRequest request,
+        CancellationToken ct = default);
+}

--- a/src/Honua.Mobile.Offline/ScenePackages/ScenePackageDownloader.cs
+++ b/src/Honua.Mobile.Offline/ScenePackages/ScenePackageDownloader.cs
@@ -48,7 +48,7 @@ public sealed class ScenePackageDownloader : IHonuaScenePackageDownloader
         ValidateRequest(request, utcNow);
 
         var outputDirectory = NormalizeOutputDirectory(request.OutputDirectory);
-        var safePackageId = SanitizePackageId(request.Manifest.PackageId!);
+        var safePackageId = EncodePackageIdForPath(request.Manifest.PackageId!);
         var stagingDirectory = Path.Combine(outputDirectory, $"{safePackageId}.partial");
         var readyDirectory = Path.Combine(outputDirectory, safePackageId);
         var baseUri = EnsureDirectoryUri(request.AssetBaseUri);
@@ -100,7 +100,6 @@ public sealed class ScenePackageDownloader : IHonuaScenePackageDownloader
             }
 
             var manifestPath = await WriteManifestAsync(stagingDirectory, request.Manifest, ct).ConfigureAwait(false);
-            ReplaceReadyDirectory(stagingDirectory, readyDirectory);
             manifestPath = Path.Combine(readyDirectory, "manifest.json");
 
             var state = request.Manifest.Validate(utcNow, downloadedAssetKeys).State;
@@ -116,7 +115,7 @@ public sealed class ScenePackageDownloader : IHonuaScenePackageDownloader
                 utcNow);
 
             await _syncStore.InitializeAsync(ct).ConfigureAwait(false);
-            await _syncStore.UpsertScenePackageAsync(catalogRecord, ct).ConfigureAwait(false);
+            await PromotePackageAsync(stagingDirectory, readyDirectory, catalogRecord, ct).ConfigureAwait(false);
 
             return new ScenePackageDownloadResult
             {
@@ -451,33 +450,58 @@ public sealed class ScenePackageDownloader : IHonuaScenePackageDownloader
         return normalized;
     }
 
-    private static string SanitizePackageId(string packageId)
+    private async Task PromotePackageAsync(
+        string stagingDirectory,
+        string readyDirectory,
+        ScenePackageRecord catalogRecord,
+        CancellationToken ct)
     {
-        var invalidCharacters = Path.GetInvalidFileNameChars();
-        var builder = new StringBuilder(packageId.Length);
+        var backupDirectory = MoveReadyDirectoryAside(readyDirectory);
+        var readyDirectoryPromoted = false;
 
-        foreach (var character in packageId.Trim())
+        try
         {
-            if (character == Path.DirectorySeparatorChar ||
-                character == Path.AltDirectorySeparatorChar ||
-                character == ':' ||
-                character == '.' ||
-                Array.IndexOf(invalidCharacters, character) >= 0)
+            Directory.Move(stagingDirectory, readyDirectory);
+            readyDirectoryPromoted = true;
+            await _syncStore.UpsertScenePackageAsync(catalogRecord, ct).ConfigureAwait(false);
+            DeleteDirectoryIfExists(backupDirectory);
+        }
+        catch
+        {
+            if (readyDirectoryPromoted)
             {
-                builder.Append('_');
-                continue;
+                DeleteDirectoryIfExists(readyDirectory);
             }
 
-            builder.Append(character);
+            RestoreReadyDirectoryBackup(backupDirectory, readyDirectory);
+            throw;
         }
+    }
 
-        var safePackageId = builder.ToString().Trim('.');
-        if (string.IsNullOrWhiteSpace(safePackageId))
+    private static string EncodePackageIdForPath(string packageId)
+    {
+        var trimmed = packageId.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
         {
             throw new InvalidOperationException("Package ID must include at least one valid file-name character.");
         }
 
-        return safePackageId;
+        var bytes = Encoding.UTF8.GetBytes(trimmed);
+        var builder = new StringBuilder(bytes.Length);
+        foreach (var value in bytes)
+        {
+            var character = (char)value;
+            if (char.IsAsciiLetterOrDigit(character) || character is '-' or '_')
+            {
+                builder.Append(character);
+                continue;
+            }
+
+            builder.Append('~');
+            builder.Append(value.ToString("X2", CultureInfo.InvariantCulture));
+        }
+
+        return builder.ToString();
     }
 
     private static Uri EnsureDirectoryUri(Uri uri)
@@ -530,10 +554,27 @@ public sealed class ScenePackageDownloader : IHonuaScenePackageDownloader
         return fullPath;
     }
 
-    private static void ReplaceReadyDirectory(string stagingDirectory, string readyDirectory)
+    private static string? MoveReadyDirectoryAside(string readyDirectory)
     {
+        if (!Directory.Exists(readyDirectory))
+        {
+            return null;
+        }
+
+        var backupDirectory = readyDirectory + $".replacing.{Guid.NewGuid():N}";
+        Directory.Move(readyDirectory, backupDirectory);
+        return backupDirectory;
+    }
+
+    private static void RestoreReadyDirectoryBackup(string? backupDirectory, string readyDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(backupDirectory) || !Directory.Exists(backupDirectory))
+        {
+            return;
+        }
+
         DeleteDirectoryIfExists(readyDirectory);
-        Directory.Move(stagingDirectory, readyDirectory);
+        Directory.Move(backupDirectory, readyDirectory);
     }
 
     private static void DeletePartialAsset(string stagingDirectory, string? assetPath)
@@ -550,9 +591,9 @@ public sealed class ScenePackageDownloader : IHonuaScenePackageDownloader
         }
     }
 
-    private static void DeleteDirectoryIfExists(string path)
+    private static void DeleteDirectoryIfExists(string? path)
     {
-        if (Directory.Exists(path))
+        if (!string.IsNullOrWhiteSpace(path) && Directory.Exists(path))
         {
             Directory.Delete(path, recursive: true);
         }

--- a/src/Honua.Mobile.Offline/ScenePackages/ScenePackageDownloader.cs
+++ b/src/Honua.Mobile.Offline/ScenePackages/ScenePackageDownloader.cs
@@ -1,0 +1,563 @@
+using System.Buffers;
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Honua.Mobile.Offline.GeoPackage;
+using Honua.Mobile.Sdk.Scenes;
+
+namespace Honua.Mobile.Offline.ScenePackages;
+
+/// <summary>
+/// HTTP downloader for immutable offline 3D scene packages.
+/// </summary>
+public sealed class ScenePackageDownloader : IHonuaScenePackageDownloader
+{
+    private static readonly JsonSerializerOptions ManifestJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    private readonly HttpClient _httpClient;
+    private readonly IGeoPackageSyncStore _syncStore;
+
+    /// <summary>
+    /// Initializes a new <see cref="ScenePackageDownloader"/>.
+    /// </summary>
+    /// <param name="httpClient">HTTP client used to fetch package-local assets.</param>
+    /// <param name="syncStore">Offline store where package metadata is registered.</param>
+    public ScenePackageDownloader(HttpClient httpClient, IGeoPackageSyncStore syncStore)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _syncStore = syncStore ?? throw new ArgumentNullException(nameof(syncStore));
+    }
+
+    /// <inheritdoc />
+    public async Task<ScenePackageDownloadResult> DownloadAsync(
+        ScenePackageDownloadRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Manifest);
+        ArgumentNullException.ThrowIfNull(request.AssetBaseUri);
+
+        var utcNow = request.UtcNow ?? DateTimeOffset.UtcNow;
+        ValidateRequest(request, utcNow);
+
+        var outputDirectory = NormalizeOutputDirectory(request.OutputDirectory);
+        var safePackageId = SanitizePackageId(request.Manifest.PackageId!);
+        var stagingDirectory = Path.Combine(outputDirectory, $"{safePackageId}.partial");
+        var readyDirectory = Path.Combine(outputDirectory, safePackageId);
+        var baseUri = EnsureDirectoryUri(request.AssetBaseUri);
+        var downloadedAssetKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var downloadedAssetCount = 0;
+        var downloadedBytes = 0L;
+
+        try
+        {
+            Directory.CreateDirectory(stagingDirectory);
+
+            foreach (var asset in request.Manifest.Assets)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (asset is null)
+                {
+                    throw new InvalidOperationException("Scene package manifest contains a null asset entry.");
+                }
+
+                try
+                {
+                    var assetBytes = await DownloadAssetAsync(
+                        asset,
+                        baseUri,
+                        stagingDirectory,
+                        request.Manifest.ByteBudget!.MaxPackageBytes!.Value,
+                        downloadedBytes,
+                        request.Progress,
+                        downloadedAssetCount,
+                        request.Manifest.Assets.Count,
+                        request.Manifest.ByteBudget.DeclaredBytes,
+                        ct).ConfigureAwait(false);
+
+                    downloadedBytes += assetBytes;
+                    downloadedAssetCount++;
+                    downloadedAssetKeys.Add(asset.Key!);
+                }
+                catch (Exception ex) when (!asset.Required && ex is not OperationCanceledException)
+                {
+                    DeletePartialAsset(stagingDirectory, asset.Path);
+                }
+            }
+
+            var finalValidation = request.Manifest.Validate(utcNow, downloadedAssetKeys);
+            if (!finalValidation.IsValid)
+            {
+                throw new InvalidOperationException(
+                    $"Scene package '{request.Manifest.PackageId}' did not pass final validation: {FormatIssues(finalValidation)}");
+            }
+
+            var manifestPath = await WriteManifestAsync(stagingDirectory, request.Manifest, ct).ConfigureAwait(false);
+            ReplaceReadyDirectory(stagingDirectory, readyDirectory);
+            manifestPath = Path.Combine(readyDirectory, "manifest.json");
+
+            var state = request.Manifest.Validate(utcNow, downloadedAssetKeys).State;
+            var storedBytes = SumDownloadedAssetBytes(request.Manifest, downloadedAssetKeys);
+            var catalogRecord = BuildCatalogRecord(
+                request.Manifest,
+                readyDirectory,
+                manifestPath,
+                state,
+                storedBytes,
+                downloadedAssetCount,
+                downloadedAssetKeys,
+                utcNow);
+
+            await _syncStore.InitializeAsync(ct).ConfigureAwait(false);
+            await _syncStore.UpsertScenePackageAsync(catalogRecord, ct).ConfigureAwait(false);
+
+            return new ScenePackageDownloadResult
+            {
+                PackageDirectory = readyDirectory,
+                ManifestPath = manifestPath,
+                DownloadedAssetCount = downloadedAssetCount,
+                DownloadedBytes = downloadedBytes,
+                CatalogRecord = catalogRecord,
+            };
+        }
+        catch
+        {
+            if (request.CleanupPartialPackageOnFailure)
+            {
+                DeleteDirectoryIfExists(stagingDirectory);
+            }
+
+            throw;
+        }
+    }
+
+    private static void ValidateRequest(ScenePackageDownloadRequest request, DateTimeOffset utcNow)
+    {
+        if (string.IsNullOrWhiteSpace(request.OutputDirectory))
+        {
+            throw new InvalidOperationException("Output directory is required.");
+        }
+
+        var validation = request.Manifest.Validate(utcNow);
+        if (!validation.IsValid)
+        {
+            throw new InvalidOperationException(
+                $"Scene package manifest is invalid: {FormatIssues(validation)}");
+        }
+
+        if (request.Manifest.AuthExpiresAtUtc.HasValue && utcNow >= request.Manifest.AuthExpiresAtUtc.Value)
+        {
+            throw new InvalidOperationException(
+                $"Scene package '{request.Manifest.PackageId}' download credentials have expired.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Manifest.PackageId))
+        {
+            throw new InvalidOperationException("Scene package manifest is missing packageId.");
+        }
+    }
+
+    private async Task<long> DownloadAssetAsync(
+        HonuaScenePackageAsset asset,
+        Uri baseUri,
+        string stagingDirectory,
+        long maxPackageBytes,
+        long downloadedPackageBytes,
+        IProgress<ScenePackageDownloadProgress>? progress,
+        int completedAssetCount,
+        int totalAssetCount,
+        long? declaredBytes,
+        CancellationToken ct)
+    {
+        var assetKey = asset.Key ?? throw new InvalidOperationException("Scene package asset is missing key.");
+        var relativePath = RequireSafeRelativePath(asset.Path, assetKey);
+        var assetUri = new Uri(baseUri, relativePath);
+        var finalPath = BuildPackageFilePath(stagingDirectory, relativePath);
+        var partialPath = finalPath + ".partial";
+        Directory.CreateDirectory(Path.GetDirectoryName(finalPath)!);
+
+        var expectedBytes = asset.Bytes ?? throw new InvalidOperationException($"Scene package asset '{assetKey}' is missing bytes.");
+        var resumeBytes = File.Exists(partialPath) ? new FileInfo(partialPath).Length : 0L;
+        if (resumeBytes < 0 || resumeBytes > expectedBytes)
+        {
+            File.Delete(partialPath);
+            resumeBytes = 0;
+        }
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, assetUri);
+        if (resumeBytes > 0)
+        {
+            request.Headers.Range = new RangeHeaderValue(resumeBytes, null);
+            if (!string.IsNullOrWhiteSpace(asset.ETag) && EntityTagHeaderValue.TryParse(asset.ETag, out var entityTag))
+            {
+                request.Headers.IfRange = new RangeConditionHeaderValue(entityTag);
+            }
+        }
+
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+        if (resumeBytes > 0 && response.StatusCode == HttpStatusCode.OK)
+        {
+            File.Delete(partialPath);
+            resumeBytes = 0;
+        }
+        else if (resumeBytes > 0 && response.StatusCode != HttpStatusCode.PartialContent)
+        {
+            response.EnsureSuccessStatusCode();
+            throw new InvalidOperationException(
+                $"Scene package asset '{assetKey}' did not return a resumable HTTP 206 response.");
+        }
+
+        response.EnsureSuccessStatusCode();
+        ValidateEtag(asset, response);
+
+        if (response.Content.Headers.ContentLength is long contentLength &&
+            resumeBytes + contentLength > expectedBytes)
+        {
+            throw new InvalidOperationException(
+                $"Scene package asset '{assetKey}' exceeds declared bytes ({expectedBytes}).");
+        }
+
+        var bytesRead = await CopyAssetAsync(
+            response.Content,
+            partialPath,
+            assetKey,
+            resumeBytes,
+            expectedBytes,
+            maxPackageBytes,
+            downloadedPackageBytes,
+            progress,
+            completedAssetCount,
+            totalAssetCount,
+            declaredBytes,
+            ct).ConfigureAwait(false);
+
+        var finalBytes = resumeBytes + bytesRead;
+        if (finalBytes != expectedBytes)
+        {
+            throw new InvalidOperationException(
+                $"Scene package asset '{assetKey}' downloaded {finalBytes} bytes but manifest declares {expectedBytes} bytes.");
+        }
+
+        await ValidateSha256Async(partialPath, asset, ct).ConfigureAwait(false);
+        if (File.Exists(finalPath))
+        {
+            File.Delete(finalPath);
+        }
+
+        File.Move(partialPath, finalPath);
+        return bytesRead;
+    }
+
+    private static async Task<long> CopyAssetAsync(
+        HttpContent content,
+        string partialPath,
+        string assetKey,
+        long resumeBytes,
+        long expectedBytes,
+        long maxPackageBytes,
+        long downloadedPackageBytes,
+        IProgress<ScenePackageDownloadProgress>? progress,
+        int completedAssetCount,
+        int totalAssetCount,
+        long? declaredBytes,
+        CancellationToken ct)
+    {
+        await using var source = await content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        await using var target = new FileStream(partialPath, FileMode.Append, FileAccess.Write, FileShare.Read);
+        var buffer = ArrayPool<byte>.Shared.Rent(81920);
+        var bytesRead = 0L;
+
+        try
+        {
+            while (true)
+            {
+                var read = await source.ReadAsync(buffer.AsMemory(0, buffer.Length), ct).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                bytesRead += read;
+                var assetTotalBytes = resumeBytes + bytesRead;
+                var packageTotalBytes = downloadedPackageBytes + bytesRead;
+
+                if (assetTotalBytes > expectedBytes)
+                {
+                    throw new InvalidOperationException(
+                        $"Scene package asset '{assetKey}' exceeds declared bytes ({expectedBytes}).");
+                }
+
+                if (packageTotalBytes > maxPackageBytes)
+                {
+                    throw new InvalidOperationException(
+                        $"Scene package download exceeds package byte budget ({maxPackageBytes}).");
+                }
+
+                await target.WriteAsync(buffer.AsMemory(0, read), ct).ConfigureAwait(false);
+                progress?.Report(new ScenePackageDownloadProgress
+                {
+                    AssetKey = assetKey,
+                    CompletedAssetCount = completedAssetCount,
+                    TotalAssetCount = totalAssetCount,
+                    DownloadedBytes = packageTotalBytes,
+                    DeclaredBytes = declaredBytes,
+                });
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        return bytesRead;
+    }
+
+    private static async Task ValidateSha256Async(
+        string partialPath,
+        HonuaScenePackageAsset asset,
+        CancellationToken ct)
+    {
+        await using var stream = File.OpenRead(partialPath);
+        var hash = await SHA256.HashDataAsync(stream, ct).ConfigureAwait(false);
+        var expected = asset.Sha256 ?? throw new InvalidOperationException($"Scene package asset '{asset.Key}' is missing sha256.");
+        if (HashMatches(expected, hash))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"Scene package asset '{asset.Key}' failed SHA-256 validation.");
+    }
+
+    private static bool HashMatches(string expected, byte[] actual)
+    {
+        var normalized = expected.Trim();
+        if (normalized.Length == 64 && normalized.All(Uri.IsHexDigit))
+        {
+            return string.Equals(
+                normalized,
+                Convert.ToHexString(actual).ToLowerInvariant(),
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        return string.Equals(normalized, Convert.ToBase64String(actual), StringComparison.Ordinal);
+    }
+
+    private static void ValidateEtag(HonuaScenePackageAsset asset, HttpResponseMessage response)
+    {
+        if (string.IsNullOrWhiteSpace(asset.ETag))
+        {
+            return;
+        }
+
+        if (response.Headers.ETag is null)
+        {
+            throw new InvalidOperationException($"Scene package asset '{asset.Key}' response is missing the manifest ETag.");
+        }
+
+        if (!string.Equals(asset.ETag, response.Headers.ETag.ToString(), StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Scene package asset '{asset.Key}' ETag does not match the manifest.");
+        }
+    }
+
+    private static async Task<string> WriteManifestAsync(
+        string stagingDirectory,
+        HonuaScenePackageManifest manifest,
+        CancellationToken ct)
+    {
+        var manifestPath = Path.Combine(stagingDirectory, "manifest.json");
+        await using var stream = File.Create(manifestPath);
+        await JsonSerializer.SerializeAsync(stream, manifest, ManifestJsonOptions, ct).ConfigureAwait(false);
+        return manifestPath;
+    }
+
+    private static ScenePackageRecord BuildCatalogRecord(
+        HonuaScenePackageManifest manifest,
+        string readyDirectory,
+        string manifestPath,
+        HonuaScenePackageState state,
+        long downloadedBytes,
+        int downloadedAssetCount,
+        ISet<string> downloadedAssetKeys,
+        DateTimeOffset utcNow)
+        => new()
+        {
+            PackageId = manifest.PackageId!,
+            SceneId = manifest.SceneId!,
+            DisplayName = manifest.DisplayName,
+            EditionGate = manifest.EditionGate!,
+            ServerRevision = manifest.ServerRevision!,
+            Extent = manifest.Extent,
+            PackageDirectory = readyDirectory,
+            ManifestPath = manifestPath,
+            State = state,
+            DeclaredBytes = manifest.ByteBudget?.DeclaredBytes ?? 0,
+            DownloadedBytes = downloadedBytes,
+            RequiredAssetCount = manifest.Assets.Count(asset => asset?.Required == true),
+            DownloadedAssetCount = downloadedAssetCount,
+            MissingOptionalAssetKeys = GetMissingOptionalAssetKeys(manifest, downloadedAssetKeys),
+            StaleAfterUtc = manifest.StaleAfterUtc,
+            OfflineUseExpiresAtUtc = manifest.OfflineUseExpiresAtUtc,
+            AuthExpiresAtUtc = manifest.AuthExpiresAtUtc,
+            UpdatedAtUtc = utcNow,
+        };
+
+    private static IReadOnlyList<string> GetMissingOptionalAssetKeys(
+        HonuaScenePackageManifest manifest,
+        ISet<string> downloadedAssetKeys)
+        => manifest.Assets
+            .Where(asset => asset is { Required: false, Key: not null } && !downloadedAssetKeys.Contains(asset.Key))
+            .Select(asset => asset.Key!)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private static long SumDownloadedAssetBytes(
+        HonuaScenePackageManifest manifest,
+        ISet<string> downloadedAssetKeys)
+    {
+        var total = 0L;
+        foreach (var asset in manifest.Assets)
+        {
+            if (asset?.Key is null || !downloadedAssetKeys.Contains(asset.Key))
+            {
+                continue;
+            }
+
+            checked
+            {
+                total += asset.Bytes ?? 0;
+            }
+        }
+
+        return total;
+    }
+
+    private static string NormalizeOutputDirectory(string outputDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(outputDirectory))
+        {
+            throw new InvalidOperationException("Output directory is required.");
+        }
+
+        var normalized = Path.GetFullPath(outputDirectory);
+        Directory.CreateDirectory(normalized);
+        return normalized;
+    }
+
+    private static string SanitizePackageId(string packageId)
+    {
+        var invalidCharacters = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(packageId.Length);
+
+        foreach (var character in packageId.Trim())
+        {
+            if (character == Path.DirectorySeparatorChar ||
+                character == Path.AltDirectorySeparatorChar ||
+                character == ':' ||
+                character == '.' ||
+                Array.IndexOf(invalidCharacters, character) >= 0)
+            {
+                builder.Append('_');
+                continue;
+            }
+
+            builder.Append(character);
+        }
+
+        var safePackageId = builder.ToString().Trim('.');
+        if (string.IsNullOrWhiteSpace(safePackageId))
+        {
+            throw new InvalidOperationException("Package ID must include at least one valid file-name character.");
+        }
+
+        return safePackageId;
+    }
+
+    private static Uri EnsureDirectoryUri(Uri uri)
+    {
+        if (!uri.IsAbsoluteUri)
+        {
+            throw new InvalidOperationException("Asset base URI must be absolute.");
+        }
+
+        return uri.AbsoluteUri.EndsWith("/", StringComparison.Ordinal)
+            ? uri
+            : new Uri(uri.AbsoluteUri + "/");
+    }
+
+    private static string RequireSafeRelativePath(string? path, string assetKey)
+    {
+        if (string.IsNullOrWhiteSpace(path) ||
+            path.Contains('\\', StringComparison.Ordinal) ||
+            path.StartsWith("/", StringComparison.Ordinal) ||
+            Uri.TryCreate(path, UriKind.Absolute, out _))
+        {
+            throw new InvalidOperationException($"Scene package asset '{assetKey}' path must be package-local and relative.");
+        }
+
+        var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Any(segment => segment is "." or ".."))
+        {
+            throw new InvalidOperationException($"Scene package asset '{assetKey}' path must stay under the package root.");
+        }
+
+        return string.Join('/', segments);
+    }
+
+    private static string BuildPackageFilePath(string packageDirectory, string relativePath)
+    {
+        var fullPath = Path.GetFullPath(Path.Combine(packageDirectory, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var root = Path.GetFullPath(packageDirectory);
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        var rootPrefix = Path.EndsInDirectorySeparator(root)
+            ? root
+            : root + Path.DirectorySeparatorChar;
+
+        if (!fullPath.StartsWith(rootPrefix, comparison))
+        {
+            throw new InvalidOperationException("Resolved scene package asset path is outside the package directory.");
+        }
+
+        return fullPath;
+    }
+
+    private static void ReplaceReadyDirectory(string stagingDirectory, string readyDirectory)
+    {
+        DeleteDirectoryIfExists(readyDirectory);
+        Directory.Move(stagingDirectory, readyDirectory);
+    }
+
+    private static void DeletePartialAsset(string stagingDirectory, string? assetPath)
+    {
+        if (string.IsNullOrWhiteSpace(assetPath))
+        {
+            return;
+        }
+
+        var partialPath = Path.Combine(stagingDirectory, assetPath.Replace('/', Path.DirectorySeparatorChar)) + ".partial";
+        if (File.Exists(partialPath))
+        {
+            File.Delete(partialPath);
+        }
+    }
+
+    private static void DeleteDirectoryIfExists(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+
+    private static string FormatIssues(HonuaScenePackageValidationResult validation)
+        => string.Join("; ", validation.Issues.Select(issue => $"{issue.Code}: {issue.Message}"));
+}

--- a/tests/Honua.Mobile.Maui.Tests/HonuaAnnotationLayerTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaAnnotationLayerTests.cs
@@ -1,5 +1,7 @@
 using Honua.Mobile.Maui;
 using Honua.Mobile.Maui.Annotations;
+using Honua.Mobile.Offline.GeoPackage;
+using Honua.Mobile.Offline.ScenePackages;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Honua.Mobile.Maui.Tests;
@@ -180,5 +182,19 @@ public sealed class HonuaAnnotationLayerTests
         var second = services.GetRequiredService<HonuaAnnotationLayer>();
 
         Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void AddHonuaScenePackageDownload_RegistersDownloader()
+    {
+        var storePath = Path.Combine(Path.GetTempPath(), $"honua-scene-package-di-{Guid.NewGuid():N}.gpkg");
+        using var services = new ServiceCollection()
+            .AddHonuaGeoPackageOfflineSync(new GeoPackageSyncStoreOptions { DatabasePath = storePath })
+            .AddHonuaScenePackageDownload()
+            .BuildServiceProvider();
+
+        var downloader = services.GetRequiredService<IHonuaScenePackageDownloader>();
+
+        Assert.IsType<ScenePackageDownloader>(downloader);
     }
 }

--- a/tests/Honua.Mobile.Offline.Tests/ScenePackageDownloaderTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/ScenePackageDownloaderTests.cs
@@ -98,6 +98,40 @@ public sealed class ScenePackageDownloaderTests : IDisposable
     }
 
     [Fact]
+    public async Task DownloadAsync_PackageDirectoryUsesCollisionSafePackageId()
+    {
+        var payload = Encoding.UTF8.GetBytes("metadata");
+        var dottedManifest = CreateManifest(
+            CreateAsset("scene-metadata", HonuaScenePackageAssetTypes.SceneMetadata, "metadata/scene.json", payload),
+            packageId: "pkg.v1");
+        var underscoredManifest = CreateManifest(
+            CreateAsset("scene-metadata", HonuaScenePackageAssetTypes.SceneMetadata, "metadata/scene.json", payload),
+            packageId: "pkg_v1");
+        var outputDirectory = Path.Combine(_rootDirectory, "packages");
+        var store = CreateStore();
+        var httpClient = new HttpClient(new StubHttpMessageHandler((_, _) =>
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(payload),
+            });
+        }));
+        var downloader = new ScenePackageDownloader(httpClient, store);
+
+        var dotted = await downloader.DownloadAsync(CreateRequest(dottedManifest, outputDirectory: outputDirectory));
+        var underscored = await downloader.DownloadAsync(CreateRequest(underscoredManifest, outputDirectory: outputDirectory));
+
+        Assert.NotEqual(dotted.PackageDirectory, underscored.PackageDirectory);
+        Assert.True(File.Exists(Path.Combine(dotted.PackageDirectory, "metadata", "scene.json")));
+        Assert.True(File.Exists(Path.Combine(underscored.PackageDirectory, "metadata", "scene.json")));
+        var packageIds = (await store.ListScenePackagesAsync())
+            .Select(record => record.PackageId)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(["pkg.v1", "pkg_v1"], packageIds);
+    }
+
+    [Fact]
     public async Task DownloadAsync_OptionalAssetFailure_RegistersMissingKey()
     {
         var metadata = Encoding.UTF8.GetBytes("""{"sceneId":"downtown-honolulu"}""");
@@ -184,6 +218,35 @@ public sealed class ScenePackageDownloaderTests : IDisposable
             downloader.DownloadAsync(CreateRequest(manifest, outputDirectory: outputDirectory)));
 
         Assert.Contains("ETag", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(Directory.Exists(Path.Combine(outputDirectory, "pkg_downtown_honolulu_2026_04.partial")));
+    }
+
+    [Fact]
+    public async Task DownloadAsync_CatalogFailure_RestoresPreviousReadyPackage()
+    {
+        var oldPayload = Encoding.UTF8.GetBytes("old-package");
+        var newPayload = Encoding.UTF8.GetBytes("new-package");
+        var outputDirectory = Path.Combine(_rootDirectory, "packages");
+        var readyPath = Path.Combine(outputDirectory, "pkg_downtown_honolulu_2026_04");
+        var readyAssetPath = Path.Combine(readyPath, "metadata", "scene.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(readyAssetPath)!);
+        await File.WriteAllBytesAsync(readyAssetPath, oldPayload);
+        var manifest = CreateManifest(
+            CreateAsset("scene-metadata", HonuaScenePackageAssetTypes.SceneMetadata, "metadata/scene.json", newPayload));
+        var httpClient = new HttpClient(new StubHttpMessageHandler((_, _) =>
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(newPayload),
+            });
+        }));
+        var downloader = new ScenePackageDownloader(httpClient, new ThrowingScenePackageStore());
+
+        var ex = await Assert.ThrowsAsync<IOException>(() =>
+            downloader.DownloadAsync(CreateRequest(manifest, outputDirectory: outputDirectory)));
+
+        Assert.Contains("catalog unavailable", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(oldPayload, await File.ReadAllBytesAsync(readyAssetPath));
         Assert.False(Directory.Exists(Path.Combine(outputDirectory, "pkg_downtown_honolulu_2026_04.partial")));
     }
 
@@ -293,8 +356,9 @@ public sealed class ScenePackageDownloaderTests : IDisposable
         HonuaScenePackageAsset asset,
         DateTimeOffset? authExpiresAtUtc = null,
         long? maxPackageBytes = null,
-        long? declaredBytes = null)
-        => CreateManifest([asset], authExpiresAtUtc, maxPackageBytes, declaredBytes);
+        long? declaredBytes = null,
+        string packageId = "pkg_downtown_honolulu_2026_04")
+        => CreateManifest([asset], authExpiresAtUtc, maxPackageBytes, declaredBytes, packageId);
 
     private static HonuaScenePackageManifest CreateManifest(
         HonuaScenePackageAsset firstAsset,
@@ -305,13 +369,14 @@ public sealed class ScenePackageDownloaderTests : IDisposable
         IReadOnlyList<HonuaScenePackageAsset> assets,
         DateTimeOffset? authExpiresAtUtc = null,
         long? maxPackageBytes = null,
-        long? declaredBytes = null)
+        long? declaredBytes = null,
+        string packageId = "pkg_downtown_honolulu_2026_04")
     {
         var assetBytes = assets.Sum(asset => asset.Bytes ?? 0);
         return new HonuaScenePackageManifest
         {
             SchemaVersion = HonuaScenePackageManifest.CurrentSchemaVersion,
-            PackageId = "pkg_downtown_honolulu_2026_04",
+            PackageId = packageId,
             SceneId = "downtown-honolulu",
             DisplayName = "Downtown Honolulu 3D",
             EditionGate = HonuaScenePackageEditionGates.Pro,
@@ -382,5 +447,59 @@ public sealed class ScenePackageDownloaderTests : IDisposable
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             => _handler(request, cancellationToken);
+    }
+
+    private sealed class ThrowingScenePackageStore : IGeoPackageSyncStore
+    {
+        public Task InitializeAsync(CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task UpsertScenePackageAsync(ScenePackageRecord scenePackage, CancellationToken ct = default)
+            => throw new IOException("catalog unavailable");
+
+        public Task EnqueueAsync(OfflineEditOperation operation, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<OfflineEditOperation>> GetPendingAsync(int maxCount, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task<int> CountPendingAsync(CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task MarkSucceededAsync(string operationId, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task MarkPendingAsync(string operationId, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task MarkFailedAsync(string operationId, string failureReason, bool retryable, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task SetSyncCursorAsync(string cursorKey, string cursorValue, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task<string?> GetSyncCursorAsync(string cursorKey, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task UpsertMapAreaAsync(MapAreaPackage mapArea, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<MapAreaPackage>> ListMapAreasAsync(CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<ScenePackageRecord>> ListScenePackagesAsync(CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task DeleteScenePackageAsync(string packageId, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task UpsertFeatureAsync(string layerKey, string featureJson, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task DeleteFeatureAsync(string layerKey, long objectId, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<string>> GetFeaturesAsync(string layerKey, CancellationToken ct = default)
+            => throw new NotSupportedException();
     }
 }

--- a/tests/Honua.Mobile.Offline.Tests/ScenePackageDownloaderTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/ScenePackageDownloaderTests.cs
@@ -1,0 +1,386 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using Honua.Mobile.Offline.GeoPackage;
+using Honua.Mobile.Offline.ScenePackages;
+using Honua.Mobile.Sdk.Scenes;
+
+namespace Honua.Mobile.Offline.Tests;
+
+public sealed class ScenePackageDownloaderTests : IDisposable
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 28, 12, 0, 0, TimeSpan.Zero);
+    private readonly string _rootDirectory;
+
+    public ScenePackageDownloaderTests()
+    {
+        _rootDirectory = Path.Combine(Path.GetTempPath(), $"honua-scene-package-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_rootDirectory);
+    }
+
+    [Fact]
+    public async Task DownloadAsync_WritesPackageAndRegistersScenePackage()
+    {
+        var metadata = Encoding.UTF8.GetBytes("""{"sceneId":"downtown-honolulu"}""");
+        var tileset = Encoding.UTF8.GetBytes("""{"asset":{"version":"1.1"}}""");
+        var manifest = CreateManifest(
+            CreateAsset("scene-metadata", HonuaScenePackageAssetTypes.SceneMetadata, "metadata/scene.json", metadata, "\"meta-1\""),
+            CreateAsset("buildings-tileset", HonuaScenePackageAssetTypes.ThreeDimensionalTileset, "tilesets/buildings/tileset.json", tileset, "\"tiles-1\""));
+        var store = CreateStore();
+        var httpClient = new HttpClient(new StubHttpMessageHandler((request, _) =>
+        {
+            var payload = ResolvePayload(request, metadata, tileset);
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(payload),
+            };
+            response.Headers.ETag = EntityTagHeaderValue.Parse(request.RequestUri!.AbsolutePath.EndsWith("scene.json", StringComparison.Ordinal)
+                ? "\"meta-1\""
+                : "\"tiles-1\"");
+            return Task.FromResult(response);
+        }));
+        var downloader = new ScenePackageDownloader(httpClient, store);
+
+        var result = await downloader.DownloadAsync(CreateRequest(manifest));
+
+        Assert.Equal(2, result.DownloadedAssetCount);
+        Assert.Equal(metadata.Length + tileset.Length, result.DownloadedBytes);
+        Assert.True(File.Exists(Path.Combine(result.PackageDirectory, "metadata", "scene.json")));
+        Assert.True(File.Exists(Path.Combine(result.PackageDirectory, "tilesets", "buildings", "tileset.json")));
+        Assert.True(File.Exists(result.ManifestPath));
+
+        var records = await store.ListScenePackagesAsync();
+        var record = Assert.Single(records);
+        Assert.Equal("pkg_downtown_honolulu_2026_04", record.PackageId);
+        Assert.Equal("downtown-honolulu", record.SceneId);
+        Assert.Equal(HonuaScenePackageState.Ready, record.State);
+        Assert.Equal(result.PackageDirectory, record.PackageDirectory);
+        Assert.Equal(2, record.RequiredAssetCount);
+        Assert.Equal(metadata.Length + tileset.Length, record.DownloadedBytes);
+        Assert.Empty(record.MissingOptionalAssetKeys);
+
+        await store.DeleteScenePackageAsync(record.PackageId);
+        Assert.Empty(await store.ListScenePackagesAsync());
+    }
+
+    [Fact]
+    public async Task DownloadAsync_ResumesPartialAssetWithRangeRequest()
+    {
+        var payload = Encoding.UTF8.GetBytes("0123456789abcdef");
+        var manifest = CreateManifest(
+            CreateAsset("scene-metadata", HonuaScenePackageAssetTypes.SceneMetadata, "metadata/scene.json", payload, "\"meta-2\""));
+        var outputDirectory = Path.Combine(_rootDirectory, "packages");
+        var partialPath = Path.Combine(outputDirectory, "pkg_downtown_honolulu_2026_04.partial", "metadata", "scene.json.partial");
+        Directory.CreateDirectory(Path.GetDirectoryName(partialPath)!);
+        await File.WriteAllBytesAsync(partialPath, payload[..5]);
+        long? requestedRangeStart = null;
+
+        var store = CreateStore();
+        var httpClient = new HttpClient(new StubHttpMessageHandler((request, _) =>
+        {
+            requestedRangeStart = request.Headers.Range?.Ranges.Single().From;
+            var response = new HttpResponseMessage(HttpStatusCode.PartialContent)
+            {
+                Content = new ByteArrayContent(payload[5..]),
+            };
+            response.Headers.ETag = EntityTagHeaderValue.Parse("\"meta-2\"");
+            return Task.FromResult(response);
+        }));
+        var downloader = new ScenePackageDownloader(httpClient, store);
+
+        var result = await downloader.DownloadAsync(CreateRequest(manifest, outputDirectory: outputDirectory));
+
+        Assert.Equal(5, requestedRangeStart);
+        Assert.Equal(payload.Length - 5, result.DownloadedBytes);
+        Assert.Equal(payload, await File.ReadAllBytesAsync(Path.Combine(result.PackageDirectory, "metadata", "scene.json")));
+        Assert.Equal(payload.Length, result.CatalogRecord.DownloadedBytes);
+    }
+
+    [Fact]
+    public async Task DownloadAsync_OptionalAssetFailure_RegistersMissingKey()
+    {
+        var metadata = Encoding.UTF8.GetBytes("""{"sceneId":"downtown-honolulu"}""");
+        var optional = Encoding.UTF8.GetBytes("expected-optional");
+        var wrongOptional = Encoding.UTF8.GetBytes("wrong-optional");
+        var manifest = CreateManifest(
+            CreateAsset("scene-metadata", HonuaScenePackageAssetTypes.SceneMetadata, "metadata/scene.json", metadata),
+            CreateAsset(
+                "texture-overview",
+                HonuaScenePackageAssetTypes.Texture,
+                "textures/overview.bin",
+                optional,
+                required: false));
+        var store = CreateStore();
+        var httpClient = new HttpClient(new StubHttpMessageHandler((request, _) =>
+        {
+            var payload = request.RequestUri!.AbsolutePath.EndsWith("scene.json", StringComparison.Ordinal)
+                ? metadata
+                : wrongOptional;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(payload),
+            });
+        }));
+        var downloader = new ScenePackageDownloader(httpClient, store);
+
+        var result = await downloader.DownloadAsync(CreateRequest(manifest));
+
+        Assert.Equal(1, result.DownloadedAssetCount);
+        Assert.Equal(HonuaScenePackageState.Ready, result.CatalogRecord.State);
+        Assert.Equal(["texture-overview"], result.CatalogRecord.MissingOptionalAssetKeys);
+        Assert.False(File.Exists(Path.Combine(result.PackageDirectory, "textures", "overview.bin")));
+        var record = Assert.Single(await store.ListScenePackagesAsync());
+        Assert.Equal(["texture-overview"], record.MissingOptionalAssetKeys);
+    }
+
+    [Fact]
+    public async Task DownloadAsync_ChecksumFailure_ThrowsAndCleansPartialPackage()
+    {
+        var payload = Encoding.UTF8.GetBytes("expected");
+        var wrongPayload = Encoding.UTF8.GetBytes("wrongone");
+        var manifest = CreateManifest(
+            CreateAsset("scene-metadata", HonuaScenePackageAssetTypes.SceneMetadata, "metadata/scene.json", payload));
+        var outputDirectory = Path.Combine(_rootDirectory, "packages");
+        var store = CreateStore();
+        var httpClient = new HttpClient(new StubHttpMessageHandler((_, _) =>
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(wrongPayload),
+            });
+        }));
+        var downloader = new ScenePackageDownloader(httpClient, store);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            downloader.DownloadAsync(CreateRequest(manifest, outputDirectory: outputDirectory)));
+
+        Assert.Contains("SHA-256", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(Directory.Exists(Path.Combine(outputDirectory, "pkg_downtown_honolulu_2026_04.partial")));
+        await store.InitializeAsync();
+        Assert.Empty(await store.ListScenePackagesAsync());
+    }
+
+    [Fact]
+    public async Task DownloadAsync_ETagMismatch_ThrowsAndCleansPartialPackage()
+    {
+        var payload = Encoding.UTF8.GetBytes("metadata");
+        var manifest = CreateManifest(
+            CreateAsset("scene-metadata", HonuaScenePackageAssetTypes.SceneMetadata, "metadata/scene.json", payload, "\"expected\""));
+        var outputDirectory = Path.Combine(_rootDirectory, "packages");
+        var store = CreateStore();
+        var httpClient = new HttpClient(new StubHttpMessageHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(payload),
+            };
+            response.Headers.ETag = EntityTagHeaderValue.Parse("\"different\"");
+            return Task.FromResult(response);
+        }));
+        var downloader = new ScenePackageDownloader(httpClient, store);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            downloader.DownloadAsync(CreateRequest(manifest, outputDirectory: outputDirectory)));
+
+        Assert.Contains("ETag", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(Directory.Exists(Path.Combine(outputDirectory, "pkg_downtown_honolulu_2026_04.partial")));
+    }
+
+    [Fact]
+    public async Task DownloadAsync_ExpiredAuth_DoesNotSendRequests()
+    {
+        var payload = Encoding.UTF8.GetBytes("metadata");
+        var manifest = CreateManifest(
+            CreateAsset("scene-metadata", HonuaScenePackageAssetTypes.SceneMetadata, "metadata/scene.json", payload),
+            authExpiresAtUtc: Now.AddMinutes(-1));
+        var requestCount = 0;
+        var store = CreateStore();
+        var httpClient = new HttpClient(new StubHttpMessageHandler((_, _) =>
+        {
+            requestCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(payload),
+            });
+        }));
+        var downloader = new ScenePackageDownloader(httpClient, store);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => downloader.DownloadAsync(CreateRequest(manifest)));
+
+        Assert.Contains("credentials have expired", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, requestCount);
+    }
+
+    [Fact]
+    public async Task DownloadAsync_OverBudgetManifest_DoesNotSendRequests()
+    {
+        var payload = Encoding.UTF8.GetBytes("metadata");
+        var manifest = CreateManifest(
+            CreateAsset("scene-metadata", HonuaScenePackageAssetTypes.SceneMetadata, "metadata/scene.json", payload),
+            maxPackageBytes: payload.Length - 1,
+            declaredBytes: payload.Length);
+        var requestCount = 0;
+        var store = CreateStore();
+        var httpClient = new HttpClient(new StubHttpMessageHandler((_, _) =>
+        {
+            requestCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(payload),
+            });
+        }));
+        var downloader = new ScenePackageDownloader(httpClient, store);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => downloader.DownloadAsync(CreateRequest(manifest)));
+
+        Assert.Contains(HonuaScenePackageValidationCodes.OverByteBudget, ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, requestCount);
+    }
+
+    [Fact]
+    public async Task DownloadAsync_Cancellation_CleansPartialPackage()
+    {
+        var payload = Encoding.UTF8.GetBytes("metadata");
+        var manifest = CreateManifest(
+            CreateAsset("scene-metadata", HonuaScenePackageAssetTypes.SceneMetadata, "metadata/scene.json", payload));
+        var outputDirectory = Path.Combine(_rootDirectory, "packages");
+        var store = CreateStore();
+        var httpClient = new HttpClient(new StubHttpMessageHandler((_, ct) =>
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(payload),
+            });
+        }));
+        var downloader = new ScenePackageDownloader(httpClient, store);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            downloader.DownloadAsync(CreateRequest(manifest, outputDirectory: outputDirectory), cts.Token));
+
+        Assert.False(Directory.Exists(Path.Combine(outputDirectory, "pkg_downtown_honolulu_2026_04.partial")));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_rootDirectory))
+        {
+            Directory.Delete(_rootDirectory, recursive: true);
+        }
+    }
+
+    private GeoPackageSyncStore CreateStore()
+        => new(new GeoPackageSyncStoreOptions
+        {
+            DatabasePath = Path.Combine(_rootDirectory, "sync-store.gpkg"),
+        });
+
+    private ScenePackageDownloadRequest CreateRequest(
+        HonuaScenePackageManifest manifest,
+        string? outputDirectory = null)
+        => new()
+        {
+            Manifest = manifest,
+            AssetBaseUri = new Uri("https://cdn.honua.test/packages/pkg_downtown_honolulu_2026_04/"),
+            OutputDirectory = outputDirectory ?? Path.Combine(_rootDirectory, "packages"),
+            UtcNow = Now,
+        };
+
+    private static HonuaScenePackageManifest CreateManifest(
+        HonuaScenePackageAsset asset,
+        DateTimeOffset? authExpiresAtUtc = null,
+        long? maxPackageBytes = null,
+        long? declaredBytes = null)
+        => CreateManifest([asset], authExpiresAtUtc, maxPackageBytes, declaredBytes);
+
+    private static HonuaScenePackageManifest CreateManifest(
+        HonuaScenePackageAsset firstAsset,
+        HonuaScenePackageAsset secondAsset)
+        => CreateManifest([firstAsset, secondAsset]);
+
+    private static HonuaScenePackageManifest CreateManifest(
+        IReadOnlyList<HonuaScenePackageAsset> assets,
+        DateTimeOffset? authExpiresAtUtc = null,
+        long? maxPackageBytes = null,
+        long? declaredBytes = null)
+    {
+        var assetBytes = assets.Sum(asset => asset.Bytes ?? 0);
+        return new HonuaScenePackageManifest
+        {
+            SchemaVersion = HonuaScenePackageManifest.CurrentSchemaVersion,
+            PackageId = "pkg_downtown_honolulu_2026_04",
+            SceneId = "downtown-honolulu",
+            DisplayName = "Downtown Honolulu 3D",
+            EditionGate = HonuaScenePackageEditionGates.Pro,
+            ServerRevision = "scene-rev-42",
+            CreatedAtUtc = Now.AddHours(-1),
+            StaleAfterUtc = Now.AddDays(30),
+            OfflineUseExpiresAtUtc = Now.AddDays(60),
+            AuthExpiresAtUtc = authExpiresAtUtc ?? Now.AddDays(1),
+            Extent = new HonuaSceneBounds
+            {
+                MinLongitude = -157.872,
+                MinLatitude = 21.293,
+                MaxLongitude = -157.841,
+                MaxLatitude = 21.319,
+            },
+            Lod = new HonuaScenePackageLod
+            {
+                MinZoom = 12,
+                MaxZoom = 17,
+                MaxGeometricErrorMeters = 4.0,
+            },
+            ByteBudget = new HonuaScenePackageByteBudget
+            {
+                MaxPackageBytes = maxPackageBytes ?? assetBytes + 1024,
+                DeclaredBytes = declaredBytes ?? assetBytes,
+            },
+            Attribution = ["Honua"],
+            Assets = assets,
+        };
+    }
+
+    private static HonuaScenePackageAsset CreateAsset(
+        string key,
+        string type,
+        string path,
+        byte[] payload,
+        string? etag = null,
+        bool required = true)
+        => new()
+        {
+            Key = key,
+            Type = type,
+            Role = "metadata",
+            Path = path,
+            ContentType = "application/octet-stream",
+            Bytes = payload.Length,
+            Sha256 = Sha256Hex(payload),
+            ETag = etag,
+            Required = required,
+        };
+
+    private static byte[] ResolvePayload(HttpRequestMessage request, byte[] metadata, byte[] tileset)
+        => request.RequestUri!.AbsolutePath.EndsWith("scene.json", StringComparison.Ordinal)
+            ? metadata
+            : tileset;
+
+    private static string Sha256Hex(byte[] payload)
+        => Convert.ToHexString(SHA256.HashData(payload)).ToLowerInvariant();
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;
+
+        public StubHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => _handler(request, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- add `IHonuaScenePackageDownloader` and the `ScenePackageDownloader` implementation for offline 3D scene package assets
- register scene package metadata in the GeoPackage sync store, including byte footprint, expiry state, and missing optional asset keys for eviction/render fallback decisions
- add MAUI DI registration plus docs and tests for success, resume, checksum/ETag failures, expired auth, over-budget manifests, optional asset fallback, cancellation cleanup, and catalog deletion

## Validation
- `dotnet test tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj --no-restore --configuration Release`
- `dotnet format Honua.Mobile.sln --no-restore --verify-no-changes --verbosity diagnostic`
- `dotnet test Honua.Mobile.sln --no-restore --configuration Release`
- `dotnet build src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj --no-restore --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj --no-restore --configuration Release /p:TreatWarningsAsErrors=true`
- `git diff --check`

Closes #41