### PR TITLE
docs(sdk): add mobile contract harmonization baseline

### DIFF
--- a/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
+++ b/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
@@ -1,0 +1,184 @@
+{
+  "schemaVersion": "honua.mobile-contract-harmonization.v1",
+  "mobileIssue": "honua-mobile#48",
+  "sdkIssue": "honua-sdk-dotnet#68",
+  "companionOfflineIssue": "honua-sdk-dotnet#56",
+  "status": "baseline",
+  "mobileBaseline": {
+    "repository": "honua-io/honua-mobile",
+    "ref": "main",
+    "packageVersion": "unreleased-source"
+  },
+  "sdkBaseline": {
+    "repository": "honua-io/honua-sdk-dotnet",
+    "ref": "main",
+    "packages": [
+      {
+        "packageId": "Honua.Sdk.Abstractions",
+        "version": "0.1.0-alpha.1"
+      }
+    ]
+  },
+  "modelFamilies": [
+    {
+      "id": "feature-query",
+      "displayName": "Feature query requests and result pages",
+      "owner": "honua-sdk-dotnet",
+      "authoritativePackage": "Honua.Sdk.Abstractions",
+      "authoritativeTypes": [
+        "Honua.Sdk.Abstractions.Features.FeatureQueryRequest",
+        "Honua.Sdk.Abstractions.Features.FeatureQueryResult",
+        "Honua.Sdk.Abstractions.Features.FeatureRecord",
+        "Honua.Sdk.Abstractions.Features.FeatureSource",
+        "Honua.Sdk.Abstractions.Features.SourceDescriptor",
+        "Honua.Sdk.Abstractions.Features.SourceQuery"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Sdk.Models.QueryFeaturesRequest",
+        "Honua.Mobile.Sdk.Models.OgcItemsRequest",
+        "Honua.Mobile.Sdk.Grpc.GrpcFeatureTranslator"
+      ],
+      "mobileDisposition": "adapter-required",
+      "notes": "Mobile request DTOs remain transport shims until callers can construct Honua.Sdk.Abstractions feature queries directly."
+    },
+    {
+      "id": "feature-edit",
+      "displayName": "Feature edit envelopes and results",
+      "owner": "honua-sdk-dotnet",
+      "authoritativePackage": "Honua.Sdk.Abstractions",
+      "authoritativeTypes": [
+        "Honua.Sdk.Abstractions.Features.FeatureEditRequest",
+        "Honua.Sdk.Abstractions.Features.FeatureEditResponse",
+        "Honua.Sdk.Abstractions.Features.FeatureEditFeature",
+        "Honua.Sdk.Abstractions.Features.FeatureEditResult",
+        "Honua.Sdk.Abstractions.Features.FeatureEditError"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Sdk.Models.ApplyEditsRequest",
+        "Honua.Mobile.Sdk.Models.OgcCreateItemRequest",
+        "Honua.Mobile.Sdk.Models.OgcReplaceItemRequest",
+        "Honua.Mobile.Sdk.Models.OgcPatchItemRequest",
+        "Honua.Mobile.Sdk.Models.OgcDeleteItemRequest",
+        "Honua.Mobile.Offline.GeoPackage.OfflineEditOperation"
+      ],
+      "mobileDisposition": "adapter-required",
+      "notes": "Offline queue rows keep mobile retry metadata, but uploaded payloads should map to FeatureEditRequest."
+    },
+    {
+      "id": "geometry",
+      "displayName": "Geometry and spatial reference values",
+      "owner": "shared-split",
+      "authoritativePackage": "pending Honua.Sdk geometry package",
+      "authoritativeTypes": [],
+      "mobileTypes": [
+        "Honua.Mobile.Sdk.Grpc.GrpcFeatureTranslator",
+        "Honua.Mobile.Sdk.Routing.RoutingCoordinate",
+        "Honua.Mobile.Maui.Annotations.HonuaMapCoordinate",
+        "Honua.Mobile.Maui.Annotations.HonuaAnnotationBounds"
+      ],
+      "mobileDisposition": "quarantine-until-sdk-geometry",
+      "notes": "Keep mobile coordinates at platform edges. Shared geometry should graduate after honua-sdk-dotnet P0.4 defines WKID/WKT/GeoJSON conversion ownership."
+    },
+    {
+      "id": "offline-sync-state",
+      "displayName": "Offline package, sync state, journal, and conflict state",
+      "owner": "shared-split",
+      "authoritativePackage": "pending Honua.Sdk offline contracts",
+      "authoritativeTypes": [],
+      "mobileTypes": [
+        "Honua.Mobile.Offline.GeoPackage.OfflineEditOperation",
+        "Honua.Mobile.Offline.Sync.SyncRunResult",
+        "Honua.Mobile.Offline.Sync.SyncFailure",
+        "Honua.Mobile.Offline.Sync.DeltaDownloadOptions",
+        "Honua.Mobile.Offline.Sync.DeltaDownloadResult"
+      ],
+      "mobileDisposition": "mobile-runtime-plus-sdk-gap",
+      "notes": "Mobile owns native queue persistence, scheduling, and GeoPackage storage. Shared SDK contracts must define source descriptors, journals, checkpoints, and conflict envelopes in honua-sdk-dotnet#56."
+    },
+    {
+      "id": "form-feature-schema",
+      "displayName": "Form-related feature schemas and field workflows",
+      "owner": "shared-split",
+      "authoritativePackage": "Honua.Sdk.Abstractions for source schema",
+      "authoritativeTypes": [
+        "Honua.Sdk.Abstractions.Features.SourceDescriptor",
+        "Honua.Sdk.Abstractions.Features.SourceSchema",
+        "Honua.Sdk.Abstractions.Features.SourceField"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Field.Forms.FormDefinition",
+        "Honua.Mobile.Field.Forms.FormField",
+        "Honua.Mobile.Field.Forms.FormValidation",
+        "Honua.Mobile.Field.Records.FieldRecord",
+        "Honua.Mobile.Field.Records.RecordWorkflow"
+      ],
+      "mobileDisposition": "mobile-workflow-owned",
+      "notes": "SDK source schema owns provider-neutral field metadata. Mobile owns device form rendering, calculated fields, duplicate detection, and capture workflow."
+    },
+    {
+      "id": "scene-metadata",
+      "displayName": "3D scene metadata and offline scene packages",
+      "owner": "honua-mobile",
+      "authoritativePackage": "Honua.Mobile.Sdk",
+      "authoritativeTypes": [
+        "Honua.Mobile.Sdk.Scenes.HonuaSceneResolveRequest",
+        "Honua.Mobile.Sdk.Scenes.HonuaSceneResolveResult",
+        "Honua.Mobile.Sdk.Scenes.HonuaScenePackageManifest",
+        "Honua.Mobile.Sdk.Scenes.HonuaScenePackageAsset"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Offline.ScenePackages.IHonuaScenePackageDownloader",
+        "Honua.Mobile.Offline.GeoPackage.ScenePackageRecord"
+      ],
+      "mobileDisposition": "mobile-authoritative-candidate-for-sdk",
+      "notes": "Scene contracts stay mobile-owned until honua-sdk-dotnet introduces a scene package. Server handoff and manifest fixtures should remain portable."
+    },
+    {
+      "id": "routing",
+      "displayName": "Routing and network analysis requests",
+      "owner": "honua-mobile",
+      "authoritativePackage": "Honua.Mobile.Sdk",
+      "authoritativeTypes": [
+        "Honua.Mobile.Sdk.Routing.RouteDirectionsRequest",
+        "Honua.Mobile.Sdk.Routing.RouteOptimizationRequest",
+        "Honua.Mobile.Sdk.Routing.ServiceAreaRequest",
+        "Honua.Mobile.Sdk.Routing.ClosestFacilityRequest",
+        "Honua.Mobile.Sdk.Routing.RoutingLocation"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Sdk.Routing.HonuaRoutingClient",
+        "Honua.Mobile.Sdk.Routing.IRoutingLocationProvider"
+      ],
+      "mobileDisposition": "mobile-authoritative",
+      "notes": "Routing remains mobile-owned because it includes device location providers and GeoServices NAServer form encoding."
+    },
+    {
+      "id": "geopackage-sync",
+      "displayName": "GeoPackage storage and native offline adapters",
+      "owner": "honua-mobile",
+      "authoritativePackage": "Honua.Mobile.Offline",
+      "authoritativeTypes": [
+        "Honua.Mobile.Offline.GeoPackage.IGeoPackageSyncStore",
+        "Honua.Mobile.Offline.GeoPackage.GeoPackageSyncStore",
+        "Honua.Mobile.Offline.GeoPackage.MapAreaPackage",
+        "Honua.Mobile.Offline.GeoPackage.ScenePackageRecord"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Offline.MapAreas.IMapAreaDownloader",
+        "Honua.Mobile.Offline.ScenePackages.IHonuaScenePackageDownloader",
+        "Honua.Mobile.Offline.Sync.BackgroundSyncOrchestrator"
+      ],
+      "mobileDisposition": "mobile-runtime-owned",
+      "notes": "SDK contracts may describe offline packages and journals, but mobile owns MAUI/native storage, GeoPackage tables, and background execution behavior."
+    }
+  ],
+  "legacyMobileSdk": {
+    "repository": "honua-io/honua-mobile-sdk",
+    "disposition": "quarantine",
+    "rules": [
+      "Do not copy DTOs into honua-mobile without mapping them through this fixture.",
+      "Migrate useful concepts only when they have a declared owner in honua-sdk-dotnet or honua-mobile.",
+      "Treat older generated clients and demo-only contracts as superseded unless a ticket names the specific concept to recover."
+    ]
+  }
+}

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -10,6 +10,7 @@ In-depth guides for building with the Honua Mobile SDK.
 | [Embeddable Map](embeddable-map.md) | Framework-agnostic `<honua-map>` web component for ISV integrations |
 | [Migration Guide](migration-guide.md) | Migrating from other field collection platforms to Honua |
 | [Mobile 3D and AR Dependency Matrix](mobile-3d-ar-dependency-matrix.md) | Server, SDK, platform, offline, and edition dependencies for scene and AR work |
+| [Mobile Contract Harmonization](mobile-contract-harmonization.md) | Ownership and compatibility baseline between `honua-mobile` and `honua-sdk-dotnet` contracts |
 | [Offline 3D Scene Packages](offline-3d-scene-packages.md) | Package manifest, cache, expiry, and platform policy for offline 3D scenes |
 | [Offline Sync](offline-sync.md) | GeoPackage storage, sync engine configuration, and conflict resolution |
 | [Performance](performance.md) | Optimizing startup time, memory usage, and sync throughput |

--- a/docs/guides/mobile-contract-harmonization.md
+++ b/docs/guides/mobile-contract-harmonization.md
@@ -1,0 +1,56 @@
+# Mobile Contract Harmonization
+
+Issue #48 aligns `honua-mobile` with `honua-sdk-dotnet` so mobile and shared
+.NET SDK packages use one contract vocabulary instead of parallel DTOs.
+
+The baseline fixture is
+`contracts/fixtures/mobile-sdk-contract-harmonization.v1.json`. Keep that file
+portable: it is intentionally plain JSON so `honua-sdk-dotnet` tests can read
+the same ownership map without referencing mobile assemblies.
+
+## Compatibility Baseline
+
+| Mobile baseline | Shared SDK baseline | Status |
+|-----------------|---------------------|--------|
+| `honua-mobile` source packages from `main` after #52 | `Honua.Sdk.Abstractions` `0.1.0-alpha.1` | Fixture-level compatibility for shared feature/source contracts |
+
+`honua-mobile` does not currently publish versioned NuGet packages. Until it
+does, compatibility is stated as source-baseline compatibility against the
+shared SDK package versions above. When mobile packages gain `PackageVersion`,
+add rows here before changing public DTO ownership.
+
+## Ownership Map
+
+| Model family | Owner | Mobile disposition |
+|--------------|-------|--------------------|
+| Feature query requests/results | `honua-sdk-dotnet` / `Honua.Sdk.Abstractions` | Mobile DTOs are transport shims; add adapters to `FeatureQueryRequest` and `FeatureQueryResult`. |
+| Feature edit envelopes/results | `honua-sdk-dotnet` / `Honua.Sdk.Abstractions` | Mobile edit DTOs and offline queue payloads should map to `FeatureEditRequest`. |
+| Geometry and spatial references | Split pending SDK geometry package | Keep mobile coordinates at platform edges until SDK geometry contracts graduate. |
+| Offline sync state, journals, conflicts | Split pending SDK offline contracts | Mobile owns native queue persistence, scheduling, and GeoPackage behavior; SDK should own portable manifests and conflict envelopes. |
+| Form-related feature schemas | Split | SDK source schema owns provider-neutral fields; mobile owns form rendering, validation, calculated fields, and record workflow. |
+| Scene metadata and offline scene packages | `honua-mobile` candidate for future SDK scene package | Keep manifest/server handoff portable and fixture-backed. |
+| Routing and network analysis | `honua-mobile` | Keep NAServer encoding and device location provider behavior in mobile. |
+| GeoPackage sync and native storage adapters | `honua-mobile` | Keep database tables, background sync, file-system downloads, and MAUI registration in mobile. |
+
+## Migration Rules
+
+- New provider-neutral feature read code should target
+  `Honua.Sdk.Abstractions.Features.FeatureQueryRequest`,
+  `FeatureQueryResult`, `FeatureSource`, and `SourceDescriptor`.
+- New provider-neutral feature edit code should target
+  `FeatureEditRequest`, `FeatureEditResponse`, and related edit result models.
+- Mobile-only APIs may keep device, MAUI, GeoPackage, background execution,
+  camera/location, route-location-provider, and offline file-system concerns.
+- Any DTO copied or recovered from `honua-mobile-sdk` must first be classified
+  in the fixture as SDK-owned, mobile-owned, or quarantined.
+- Companion SDK issues must close SDK gaps before mobile deletes local runtime
+  shims that still have no shared package owner.
+
+## Follow-Up Work
+
+- #49 maps current offline queue and GeoPackage state to future SDK offline
+  package, journal, checkpoint, and conflict-envelope contracts.
+- `honua-sdk-dotnet#68` should consume the fixture and add matching tests on
+  the shared SDK side.
+- Once a mobile package version exists, add it to the compatibility table and
+  fixture before changing public model ownership.

--- a/tests/Honua.Mobile.Sdk.Tests/MobileContractHarmonizationFixtureTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/MobileContractHarmonizationFixtureTests.cs
@@ -1,0 +1,181 @@
+using System.Text.Json;
+
+namespace Honua.Mobile.Sdk.Tests;
+
+public sealed class MobileContractHarmonizationFixtureTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    [Fact]
+    public void Fixture_CoversRequiredContractFamilies()
+    {
+        var fixture = LoadFixture();
+        var familyIds = fixture.ModelFamilies
+            .Select(family => family.Id)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(
+        [
+            "feature-edit",
+            "feature-query",
+            "form-feature-schema",
+            "geometry",
+            "geopackage-sync",
+            "offline-sync-state",
+            "routing",
+            "scene-metadata",
+        ], familyIds);
+    }
+
+    [Fact]
+    public void Fixture_DeclaresSdkOwnedFeatureContracts()
+    {
+        var fixture = LoadFixture();
+
+        var query = FindFamily(fixture, "feature-query");
+        Assert.Equal("honua-sdk-dotnet", query.Owner);
+        Assert.Equal("Honua.Sdk.Abstractions", query.AuthoritativePackage);
+        Assert.Contains(
+            "Honua.Sdk.Abstractions.Features.FeatureQueryRequest",
+            query.AuthoritativeTypes);
+        Assert.Contains(
+            "Honua.Mobile.Sdk.Models.QueryFeaturesRequest",
+            query.MobileTypes);
+        Assert.Equal("adapter-required", query.MobileDisposition);
+
+        var edits = FindFamily(fixture, "feature-edit");
+        Assert.Equal("honua-sdk-dotnet", edits.Owner);
+        Assert.Contains(
+            "Honua.Sdk.Abstractions.Features.FeatureEditRequest",
+            edits.AuthoritativeTypes);
+        Assert.Contains(
+            "Honua.Mobile.Offline.GeoPackage.OfflineEditOperation",
+            edits.MobileTypes);
+    }
+
+    [Fact]
+    public void Fixture_DeclaresMobileOwnedRuntimeContracts()
+    {
+        var fixture = LoadFixture();
+
+        var scene = FindFamily(fixture, "scene-metadata");
+        Assert.Equal("honua-mobile", scene.Owner);
+        Assert.Equal("Honua.Mobile.Sdk", scene.AuthoritativePackage);
+        Assert.Contains(
+            "Honua.Mobile.Sdk.Scenes.HonuaScenePackageManifest",
+            scene.AuthoritativeTypes);
+
+        var routing = FindFamily(fixture, "routing");
+        Assert.Equal("honua-mobile", routing.Owner);
+        Assert.Contains(
+            "Honua.Mobile.Sdk.Routing.IRoutingLocationProvider",
+            routing.MobileTypes);
+
+        var geopackage = FindFamily(fixture, "geopackage-sync");
+        Assert.Equal("honua-mobile", geopackage.Owner);
+        Assert.Equal("Honua.Mobile.Offline", geopackage.AuthoritativePackage);
+        Assert.Contains(
+            "Honua.Mobile.Offline.GeoPackage.IGeoPackageSyncStore",
+            geopackage.AuthoritativeTypes);
+    }
+
+    [Fact]
+    public void Fixture_HasPortableCompatibilityMetadata()
+    {
+        var fixture = LoadFixture();
+
+        Assert.Equal("honua.mobile-contract-harmonization.v1", fixture.SchemaVersion);
+        Assert.Equal("honua-mobile#48", fixture.MobileIssue);
+        Assert.Equal("honua-sdk-dotnet#68", fixture.SdkIssue);
+        Assert.Equal("honua-io/honua-mobile", fixture.MobileBaseline.Repository);
+        Assert.Equal("unreleased-source", fixture.MobileBaseline.PackageVersion);
+
+        var abstractionsPackage = Assert.Single(fixture.SdkBaseline.Packages);
+        Assert.Equal("Honua.Sdk.Abstractions", abstractionsPackage.PackageId);
+        Assert.Equal("0.1.0-alpha.1", abstractionsPackage.Version);
+    }
+
+    private static ContractFixture LoadFixture()
+    {
+        var path = Path.Combine(
+            FindRepositoryRoot(),
+            "contracts",
+            "fixtures",
+            "mobile-sdk-contract-harmonization.v1.json");
+        var json = File.ReadAllText(path);
+        return JsonSerializer.Deserialize<ContractFixture>(json, JsonOptions)
+            ?? throw new InvalidOperationException("Contract harmonization fixture was empty.");
+    }
+
+    private static ContractFamily FindFamily(ContractFixture fixture, string id)
+        => fixture.ModelFamilies.Single(family => string.Equals(family.Id, id, StringComparison.Ordinal));
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Honua.Mobile.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate Honua.Mobile.sln from the test output directory.");
+    }
+
+    private sealed record ContractFixture
+    {
+        public string SchemaVersion { get; init; } = string.Empty;
+
+        public string MobileIssue { get; init; } = string.Empty;
+
+        public string SdkIssue { get; init; } = string.Empty;
+
+        public ContractBaseline MobileBaseline { get; init; } = new();
+
+        public SdkBaseline SdkBaseline { get; init; } = new();
+
+        public IReadOnlyList<ContractFamily> ModelFamilies { get; init; } = [];
+    }
+
+    private sealed record ContractBaseline
+    {
+        public string Repository { get; init; } = string.Empty;
+
+        public string PackageVersion { get; init; } = string.Empty;
+    }
+
+    private sealed record SdkBaseline
+    {
+        public IReadOnlyList<SdkPackage> Packages { get; init; } = [];
+    }
+
+    private sealed record SdkPackage
+    {
+        public string PackageId { get; init; } = string.Empty;
+
+        public string Version { get; init; } = string.Empty;
+    }
+
+    private sealed record ContractFamily
+    {
+        public string Id { get; init; } = string.Empty;
+
+        public string Owner { get; init; } = string.Empty;
+
+        public string AuthoritativePackage { get; init; } = string.Empty;
+
+        public IReadOnlyList<string> AuthoritativeTypes { get; init; } = [];
+
+        public IReadOnlyList<string> MobileTypes { get; init; } = [];
+
+        public string MobileDisposition { get; init; } = string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary
- add a portable JSON ownership fixture for honua-mobile / honua-sdk-dotnet contract harmonization
- document authoritative package ownership, compatibility baseline, migration rules, and honua-mobile-sdk quarantine rules
- add fixture tests covering required model families, SDK-owned feature contracts, mobile-owned runtime contracts, and package compatibility metadata

## Validation
- `dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --no-restore --configuration Release`
- `dotnet format Honua.Mobile.sln --no-restore --verify-no-changes --verbosity diagnostic`
- `dotnet test Honua.Mobile.sln --no-restore --configuration Release`
- `dotnet build src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj --no-restore --configuration Release /p:TreatWarningsAsErrors=true`
- `git diff --check`

## Notes
- Mobile packages are not versioned NuGet packages yet, so the compatibility note records source-baseline compatibility against `Honua.Sdk.Abstractions` `0.1.0-alpha.1`.
- Follow-up implementation should consume this fixture from `honua-sdk-dotnet#68` and continue offline state mapping in #49.

Closes #48