### PR TITLE
ci: publish mobile packages to GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,9 @@ on:
   pull_request:
     branches: [main, trunk]
 
-permissions: {}
+permissions:
+  contents: read
+  packages: read
 
 env:
   DOTNET_VERSION: '10.0.x'  # Current repo targets net10
@@ -20,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     outputs:
       src_changed: ${{ steps.filter.outputs.src_changed }}
       test_changed: ${{ steps.filter.outputs.test_changed }}
@@ -61,6 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     outputs:
       build-succeeded: ${{ steps.build.outcome == 'success' }}
     steps:
@@ -70,6 +74,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure GitHub Packages
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -121,6 +128,7 @@ jobs:
     needs: build
     permissions:
       contents: read
+      packages: read
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -129,6 +137,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure GitHub Packages
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -220,6 +231,7 @@ jobs:
     continue-on-error: true
     permissions:
       contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v4
 
@@ -227,6 +239,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure GitHub Packages
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -277,6 +292,7 @@ jobs:
     if: needs.changes.outputs.src_changed == 'true'
     permissions:
       contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v4
 
@@ -284,6 +300,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure GitHub Packages
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
       - name: Install MAUI workload
         run: dotnet workload install maui
@@ -308,6 +327,7 @@ jobs:
     needs: build
     permissions:
       contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v4
 
@@ -315,6 +335,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure GitHub Packages
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
       - name: Validate gRPC Protocol Compatibility
         run: |
@@ -340,6 +363,7 @@ jobs:
     needs: build
     permissions:
       contents: read
+      packages: read
       security-events: write
     steps:
       - uses: actions/checkout@v4
@@ -353,6 +377,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure GitHub Packages
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
       - name: Restore and Build for Analysis
         run: |
@@ -373,6 +400,7 @@ jobs:
     needs: build
     permissions:
       contents: read
+      packages: read
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -381,6 +409,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure GitHub Packages
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
       - name: Cache NuGet packages
         uses: actions/cache@v5

--- a/.github/workflows/publish-dotnet-mobile.yml
+++ b/.github/workflows/publish-dotnet-mobile.yml
@@ -1,0 +1,275 @@
+name: Publish Mobile .NET Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Package version to build"
+        required: false
+        default: "0.1.0-alpha.1"
+        type: string
+      dry_run:
+        description: "Run validation only (skip publish)"
+        required: false
+        default: true
+        type: boolean
+  push:
+    tags:
+      - "mobile-dotnet-v*"
+
+env:
+  DOTNET_VERSION: "10.0.x"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
+
+jobs:
+  package-smoke:
+    name: Package Smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/packages.lock.json') }}
+          restore-keys: |
+            ${{ github.repository }}-${{ runner.os }}-nuget-
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure GitHub Packages
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
+
+      - name: Resolve package version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            package_version="${GITHUB_REF_NAME#mobile-dotnet-v}"
+          else
+            package_version="${{ github.event.inputs.version }}"
+          fi
+
+          if [[ -z "${package_version}" ]]; then
+            echo "Package version is required."
+            exit 1
+          fi
+
+          echo "PACKAGE_VERSION=${package_version}" >> "${GITHUB_ENV}"
+
+      - name: Build mobile packages
+        shell: bash
+        run: |
+          projects=(
+            "src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj"
+            "src/Honua.Mobile.Field/Honua.Mobile.Field.csproj"
+            "src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj"
+            "src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj"
+          )
+
+          for project in "${projects[@]}"; do
+            dotnet build "${project}" \
+              --configuration Release \
+              /p:TreatWarningsAsErrors=true
+          done
+
+      - name: Test mobile packages
+        shell: bash
+        run: |
+          tests=(
+            "tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj"
+            "tests/Honua.Mobile.Field.Tests/Honua.Mobile.Field.Tests.csproj"
+            "tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj"
+            "tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj"
+            "tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj"
+          )
+
+          for project in "${tests[@]}"; do
+            dotnet test "${project}" \
+              --configuration Release \
+              /p:TreatWarningsAsErrors=true
+          done
+
+      - name: Pack NuGet packages
+        shell: bash
+        run: |
+          mkdir -p nupkgs
+          projects=(
+            "src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj"
+            "src/Honua.Mobile.Field/Honua.Mobile.Field.csproj"
+            "src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj"
+            "src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj"
+          )
+
+          for project in "${projects[@]}"; do
+            dotnet pack "${project}" \
+              --configuration Release \
+              --no-build \
+              -o nupkgs \
+              -p:PackageVersion="${PACKAGE_VERSION}" \
+              -p:Version="${PACKAGE_VERSION}"
+          done
+
+      - name: Package install smoke
+        shell: bash
+        run: |
+          smoke_dir="$(mktemp -d)"
+          trap 'rm -rf "${smoke_dir}"' EXIT
+
+          dotnet new console --framework net10.0 --output "${smoke_dir}"
+
+          pushd "${smoke_dir}" >/dev/null
+
+          cat > NuGet.config <<EOF
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <clear />
+              <add key="local-mobile" value="${GITHUB_WORKSPACE}/nupkgs" />
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+              <add key="github-honua" value="https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" />
+            </packageSources>
+            <packageSourceCredentials>
+              <github-honua>
+                <add key="Username" value="${{ github.actor }}" />
+                <add key="ClearTextPassword" value="${{ secrets.GITHUB_TOKEN }}" />
+              </github-honua>
+            </packageSourceCredentials>
+            <packageSourceMapping>
+              <packageSource key="local-mobile">
+                <package pattern="Honua.Mobile.*" />
+              </packageSource>
+              <packageSource key="github-honua">
+                <package pattern="Geospatial.Grpc" />
+                <package pattern="Honua.Core" />
+                <package pattern="Honua.Sdk.*" />
+              </packageSource>
+              <packageSource key="nuget.org">
+                <package pattern="*" />
+              </packageSource>
+            </packageSourceMapping>
+          </configuration>
+          EOF
+
+          dotnet add package Microsoft.Extensions.DependencyInjection --version 10.0.0
+          dotnet add package Honua.Mobile.Sdk --version "${PACKAGE_VERSION}"
+          dotnet add package Honua.Mobile.Field --version "${PACKAGE_VERSION}"
+          dotnet add package Honua.Mobile.Offline --version "${PACKAGE_VERSION}"
+          dotnet add package Honua.Mobile.Maui --version "${PACKAGE_VERSION}"
+
+          cat > Program.cs <<'EOF'
+          using Honua.Mobile.Field.Forms;
+          using Honua.Mobile.Maui;
+          using Honua.Mobile.Offline.GeoPackage;
+          using Honua.Mobile.Offline.Sync;
+          using Honua.Mobile.Sdk;
+          using Honua.Mobile.Sdk.Models;
+          using Microsoft.Extensions.DependencyInjection;
+
+          var services = new ServiceCollection();
+
+          services
+              .AddHonuaMobileSdk(new HonuaMobileClientOptions
+              {
+                  BaseUri = new Uri("https://example.honua.test"),
+                  PreferGrpcForFeatureQueries = false,
+                  PreferGrpcForFeatureEdits = false
+              })
+              .AddHonuaMobileFieldCollection()
+              .AddHonuaApiOfflineUploader()
+              .AddHonuaGeoPackageOfflineSync(
+                  new GeoPackageSyncStoreOptions
+                  {
+                      DatabasePath = Path.Combine(Path.GetTempPath(), "honua-mobile-package-smoke.gpkg")
+                  },
+                  new OfflineSyncEngineOptions
+                  {
+                      BatchSize = 1,
+                      ConflictStrategy = SyncConflictStrategy.ManualReview
+                  });
+
+          _ = new QueryFeaturesRequest
+          {
+              ServiceId = "field",
+              LayerId = 0,
+              ResultRecordCount = 1
+          };
+
+          _ = new FormDefinition
+          {
+              FormId = "inspection",
+              Name = "Inspection",
+              Sections = new[]
+              {
+                  new FormSection
+                  {
+                      SectionId = "details",
+                      Label = "Details",
+                      Fields = new[]
+                      {
+                          new FormField
+                          {
+                              FieldId = "name",
+                              Label = "Name",
+                              Type = FormFieldType.Text,
+                              Required = true
+                          }
+                      }
+                  }
+              }
+          };
+          EOF
+
+          dotnet build --configuration Release /p:TreatWarningsAsErrors=true
+
+          popd >/dev/null
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: honua-mobile-dotnet-${{ github.run_id }}-packages
+          path: nupkgs/*.nupkg
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Dry-run summary
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}
+        shell: bash
+        run: |
+          echo "Dry run complete. Built packages:" >> "${GITHUB_STEP_SUMMARY}"
+          ls -1 nupkgs/*.nupkg >> "${GITHUB_STEP_SUMMARY}"
+
+  publish:
+    name: Publish to GitHub Packages
+    needs: package-smoke
+    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download package artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: honua-mobile-dotnet-${{ github.run_id }}-packages
+          path: nupkgs
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Publish to GitHub Packages
+        run: |
+          dotnet nuget push nupkgs/*.nupkg \
+            --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
+            --api-key "${{ secrets.GITHUB_TOKEN }}" \
+            --skip-duplicate

--- a/.github/workflows/publish-npm-embed.yml
+++ b/.github/workflows/publish-npm-embed.yml
@@ -1,0 +1,117 @@
+name: Publish Embed npm Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run validation only (skip publish)"
+        required: false
+        default: true
+        type: boolean
+  push:
+    tags:
+      - "mobile-embed-v*"
+
+env:
+  NODE_VERSION: "24.x"
+
+jobs:
+  package-smoke:
+    name: Package Smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: src/Honua.Embed
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@honua"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate package version
+        shell: bash
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+
+          if [[ -z "${package_version}" ]]; then
+            echo "Could not resolve package version from package.json."
+            exit 1
+          fi
+
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            tag_version="${GITHUB_REF_NAME#mobile-embed-v}"
+            if [[ "${tag_version}" != "${package_version}" ]]; then
+              echo "Tag version (${tag_version}) does not match package.json version (${package_version})."
+              exit 1
+            fi
+          fi
+
+          echo "PACKAGE_VERSION=${package_version}" >> "${GITHUB_ENV}"
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Pack npm package
+        shell: bash
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/npm-packages"
+          npm pack --pack-destination "${GITHUB_WORKSPACE}/npm-packages"
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: honua-mobile-embed-${{ github.run_id }}-packages
+          path: npm-packages/*.tgz
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Dry-run summary
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}
+        shell: bash
+        run: |
+          echo "Dry run complete. Built npm package:" >> "${GITHUB_STEP_SUMMARY}"
+          ls -1 "${GITHUB_WORKSPACE}"/npm-packages/*.tgz >> "${GITHUB_STEP_SUMMARY}"
+
+  publish:
+    name: Publish to GitHub Packages
+    needs: package-smoke
+    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download package artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: honua-mobile-embed-${{ github.run_id }}-packages
+          path: npm-packages
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@honua"
+
+      - name: Publish to GitHub Packages
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm publish npm-packages/*.tgz --registry "https://npm.pkg.github.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# Repository Guidance
+
+This repo owns mobile runtime behavior and display/app integration. It should
+consume reusable .NET SDK packages from `honua-sdk-dotnet` rather than carrying
+parallel platform-neutral clients or contracts.
+
+## Belongs Here
+
+- MAUI registration, dependency injection glue, app lifecycle integration, and
+  platform-specific service wiring.
+- Native storage adapters, GeoPackage/SQLite file placement and lifecycle,
+  mobile cache directories, cleanup, and platform constraints.
+- Background sync scheduling, reachability, battery-aware retry behavior,
+  permissions, camera/media capture, GPS acquisition, and device sensors.
+- Field workflow screens, form rendering, local media paths, capture UX, and
+  mobile validation presentation.
+- Native/mobile map UI, annotations/drawing UI, AR/VR anchoring, and platform
+  display integration.
+- `@honua/embed`, web components, Cesium, MapLibre, deck.gl, browser cache
+  adapters, and viewer packaging.
+- Native .NET map/viewer adapters, including any Mapsui evaluation or
+  integration, as long as they consume SDK source descriptors and geometry
+  contracts rather than redefining them.
+- Thin compatibility adapters that translate SDK contracts into mobile runtime
+  behavior.
+
+## Does Not Belong Here
+
+- New plain `net*` service clients for Honua Server APIs.
+- Provider-neutral feature query/edit contracts, gRPC/GeoServices/OGC/WFS
+  clients, routing clients, geocoding clients, catalog clients, admin REST
+  clients, real-time stream contracts, or replica sync API clients.
+- Stable scene metadata models, scene package manifests, field form schemas,
+  field validation engines, record workflow rules, non-UI plugin manifests, or
+  shared geometry/spatial-reference primitives.
+- Server contract DTOs that should be tested across repos.
+
+## Mismatch Checks
+
+- If a class can run without MAUI, DOM APIs, native storage, OS permissions, or
+  renderer APIs, check `honua-sdk-dotnet` first.
+- If a class implements geometry predicates, topology, buffers, simplification,
+  WKT/WKB parsing, GeoJSON conversion, ring orientation, spatial indexes, or CRS
+  transforms, consume the SDK's NetTopologySuite/ProjNet-backed geometry surface
+  instead of adding mobile-local geometry logic.
+- If a file under `src/Honua.Mobile.Sdk` is a server API client or plain model,
+  treat it as migration input for the SDK, not as new mobile-owned surface.
+- If a feature requires server functionality, link the `honua-server` dependency
+  issue from the mobile issue.
+- If a mobile task consumes new SDK contracts, cross-link the SDK issue and keep
+  local work limited to adapters, registration, tests, and migration shims.
+- Consume `Honua.Sdk.*` through published, versioned NuGet packages. Do not copy
+  SDK source or add long-lived sibling `ProjectReference` links to
+  `honua-sdk-dotnet`; temporary local references need an explicit removal issue.
+
+## Migration Targets
+
+- Replace `Honua.Mobile.Sdk` query/edit/OGC/gRPC/routing/scene clients with
+  versioned `Honua.Sdk.*` NuGet packages.
+- Replace generic mobile geometry/bounds primitives with SDK geometry and
+  spatial-reference types.
+- Keep native SQLite/GeoPackage implementations here unless a separate
+  platform-specific SDK storage package is explicitly created.

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="github-honua" value="https://nuget.pkg.github.com/honua-io/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="github-honua">
+      <package pattern="Geospatial.Grpc" />
+      <package pattern="Honua.Core" />
+      <package pattern="Honua.Mobile.*" />
+      <package pattern="Honua.Sdk.*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
+++ b/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
@@ -1,0 +1,184 @@
+{
+  "schemaVersion": "honua.mobile-contract-harmonization.v1",
+  "mobileIssue": "honua-mobile#48",
+  "sdkIssue": "honua-sdk-dotnet#68",
+  "companionOfflineIssue": "honua-sdk-dotnet#56",
+  "status": "baseline",
+  "mobileBaseline": {
+    "repository": "honua-io/honua-mobile",
+    "ref": "main",
+    "packageVersion": "unreleased-source"
+  },
+  "sdkBaseline": {
+    "repository": "honua-io/honua-sdk-dotnet",
+    "ref": "main",
+    "packages": [
+      {
+        "packageId": "Honua.Sdk.Abstractions",
+        "version": "0.1.0-alpha.1"
+      }
+    ]
+  },
+  "modelFamilies": [
+    {
+      "id": "feature-query",
+      "displayName": "Feature query requests and result pages",
+      "owner": "honua-sdk-dotnet",
+      "authoritativePackage": "Honua.Sdk.Abstractions",
+      "authoritativeTypes": [
+        "Honua.Sdk.Abstractions.Features.FeatureQueryRequest",
+        "Honua.Sdk.Abstractions.Features.FeatureQueryResult",
+        "Honua.Sdk.Abstractions.Features.FeatureRecord",
+        "Honua.Sdk.Abstractions.Features.FeatureSource",
+        "Honua.Sdk.Abstractions.Features.SourceDescriptor",
+        "Honua.Sdk.Abstractions.Features.SourceQuery"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Sdk.Models.QueryFeaturesRequest",
+        "Honua.Mobile.Sdk.Models.OgcItemsRequest",
+        "Honua.Mobile.Sdk.Grpc.GrpcFeatureTranslator"
+      ],
+      "mobileDisposition": "adapter-required",
+      "notes": "Mobile request DTOs remain transport shims until callers can construct Honua.Sdk.Abstractions feature queries directly."
+    },
+    {
+      "id": "feature-edit",
+      "displayName": "Feature edit envelopes and results",
+      "owner": "honua-sdk-dotnet",
+      "authoritativePackage": "Honua.Sdk.Abstractions",
+      "authoritativeTypes": [
+        "Honua.Sdk.Abstractions.Features.FeatureEditRequest",
+        "Honua.Sdk.Abstractions.Features.FeatureEditResponse",
+        "Honua.Sdk.Abstractions.Features.FeatureEditFeature",
+        "Honua.Sdk.Abstractions.Features.FeatureEditResult",
+        "Honua.Sdk.Abstractions.Features.FeatureEditError"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Sdk.Models.ApplyEditsRequest",
+        "Honua.Mobile.Sdk.Models.OgcCreateItemRequest",
+        "Honua.Mobile.Sdk.Models.OgcReplaceItemRequest",
+        "Honua.Mobile.Sdk.Models.OgcPatchItemRequest",
+        "Honua.Mobile.Sdk.Models.OgcDeleteItemRequest",
+        "Honua.Mobile.Offline.GeoPackage.OfflineEditOperation"
+      ],
+      "mobileDisposition": "adapter-required",
+      "notes": "Offline queue rows keep mobile retry metadata, but uploaded payloads should map to FeatureEditRequest."
+    },
+    {
+      "id": "geometry",
+      "displayName": "Geometry and spatial reference values",
+      "owner": "shared-split",
+      "authoritativePackage": "pending Honua.Sdk geometry package",
+      "authoritativeTypes": [],
+      "mobileTypes": [
+        "Honua.Mobile.Sdk.Grpc.GrpcFeatureTranslator",
+        "Honua.Mobile.Sdk.Routing.RoutingCoordinate",
+        "Honua.Mobile.Maui.Annotations.HonuaMapCoordinate",
+        "Honua.Mobile.Maui.Annotations.HonuaAnnotationBounds"
+      ],
+      "mobileDisposition": "quarantine-until-sdk-geometry",
+      "notes": "Keep mobile coordinates at platform edges. Shared geometry should graduate after honua-sdk-dotnet P0.4 defines WKID/WKT/GeoJSON conversion ownership."
+    },
+    {
+      "id": "offline-sync-state",
+      "displayName": "Offline package, sync state, journal, and conflict state",
+      "owner": "shared-split",
+      "authoritativePackage": "pending Honua.Sdk offline contracts",
+      "authoritativeTypes": [],
+      "mobileTypes": [
+        "Honua.Mobile.Offline.GeoPackage.OfflineEditOperation",
+        "Honua.Mobile.Offline.Sync.SyncRunResult",
+        "Honua.Mobile.Offline.Sync.SyncFailure",
+        "Honua.Mobile.Offline.Sync.DeltaDownloadOptions",
+        "Honua.Mobile.Offline.Sync.DeltaDownloadResult"
+      ],
+      "mobileDisposition": "mobile-runtime-plus-sdk-gap",
+      "notes": "Mobile owns native queue persistence, scheduling, and GeoPackage storage. Shared SDK contracts must define source descriptors, journals, checkpoints, and conflict envelopes in honua-sdk-dotnet#56."
+    },
+    {
+      "id": "form-feature-schema",
+      "displayName": "Form-related feature schemas and field workflows",
+      "owner": "shared-split",
+      "authoritativePackage": "Honua.Sdk.Abstractions for source schema",
+      "authoritativeTypes": [
+        "Honua.Sdk.Abstractions.Features.SourceDescriptor",
+        "Honua.Sdk.Abstractions.Features.SourceSchema",
+        "Honua.Sdk.Abstractions.Features.SourceField"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Field.Forms.FormDefinition",
+        "Honua.Mobile.Field.Forms.FormField",
+        "Honua.Mobile.Field.Forms.FormValidation",
+        "Honua.Mobile.Field.Records.FieldRecord",
+        "Honua.Mobile.Field.Records.RecordWorkflow"
+      ],
+      "mobileDisposition": "mobile-workflow-owned",
+      "notes": "SDK source schema owns provider-neutral field metadata. Mobile owns device form rendering, calculated fields, duplicate detection, and capture workflow."
+    },
+    {
+      "id": "scene-metadata",
+      "displayName": "3D scene metadata and offline scene packages",
+      "owner": "honua-mobile",
+      "authoritativePackage": "Honua.Mobile.Sdk",
+      "authoritativeTypes": [
+        "Honua.Mobile.Sdk.Scenes.HonuaSceneResolveRequest",
+        "Honua.Mobile.Sdk.Scenes.HonuaSceneResolveResult",
+        "Honua.Mobile.Sdk.Scenes.HonuaScenePackageManifest",
+        "Honua.Mobile.Sdk.Scenes.HonuaScenePackageAsset"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Offline.ScenePackages.IHonuaScenePackageDownloader",
+        "Honua.Mobile.Offline.GeoPackage.ScenePackageRecord"
+      ],
+      "mobileDisposition": "mobile-authoritative-candidate-for-sdk",
+      "notes": "Scene contracts stay mobile-owned until honua-sdk-dotnet introduces a scene package. Server handoff and manifest fixtures should remain portable."
+    },
+    {
+      "id": "routing",
+      "displayName": "Routing and network analysis requests",
+      "owner": "honua-mobile",
+      "authoritativePackage": "Honua.Mobile.Sdk",
+      "authoritativeTypes": [
+        "Honua.Mobile.Sdk.Routing.RouteDirectionsRequest",
+        "Honua.Mobile.Sdk.Routing.RouteOptimizationRequest",
+        "Honua.Mobile.Sdk.Routing.ServiceAreaRequest",
+        "Honua.Mobile.Sdk.Routing.ClosestFacilityRequest",
+        "Honua.Mobile.Sdk.Routing.RoutingLocation"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Sdk.Routing.HonuaRoutingClient",
+        "Honua.Mobile.Sdk.Routing.IRoutingLocationProvider"
+      ],
+      "mobileDisposition": "mobile-authoritative",
+      "notes": "Routing remains mobile-owned because it includes device location providers and GeoServices NAServer form encoding."
+    },
+    {
+      "id": "geopackage-sync",
+      "displayName": "GeoPackage storage and native offline adapters",
+      "owner": "honua-mobile",
+      "authoritativePackage": "Honua.Mobile.Offline",
+      "authoritativeTypes": [
+        "Honua.Mobile.Offline.GeoPackage.IGeoPackageSyncStore",
+        "Honua.Mobile.Offline.GeoPackage.GeoPackageSyncStore",
+        "Honua.Mobile.Offline.GeoPackage.MapAreaPackage",
+        "Honua.Mobile.Offline.GeoPackage.ScenePackageRecord"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Offline.MapAreas.IMapAreaDownloader",
+        "Honua.Mobile.Offline.ScenePackages.IHonuaScenePackageDownloader",
+        "Honua.Mobile.Offline.Sync.BackgroundSyncOrchestrator"
+      ],
+      "mobileDisposition": "mobile-runtime-owned",
+      "notes": "SDK contracts may describe offline packages and journals, but mobile owns MAUI/native storage, GeoPackage tables, and background execution behavior."
+    }
+  ],
+  "legacyMobileSdk": {
+    "repository": "honua-io/honua-mobile-sdk",
+    "disposition": "quarantine",
+    "rules": [
+      "Do not copy DTOs into honua-mobile without mapping them through this fixture.",
+      "Migrate useful concepts only when they have a declared owner in honua-sdk-dotnet or honua-mobile.",
+      "Treat older generated clients and demo-only contracts as superseded unless a ticket names the specific concept to recover."
+    ]
+  }
+}

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -10,6 +10,7 @@ In-depth guides for building with the Honua Mobile SDK.
 | [Embeddable Map](embeddable-map.md) | Framework-agnostic `<honua-map>` web component for ISV integrations |
 | [Migration Guide](migration-guide.md) | Migrating from other field collection platforms to Honua |
 | [Mobile 3D and AR Dependency Matrix](mobile-3d-ar-dependency-matrix.md) | Server, SDK, platform, offline, and edition dependencies for scene and AR work |
+| [Mobile Contract Harmonization](mobile-contract-harmonization.md) | Ownership and compatibility baseline between `honua-mobile` and `honua-sdk-dotnet` contracts |
 | [Offline 3D Scene Packages](offline-3d-scene-packages.md) | Package manifest, cache, expiry, and platform policy for offline 3D scenes |
 | [Offline Sync](offline-sync.md) | GeoPackage storage, sync engine configuration, and conflict resolution |
 | [Performance](performance.md) | Optimizing startup time, memory usage, and sync throughput |

--- a/docs/guides/mobile-contract-harmonization.md
+++ b/docs/guides/mobile-contract-harmonization.md
@@ -1,0 +1,56 @@
+# Mobile Contract Harmonization
+
+Issue #48 aligns `honua-mobile` with `honua-sdk-dotnet` so mobile and shared
+.NET SDK packages use one contract vocabulary instead of parallel DTOs.
+
+The baseline fixture is
+`contracts/fixtures/mobile-sdk-contract-harmonization.v1.json`. Keep that file
+portable: it is intentionally plain JSON so `honua-sdk-dotnet` tests can read
+the same ownership map without referencing mobile assemblies.
+
+## Compatibility Baseline
+
+| Mobile baseline | Shared SDK baseline | Status |
+|-----------------|---------------------|--------|
+| `honua-mobile` source packages from `main` after #52 | `Honua.Sdk.Abstractions` `0.1.0-alpha.1` | Fixture-level compatibility for shared feature/source contracts |
+
+`honua-mobile` does not currently publish versioned NuGet packages. Until it
+does, compatibility is stated as source-baseline compatibility against the
+shared SDK package versions above. When mobile packages gain `PackageVersion`,
+add rows here before changing public DTO ownership.
+
+## Ownership Map
+
+| Model family | Owner | Mobile disposition |
+|--------------|-------|--------------------|
+| Feature query requests/results | `honua-sdk-dotnet` / `Honua.Sdk.Abstractions` | Mobile DTOs are transport shims; add adapters to `FeatureQueryRequest` and `FeatureQueryResult`. |
+| Feature edit envelopes/results | `honua-sdk-dotnet` / `Honua.Sdk.Abstractions` | Mobile edit DTOs and offline queue payloads should map to `FeatureEditRequest`. |
+| Geometry and spatial references | Split pending SDK geometry package | Keep mobile coordinates at platform edges until SDK geometry contracts graduate. |
+| Offline sync state, journals, conflicts | Split pending SDK offline contracts | Mobile owns native queue persistence, scheduling, and GeoPackage behavior; SDK should own portable manifests and conflict envelopes. |
+| Form-related feature schemas | Split | SDK source schema owns provider-neutral fields; mobile owns form rendering, validation, calculated fields, and record workflow. |
+| Scene metadata and offline scene packages | `honua-mobile` candidate for future SDK scene package | Keep manifest/server handoff portable and fixture-backed. |
+| Routing and network analysis | `honua-mobile` | Keep NAServer encoding and device location provider behavior in mobile. |
+| GeoPackage sync and native storage adapters | `honua-mobile` | Keep database tables, background sync, file-system downloads, and MAUI registration in mobile. |
+
+## Migration Rules
+
+- New provider-neutral feature read code should target
+  `Honua.Sdk.Abstractions.Features.FeatureQueryRequest`,
+  `FeatureQueryResult`, `FeatureSource`, and `SourceDescriptor`.
+- New provider-neutral feature edit code should target
+  `FeatureEditRequest`, `FeatureEditResponse`, and related edit result models.
+- Mobile-only APIs may keep device, MAUI, GeoPackage, background execution,
+  camera/location, route-location-provider, and offline file-system concerns.
+- Any DTO copied or recovered from `honua-mobile-sdk` must first be classified
+  in the fixture as SDK-owned, mobile-owned, or quarantined.
+- Companion SDK issues must close SDK gaps before mobile deletes local runtime
+  shims that still have no shared package owner.
+
+## Follow-Up Work
+
+- #49 maps current offline queue and GeoPackage state to future SDK offline
+  package, journal, checkpoint, and conflict-envelope contracts.
+- `honua-sdk-dotnet#68` should consume the fixture and add matching tests on
+  the shared SDK side.
+- Once a mobile package version exists, add it to the compatibility table and
+  fixture before changing public model ownership.

--- a/scripts/publish-packages.ps1
+++ b/scripts/publish-packages.ps1
@@ -2,11 +2,11 @@
 # Automates building and publishing NuGet packages for the SDK
 
 param(
-    [string]$Version = "1.0.0",
+    [string]$Version = "0.1.0-alpha.1",
     [string]$NuGetApiKey = "",
-    [string]$NuGetSource = "https://api.nuget.org/v3/index.json",
+    [string]$NuGetSource = "https://nuget.pkg.github.com/honua-io/index.json",
     [switch]$DryRun = $false,
-    [switch]$IncludeTemplates = $true,
+    [switch]$IncludeTemplates = $false,
     [switch]$SkipTests = $false
 )
 
@@ -22,24 +22,24 @@ if ($DryRun) {
 # Package definitions
 $packages = @(
     @{
-        Name = "Honua.Mobile.Core"
-        Path = "Honua.Mobile.Core/Honua.Mobile.Core.csproj"
-        Description = "Core gRPC client and authentication for Honua mobile apps"
+        Name = "Honua.Mobile.Sdk"
+        Path = "src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj"
+        Description = "Core mobile client, gRPC transport, routing, and scene metadata"
     },
     @{
-        Name = "Honua.Mobile.Storage"
-        Path = "Honua.Mobile.Storage/Honua.Mobile.Storage.csproj"
-        Description = "Offline storage and sync capabilities"
+        Name = "Honua.Mobile.Field"
+        Path = "src/Honua.Mobile.Field/Honua.Mobile.Field.csproj"
+        Description = "Field data collection forms, validation, and workflow"
     },
     @{
-        Name = "Honua.Mobile.IoT"
-        Path = "Honua.Mobile.IoT/Honua.Mobile.IoT.csproj"
-        Description = "IoT sensor integration (Bluetooth LE, LoRa, WiFi)"
+        Name = "Honua.Mobile.Offline"
+        Path = "src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj"
+        Description = "Offline GeoPackage storage and sync capabilities"
     },
     @{
         Name = "Honua.Mobile.Maui"
-        Path = "Honua.Mobile.Maui/Honua.Mobile.Maui.csproj"
-        Description = "MAUI platform handlers and UI components"
+        Path = "src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj"
+        Description = "MAUI dependency injection and platform integration helpers"
     }
 )
 
@@ -58,7 +58,7 @@ function Test-Prerequisites {
         Write-Host "✅ .NET SDK: $dotnetVersion" -ForegroundColor Green
     }
     catch {
-        Write-Error "❌ .NET SDK not found. Please install .NET 8.0+ SDK"
+        Write-Error "❌ .NET SDK not found. Please install .NET 10.0+ SDK"
         exit 1
     }
 
@@ -74,7 +74,7 @@ function Test-Prerequisites {
 
     # Validate API key if not dry run
     if (-not $DryRun -and [string]::IsNullOrEmpty($NuGetApiKey)) {
-        Write-Error "❌ NuGet API key is required for publishing. Use -NuGetApiKey parameter or set NUGET_API_KEY environment variable"
+        Write-Error "❌ GitHub Packages token is required for publishing. Use -NuGetApiKey or pass GITHUB_TOKEN/PAT through this parameter"
         exit 1
     }
 
@@ -111,8 +111,7 @@ function Build-Package {
             --configuration Release `
             --output "./dist" `
             -p:PackageVersion=$Version `
-            -p:AssemblyVersion=$Version `
-            -p:FileVersion=$Version `
+            -p:Version=$Version `
             --include-symbols `
             --include-source
     }
@@ -168,15 +167,15 @@ function Update-PackageVersions {
     # Update version in all .csproj files
     Get-ChildItem -Recurse -Filter "*.csproj" | ForEach-Object {
         $content = Get-Content $_.FullName
-        $updated = $content -replace '<Version>[\d\.]+</Version>', "<Version>$Version</Version>"
-        $updated = $updated -replace '<PackageVersion>[\d\.]+</PackageVersion>', "<PackageVersion>$Version</PackageVersion>"
+        $updated = $content -replace '<Version>[^<]+</Version>', "<Version>$Version</Version>"
+        $updated = $updated -replace '<PackageVersion>[^<]+</PackageVersion>', "<PackageVersion>$Version</PackageVersion>"
         Set-Content $_.FullName $updated
     }
 
     # Update version in template nuspec
     if (Test-Path $templatePackage.Path) {
         $content = Get-Content $templatePackage.Path
-        $updated = $content -replace '<version>[\d\.]+</version>', "<version>$Version</version>"
+        $updated = $content -replace '<version>[^<]+</version>', "<version>$Version</version>"
         Set-Content $templatePackage.Path $updated
     }
 
@@ -198,10 +197,10 @@ function Generate-ReleaseNotes {
 ## 📦 Packages Released
 
 ### Core Libraries
-- **Honua.Mobile.Core** v$Version - gRPC client and authentication
-- **Honua.Mobile.Storage** v$Version - Offline storage and sync
-- **Honua.Mobile.IoT** v$Version - IoT sensor integration
-- **Honua.Mobile.Maui** v$Version - MAUI platform handlers
+- **Honua.Mobile.Sdk** v$Version - Core mobile client and gRPC transport
+- **Honua.Mobile.Field** v$Version - Field forms, validation, and workflow
+- **Honua.Mobile.Offline** v$Version - Offline storage and sync
+- **Honua.Mobile.Maui** v$Version - MAUI platform integration
 
 ### Development Tools
 - **Honua.Mobile.Templates** v$Version - Visual Studio project templates
@@ -228,9 +227,9 @@ dotnet new honua-fieldcollector -n MyFieldApp
 
 ### Manual Package Installation
 ```bash
-dotnet add package Honua.Mobile.Core --version $Version
-dotnet add package Honua.Mobile.Storage --version $Version
-dotnet add package Honua.Mobile.IoT --version $Version
+dotnet add package Honua.Mobile.Sdk --version $Version
+dotnet add package Honua.Mobile.Field --version $Version
+dotnet add package Honua.Mobile.Offline --version $Version
 dotnet add package Honua.Mobile.Maui --version $Version
 ```
 
@@ -291,7 +290,7 @@ function Main {
         }
 
         Write-Host "🎉 All packages published successfully!" -ForegroundColor Green
-        Write-Host "📖 View packages at: https://www.nuget.org/profiles/HonuaProject" -ForegroundColor Cyan
+        Write-Host "📖 View packages at: https://github.com/orgs/honua-io/packages" -ForegroundColor Cyan
     }
     else {
         Write-Host "🔍 DRY RUN COMPLETED" -ForegroundColor Yellow

--- a/src/Honua.Embed/package.json
+++ b/src/Honua.Embed/package.json
@@ -2,10 +2,18 @@
   "name": "@honua/embed",
   "version": "0.1.0",
   "description": "Framework-agnostic Honua embeddable map web component.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/honua-io/honua-mobile.git",
+    "directory": "src/Honua.Embed"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/src/Honua.Mobile.Field/Honua.Mobile.Field.csproj
+++ b/src/Honua.Mobile.Field/Honua.Mobile.Field.csproj
@@ -4,6 +4,20 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackageId>Honua.Mobile.Field</PackageId>
+    <PackageVersion>0.1.0-alpha.1</PackageVersion>
+    <Authors>Honua</Authors>
+    <Description>Field data collection forms, validation, calculated fields, workflows, and duplicate detection for Honua mobile apps.</Description>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageProjectUrl>https://github.com/honua-io/honua-mobile</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/honua-io/honua-mobile</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>honua;mobile;field-data;forms;geospatial</PackageTags>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
 </Project>

--- a/src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
+++ b/src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
@@ -15,6 +15,20 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackageId>Honua.Mobile.Maui</PackageId>
+    <PackageVersion>0.1.0-alpha.1</PackageVersion>
+    <Authors>Honua</Authors>
+    <Description>MAUI dependency-injection extensions and mobile integration helpers for Honua mobile apps.</Description>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageProjectUrl>https://github.com/honua-io/honua-mobile</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/honua-io/honua-mobile</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>honua;mobile;maui;geospatial;field-data</PackageTags>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
 </Project>

--- a/src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj
+++ b/src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj
@@ -14,6 +14,20 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackageId>Honua.Mobile.Offline</PackageId>
+    <PackageVersion>0.1.0-alpha.1</PackageVersion>
+    <Authors>Honua</Authors>
+    <Description>Offline GeoPackage storage, sync queue, map area downloads, and conflict handling for Honua mobile apps.</Description>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageProjectUrl>https://github.com/honua-io/honua-mobile</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/honua-io/honua-mobile</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>honua;mobile;offline;geopackage;sync;geospatial</PackageTags>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
 </Project>

--- a/src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj
+++ b/src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj
@@ -4,9 +4,20 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackageId>Honua.Mobile.Sdk</PackageId>
+    <PackageVersion>0.1.0-alpha.1</PackageVersion>
+    <Authors>Honua</Authors>
+    <Description>Core mobile client for Honua feature queries, edits, routing, scenes, and gRPC transport.</Description>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageProjectUrl>https://github.com/honua-io/honua-mobile</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/honua-io/honua-mobile</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>honua;mobile;geospatial;gis;grpc</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <PackageReference Include="Google.Protobuf" Version="3.33.1" />
     <PackageReference Include="Grpc.Core.Api" Version="2.71.0" />
     <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />

--- a/tests/Honua.Mobile.Sdk.Tests/MobileContractHarmonizationFixtureTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/MobileContractHarmonizationFixtureTests.cs
@@ -1,0 +1,181 @@
+using System.Text.Json;
+
+namespace Honua.Mobile.Sdk.Tests;
+
+public sealed class MobileContractHarmonizationFixtureTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    [Fact]
+    public void Fixture_CoversRequiredContractFamilies()
+    {
+        var fixture = LoadFixture();
+        var familyIds = fixture.ModelFamilies
+            .Select(family => family.Id)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(
+        [
+            "feature-edit",
+            "feature-query",
+            "form-feature-schema",
+            "geometry",
+            "geopackage-sync",
+            "offline-sync-state",
+            "routing",
+            "scene-metadata",
+        ], familyIds);
+    }
+
+    [Fact]
+    public void Fixture_DeclaresSdkOwnedFeatureContracts()
+    {
+        var fixture = LoadFixture();
+
+        var query = FindFamily(fixture, "feature-query");
+        Assert.Equal("honua-sdk-dotnet", query.Owner);
+        Assert.Equal("Honua.Sdk.Abstractions", query.AuthoritativePackage);
+        Assert.Contains(
+            "Honua.Sdk.Abstractions.Features.FeatureQueryRequest",
+            query.AuthoritativeTypes);
+        Assert.Contains(
+            "Honua.Mobile.Sdk.Models.QueryFeaturesRequest",
+            query.MobileTypes);
+        Assert.Equal("adapter-required", query.MobileDisposition);
+
+        var edits = FindFamily(fixture, "feature-edit");
+        Assert.Equal("honua-sdk-dotnet", edits.Owner);
+        Assert.Contains(
+            "Honua.Sdk.Abstractions.Features.FeatureEditRequest",
+            edits.AuthoritativeTypes);
+        Assert.Contains(
+            "Honua.Mobile.Offline.GeoPackage.OfflineEditOperation",
+            edits.MobileTypes);
+    }
+
+    [Fact]
+    public void Fixture_DeclaresMobileOwnedRuntimeContracts()
+    {
+        var fixture = LoadFixture();
+
+        var scene = FindFamily(fixture, "scene-metadata");
+        Assert.Equal("honua-mobile", scene.Owner);
+        Assert.Equal("Honua.Mobile.Sdk", scene.AuthoritativePackage);
+        Assert.Contains(
+            "Honua.Mobile.Sdk.Scenes.HonuaScenePackageManifest",
+            scene.AuthoritativeTypes);
+
+        var routing = FindFamily(fixture, "routing");
+        Assert.Equal("honua-mobile", routing.Owner);
+        Assert.Contains(
+            "Honua.Mobile.Sdk.Routing.IRoutingLocationProvider",
+            routing.MobileTypes);
+
+        var geopackage = FindFamily(fixture, "geopackage-sync");
+        Assert.Equal("honua-mobile", geopackage.Owner);
+        Assert.Equal("Honua.Mobile.Offline", geopackage.AuthoritativePackage);
+        Assert.Contains(
+            "Honua.Mobile.Offline.GeoPackage.IGeoPackageSyncStore",
+            geopackage.AuthoritativeTypes);
+    }
+
+    [Fact]
+    public void Fixture_HasPortableCompatibilityMetadata()
+    {
+        var fixture = LoadFixture();
+
+        Assert.Equal("honua.mobile-contract-harmonization.v1", fixture.SchemaVersion);
+        Assert.Equal("honua-mobile#48", fixture.MobileIssue);
+        Assert.Equal("honua-sdk-dotnet#68", fixture.SdkIssue);
+        Assert.Equal("honua-io/honua-mobile", fixture.MobileBaseline.Repository);
+        Assert.Equal("unreleased-source", fixture.MobileBaseline.PackageVersion);
+
+        var abstractionsPackage = Assert.Single(fixture.SdkBaseline.Packages);
+        Assert.Equal("Honua.Sdk.Abstractions", abstractionsPackage.PackageId);
+        Assert.Equal("0.1.0-alpha.1", abstractionsPackage.Version);
+    }
+
+    private static ContractFixture LoadFixture()
+    {
+        var path = Path.Combine(
+            FindRepositoryRoot(),
+            "contracts",
+            "fixtures",
+            "mobile-sdk-contract-harmonization.v1.json");
+        var json = File.ReadAllText(path);
+        return JsonSerializer.Deserialize<ContractFixture>(json, JsonOptions)
+            ?? throw new InvalidOperationException("Contract harmonization fixture was empty.");
+    }
+
+    private static ContractFamily FindFamily(ContractFixture fixture, string id)
+        => fixture.ModelFamilies.Single(family => string.Equals(family.Id, id, StringComparison.Ordinal));
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Honua.Mobile.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate Honua.Mobile.sln from the test output directory.");
+    }
+
+    private sealed record ContractFixture
+    {
+        public string SchemaVersion { get; init; } = string.Empty;
+
+        public string MobileIssue { get; init; } = string.Empty;
+
+        public string SdkIssue { get; init; } = string.Empty;
+
+        public ContractBaseline MobileBaseline { get; init; } = new();
+
+        public SdkBaseline SdkBaseline { get; init; } = new();
+
+        public IReadOnlyList<ContractFamily> ModelFamilies { get; init; } = [];
+    }
+
+    private sealed record ContractBaseline
+    {
+        public string Repository { get; init; } = string.Empty;
+
+        public string PackageVersion { get; init; } = string.Empty;
+    }
+
+    private sealed record SdkBaseline
+    {
+        public IReadOnlyList<SdkPackage> Packages { get; init; } = [];
+    }
+
+    private sealed record SdkPackage
+    {
+        public string PackageId { get; init; } = string.Empty;
+
+        public string Version { get; init; } = string.Empty;
+    }
+
+    private sealed record ContractFamily
+    {
+        public string Id { get; init; } = string.Empty;
+
+        public string Owner { get; init; } = string.Empty;
+
+        public string AuthoritativePackage { get; init; } = string.Empty;
+
+        public IReadOnlyList<string> AuthoritativeTypes { get; init; } = [];
+
+        public IReadOnlyList<string> MobileTypes { get; init; } = [];
+
+        public string MobileDisposition { get; init; } = string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary

Adds GitHub Packages publishing for mobile `.NET` packages and the `@honua/embed` npm package.

## Details

- Adds `NuGet.config` mappings for Honua internal packages and authenticates GitHub Packages in CI.
- Adds `Publish Mobile .NET Packages` workflow for `Honua.Mobile.Sdk`, `Honua.Mobile.Field`, `Honua.Mobile.Offline`, and `Honua.Mobile.Maui`.
- Adds `Publish Embed npm Package` workflow targeting `https://npm.pkg.github.com`.
- Adds package metadata/readmes to the mobile NuGet packages so pack emits no readme warnings.
- Updates the legacy mobile publishing script to use current package names and GitHub Packages defaults.

## Validation

- workflow YAML parse checks
- `dotnet pack` for all four mobile NuGet packages with `/p:TreatWarningsAsErrors=true`
- local package install smoke for all four mobile NuGet packages, build passed with 0 warnings
- `npm ci`
- `npm run typecheck`
- `npm test` (17 tests)
- `npm run build`
- `npm pack`
- `dotnet restore src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj`
- `dotnet restore tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj`
- `git diff --check`
