### PR TITLE
ci: publish embed package from absolute tarball path

### DIFF
--- a/.github/workflows/publish-npm-embed.yml
+++ b/.github/workflows/publish-npm-embed.yml
@@ -115,7 +115,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          package="$(find npm-packages -maxdepth 1 -type f -name '*.tgz' | sort | head -n 1)"
+          package="$(find "${GITHUB_WORKSPACE}/npm-packages" -maxdepth 1 -type f -name '*.tgz' | sort | head -n 1)"
 
           if [[ -z "${package}" ]]; then
             echo "No npm package artifact found."


### PR DESCRIPTION
## Summary
- publishes the embed npm tarball from an absolute artifact path

## Root cause
`npm publish` still interpreted the relative `npm-packages/...tgz` argument as a package spec. Passing an absolute `.tgz` path forces npm to use the downloaded package file.

## Validation
- `git diff --check`
- parsed all workflow YAML files with Python/PyYAML
