### PR TITLE
ci: align embed npm scope with GitHub owner

### DIFF
--- a/.github/workflows/publish-npm-embed.yml
+++ b/.github/workflows/publish-npm-embed.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://npm.pkg.github.com"
-          scope: "@honua"
+          scope: "@honua-io"
 
       - name: Install dependencies
         run: npm ci
@@ -108,7 +108,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://npm.pkg.github.com"
-          scope: "@honua"
+          scope: "@honua-io"
 
       - name: Publish to GitHub Packages
         shell: bash

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -1,18 +1,18 @@
-# @honua/embed
+# @honua-io/embed
 
 Framework-agnostic web components for embedding Honua map and 3D scene views in SaaS and ISV applications.
 
 ## Install
 
 ```bash
-npm install @honua/embed
+npm install @honua-io/embed
 ```
 
 ## Map Use
 
 ```html
 <script type="module">
-  import '@honua/embed';
+  import '@honua-io/embed';
 </script>
 
 <honua-map
@@ -32,7 +32,7 @@ npm install @honua/embed
 
 ```html
 <script type="module">
-  import '@honua/embed';
+  import '@honua-io/embed';
 </script>
 
 <honua-scene

--- a/src/Honua.Embed/package-lock.json
+++ b/src/Honua.Embed/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@honua/embed",
+  "name": "@honua-io/embed",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@honua/embed",
+      "name": "@honua-io/embed",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/Honua.Embed/package.json
+++ b/src/Honua.Embed/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@honua/embed",
+  "name": "@honua-io/embed",
   "version": "0.1.0",
   "description": "Framework-agnostic Honua embeddable map web component.",
   "repository": {


### PR DESCRIPTION
## Summary
- renames the embed npm package to `@honua-io/embed`
- updates package-lock and README references
- configures the GitHub Packages workflow npm scope as `@honua-io`

## Root cause
GitHub Packages npm publishing with `GITHUB_TOKEN` is tied to the repository owner. The package was scoped as `@honua/embed`, so GitHub Packages rejected the publish from the `honua-io/honua-mobile` repository with `permission_denied: The requested installation does not exist`.

## Validation
- `git diff --check`
- parsed all workflow YAML files with Python/PyYAML
- `npm ci`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm pack --dry-run`
