### PR TITLE
feat(offline): consume sdk sync core

### DIFF
--- a/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
+++ b/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
@@ -16,6 +16,14 @@
       {
         "packageId": "Honua.Sdk.Abstractions",
         "version": "0.1.0-alpha.1"
+      },
+      {
+        "packageId": "Honua.Sdk.Offline.Abstractions",
+        "version": "0.1.0-alpha.1"
+      },
+      {
+        "packageId": "Honua.Sdk.Offline",
+        "version": "0.1.0-alpha.1"
       }
     ]
   },
@@ -83,17 +91,28 @@
       "id": "offline-sync-state",
       "displayName": "Offline package, sync state, journal, and conflict state",
       "owner": "shared-split",
-      "authoritativePackage": "pending Honua.Sdk offline contracts",
-      "authoritativeTypes": [],
+      "authoritativePackage": "Honua.Sdk.Offline.Abstractions",
+      "authoritativeTypes": [
+        "Honua.Sdk.Offline.Abstractions.OfflinePackageManifest",
+        "Honua.Sdk.Offline.Abstractions.OfflineSourceDescriptor",
+        "Honua.Sdk.Offline.Abstractions.OfflineSyncState",
+        "Honua.Sdk.Offline.Abstractions.OfflineSyncCheckpoint",
+        "Honua.Sdk.Offline.Abstractions.OfflineChangeJournalEntry",
+        "Honua.Sdk.Offline.Abstractions.OfflineConflictEnvelope",
+        "Honua.Sdk.Offline.Abstractions.OfflineRetryCheckpoint"
+      ],
       "mobileTypes": [
         "Honua.Mobile.Offline.GeoPackage.OfflineEditOperation",
+        "Honua.Mobile.Offline.GeoPackage.GeoPackageSdkOfflineStoreAdapter",
+        "Honua.Mobile.Offline.Sync.HonuaMobileSdkFeatureClient",
+        "Honua.Mobile.Offline.Sync.SdkOfflineSyncRunner",
         "Honua.Mobile.Offline.Sync.SyncRunResult",
         "Honua.Mobile.Offline.Sync.SyncFailure",
         "Honua.Mobile.Offline.Sync.DeltaDownloadOptions",
         "Honua.Mobile.Offline.Sync.DeltaDownloadResult"
       ],
-      "mobileDisposition": "mobile-runtime-plus-sdk-gap",
-      "notes": "Mobile owns native queue persistence, scheduling, and GeoPackage storage. Shared SDK contracts must define source descriptors, journals, checkpoints, and conflict envelopes in honua-sdk-dotnet#56."
+      "mobileDisposition": "mobile-runtime-adapter",
+      "notes": "Mobile owns native queue persistence, scheduling, and GeoPackage storage. SDK contracts define source descriptors, journals, checkpoints, retry checkpoints, and conflict envelopes; mobile adapters bridge those contracts to SQLite/GeoPackage and MAUI runtime behavior."
     },
     {
       "id": "form-feature-schema",

--- a/docs/guides/offline-sync.md
+++ b/docs/guides/offline-sync.md
@@ -77,6 +77,8 @@ builder.Services
 - `HonuaMobileSdkFeatureClient` for SDK query/edit abstractions over the existing `HonuaMobileClient`.
 - `SdkOfflineSyncRunner` for the existing mobile `IOfflineSyncRunner` used by foreground and background sync scheduling.
 
+The adapter partitions cached features and queued edits by SDK package ID and source ID, so multiple offline packages can safely include the same source without overwriting feature rows or claiming each other's pending edits.
+
 ## Configuration
 
 ### Basic Setup

--- a/docs/guides/offline-sync.md
+++ b/docs/guides/offline-sync.md
@@ -6,6 +6,13 @@ This guide covers implementing offline-first data synchronization in mobile appl
 
 The Honua Mobile SDK provides comprehensive offline synchronization capabilities designed for field data collection scenarios where network connectivity may be intermittent or unavailable.
 
+The reusable offline package, journal, checkpoint, conflict, and sync engine contracts are supplied by `honua-sdk-dotnet`:
+
+- `Honua.Sdk.Offline.Abstractions`
+- `Honua.Sdk.Offline`
+
+This mobile repo supplies the native runtime layer around those SDK contracts: GeoPackage/SQLite adapters, local file placement, MAUI dependency injection, app lifecycle integration, reachability checks, background scheduling, permissions, and field workflow UX.
+
 ## Core Concepts
 
 ### Offline-First Architecture
@@ -21,6 +28,54 @@ The SDK follows an offline-first approach:
 - **SQLite**: Local database for structured data
 - **File System**: Local storage for photos, attachments, and cached maps
 - **GeoPackage**: Standards-compliant offline geodatabase format
+
+### SDK-backed sync registration
+
+For new offline workflows, register the SDK sync core with the mobile GeoPackage adapters:
+
+```csharp
+using Honua.Mobile.Maui;
+using Honua.Mobile.Offline.GeoPackage;
+using Honua.Mobile.Sdk;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Offline.Abstractions;
+
+var manifest = new OfflinePackageManifest
+{
+    PackageId = "inspection-area-1",
+    Sources =
+    [
+        new OfflineSourceDescriptor
+        {
+            SourceId = "parks",
+            Source = new SourceDescriptor
+            {
+                Id = "parks",
+                Protocol = FeatureProtocolIds.OgcFeatures,
+                Locator = new SourceLocator { CollectionId = "parks" },
+            },
+            OutFields = ["name", "status"],
+            PageSize = 500,
+        },
+    ],
+};
+
+builder.Services
+    .AddHonuaMobileSdk(new HonuaMobileClientOptions
+    {
+        BaseUri = new Uri("https://api.example.com"),
+    })
+    .AddHonuaSdkGeoPackageOfflineSync(
+        new GeoPackageSyncStoreOptions { DatabasePath = "fielddata.gpkg" },
+        manifest)
+    .AddHonuaBackgroundSync();
+```
+
+`AddHonuaSdkGeoPackageOfflineSync` wires `Honua.Sdk.Offline.OfflineSyncEngine` to:
+
+- `GeoPackageSdkOfflineStoreAdapter` for SDK feature store, journal, checkpoint, and sync state interfaces.
+- `HonuaMobileSdkFeatureClient` for SDK query/edit abstractions over the existing `HonuaMobileClient`.
+- `SdkOfflineSyncRunner` for the existing mobile `IOfflineSyncRunner` used by foreground and background sync scheduling.
 
 ## Configuration
 

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -8,8 +8,16 @@ using Honua.Mobile.Offline.Sync;
 using Honua.Mobile.Sdk;
 using Honua.Mobile.Sdk.Routing;
 using Honua.Mobile.Sdk.Scenes;
+using Honua.Sdk.Abstractions.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using SdkOfflineChangeJournal = Honua.Sdk.Offline.Abstractions.IOfflineChangeJournal;
+using SdkOfflineFeatureStore = Honua.Sdk.Offline.Abstractions.IOfflineFeatureStore;
+using SdkOfflinePackageManifest = Honua.Sdk.Offline.Abstractions.OfflinePackageManifest;
+using SdkOfflineStateStore = Honua.Sdk.Offline.Abstractions.IOfflineSyncStateStore;
+using SdkOfflineCheckpointStore = Honua.Sdk.Offline.Abstractions.IOfflineSyncCheckpointStore;
+using SdkOfflineSyncEngine = Honua.Sdk.Offline.OfflineSyncEngine;
+using SdkOfflineSyncEngineOptions = Honua.Sdk.Offline.OfflineSyncEngineOptions;
 
 namespace Honua.Mobile.Maui;
 
@@ -132,6 +140,54 @@ public static class HonuaMobileServiceCollectionExtensions
             return new OfflineSyncEngine(store, uploader, options);
         });
         services.AddSingleton<IOfflineSyncRunner>(sp => sp.GetRequiredService<OfflineSyncEngine>());
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the SDK-owned offline sync engine with mobile GeoPackage storage adapters.
+    /// Requires <see cref="AddHonuaMobileSdk"/> to be called first.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="storeOptions">GeoPackage store configuration.</param>
+    /// <param name="manifest">SDK offline package manifest to sync.</param>
+    /// <param name="syncOptions">SDK sync engine options; defaults are used when <see langword="null"/>.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaSdkGeoPackageOfflineSync(
+        this IServiceCollection services,
+        GeoPackageSyncStoreOptions storeOptions,
+        SdkOfflinePackageManifest manifest,
+        SdkOfflineSyncEngineOptions? syncOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(storeOptions);
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        services.AddSingleton(storeOptions);
+        services.AddSingleton(manifest);
+        services.AddSingleton(syncOptions ?? new SdkOfflineSyncEngineOptions());
+        services.AddSingleton<IGeoPackageSyncStore, GeoPackageSyncStore>();
+        services.AddSingleton<IConnectivityStateProvider, AlwaysOnlineConnectivityStateProvider>();
+        services.AddSingleton<GeoPackageSdkOfflineStoreAdapter>();
+        services.AddSingleton<HonuaMobileSdkFeatureClient>();
+        services.AddSingleton<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<HonuaMobileSdkFeatureClient>());
+        services.AddSingleton<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaMobileSdkFeatureClient>());
+        services.AddSingleton<SdkOfflineFeatureStore>(sp => sp.GetRequiredService<GeoPackageSdkOfflineStoreAdapter>());
+        services.AddSingleton<SdkOfflineChangeJournal>(sp => sp.GetRequiredService<GeoPackageSdkOfflineStoreAdapter>());
+        services.AddSingleton<SdkOfflineCheckpointStore>(sp => sp.GetRequiredService<GeoPackageSdkOfflineStoreAdapter>());
+        services.AddSingleton<SdkOfflineStateStore>(sp => sp.GetRequiredService<GeoPackageSdkOfflineStoreAdapter>());
+
+        services.AddSingleton<SdkOfflineSyncEngine>(sp => new SdkOfflineSyncEngine(
+            sp.GetRequiredService<IHonuaFeatureQueryClient>(),
+            sp.GetRequiredService<IHonuaFeatureEditClient>(),
+            sp.GetRequiredService<SdkOfflineFeatureStore>(),
+            sp.GetRequiredService<SdkOfflineChangeJournal>(),
+            sp.GetRequiredService<SdkOfflineCheckpointStore>(),
+            sp.GetRequiredService<SdkOfflineSyncEngineOptions>(),
+            sp.GetRequiredService<SdkOfflineStateStore>()));
+
+        services.AddSingleton<SdkOfflineSyncRunner>();
+        services.AddSingleton<IOfflineSyncRunner>(sp => sp.GetRequiredService<SdkOfflineSyncRunner>());
 
         return services;
     }

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSdkOfflineStoreAdapter.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSdkOfflineStoreAdapter.cs
@@ -1,0 +1,399 @@
+using System.Globalization;
+using System.Text.Json;
+using Honua.Mobile.Offline.Sync;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Offline.Abstractions;
+
+namespace Honua.Mobile.Offline.GeoPackage;
+
+/// <summary>
+/// Adapts the mobile GeoPackage sync store to the platform-neutral Honua SDK offline storage contracts.
+/// </summary>
+public sealed class GeoPackageSdkOfflineStoreAdapter :
+    IOfflineFeatureStore,
+    IOfflineChangeJournal,
+    IOfflineSyncCheckpointStore,
+    IOfflineSyncStateStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly IGeoPackageSyncStore _store;
+
+    /// <summary>
+    /// Initializes a new <see cref="GeoPackageSdkOfflineStoreAdapter"/>.
+    /// </summary>
+    /// <param name="store">Mobile GeoPackage sync store.</param>
+    public GeoPackageSdkOfflineStoreAdapter(IGeoPackageSyncStore store)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+    }
+
+    /// <inheritdoc />
+    public async Task SaveFeaturesAsync(OfflineFeaturePage page, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        await _store.InitializeAsync(ct).ConfigureAwait(false);
+        foreach (var feature in page.Result.Features)
+        {
+            var featureJson = SerializeFeatureRecord(feature, page.Result.ObjectIdFieldName);
+            await _store.UpsertFeatureAsync(page.SourceId, featureJson, ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteFeaturesAsync(
+        string packageId,
+        string sourceId,
+        IReadOnlyList<string> featureIds,
+        IReadOnlyList<long> objectIds,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceId);
+
+        await _store.InitializeAsync(ct).ConfigureAwait(false);
+        foreach (var objectId in objectIds)
+        {
+            await _store.DeleteFeatureAsync(sourceId, objectId, ct).ConfigureAwait(false);
+        }
+
+        foreach (var featureId in featureIds)
+        {
+            if (long.TryParse(featureId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
+            {
+                await _store.DeleteFeatureAsync(sourceId, objectId, ct).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task EnqueueAsync(OfflineChangeJournalEntry entry, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        await _store.InitializeAsync(ct).ConfigureAwait(false);
+        await _store.EnqueueAsync(ToMobileOperation(entry), ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<OfflineChangeJournalEntry>> GetPendingAsync(
+        string packageId,
+        int maxCount,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+
+        await _store.InitializeAsync(ct).ConfigureAwait(false);
+        var pending = await _store.GetPendingAsync(maxCount, ct).ConfigureAwait(false);
+        return pending.Select(operation => ToSdkEntry(packageId, operation)).ToArray();
+    }
+
+    /// <inheritdoc />
+    public Task MarkSucceededAsync(string operationId, CancellationToken ct = default)
+        => _store.MarkSucceededAsync(operationId, ct);
+
+    /// <inheritdoc />
+    public Task MarkPendingAsync(string operationId, CancellationToken ct = default)
+        => _store.MarkPendingAsync(operationId, ct);
+
+    /// <inheritdoc />
+    public Task MarkRetryAsync(OfflineRetryCheckpoint checkpoint, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(checkpoint);
+        return _store.MarkFailedAsync(checkpoint.OperationId, checkpoint.Reason ?? "retryable sync failure", retryable: true, ct);
+    }
+
+    /// <inheritdoc />
+    public Task MarkFailedAsync(string operationId, string reason, CancellationToken ct = default)
+        => _store.MarkFailedAsync(operationId, reason, retryable: false, ct);
+
+    /// <inheritdoc />
+    public Task MarkConflictAsync(OfflineConflictEnvelope conflict, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(conflict);
+        return _store.MarkFailedAsync(
+            conflict.OperationId,
+            conflict.Reason ?? "conflict requires manual review",
+            retryable: false,
+            ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<OfflineSyncCheckpoint?> GetCheckpointAsync(string packageId, string sourceId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceId);
+
+        await _store.InitializeAsync(ct).ConfigureAwait(false);
+        var value = await _store.GetSyncCursorAsync(GetCheckpointKey(packageId, sourceId), ct).ConfigureAwait(false);
+        return string.IsNullOrWhiteSpace(value)
+            ? null
+            : JsonSerializer.Deserialize<OfflineSyncCheckpoint>(value, JsonOptions);
+    }
+
+    /// <inheritdoc />
+    public async Task SaveCheckpointAsync(OfflineSyncCheckpoint checkpoint, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(checkpoint);
+
+        await _store.InitializeAsync(ct).ConfigureAwait(false);
+        await _store.SetSyncCursorAsync(
+            GetCheckpointKey(checkpoint.PackageId, checkpoint.SourceId),
+            JsonSerializer.Serialize(checkpoint, JsonOptions),
+            ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<OfflineSyncState?> GetStateAsync(string packageId, string? sourceId = null, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+
+        await _store.InitializeAsync(ct).ConfigureAwait(false);
+        var value = await _store.GetSyncCursorAsync(GetStateKey(packageId, sourceId), ct).ConfigureAwait(false);
+        return string.IsNullOrWhiteSpace(value)
+            ? null
+            : JsonSerializer.Deserialize<OfflineSyncState>(value, JsonOptions);
+    }
+
+    /// <inheritdoc />
+    public async Task SaveStateAsync(OfflineSyncState state, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+
+        await _store.InitializeAsync(ct).ConfigureAwait(false);
+        await _store.SetSyncCursorAsync(
+            GetStateKey(state.PackageId, state.SourceId),
+            JsonSerializer.Serialize(state, JsonOptions),
+            ct).ConfigureAwait(false);
+    }
+
+    private static OfflineEditOperation ToMobileOperation(OfflineChangeJournalEntry entry)
+    {
+        var payload = ToPayload(entry);
+        return new OfflineEditOperation
+        {
+            OperationId = entry.OperationId,
+            LayerKey = entry.SourceId,
+            TargetCollection = payload.CollectionId ?? payload.ServiceId ?? entry.SourceId,
+            OperationType = entry.OperationKind switch
+            {
+                OfflineEditOperationKind.Add => OfflineOperationType.Add,
+                OfflineEditOperationKind.Update => OfflineOperationType.Update,
+                OfflineEditOperationKind.Delete => OfflineOperationType.Delete,
+                _ => throw new InvalidOperationException($"Unsupported SDK offline operation kind '{entry.OperationKind}'."),
+            },
+            PayloadJson = JsonSerializer.Serialize(payload, JsonOptions),
+            CreatedAtUtc = entry.CreatedAtUtc,
+            AttemptCount = entry.AttemptCount,
+        };
+    }
+
+    private static OfflineOperationPayload ToPayload(OfflineChangeJournalEntry entry)
+    {
+        var isOgc = !string.IsNullOrWhiteSpace(entry.Source.CollectionId);
+        return new OfflineOperationPayload
+        {
+            PackageId = entry.PackageId,
+            SourceId = entry.SourceId,
+            BaseSyncToken = entry.BaseSyncToken,
+            Protocol = isOgc ? "ogcfeatures" : "FeatureServer",
+            ServiceId = entry.Source.ServiceId,
+            LayerId = entry.Source.LayerId,
+            CollectionId = entry.Source.CollectionId,
+            FeatureId = entry.Feature?.Id ?? entry.DeleteIds.FirstOrDefault(),
+            Feature = entry.Feature is null
+                ? null
+                : isOgc ? ToGeoJsonFeature(entry.Feature) : ToFeatureServerFeature(entry.Feature),
+            DeleteObjectIds = entry.DeleteObjectIds,
+            DeletesCsv = entry.DeleteObjectIds.Count == 0 ? null : string.Join(',', entry.DeleteObjectIds),
+            Metadata = entry.Metadata,
+        };
+    }
+
+    private static OfflineChangeJournalEntry ToSdkEntry(string fallbackPackageId, OfflineEditOperation operation)
+    {
+        var payload = DeserializePayload(operation.PayloadJson);
+        var source = new FeatureSource
+        {
+            ServiceId = payload.ServiceId,
+            LayerId = payload.LayerId,
+            CollectionId = payload.CollectionId,
+        };
+
+        return new OfflineChangeJournalEntry
+        {
+            OperationId = operation.OperationId,
+            PackageId = payload.PackageId ?? fallbackPackageId,
+            SourceId = payload.SourceId ?? operation.LayerKey,
+            Source = source,
+            OperationKind = operation.OperationType switch
+            {
+                OfflineOperationType.Add => OfflineEditOperationKind.Add,
+                OfflineOperationType.Update => OfflineEditOperationKind.Update,
+                OfflineOperationType.Delete => OfflineEditOperationKind.Delete,
+                _ => throw new InvalidOperationException($"Unsupported mobile offline operation type '{operation.OperationType}'."),
+            },
+            Feature = ToFeatureEditFeature(payload, operation.OperationType),
+            DeleteIds = payload.FeatureId is null ? [] : [payload.FeatureId],
+            DeleteObjectIds = payload.DeleteObjectIds ?? ParseDeleteCsv(payload.DeletesCsv),
+            BaseSyncToken = payload.BaseSyncToken,
+            CreatedAtUtc = operation.CreatedAtUtc,
+            AttemptCount = operation.AttemptCount,
+            Metadata = payload.Metadata ?? new Dictionary<string, string>(),
+        };
+    }
+
+    private static OfflineOperationPayload DeserializePayload(string payloadJson)
+        => JsonSerializer.Deserialize<OfflineOperationPayload>(payloadJson, JsonOptions)
+           ?? throw new InvalidOperationException("Offline operation payload cannot be null.");
+
+    private static FeatureEditFeature? ToFeatureEditFeature(OfflineOperationPayload payload, OfflineOperationType operationType)
+    {
+        if (operationType == OfflineOperationType.Delete)
+        {
+            return null;
+        }
+
+        var feature = payload.Feature;
+        if (feature is null && !string.IsNullOrWhiteSpace(payload.AddsJson))
+        {
+            feature = ReadFirstFeature(payload.AddsJson);
+        }
+
+        if (feature is null && !string.IsNullOrWhiteSpace(payload.UpdatesJson))
+        {
+            feature = ReadFirstFeature(payload.UpdatesJson);
+        }
+
+        return feature is null ? null : ToFeatureEditFeature(feature.Value, payload.FeatureId);
+    }
+
+    private static JsonElement? ReadFirstFeature(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        if (doc.RootElement.ValueKind == JsonValueKind.Array && doc.RootElement.GetArrayLength() > 0)
+        {
+            return doc.RootElement[0].Clone();
+        }
+
+        return doc.RootElement.Clone();
+    }
+
+    private static FeatureEditFeature ToFeatureEditFeature(JsonElement feature, string? fallbackId)
+    {
+        IReadOnlyDictionary<string, JsonElement> attributes = new Dictionary<string, JsonElement>();
+        JsonElement? geometry = null;
+        var id = fallbackId;
+        long? objectId = null;
+
+        if (feature.TryGetProperty("id", out var idElement))
+        {
+            id = idElement.ValueKind == JsonValueKind.String ? idElement.GetString() : idElement.GetRawText();
+        }
+
+        if (feature.TryGetProperty("properties", out var properties))
+        {
+            attributes = ReadJsonObject(properties);
+        }
+        else if (feature.TryGetProperty("attributes", out var featureAttributes))
+        {
+            attributes = ReadJsonObject(featureAttributes);
+        }
+
+        if (feature.TryGetProperty("geometry", out var geometryElement) && geometryElement.ValueKind != JsonValueKind.Null)
+        {
+            geometry = geometryElement.Clone();
+        }
+
+        if (attributes.TryGetValue("objectid", out var objectIdElement) && objectIdElement.TryGetInt64(out var parsedObjectId))
+        {
+            objectId = parsedObjectId;
+        }
+        else if (attributes.TryGetValue("OBJECTID", out objectIdElement) && objectIdElement.TryGetInt64(out parsedObjectId))
+        {
+            objectId = parsedObjectId;
+        }
+
+        return new FeatureEditFeature
+        {
+            Id = id,
+            ObjectId = objectId,
+            Attributes = attributes,
+            Geometry = geometry,
+        };
+    }
+
+    private static IReadOnlyDictionary<string, JsonElement> ReadJsonObject(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            return new Dictionary<string, JsonElement>();
+        }
+
+        return element.EnumerateObject().ToDictionary(property => property.Name, property => property.Value.Clone());
+    }
+
+    private static IReadOnlyList<long> ParseDeleteCsv(string? deletesCsv)
+    {
+        if (string.IsNullOrWhiteSpace(deletesCsv))
+        {
+            return [];
+        }
+
+        return deletesCsv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(value => long.Parse(value, CultureInfo.InvariantCulture))
+            .ToArray();
+    }
+
+    private static string SerializeFeatureRecord(FeatureRecord feature, string? objectIdFieldName)
+    {
+        var attributes = new Dictionary<string, JsonElement>(feature.Attributes, StringComparer.Ordinal);
+        var objectIdField = string.IsNullOrWhiteSpace(objectIdFieldName) ? "objectid" : objectIdFieldName;
+        if (!attributes.ContainsKey(objectIdField) &&
+            !attributes.ContainsKey("objectid") &&
+            !attributes.ContainsKey("OBJECTID") &&
+            long.TryParse(feature.Id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
+        {
+            attributes[objectIdField] = JsonSerializer.SerializeToElement(objectId);
+        }
+
+        var payload = new Dictionary<string, object?>
+        {
+            ["attributes"] = attributes,
+        };
+
+        if (feature.Geometry is not null)
+        {
+            payload["geometry"] = feature.Geometry.Value;
+        }
+
+        return JsonSerializer.Serialize(payload, JsonOptions);
+    }
+
+    private static JsonElement ToFeatureServerFeature(FeatureEditFeature feature)
+        => JsonSerializer.SerializeToElement(new Dictionary<string, object?>
+        {
+            ["attributes"] = feature.Attributes,
+            ["geometry"] = feature.Geometry,
+        }, JsonOptions);
+
+    private static JsonElement ToGeoJsonFeature(FeatureEditFeature feature)
+        => JsonSerializer.SerializeToElement(new Dictionary<string, object?>
+        {
+            ["type"] = "Feature",
+            ["id"] = feature.Id,
+            ["properties"] = feature.Attributes,
+            ["geometry"] = feature.Geometry,
+        }, JsonOptions);
+
+    private static string GetCheckpointKey(string packageId, string sourceId)
+        => $"sdk-checkpoint:{packageId}:{sourceId}";
+
+    private static string GetStateKey(string packageId, string? sourceId)
+        => string.IsNullOrWhiteSpace(sourceId)
+            ? $"sdk-state:{packageId}"
+            : $"sdk-state:{packageId}:{sourceId}";
+}

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSdkOfflineStoreAdapter.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSdkOfflineStoreAdapter.cs
@@ -35,12 +35,15 @@ public sealed class GeoPackageSdkOfflineStoreAdapter :
     public async Task SaveFeaturesAsync(OfflineFeaturePage page, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(page);
+        ArgumentException.ThrowIfNullOrWhiteSpace(page.PackageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(page.SourceId);
 
         await _store.InitializeAsync(ct).ConfigureAwait(false);
+        var layerKey = GetPackageSourceKey(page.PackageId, page.SourceId);
         foreach (var feature in page.Result.Features)
         {
             var featureJson = SerializeFeatureRecord(feature, page.Result.ObjectIdFieldName);
-            await _store.UpsertFeatureAsync(page.SourceId, featureJson, ct).ConfigureAwait(false);
+            await _store.UpsertFeatureAsync(layerKey, featureJson, ct).ConfigureAwait(false);
         }
     }
 
@@ -52,19 +55,21 @@ public sealed class GeoPackageSdkOfflineStoreAdapter :
         IReadOnlyList<long> objectIds,
         CancellationToken ct = default)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
         ArgumentException.ThrowIfNullOrWhiteSpace(sourceId);
 
         await _store.InitializeAsync(ct).ConfigureAwait(false);
+        var layerKey = GetPackageSourceKey(packageId, sourceId);
         foreach (var objectId in objectIds)
         {
-            await _store.DeleteFeatureAsync(sourceId, objectId, ct).ConfigureAwait(false);
+            await _store.DeleteFeatureAsync(layerKey, objectId, ct).ConfigureAwait(false);
         }
 
         foreach (var featureId in featureIds)
         {
             if (long.TryParse(featureId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
             {
-                await _store.DeleteFeatureAsync(sourceId, objectId, ct).ConfigureAwait(false);
+                await _store.DeleteFeatureAsync(layerKey, objectId, ct).ConfigureAwait(false);
             }
         }
     }
@@ -87,7 +92,7 @@ public sealed class GeoPackageSdkOfflineStoreAdapter :
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
 
         await _store.InitializeAsync(ct).ConfigureAwait(false);
-        var pending = await _store.GetPendingAsync(maxCount, ct).ConfigureAwait(false);
+        var pending = await _store.GetPendingByLayerKeyPrefixAsync(GetPackageKeyPrefix(packageId), maxCount, ct).ConfigureAwait(false);
         return pending.Select(operation => ToSdkEntry(packageId, operation)).ToArray();
     }
 
@@ -176,7 +181,7 @@ public sealed class GeoPackageSdkOfflineStoreAdapter :
         return new OfflineEditOperation
         {
             OperationId = entry.OperationId,
-            LayerKey = entry.SourceId,
+            LayerKey = GetPackageSourceKey(entry.PackageId, entry.SourceId),
             TargetCollection = payload.CollectionId ?? payload.ServiceId ?? entry.SourceId,
             OperationType = entry.OperationKind switch
             {
@@ -227,7 +232,7 @@ public sealed class GeoPackageSdkOfflineStoreAdapter :
         {
             OperationId = operation.OperationId,
             PackageId = payload.PackageId ?? fallbackPackageId,
-            SourceId = payload.SourceId ?? operation.LayerKey,
+            SourceId = payload.SourceId ?? GetSourceIdFromLayerKey(fallbackPackageId, operation.LayerKey),
             Source = source,
             OperationKind = operation.OperationType switch
             {
@@ -396,4 +401,18 @@ public sealed class GeoPackageSdkOfflineStoreAdapter :
         => string.IsNullOrWhiteSpace(sourceId)
             ? $"sdk-state:{packageId}"
             : $"sdk-state:{packageId}:{sourceId}";
+
+    private static string GetPackageSourceKey(string packageId, string sourceId)
+        => $"{GetPackageKeyPrefix(packageId)}{sourceId}";
+
+    private static string GetPackageKeyPrefix(string packageId)
+        => $"sdk-package:{packageId}:";
+
+    private static string GetSourceIdFromLayerKey(string packageId, string layerKey)
+    {
+        var prefix = GetPackageKeyPrefix(packageId);
+        return layerKey.StartsWith(prefix, StringComparison.Ordinal)
+            ? layerKey[prefix.Length..]
+            : layerKey;
+    }
 }

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
@@ -199,6 +199,22 @@ ON CONFLICT(operation_id) DO UPDATE SET
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<OfflineEditOperation>> GetPendingAsync(int maxCount, CancellationToken ct = default)
+        => await GetPendingCoreAsync(maxCount, layerKeyPrefix: null, ct).ConfigureAwait(false);
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<OfflineEditOperation>> GetPendingByLayerKeyPrefixAsync(
+        string layerKeyPrefix,
+        int maxCount,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(layerKeyPrefix);
+        return await GetPendingCoreAsync(maxCount, layerKeyPrefix, ct).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<OfflineEditOperation>> GetPendingCoreAsync(
+        int maxCount,
+        string? layerKeyPrefix,
+        CancellationToken ct)
     {
         if (maxCount <= 0)
         {
@@ -215,7 +231,12 @@ ON CONFLICT(operation_id) DO UPDATE SET
                 ? TimeSpan.Zero
                 : _options.InProgressLeaseTimeout;
             var staleClaimCutoffUtc = DateTimeOffset.UtcNow - leaseTimeout;
-            var claimedOperationIds = await ReadPendingOperationIdsAsync(connection, maxCount, staleClaimCutoffUtc, ct).ConfigureAwait(false);
+            var claimedOperationIds = await ReadPendingOperationIdsAsync(
+                connection,
+                maxCount,
+                staleClaimCutoffUtc,
+                layerKeyPrefix,
+                ct).ConfigureAwait(false);
             if (claimedOperationIds.Count == 0)
             {
                 await ExecuteTransactionCommandAsync(connection, "COMMIT;", ct).ConfigureAwait(false);
@@ -718,25 +739,31 @@ ON CONFLICT(layer_key, object_id) DO UPDATE SET
         SqliteConnection connection,
         int maxCount,
         DateTimeOffset staleClaimCutoffUtc,
+        string? layerKeyPrefix,
         CancellationToken ct)
     {
         await using var command = connection.CreateCommand();
         command.CommandText = @"
 SELECT operation_id
 FROM honua_sync_queue
-WHERE status IN ('pending', 'retry')
-   OR (
-      status = 'in_progress'
-      AND (
-        claimed_at_utc IS NULL
-        OR claimed_at_utc <= $stale_claim_cutoff_utc
-      )
-   )
+WHERE ($layer_key_prefix IS NULL OR layer_key LIKE $layer_key_prefix_like ESCAPE '\')
+  AND (
+    status IN ('pending', 'retry')
+    OR (
+        status = 'in_progress'
+        AND (
+          claimed_at_utc IS NULL
+          OR claimed_at_utc <= $stale_claim_cutoff_utc
+        )
+    )
+  )
 ORDER BY priority ASC, created_at_utc ASC
 LIMIT $limit;
 ";
         command.Parameters.AddWithValue("$limit", maxCount);
         command.Parameters.AddWithValue("$stale_claim_cutoff_utc", staleClaimCutoffUtc.ToString("O", CultureInfo.InvariantCulture));
+        command.Parameters.AddWithValue("$layer_key_prefix", ToDbValue(layerKeyPrefix));
+        command.Parameters.AddWithValue("$layer_key_prefix_like", layerKeyPrefix is null ? DBNull.Value : EscapeLikePattern(layerKeyPrefix) + "%");
 
         var operationIds = new List<string>(capacity: maxCount);
         await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
@@ -747,6 +774,11 @@ LIMIT $limit;
 
         return operationIds;
     }
+
+    private static string EscapeLikePattern(string value)
+        => value.Replace(@"\", @"\\", StringComparison.Ordinal)
+            .Replace("%", @"\%", StringComparison.Ordinal)
+            .Replace("_", @"\_", StringComparison.Ordinal);
 
     private static OfflineEditOperation ReadOfflineEditOperation(SqliteDataReader reader)
     {

--- a/src/Honua.Mobile.Offline/GeoPackage/IGeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/IGeoPackageSyncStore.cs
@@ -29,6 +29,17 @@ public interface IGeoPackageSyncStore
     Task<IReadOnlyList<OfflineEditOperation>> GetPendingAsync(int maxCount, CancellationToken ct = default);
 
     /// <summary>
+    /// Claims pending operations whose layer keys start with <paramref name="layerKeyPrefix"/>, marking them as in-progress.
+    /// Stale claims older than the configured lease timeout are reclaimed.
+    /// </summary>
+    /// <param name="layerKeyPrefix">Layer key prefix used to partition queued operations.</param>
+    /// <param name="maxCount">Maximum number of operations to retrieve.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The claimed operations ordered by priority then creation time.</returns>
+    Task<IReadOnlyList<OfflineEditOperation>> GetPendingByLayerKeyPrefixAsync(string layerKeyPrefix, int maxCount, CancellationToken ct = default)
+        => throw new NotSupportedException("This GeoPackage sync store does not support partitioned queue claims by layer key prefix.");
+
+    /// <summary>
     /// Returns the number of operations in pending or retry status.
     /// </summary>
     /// <param name="ct">Cancellation token.</param>

--- a/src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj
+++ b/src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj
@@ -6,6 +6,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Honua.Sdk.Offline" Version="0.1.0-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Offline.Abstractions" Version="0.1.0-alpha.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
   </ItemGroup>

--- a/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
+++ b/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
@@ -350,6 +350,21 @@ public sealed class HonuaApiOfflineOperationUploader : IOfflineOperationUploader
 public sealed class OfflineOperationPayload
 {
     /// <summary>
+    /// SDK offline package identifier when the payload was produced from <c>Honua.Sdk.Offline.Abstractions</c>.
+    /// </summary>
+    public string? PackageId { get; init; }
+
+    /// <summary>
+    /// SDK offline source identifier when the payload was produced from <c>Honua.Sdk.Offline.Abstractions</c>.
+    /// </summary>
+    public string? SourceId { get; init; }
+
+    /// <summary>
+    /// Provider sync token observed when the local edit was queued.
+    /// </summary>
+    public string? BaseSyncToken { get; init; }
+
+    /// <summary>
     /// API protocol to use: <c>"FeatureServer"</c>/<c>"esri"</c> or <c>"ogcfeatures"</c>/<c>"ogc"</c>. Defaults to <c>"FeatureServer"</c>.
     /// </summary>
     public string Protocol { get; init; } = "FeatureServer";
@@ -403,4 +418,9 @@ public sealed class OfflineOperationPayload
     /// Typed list of object IDs for delete operations (alternative to <see cref="DeletesCsv"/>).
     /// </summary>
     public IReadOnlyList<long>? DeleteObjectIds { get; init; }
+
+    /// <summary>
+    /// SDK or application metadata associated with the queued edit.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Metadata { get; init; }
 }

--- a/src/Honua.Mobile.Offline/Sync/HonuaMobileSdkFeatureClient.cs
+++ b/src/Honua.Mobile.Offline/Sync/HonuaMobileSdkFeatureClient.cs
@@ -1,0 +1,406 @@
+using System.Collections.ObjectModel;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Honua.Mobile.Sdk;
+using Honua.Mobile.Sdk.Models;
+using Honua.Sdk.Abstractions.Features;
+
+namespace Honua.Mobile.Offline.Sync;
+
+/// <summary>
+/// Adapts <see cref="HonuaMobileClient"/> to the SDK feature query and edit abstractions used by the SDK offline sync engine.
+/// </summary>
+public sealed class HonuaMobileSdkFeatureClient : IHonuaFeatureQueryClient, IHonuaFeatureEditClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly HonuaMobileClient _client;
+
+    /// <summary>
+    /// Initializes a new <see cref="HonuaMobileSdkFeatureClient"/>.
+    /// </summary>
+    /// <param name="client">Mobile client used for server calls.</param>
+    public HonuaMobileSdkFeatureClient(HonuaMobileClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <inheritdoc />
+    public string ProviderName => "honua-mobile";
+
+    /// <inheritdoc />
+    public FeatureEditCapabilities EditCapabilities { get; } = new()
+    {
+        SupportsAdds = true,
+        SupportsUpdates = true,
+        SupportsDeletes = true,
+        SupportsRollbackOnFailure = true,
+        NativeSurface = "HonuaMobileClient",
+    };
+
+    /// <inheritdoc />
+    public async Task<FeatureQueryResult> QueryAsync(FeatureQueryRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!string.IsNullOrWhiteSpace(request.Source.CollectionId))
+        {
+            using var response = await _client.GetOgcItemsAsync(ToOgcRequest(request), ct).ConfigureAwait(false);
+            return ParseQueryResult(response.RootElement, request, "ogcfeatures");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Source.ServiceId) && request.Source.LayerId.HasValue)
+        {
+            using var response = await _client.QueryFeaturesAsync(ToFeatureServerRequest(request), ct).ConfigureAwait(false);
+            return ParseQueryResult(response.RootElement, request, "featureserver");
+        }
+
+        throw new InvalidOperationException("Feature query requires either an OGC collection ID or FeatureServer service/layer identifiers.");
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<FeatureQueryResult> QueryPagesAsync(
+        FeatureQueryRequest request,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var offset = request.Offset ?? 0;
+        var limit = request.Limit;
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+            var page = await QueryAsync(request with { Offset = offset, Limit = limit }, ct).ConfigureAwait(false);
+            yield return page;
+
+            if (!page.HasMoreResults || limit is null || page.NumberReturned == 0)
+            {
+                yield break;
+            }
+
+            offset += page.NumberReturned;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(request.Source.CollectionId))
+            {
+                return await ApplyOgcEditsAsync(request, ct).ConfigureAwait(false);
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.Source.ServiceId) && request.Source.LayerId.HasValue)
+            {
+                using var response = await _client.ApplyEditsAsync(ToFeatureServerEditRequest(request), ct).ConfigureAwait(false);
+                return ParseEditResponse(response.RootElement, "featureserver");
+            }
+        }
+        catch (HonuaMobileApiException ex)
+        {
+            return new FeatureEditResponse
+            {
+                ProviderName = ProviderName,
+                Error = new FeatureEditError { Code = (int)ex.StatusCode, Message = ex.Message },
+            };
+        }
+
+        return new FeatureEditResponse
+        {
+            ProviderName = ProviderName,
+            Error = new FeatureEditError { Message = "Feature edit requires either an OGC collection ID or FeatureServer service/layer identifiers." },
+        };
+    }
+
+    private async Task<FeatureEditResponse> ApplyOgcEditsAsync(FeatureEditRequest request, CancellationToken ct)
+    {
+        var addResults = new List<FeatureEditResult>();
+        var updateResults = new List<FeatureEditResult>();
+        var deleteResults = new List<FeatureEditResult>();
+        var collectionId = request.Source.CollectionId ?? throw new InvalidOperationException("OGC edit request requires collection ID.");
+
+        foreach (var add in request.Adds)
+        {
+            using var response = await _client.CreateOgcItemAsync(new OgcCreateItemRequest
+            {
+                CollectionId = collectionId,
+                Feature = ToGeoJsonFeature(add),
+            }, ct).ConfigureAwait(false);
+            addResults.Add(ToOgcSuccessResult(response.RootElement, add.Id, add.ObjectId));
+        }
+
+        foreach (var update in request.Updates)
+        {
+            if (string.IsNullOrWhiteSpace(update.Id))
+            {
+                updateResults.Add(new FeatureEditResult
+                {
+                    Succeeded = false,
+                    ObjectId = update.ObjectId,
+                    Error = new FeatureEditError { Message = "OGC update requires feature ID." },
+                });
+                continue;
+            }
+
+            using var response = await _client.ReplaceOgcItemAsync(new OgcReplaceItemRequest
+            {
+                CollectionId = collectionId,
+                FeatureId = update.Id,
+                Feature = ToGeoJsonFeature(update),
+            }, ct).ConfigureAwait(false);
+            updateResults.Add(ToOgcSuccessResult(response.RootElement, update.Id, update.ObjectId));
+        }
+
+        foreach (var deleteId in request.DeleteIds)
+        {
+            using var response = await _client.DeleteOgcItemAsync(new OgcDeleteItemRequest
+            {
+                CollectionId = collectionId,
+                FeatureId = deleteId,
+            }, ct).ConfigureAwait(false);
+            deleteResults.Add(ToOgcSuccessResult(response.RootElement, deleteId, null));
+        }
+
+        return new FeatureEditResponse
+        {
+            ProviderName = "ogcfeatures",
+            AddResults = addResults,
+            UpdateResults = updateResults,
+            DeleteResults = deleteResults,
+        };
+    }
+
+    private static QueryFeaturesRequest ToFeatureServerRequest(FeatureQueryRequest request)
+        => new()
+        {
+            ServiceId = request.Source.ServiceId ?? throw new InvalidOperationException("FeatureServer query requires service ID."),
+            LayerId = request.Source.LayerId ?? throw new InvalidOperationException("FeatureServer query requires layer ID."),
+            Where = request.Filter ?? "1=1",
+            ObjectIds = request.ObjectIds,
+            OutFields = request.OutFields,
+            ReturnGeometry = request.ReturnGeometry ?? true,
+            ResultOffset = request.Offset,
+            ResultRecordCount = request.Limit,
+            OrderBy = request.OrderBy,
+        };
+
+    private static OgcItemsRequest ToOgcRequest(FeatureQueryRequest request)
+        => new()
+        {
+            CollectionId = request.Source.CollectionId ?? throw new InvalidOperationException("OGC query requires collection ID."),
+            CqlFilter = request.Filter,
+            PropertyNames = request.OutFields,
+            Limit = request.Limit,
+            Offset = request.Offset,
+        };
+
+    private static ApplyEditsRequest ToFeatureServerEditRequest(FeatureEditRequest request)
+        => new()
+        {
+            ServiceId = request.Source.ServiceId ?? throw new InvalidOperationException("FeatureServer edit requires service ID."),
+            LayerId = request.Source.LayerId ?? throw new InvalidOperationException("FeatureServer edit requires layer ID."),
+            AddsJson = request.Adds.Count == 0 ? null : JsonSerializer.Serialize(request.Adds.Select(ToFeatureServerFeature), JsonOptions),
+            UpdatesJson = request.Updates.Count == 0 ? null : JsonSerializer.Serialize(request.Updates.Select(ToFeatureServerFeature), JsonOptions),
+            DeletesCsv = request.DeleteObjectIds.Count > 0
+                ? string.Join(',', request.DeleteObjectIds)
+                : request.DeleteIds.Count == 0 ? null : string.Join(',', request.DeleteIds),
+            RollbackOnFailure = request.RollbackOnFailure,
+            ForceWrite = request.ForceWrite,
+        };
+
+    private static FeatureQueryResult ParseQueryResult(JsonElement root, FeatureQueryRequest request, string providerName)
+    {
+        var features = root.TryGetProperty("features", out var featuresElement) && featuresElement.ValueKind == JsonValueKind.Array
+            ? featuresElement.EnumerateArray().Select(ParseFeatureRecord).ToArray()
+            : [];
+
+        var matched = ReadInt64(root, "numberMatched") ?? ReadInt64(root, "count");
+        var exceededTransferLimit = root.TryGetProperty("exceededTransferLimit", out var exceeded) && exceeded.ValueKind == JsonValueKind.True;
+        var hasNextLink = HasNextLink(root);
+        var inferredHasMore = matched.HasValue && request.Offset.HasValue && request.Limit.HasValue
+            ? request.Offset.Value + features.Length < matched.Value
+            : false;
+
+        return new FeatureQueryResult
+        {
+            ProviderName = providerName,
+            Features = features,
+            NumberMatched = matched,
+            NumberReturned = features.Length,
+            HasMoreResults = exceededTransferLimit || hasNextLink || inferredHasMore,
+            ObjectIdFieldName = root.TryGetProperty("objectIdFieldName", out var objectIdField) && objectIdField.ValueKind == JsonValueKind.String
+                ? objectIdField.GetString()
+                : null,
+        };
+    }
+
+    private static FeatureRecord ParseFeatureRecord(JsonElement feature)
+    {
+        var attributes = feature.TryGetProperty("attributes", out var featureServerAttributes)
+            ? ReadJsonObject(featureServerAttributes)
+            : feature.TryGetProperty("properties", out var geoJsonProperties)
+                ? ReadJsonObject(geoJsonProperties)
+                : new ReadOnlyDictionary<string, JsonElement>(new Dictionary<string, JsonElement>());
+
+        JsonElement? geometry = null;
+        if (feature.TryGetProperty("geometry", out var geometryElement) && geometryElement.ValueKind != JsonValueKind.Null)
+        {
+            geometry = geometryElement.Clone();
+        }
+
+        return new FeatureRecord
+        {
+            Id = ReadFeatureId(feature, attributes),
+            Attributes = attributes,
+            Geometry = geometry,
+        };
+    }
+
+    private static FeatureEditResponse ParseEditResponse(JsonElement root, string providerName)
+        => new()
+        {
+            ProviderName = providerName,
+            AddResults = ParseEditResults(root, "addResults"),
+            UpdateResults = ParseEditResults(root, "updateResults"),
+            DeleteResults = ParseEditResults(root, "deleteResults"),
+            Error = TryReadError(root, out var error) ? error : null,
+        };
+
+    private static IReadOnlyList<FeatureEditResult> ParseEditResults(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var results) || results.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return results.EnumerateArray().Select(result => new FeatureEditResult
+        {
+            Id = ReadString(result, "id") ?? ReadString(result, "globalId"),
+            ObjectId = ReadInt64(result, "objectId"),
+            Succeeded = result.TryGetProperty("success", out var success) && success.ValueKind == JsonValueKind.True,
+            Error = TryReadError(result, out var error) ? error : null,
+        }).ToArray();
+    }
+
+    private static FeatureEditResult ToOgcSuccessResult(JsonElement root, string? fallbackId, long? objectId)
+    {
+        if (TryReadError(root, out var error))
+        {
+            return new FeatureEditResult
+            {
+                Id = fallbackId,
+                ObjectId = objectId,
+                Succeeded = false,
+                Error = error,
+            };
+        }
+
+        return new FeatureEditResult
+        {
+            Id = ReadString(root, "id") ?? fallbackId,
+            ObjectId = objectId,
+            Succeeded = true,
+        };
+    }
+
+    private static JsonElement ToFeatureServerFeature(FeatureEditFeature feature)
+        => JsonSerializer.SerializeToElement(new Dictionary<string, object?>
+        {
+            ["attributes"] = feature.Attributes,
+            ["geometry"] = feature.Geometry,
+        }, JsonOptions);
+
+    private static JsonElement ToGeoJsonFeature(FeatureEditFeature feature)
+        => JsonSerializer.SerializeToElement(new Dictionary<string, object?>
+        {
+            ["type"] = "Feature",
+            ["id"] = feature.Id,
+            ["properties"] = feature.Attributes,
+            ["geometry"] = feature.Geometry,
+        }, JsonOptions);
+
+    private static IReadOnlyDictionary<string, JsonElement> ReadJsonObject(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            return new ReadOnlyDictionary<string, JsonElement>(new Dictionary<string, JsonElement>());
+        }
+
+        return new ReadOnlyDictionary<string, JsonElement>(
+            element.EnumerateObject().ToDictionary(property => property.Name, property => property.Value.Clone()));
+    }
+
+    private static bool TryReadError(JsonElement element, out FeatureEditError? error)
+    {
+        error = null;
+        if (element.ValueKind == JsonValueKind.Object && element.TryGetProperty("error", out var nestedError))
+        {
+            return TryReadError(nestedError, out error);
+        }
+
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        var code = ReadInt32(element, "code");
+        var message = ReadString(element, "message");
+        if (code is null && string.IsNullOrWhiteSpace(message))
+        {
+            return false;
+        }
+
+        error = new FeatureEditError
+        {
+            Code = code,
+            Message = message ?? "Provider reported an edit error.",
+        };
+        return true;
+    }
+
+    private static string? ReadFeatureId(JsonElement feature, IReadOnlyDictionary<string, JsonElement> attributes)
+    {
+        if (feature.TryGetProperty("id", out var id))
+        {
+            return id.ValueKind == JsonValueKind.String ? id.GetString() : id.GetRawText();
+        }
+
+        foreach (var key in new[] { "OBJECTID", "objectid", "ObjectID", "FID" })
+        {
+            if (attributes.TryGetValue(key, out var objectId))
+            {
+                return objectId.ValueKind == JsonValueKind.String ? objectId.GetString() : objectId.GetRawText();
+            }
+        }
+
+        return null;
+    }
+
+    private static bool HasNextLink(JsonElement root)
+    {
+        if (!root.TryGetProperty("links", out var links) || links.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        return links.EnumerateArray().Any(link =>
+            link.TryGetProperty("rel", out var rel) &&
+            rel.ValueKind == JsonValueKind.String &&
+            string.Equals(rel.GetString(), "next", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string? ReadString(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static int? ReadInt32(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var value) && value.TryGetInt32(out var parsed) ? parsed : null;
+
+    private static long? ReadInt64(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var value) && value.TryGetInt64(out var parsed) ? parsed : null;
+}

--- a/src/Honua.Mobile.Offline/Sync/SdkOfflineSyncRunner.cs
+++ b/src/Honua.Mobile.Offline/Sync/SdkOfflineSyncRunner.cs
@@ -1,0 +1,41 @@
+using Honua.Sdk.Offline.Abstractions;
+using SdkOfflineSyncEngine = Honua.Sdk.Offline.OfflineSyncEngine;
+
+namespace Honua.Mobile.Offline.Sync;
+
+/// <summary>
+/// Exposes the SDK offline sync engine through the mobile sync runner contract used by app lifecycle and background scheduling.
+/// </summary>
+public sealed class SdkOfflineSyncRunner : IOfflineSyncRunner
+{
+    private readonly SdkOfflineSyncEngine _engine;
+    private readonly OfflinePackageManifest _manifest;
+
+    /// <summary>
+    /// Initializes a new <see cref="SdkOfflineSyncRunner"/>.
+    /// </summary>
+    /// <param name="engine">SDK offline sync engine.</param>
+    /// <param name="manifest">Offline package manifest to sync.</param>
+    public SdkOfflineSyncRunner(SdkOfflineSyncEngine engine, OfflinePackageManifest manifest)
+    {
+        _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        _manifest = manifest ?? throw new ArgumentNullException(nameof(manifest));
+    }
+
+    /// <inheritdoc />
+    public async Task<SyncRunResult> SyncAsync(CancellationToken ct = default)
+    {
+        var result = await _engine.SyncAsync(_manifest, ct).ConfigureAwait(false);
+        var failures = result.Push.Failures.Concat(result.Pull.Failures)
+            .Select(failure => new SyncFailure(failure.OperationId ?? failure.SourceId ?? _manifest.PackageId, failure.Reason))
+            .ToArray();
+
+        return new SyncRunResult
+        {
+            Loaded = result.Push.Loaded,
+            Succeeded = result.Push.Succeeded,
+            Failed = failures.Length,
+            Failures = failures,
+        };
+    }
+}

--- a/tests/Honua.Mobile.Maui.Tests/SdkOfflineRegistrationTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/SdkOfflineRegistrationTests.cs
@@ -1,0 +1,66 @@
+using Honua.Mobile.Maui;
+using Honua.Mobile.Offline.GeoPackage;
+using Honua.Mobile.Offline.Sync;
+using Honua.Mobile.Sdk;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Offline.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using MobileOfflineSyncRunner = Honua.Mobile.Offline.Sync.IOfflineSyncRunner;
+using SdkOfflineFeatureStore = Honua.Sdk.Offline.Abstractions.IOfflineFeatureStore;
+
+namespace Honua.Mobile.Maui.Tests;
+
+public sealed class SdkOfflineRegistrationTests
+{
+    [Fact]
+    public void AddHonuaSdkGeoPackageOfflineSync_RegistersSdkBackedRunnerAndAdapters()
+    {
+        var databasePath = Path.Combine(Path.GetTempPath(), $"honua-sdk-offline-di-{Guid.NewGuid():N}.gpkg");
+        try
+        {
+            using var provider = new ServiceCollection()
+                .AddLogging()
+                .AddHonuaMobileSdk(new HonuaMobileClientOptions
+                {
+                    BaseUri = new Uri("https://example.honua.test"),
+                })
+                .AddHonuaSdkGeoPackageOfflineSync(
+                    new GeoPackageSyncStoreOptions { DatabasePath = databasePath },
+                    CreateManifest())
+                .BuildServiceProvider();
+
+            var runner = provider.GetRequiredService<MobileOfflineSyncRunner>();
+
+            Assert.IsType<SdkOfflineSyncRunner>(runner);
+            Assert.IsType<GeoPackageSdkOfflineStoreAdapter>(provider.GetRequiredService<SdkOfflineFeatureStore>());
+            Assert.IsType<HonuaMobileSdkFeatureClient>(provider.GetRequiredService<IHonuaFeatureQueryClient>());
+            Assert.IsType<HonuaMobileSdkFeatureClient>(provider.GetRequiredService<IHonuaFeatureEditClient>());
+        }
+        finally
+        {
+            if (File.Exists(databasePath))
+            {
+                File.Delete(databasePath);
+            }
+        }
+    }
+
+    private static OfflinePackageManifest CreateManifest()
+        => new()
+        {
+            PackageId = "area-1",
+            Sources =
+            [
+                new OfflineSourceDescriptor
+                {
+                    SourceId = "parks",
+                    Source = new SourceDescriptor
+                    {
+                        Id = "parks",
+                        Protocol = FeatureProtocolIds.OgcFeatures,
+                        Locator = new SourceLocator { CollectionId = "parks" },
+                    },
+                },
+            ],
+        };
+}

--- a/tests/Honua.Mobile.Offline.Tests/GeoPackageSdkOfflineStoreAdapterTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/GeoPackageSdkOfflineStoreAdapterTests.cs
@@ -44,12 +44,32 @@ public sealed class GeoPackageSdkOfflineStoreAdapterTests : IDisposable
             },
         });
 
-        var features = await store.GetFeaturesAsync("parks");
+        var features = await store.GetFeaturesAsync("sdk-package:area-1:parks");
+        var unpartitionedFeatures = await store.GetFeaturesAsync("parks");
 
         var featureJson = Assert.Single(features);
         using var document = JsonDocument.Parse(featureJson);
         Assert.Equal(42, document.RootElement.GetProperty("attributes").GetProperty("objectid").GetInt64());
         Assert.Equal("Ala Moana", document.RootElement.GetProperty("attributes").GetProperty("name").GetString());
+        Assert.Empty(unpartitionedFeatures);
+    }
+
+    [Fact]
+    public async Task SaveFeaturesAsync_PartitionsSameSourceIdByPackage()
+    {
+        var store = CreateStore();
+        var adapter = new GeoPackageSdkOfflineStoreAdapter(store);
+
+        await adapter.SaveFeaturesAsync(CreateFeaturePage("area-1", "parks", "42", "Ala Moana"));
+        await adapter.SaveFeaturesAsync(CreateFeaturePage("area-2", "parks", "42", "Kapiolani"));
+
+        var area1Features = await store.GetFeaturesAsync("sdk-package:area-1:parks");
+        var area2Features = await store.GetFeaturesAsync("sdk-package:area-2:parks");
+
+        using var area1Document = JsonDocument.Parse(Assert.Single(area1Features));
+        using var area2Document = JsonDocument.Parse(Assert.Single(area2Features));
+        Assert.Equal("Ala Moana", area1Document.RootElement.GetProperty("attributes").GetProperty("name").GetString());
+        Assert.Equal("Kapiolani", area2Document.RootElement.GetProperty("attributes").GetProperty("name").GetString());
     }
 
     [Fact]
@@ -102,6 +122,26 @@ public sealed class GeoPackageSdkOfflineStoreAdapterTests : IDisposable
     }
 
     [Fact]
+    public async Task ChangeJournal_OnlyClaimsEntriesForRequestedPackage()
+    {
+        var store = CreateStore();
+        var adapter = new GeoPackageSdkOfflineStoreAdapter(store);
+
+        await adapter.EnqueueAsync(CreateJournalEntry("area-1", "parks", "op-1"));
+        await adapter.EnqueueAsync(CreateJournalEntry("area-2", "parks", "op-2"));
+
+        var area1Pending = await adapter.GetPendingAsync("area-1", 10);
+        var area2Pending = await adapter.GetPendingAsync("area-2", 10);
+
+        Assert.Collection(
+            area1Pending,
+            entry => Assert.Equal("op-1", entry.OperationId));
+        Assert.Collection(
+            area2Pending,
+            entry => Assert.Equal("op-2", entry.OperationId));
+    }
+
+    [Fact]
     public async Task CheckpointsAndState_RoundTripThroughSyncCursors()
     {
         var adapter = new GeoPackageSdkOfflineStoreAdapter(CreateStore());
@@ -144,6 +184,49 @@ public sealed class GeoPackageSdkOfflineStoreAdapterTests : IDisposable
 
     private GeoPackageSyncStore CreateStore()
         => new(new GeoPackageSyncStoreOptions { DatabasePath = _databasePath });
+
+    private static OfflineFeaturePage CreateFeaturePage(string packageId, string sourceId, string featureId, string name)
+        => new()
+        {
+            PackageId = packageId,
+            SourceId = sourceId,
+            Source = CreateSourceDescriptor(),
+            Result = new FeatureQueryResult
+            {
+                ProviderName = "fake",
+                ObjectIdFieldName = "objectid",
+                Features =
+                [
+                    new FeatureRecord
+                    {
+                        Id = featureId,
+                        Attributes = new Dictionary<string, JsonElement>
+                        {
+                            ["name"] = JsonSerializer.SerializeToElement(name),
+                        },
+                    },
+                ],
+                NumberReturned = 1,
+            },
+        };
+
+    private static OfflineChangeJournalEntry CreateJournalEntry(string packageId, string sourceId, string operationId)
+        => new()
+        {
+            OperationId = operationId,
+            PackageId = packageId,
+            SourceId = sourceId,
+            Source = new FeatureSource { CollectionId = sourceId },
+            OperationKind = OfflineEditOperationKind.Update,
+            Feature = new FeatureEditFeature
+            {
+                Id = $"{operationId}-feature",
+                Attributes = new Dictionary<string, JsonElement>
+                {
+                    ["name"] = JsonSerializer.SerializeToElement(operationId),
+                },
+            },
+        };
 
     private static SourceDescriptor CreateSourceDescriptor()
         => new()

--- a/tests/Honua.Mobile.Offline.Tests/GeoPackageSdkOfflineStoreAdapterTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/GeoPackageSdkOfflineStoreAdapterTests.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using Honua.Mobile.Offline.GeoPackage;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Offline.Abstractions;
+
+namespace Honua.Mobile.Offline.Tests;
+
+public sealed class GeoPackageSdkOfflineStoreAdapterTests : IDisposable
+{
+    private readonly string _databasePath;
+
+    public GeoPackageSdkOfflineStoreAdapterTests()
+    {
+        _databasePath = Path.Combine(Path.GetTempPath(), $"honua-sdk-offline-{Guid.NewGuid():N}.gpkg");
+    }
+
+    [Fact]
+    public async Task SaveFeaturesAsync_PersistsSdkFeatureRecordsInGeoPackageStore()
+    {
+        var store = CreateStore();
+        var adapter = new GeoPackageSdkOfflineStoreAdapter(store);
+
+        await adapter.SaveFeaturesAsync(new OfflineFeaturePage
+        {
+            PackageId = "area-1",
+            SourceId = "parks",
+            Source = CreateSourceDescriptor(),
+            Result = new FeatureQueryResult
+            {
+                ProviderName = "fake",
+                ObjectIdFieldName = "objectid",
+                Features =
+                [
+                    new FeatureRecord
+                    {
+                        Id = "42",
+                        Attributes = new Dictionary<string, JsonElement>
+                        {
+                            ["name"] = JsonSerializer.SerializeToElement("Ala Moana"),
+                        },
+                    },
+                ],
+                NumberReturned = 1,
+            },
+        });
+
+        var features = await store.GetFeaturesAsync("parks");
+
+        var featureJson = Assert.Single(features);
+        using var document = JsonDocument.Parse(featureJson);
+        Assert.Equal(42, document.RootElement.GetProperty("attributes").GetProperty("objectid").GetInt64());
+        Assert.Equal("Ala Moana", document.RootElement.GetProperty("attributes").GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task ChangeJournal_RoundTripsSdkEntriesThroughMobileQueue()
+    {
+        var store = CreateStore();
+        var adapter = new GeoPackageSdkOfflineStoreAdapter(store);
+
+        await adapter.EnqueueAsync(new OfflineChangeJournalEntry
+        {
+            OperationId = "op-1",
+            PackageId = "area-1",
+            SourceId = "parks",
+            Source = new FeatureSource { CollectionId = "parks" },
+            OperationKind = OfflineEditOperationKind.Update,
+            Feature = new FeatureEditFeature
+            {
+                Id = "park-1",
+                Attributes = new Dictionary<string, JsonElement>
+                {
+                    ["name"] = JsonSerializer.SerializeToElement("Updated"),
+                },
+            },
+            BaseSyncToken = "server-token",
+            Metadata = new Dictionary<string, string> { ["formId"] = "inspection" },
+        });
+
+        var pending = await adapter.GetPendingAsync("area-1", 10);
+
+        var entry = Assert.Single(pending);
+        Assert.Equal("op-1", entry.OperationId);
+        Assert.Equal("area-1", entry.PackageId);
+        Assert.Equal("parks", entry.SourceId);
+        Assert.Equal("parks", entry.Source.CollectionId);
+        Assert.Equal(OfflineEditOperationKind.Update, entry.OperationKind);
+        Assert.Equal("park-1", entry.Feature?.Id);
+        Assert.Equal("server-token", entry.BaseSyncToken);
+        Assert.Equal("inspection", entry.Metadata["formId"]);
+
+        await adapter.MarkRetryAsync(new OfflineRetryCheckpoint
+        {
+            OperationId = "op-1",
+            PackageId = "area-1",
+            SourceId = "parks",
+            AttemptCount = 1,
+            Reason = "network unavailable",
+        });
+
+        Assert.Equal(1, await store.CountPendingAsync());
+    }
+
+    [Fact]
+    public async Task CheckpointsAndState_RoundTripThroughSyncCursors()
+    {
+        var adapter = new GeoPackageSdkOfflineStoreAdapter(CreateStore());
+
+        await adapter.SaveCheckpointAsync(new OfflineSyncCheckpoint
+        {
+            PackageId = "area-1",
+            SourceId = "parks",
+            SyncToken = "server-token",
+            PulledFeatureCount = 12,
+        });
+
+        await adapter.SaveStateAsync(new OfflineSyncState
+        {
+            PackageId = "area-1",
+            SourceId = "parks",
+            Phase = OfflineSyncPhase.Completed,
+            LastSyncToken = "server-token",
+            PendingChangeCount = 3,
+        });
+
+        var checkpoint = await adapter.GetCheckpointAsync("area-1", "parks");
+        var state = await adapter.GetStateAsync("area-1", "parks");
+
+        Assert.NotNull(checkpoint);
+        Assert.Equal("server-token", checkpoint!.SyncToken);
+        Assert.Equal(12, checkpoint.PulledFeatureCount);
+        Assert.NotNull(state);
+        Assert.Equal(OfflineSyncPhase.Completed, state!.Phase);
+        Assert.Equal(3, state.PendingChangeCount);
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_databasePath))
+        {
+            File.Delete(_databasePath);
+        }
+    }
+
+    private GeoPackageSyncStore CreateStore()
+        => new(new GeoPackageSyncStoreOptions { DatabasePath = _databasePath });
+
+    private static SourceDescriptor CreateSourceDescriptor()
+        => new()
+        {
+            Id = "parks",
+            Protocol = FeatureProtocolIds.OgcFeatures,
+            Locator = new SourceLocator { CollectionId = "parks" },
+        };
+}

--- a/tests/Honua.Mobile.Offline.Tests/GeoPackageSyncStoreTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/GeoPackageSyncStoreTests.cs
@@ -110,6 +110,41 @@ public sealed class GeoPackageSyncStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task GetPendingByLayerKeyPrefixAsync_ClaimsOnlyMatchingLayerKeys()
+    {
+        var store = CreateStore();
+        await store.InitializeAsync();
+
+        await store.EnqueueAsync(new OfflineEditOperation
+        {
+            OperationId = "area-1-op",
+            LayerKey = "sdk-package:area-1:parks",
+            TargetCollection = "parks",
+            OperationType = OfflineOperationType.Update,
+            PayloadJson = "{}",
+            Priority = 1,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+        });
+
+        await store.EnqueueAsync(new OfflineEditOperation
+        {
+            OperationId = "area-2-op",
+            LayerKey = "sdk-package:area-2:parks",
+            TargetCollection = "parks",
+            OperationType = OfflineOperationType.Update,
+            PayloadJson = "{}",
+            Priority = 1,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+        });
+
+        var area1Pending = await store.GetPendingByLayerKeyPrefixAsync("sdk-package:area-1:", 10);
+        var area2Pending = await store.GetPendingByLayerKeyPrefixAsync("sdk-package:area-2:", 10);
+
+        Assert.Collection(area1Pending, operation => Assert.Equal("area-1-op", operation.OperationId));
+        Assert.Collection(area2Pending, operation => Assert.Equal("area-2-op", operation.OperationId));
+    }
+
+    [Fact]
     public async Task MapAreas_CanBeUpsertedAndListed()
     {
         var store = CreateStore();

--- a/tests/Honua.Mobile.Offline.Tests/ScenePackageDownloaderTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/ScenePackageDownloaderTests.cs
@@ -463,6 +463,9 @@ public sealed class ScenePackageDownloaderTests : IDisposable
         public Task<IReadOnlyList<OfflineEditOperation>> GetPendingAsync(int maxCount, CancellationToken ct = default)
             => throw new NotSupportedException();
 
+        public Task<IReadOnlyList<OfflineEditOperation>> GetPendingByLayerKeyPrefixAsync(string layerKeyPrefix, int maxCount, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
         public Task<int> CountPendingAsync(CancellationToken ct = default)
             => throw new NotSupportedException();
 

--- a/tests/Honua.Mobile.Sdk.Tests/MobileContractHarmonizationFixtureTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/MobileContractHarmonizationFixtureTests.cs
@@ -94,9 +94,12 @@ public sealed class MobileContractHarmonizationFixtureTests
         Assert.Equal("honua-io/honua-mobile", fixture.MobileBaseline.Repository);
         Assert.Equal("unreleased-source", fixture.MobileBaseline.PackageVersion);
 
-        var abstractionsPackage = Assert.Single(fixture.SdkBaseline.Packages);
+        var abstractionsPackage = fixture.SdkBaseline.Packages.Single(package => package.PackageId == "Honua.Sdk.Abstractions");
         Assert.Equal("Honua.Sdk.Abstractions", abstractionsPackage.PackageId);
         Assert.Equal("0.1.0-alpha.1", abstractionsPackage.Version);
+
+        Assert.Contains(fixture.SdkBaseline.Packages, package => package.PackageId == "Honua.Sdk.Offline.Abstractions");
+        Assert.Contains(fixture.SdkBaseline.Packages, package => package.PackageId == "Honua.Sdk.Offline");
     }
 
     private static ContractFixture LoadFixture()


### PR DESCRIPTION
## Summary
- Consume `Honua.Sdk.Offline` and `Honua.Sdk.Offline.Abstractions` from NuGet for mobile offline workflows.
- Add GeoPackage adapters for SDK feature store, change journal, checkpoints, and sync state, plus a mobile feature query/edit adapter and SDK-backed sync runner.
- Add MAUI registration, docs, contract fixture updates, and integration tests for the SDK-backed offline path.
- Partition SDK-backed feature cache rows and queued edit claims by package/source so multiple offline packages can share source IDs safely.

## Platform Impact
- Shared `net10.0` library and DI changes only; no platform-specific code paths were added.
- Android and Windows MAUI CI builds pass on the PR.

## Sync Impact
- SDK-backed offline sync now stores pulled features under package/source scoped layer keys.
- SDK-backed pending edit claims are filtered before rows are marked `in_progress`, preventing one package sync from claiming another package's edits.
- Existing mobile-only offline queue behavior is preserved through the existing `GetPendingAsync` path.

## Breaking Changes
- None expected. `IGeoPackageSyncStore` gained a default partitioned-claim member for SDK-backed adapters; the concrete SQLite store implements it.

## Testing
- `dotnet test Honua.Mobile.sln --configuration Release --no-restore`
- `dotnet format src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj --no-restore --verify-no-changes --verbosity minimal`
- `dotnet format src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj --no-restore --verify-no-changes --verbosity minimal`
- `dotnet format src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj --no-restore --verify-no-changes --verbosity minimal`
- `npm test --prefix src/Honua.Embed`
- `git diff --check`

Notes: local restore used a temporary local feed for the newly published SDK offline packages because my local GitHub token cannot read GitHub Packages. The packages were published successfully from `honua-sdk-dotnet` workflow run `25087792887`.

Closes #49
