### PR TITLE
sdk: use transport package models in mobile client

### DIFF
--- a/src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
+++ b/src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Honua.Sdk.Abstractions" Version="0.1.2-alpha.1" />
     <PackageReference Include="Honua.Sdk.Offline" Version="0.1.2-alpha.1" />
     <PackageReference Include="Honua.Sdk.Offline.Abstractions" Version="0.1.2-alpha.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj
+++ b/src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Honua.Sdk.Offline" Version="0.1.2-alpha.1" />
     <PackageReference Include="Honua.Sdk.Offline.Abstractions" Version="0.1.2-alpha.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Honua.Mobile.Sdk/Features/HonuaMobileSdkFeatureClient.cs
+++ b/src/Honua.Mobile.Sdk/Features/HonuaMobileSdkFeatureClient.cs
@@ -11,8 +11,6 @@ namespace Honua.Mobile.Sdk.Features;
 /// </summary>
 public sealed class HonuaMobileSdkFeatureClient : IHonuaFeatureQueryClient, IHonuaFeatureEditClient
 {
-    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
-
     private readonly HonuaMobileClient _client;
 
     /// <summary>
@@ -127,7 +125,7 @@ public sealed class HonuaMobileSdkFeatureClient : IHonuaFeatureQueryClient, IHon
             using var response = await _client.CreateOgcItemAsync(new OgcCreateItemRequest
             {
                 CollectionId = collectionId,
-                Feature = ToGeoJsonFeature(add),
+                Feature = SdkFeatureTransportMappings.ToOgcFeature(add),
             }, ct).ConfigureAwait(false);
             addResults.Add(ToOgcSuccessResult(response.RootElement, add.Id, add.ObjectId));
         }
@@ -149,7 +147,7 @@ public sealed class HonuaMobileSdkFeatureClient : IHonuaFeatureQueryClient, IHon
             {
                 CollectionId = collectionId,
                 FeatureId = update.Id,
-                Feature = ToGeoJsonFeature(update),
+                Feature = SdkFeatureTransportMappings.ToOgcFeature(update, update.Id),
             }, ct).ConfigureAwait(false);
             updateResults.Add(ToOgcSuccessResult(response.RootElement, update.Id, update.ObjectId));
         }
@@ -162,6 +160,17 @@ public sealed class HonuaMobileSdkFeatureClient : IHonuaFeatureQueryClient, IHon
                 FeatureId = deleteId,
             }, ct).ConfigureAwait(false);
             deleteResults.Add(ToOgcSuccessResult(response.RootElement, deleteId, null));
+        }
+
+        foreach (var deleteObjectId in request.DeleteObjectIds)
+        {
+            var deleteId = SdkFeatureTransportMappings.ToOgcFeatureId(deleteObjectId);
+            using var response = await _client.DeleteOgcItemAsync(new OgcDeleteItemRequest
+            {
+                CollectionId = collectionId,
+                FeatureId = deleteId,
+            }, ct).ConfigureAwait(false);
+            deleteResults.Add(ToOgcSuccessResult(response.RootElement, deleteId, deleteObjectId));
         }
 
         return new FeatureEditResponse
@@ -202,11 +211,13 @@ public sealed class HonuaMobileSdkFeatureClient : IHonuaFeatureQueryClient, IHon
         {
             ServiceId = request.Source.ServiceId ?? throw new InvalidOperationException("FeatureServer edit requires service ID."),
             LayerId = request.Source.LayerId ?? throw new InvalidOperationException("FeatureServer edit requires layer ID."),
-            AddsJson = request.Adds.Count == 0 ? null : JsonSerializer.Serialize(request.Adds.Select(ToFeatureServerFeature), JsonOptions),
-            UpdatesJson = request.Updates.Count == 0 ? null : JsonSerializer.Serialize(request.Updates.Select(ToFeatureServerFeature), JsonOptions),
-            DeletesCsv = request.DeleteObjectIds.Count > 0
-                ? string.Join(',', request.DeleteObjectIds)
-                : request.DeleteIds.Count == 0 ? null : string.Join(',', request.DeleteIds),
+            Adds = request.Adds.Count == 0
+                ? null
+                : request.Adds.Select(SdkFeatureTransportMappings.ToFeatureServerFeature).ToList(),
+            Updates = request.Updates.Count == 0
+                ? null
+                : request.Updates.Select(SdkFeatureTransportMappings.ToFeatureServerFeature).ToList(),
+            Deletes = SdkFeatureTransportMappings.ToFeatureServerDeleteObjectIds(request),
             RollbackOnFailure = request.RollbackOnFailure,
             ForceWrite = request.ForceWrite,
         };
@@ -305,22 +316,6 @@ public sealed class HonuaMobileSdkFeatureClient : IHonuaFeatureQueryClient, IHon
             Succeeded = true,
         };
     }
-
-    private static JsonElement ToFeatureServerFeature(FeatureEditFeature feature)
-        => JsonSerializer.SerializeToElement(new Dictionary<string, object?>
-        {
-            ["attributes"] = feature.Attributes,
-            ["geometry"] = feature.Geometry,
-        }, JsonOptions);
-
-    private static JsonElement ToGeoJsonFeature(FeatureEditFeature feature)
-        => JsonSerializer.SerializeToElement(new Dictionary<string, object?>
-        {
-            ["type"] = "Feature",
-            ["id"] = feature.Id,
-            ["properties"] = feature.Attributes,
-            ["geometry"] = feature.Geometry,
-        }, JsonOptions);
 
     private static IReadOnlyDictionary<string, JsonElement> ReadJsonObject(JsonElement element)
     {

--- a/src/Honua.Mobile.Sdk/Grpc/GrpcFeatureTranslator.cs
+++ b/src/Honua.Mobile.Sdk/Grpc/GrpcFeatureTranslator.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text.Json;
 using Honua.Mobile.Sdk.Models;
+using Honua.Sdk.GeoServices.FeatureServer.Models;
 using Proto = Honua.Server.Features.Grpc.Proto;
 
 namespace Honua.Mobile.Sdk.Grpc;
@@ -67,17 +68,17 @@ public static class GrpcFeatureTranslator
             ForceWrite = request.ForceWrite,
         };
 
-        foreach (var feature in ParseFeaturePayload(request.AddsJson))
+        foreach (var feature in ParseFeaturePayload(request.Adds, request.AddsJson))
         {
             proto.Adds.Add(feature);
         }
 
-        foreach (var feature in ParseFeaturePayload(request.UpdatesJson))
+        foreach (var feature in ParseFeaturePayload(request.Updates, request.UpdatesJson))
         {
             proto.Updates.Add(feature);
         }
 
-        foreach (var objectId in ParseDeleteObjectIds(request.DeletesCsv))
+        foreach (var objectId in ParseDeleteObjectIds(request.Deletes, request.DeletesCsv))
         {
             proto.Deletes.Add(objectId);
         }
@@ -169,6 +170,16 @@ public static class GrpcFeatureTranslator
         return JsonSerializer.SerializeToDocument(payload);
     }
 
+    private static IEnumerable<Proto.Feature> ParseFeaturePayload(IReadOnlyList<FeatureServerFeature>? features, string? json)
+    {
+        if (features is { Count: > 0 })
+        {
+            return features.Select(ToFeature);
+        }
+
+        return ParseFeaturePayload(json);
+    }
+
     private static IEnumerable<Proto.Feature> ParseFeaturePayload(string? json)
     {
         if (string.IsNullOrWhiteSpace(json))
@@ -193,6 +204,9 @@ public static class GrpcFeatureTranslator
             yield return ToFeature(document.RootElement);
         }
     }
+
+    private static IEnumerable<long> ParseDeleteObjectIds(IReadOnlyList<long>? deletes, string? deletesCsv)
+        => deletes is { Count: > 0 } ? deletes : ParseDeleteObjectIds(deletesCsv);
 
     private static IEnumerable<long> ParseDeleteObjectIds(string? deletesCsv)
     {
@@ -235,6 +249,30 @@ public static class GrpcFeatureTranslator
         }
 
         if (source.TryGetProperty("geometry", out var geometryNode) && geometryNode.ValueKind == JsonValueKind.Object)
+        {
+            var geometry = ToGeometry(geometryNode);
+            if (geometry is not null)
+            {
+                feature.Geometry = geometry;
+            }
+        }
+
+        return feature;
+    }
+
+    private static Proto.Feature ToFeature(FeatureServerFeature source)
+    {
+        var feature = new Proto.Feature();
+
+        if (source.Attributes is not null)
+        {
+            foreach (var attribute in source.Attributes)
+            {
+                feature.Attributes[attribute.Key] = ToAttributeValue(attribute.Value);
+            }
+        }
+
+        if (source.Geometry is { ValueKind: JsonValueKind.Object } geometryNode)
         {
             var geometry = ToGeometry(geometryNode);
             if (geometry is not null)

--- a/src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj
+++ b/src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj
@@ -19,6 +19,8 @@
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <PackageReference Include="Honua.Sdk.Abstractions" Version="0.1.2-alpha.1" />
+    <PackageReference Include="Honua.Sdk.GeoServices" Version="0.1.2-alpha.1" />
+    <PackageReference Include="Honua.Sdk.OgcFeatures" Version="0.1.2-alpha.1" />
     <PackageReference Include="Google.Protobuf" Version="3.33.1" />
     <PackageReference Include="Grpc.Core.Api" Version="2.71.0" />
     <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
@@ -185,17 +185,8 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var query = new Dictionary<string, string?>
-        {
-            ["f"] = request.ResponseFormat,
-            ["limit"] = request.Limit?.ToString(),
-            ["offset"] = request.Offset?.ToString(),
-            ["properties"] = request.PropertyNames is { Count: > 0 } ? string.Join(',', request.PropertyNames) : null,
-            ["filter"] = request.CqlFilter,
-        };
-
         var path = $"/ogc/features/collections/{Uri.EscapeDataString(request.CollectionId)}/items";
-        return SendJsonAsync(HttpMethod.Get, path, query, null, ct);
+        return SendJsonAsync(HttpMethod.Get, path, SdkFeatureTransportMappings.ToOgcItemsQueryParameters(request), null, ct);
     }
 
     /// <summary>
@@ -211,8 +202,8 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
         ArgumentNullException.ThrowIfNull(request);
 
         var path = $"/ogc/features/collections/{Uri.EscapeDataString(request.CollectionId)}/items";
-        var payload = JsonSerializer.Serialize(request.Feature);
-        return SendJsonAsync(HttpMethod.Post, path, null, new StringContent(payload, Encoding.UTF8, "application/json"), ct);
+        var payload = SdkFeatureTransportMappings.SerializeOgcFeature(request.Feature);
+        return SendJsonAsync(HttpMethod.Post, path, null, new StringContent(payload, Encoding.UTF8, "application/geo+json"), ct);
     }
 
     /// <summary>
@@ -228,8 +219,8 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
         ArgumentNullException.ThrowIfNull(request);
 
         var path = $"/ogc/features/collections/{Uri.EscapeDataString(request.CollectionId)}/items/{Uri.EscapeDataString(request.FeatureId)}";
-        var payload = JsonSerializer.Serialize(request.Feature);
-        return SendJsonAsync(HttpMethod.Put, path, null, new StringContent(payload, Encoding.UTF8, "application/json"), ct);
+        var payload = SdkFeatureTransportMappings.SerializeOgcFeature(request.Feature);
+        return SendJsonAsync(HttpMethod.Put, path, null, new StringContent(payload, Encoding.UTF8, "application/geo+json"), ct);
     }
 
     /// <summary>
@@ -313,42 +304,19 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
 
     private Task<JsonDocument> QueryFeaturesRestAsync(QueryFeaturesRequest request, CancellationToken ct)
     {
-        var query = new Dictionary<string, string?>
-        {
-            ["f"] = request.ResponseFormat,
-            ["where"] = request.Where,
-            ["objectIds"] = request.ObjectIds is { Count: > 0 } ? string.Join(',', request.ObjectIds) : null,
-            ["outFields"] = request.OutFields is { Count: > 0 } ? string.Join(',', request.OutFields) : "*",
-            ["returnGeometry"] = request.ReturnGeometry ? "true" : "false",
-            ["resultOffset"] = request.ResultOffset?.ToString(),
-            ["resultRecordCount"] = request.ResultRecordCount?.ToString(),
-            ["orderByFields"] = request.OrderBy,
-            ["returnDistinctValues"] = request.ReturnDistinct ? "true" : null,
-            ["returnCountOnly"] = request.ReturnCountOnly ? "true" : null,
-            ["returnIdsOnly"] = request.ReturnIdsOnly ? "true" : null,
-            ["returnExtentOnly"] = request.ReturnExtentOnly ? "true" : null,
-        };
-
         var path = $"/rest/services/{Uri.EscapeDataString(request.ServiceId)}/FeatureServer/{request.LayerId}/query";
-        return SendJsonAsync(HttpMethod.Get, path, query, content: null, ct);
+        return SendJsonAsync(HttpMethod.Get, path, SdkFeatureTransportMappings.ToFeatureServerQueryParameters(request), content: null, ct);
     }
 
     private Task<JsonDocument> ApplyEditsRestAsync(ApplyEditsRequest request, CancellationToken ct)
     {
         var path = $"/rest/services/{Uri.EscapeDataString(request.ServiceId)}/FeatureServer/{request.LayerId}/applyEdits";
-        var body = new Dictionary<string, string?>
-        {
-            ["f"] = request.ResponseFormat,
-            ["adds"] = request.AddsJson,
-            ["updates"] = request.UpdatesJson,
-            ["deletes"] = request.DeletesCsv,
-            ["rollbackOnFailure"] = request.RollbackOnFailure ? "true" : "false",
-            ["forceWrite"] = request.ForceWrite ? "true" : null,
-        }
-        .Where(pair => !string.IsNullOrWhiteSpace(pair.Value))
-        .ToDictionary(pair => pair.Key, pair => pair.Value!);
-
-        return SendJsonAsync(HttpMethod.Post, path, query: null, new FormUrlEncodedContent(body), ct);
+        return SendJsonAsync(
+            HttpMethod.Post,
+            path,
+            query: null,
+            new FormUrlEncodedContent(SdkFeatureTransportMappings.ToFeatureServerEditFormParameters(request)),
+            ct);
     }
 
     internal async Task<JsonDocument> SendJsonAsync(

--- a/src/Honua.Mobile.Sdk/Models/Requests.cs
+++ b/src/Honua.Mobile.Sdk/Models/Requests.cs
@@ -1,3 +1,5 @@
+using Honua.Sdk.GeoServices.FeatureServer.Models;
+
 namespace Honua.Mobile.Sdk.Models;
 
 public sealed class QueryFeaturesRequest
@@ -36,6 +38,12 @@ public sealed class ApplyEditsRequest
     public required string ServiceId { get; init; }
 
     public required int LayerId { get; init; }
+
+    public IReadOnlyList<FeatureServerFeature>? Adds { get; init; }
+
+    public IReadOnlyList<FeatureServerFeature>? Updates { get; init; }
+
+    public IReadOnlyList<long>? Deletes { get; init; }
 
     public string? AddsJson { get; init; }
 

--- a/src/Honua.Mobile.Sdk/SdkFeatureTransportMappings.cs
+++ b/src/Honua.Mobile.Sdk/SdkFeatureTransportMappings.cs
@@ -1,0 +1,189 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Mobile.Sdk.Models;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.GeoServices.FeatureServer.Models;
+using Honua.Sdk.OgcFeatures.Models;
+
+namespace Honua.Mobile.Sdk;
+
+internal static class SdkFeatureTransportMappings
+{
+    public static IReadOnlyDictionary<string, string?> ToFeatureServerQueryParameters(QueryFeaturesRequest request)
+    {
+        var query = ToFeatureServerQueryParams(request);
+        return new Dictionary<string, string?>
+        {
+            ["f"] = request.ResponseFormat,
+            ["where"] = query.Where ?? "1=1",
+            ["objectIds"] = query.ObjectIds is { Count: > 0 } ? JoinInvariant(query.ObjectIds) : null,
+            ["outFields"] = query.OutFields,
+            ["returnGeometry"] = query.ReturnGeometry is false ? "false" : "true",
+            ["resultOffset"] = query.ResultOffset?.ToString(CultureInfo.InvariantCulture),
+            ["resultRecordCount"] = query.ResultRecordCount?.ToString(CultureInfo.InvariantCulture),
+            ["orderByFields"] = query.OrderByFields,
+            ["returnDistinctValues"] = query.ReturnDistinctValues is true ? "true" : null,
+            ["returnCountOnly"] = request.ReturnCountOnly ? "true" : null,
+            ["returnIdsOnly"] = request.ReturnIdsOnly ? "true" : null,
+            ["returnExtentOnly"] = request.ReturnExtentOnly ? "true" : null,
+        };
+    }
+
+    public static IReadOnlyDictionary<string, string> ToFeatureServerEditFormParameters(ApplyEditsRequest request)
+    {
+        var edit = new FeatureServerEditRequest
+        {
+            Adds = request.Adds,
+            Updates = request.Updates,
+            Deletes = request.Deletes,
+            RollbackOnFailure = request.RollbackOnFailure,
+        };
+
+        var body = new Dictionary<string, string?>
+        {
+            ["f"] = request.ResponseFormat,
+            ["adds"] = edit.Adds is { Count: > 0 } ? SerializeFeatureServerFeatures(edit.Adds) : request.AddsJson,
+            ["updates"] = edit.Updates is { Count: > 0 } ? SerializeFeatureServerFeatures(edit.Updates) : request.UpdatesJson,
+            ["deletes"] = edit.Deletes is { Count: > 0 } ? JoinInvariant(edit.Deletes) : request.DeletesCsv,
+            ["rollbackOnFailure"] = edit.RollbackOnFailure ? "true" : "false",
+            ["forceWrite"] = request.ForceWrite ? "true" : null,
+        };
+
+        return body
+            .Where(pair => !string.IsNullOrWhiteSpace(pair.Value))
+            .ToDictionary(pair => pair.Key, pair => pair.Value!);
+    }
+
+    public static IReadOnlyDictionary<string, string?> ToOgcItemsQueryParameters(OgcItemsRequest request)
+    {
+        var query = ToOgcItemsParams(request);
+        return new Dictionary<string, string?>
+        {
+            ["f"] = request.ResponseFormat,
+            ["limit"] = query.Limit?.ToString(CultureInfo.InvariantCulture),
+            ["offset"] = query.Offset?.ToString(CultureInfo.InvariantCulture),
+            ["properties"] = query.Properties,
+            ["filter"] = query.Filter,
+        };
+    }
+
+    public static FeatureServerFeature ToFeatureServerFeature(FeatureEditFeature feature)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+
+        return new FeatureServerFeature
+        {
+            Attributes = feature.Attributes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone()),
+            Geometry = feature.Geometry.HasValue ? feature.Geometry.Value.Clone() : null,
+        };
+    }
+
+    public static IReadOnlyList<long>? ToFeatureServerDeleteObjectIds(FeatureEditRequest request)
+    {
+        var objectIds = new List<long>(request.DeleteObjectIds);
+        foreach (var id in request.DeleteIds)
+        {
+            if (!long.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
+            {
+                throw new ArgumentException("FeatureServer feature deletes require numeric feature IDs.", nameof(request));
+            }
+
+            objectIds.Add(objectId);
+        }
+
+        return objectIds.Count == 0 ? null : objectIds;
+    }
+
+    public static OgcFeature ToOgcFeature(FeatureEditFeature feature, string? featureId = null)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+
+        var id = featureId ?? ResolveOptionalFeatureId(feature);
+        return new OgcFeature
+        {
+            Id = id is null ? null : JsonSerializer.SerializeToElement(id),
+            Geometry = feature.Geometry.HasValue ? feature.Geometry.Value.Clone() : null,
+            Properties = feature.Attributes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone()),
+        };
+    }
+
+    public static string ToOgcFeatureId(long objectId)
+        => objectId.ToString(CultureInfo.InvariantCulture);
+
+    public static string SerializeOgcFeature(object feature)
+        => feature is OgcFeature ogcFeature
+            ? JsonSerializer.Serialize(ogcFeature, HonuaMobileSdkTransportJsonContext.Default.OgcFeature)
+            : JsonSerializer.Serialize(feature);
+
+    private static FeatureServerQueryParams ToFeatureServerQueryParams(QueryFeaturesRequest request)
+        => new()
+        {
+            Where = request.Where,
+            ObjectIds = request.ObjectIds,
+            OutFields = request.OutFields is { Count: > 0 } ? string.Join(',', request.OutFields) : "*",
+            ReturnGeometry = request.ReturnGeometry,
+            ResultOffset = request.ResultOffset,
+            ResultRecordCount = request.ResultRecordCount,
+            OrderByFields = request.OrderBy,
+            ReturnDistinctValues = request.ReturnDistinct ? true : null,
+            Format = ToFeatureServerFormat(request.ResponseFormat),
+        };
+
+    private static OgcItemsParams ToOgcItemsParams(OgcItemsRequest request)
+        => new()
+        {
+            Limit = request.Limit,
+            Offset = request.Offset,
+            Properties = request.PropertyNames is { Count: > 0 } ? string.Join(',', request.PropertyNames) : null,
+            Filter = request.CqlFilter,
+            Format = ToOgcFeaturesFormat(request.ResponseFormat),
+        };
+
+    private static string SerializeFeatureServerFeatures(IReadOnlyList<FeatureServerFeature> features)
+        => JsonSerializer.Serialize(
+            features.ToArray(),
+            HonuaMobileSdkTransportJsonContext.Default.FeatureServerFeatureArray);
+
+    private static string JoinInvariant(IEnumerable<long> values)
+        => string.Join(',', values.Select(value => value.ToString(CultureInfo.InvariantCulture)));
+
+    private static string? ResolveOptionalFeatureId(FeatureEditFeature feature)
+        => !string.IsNullOrWhiteSpace(feature.Id)
+            ? feature.Id
+            : feature.ObjectId?.ToString(CultureInfo.InvariantCulture);
+
+    private static FeatureServerFormat? ToFeatureServerFormat(string? responseFormat)
+        => responseFormat?.Trim().ToLowerInvariant() switch
+        {
+            null or "" or "json" => FeatureServerFormat.Json,
+            "geojson" => FeatureServerFormat.GeoJson,
+            "pbf" => FeatureServerFormat.Pbf,
+            "flatgeobuf" => FeatureServerFormat.FlatGeobuf,
+            "parquet" => FeatureServerFormat.Parquet,
+            _ => null,
+        };
+
+    private static OgcFeaturesFormat? ToOgcFeaturesFormat(string? responseFormat)
+        => responseFormat?.Trim().ToLowerInvariant() switch
+        {
+            null or "" or "json" => OgcFeaturesFormat.Json,
+            "geojson" => OgcFeaturesFormat.GeoJson,
+            "html" => OgcFeaturesFormat.Html,
+            "gml" => OgcFeaturesFormat.Gml,
+            "csv" => OgcFeaturesFormat.Csv,
+            "flatgeobuf" => OgcFeaturesFormat.FlatGeobuf,
+            "parquet" => OgcFeaturesFormat.Parquet,
+            _ => null,
+        };
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(FeatureServerFeature[]))]
+[JsonSerializable(typeof(OgcFeature))]
+[JsonSerializable(typeof(JsonElement))]
+internal sealed partial class HonuaMobileSdkTransportJsonContext : JsonSerializerContext
+{
+}

--- a/tests/Honua.Mobile.Sdk.Tests/GrpcFeatureTranslatorTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/GrpcFeatureTranslatorTests.cs
@@ -1,5 +1,7 @@
+using System.Text.Json;
 using Honua.Mobile.Sdk.Grpc;
 using Honua.Mobile.Sdk.Models;
+using Honua.Sdk.GeoServices.FeatureServer.Models;
 using Proto = Honua.Server.Features.Grpc.Proto;
 
 namespace Honua.Mobile.Sdk.Tests;
@@ -86,6 +88,38 @@ public sealed class GrpcFeatureTranslatorTests
 
         Assert.Equal(11L, proto.Updates[0].Id);
         Assert.Equal(4L, proto.Updates[0].Attributes["priority"].Int64Value);
+    }
+
+    [Fact]
+    public void ToProtoApplyEditsRequest_MapsSdkFeatureServerModels()
+    {
+        var request = new ApplyEditsRequest
+        {
+            ServiceId = "default",
+            LayerId = 0,
+            Adds =
+            [
+                new FeatureServerFeature
+                {
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["asset_id"] = JsonSerializer.SerializeToElement("A-1"),
+                        ["priority"] = JsonSerializer.SerializeToElement(3),
+                    },
+                    Geometry = JsonSerializer.SerializeToElement(new { x = -157.8583, y = 21.3069 }),
+                },
+            ],
+            Deletes = [9, 10],
+        };
+
+        var proto = GrpcFeatureTranslator.ToProtoApplyEditsRequest(request);
+
+        Assert.Single(proto.Adds);
+        Assert.Equal([9L, 10L], proto.Deletes);
+        Assert.Equal("A-1", proto.Adds[0].Attributes["asset_id"].StringValue);
+        Assert.Equal(3L, proto.Adds[0].Attributes["priority"].Int64Value);
+        Assert.Equal(-157.8583, proto.Adds[0].Geometry.Point.X, 4);
+        Assert.Equal(21.3069, proto.Adds[0].Geometry.Point.Y, 4);
     }
 
     [Fact]

--- a/tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj
+++ b/tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Honua.Sdk.Abstractions" Version="0.1.2-alpha.1" />
+    <PackageReference Include="Honua.Sdk.GeoServices" Version="0.1.2-alpha.1" />
+    <PackageReference Include="Honua.Sdk.OgcFeatures" Version="0.1.2-alpha.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/tests/Honua.Mobile.Sdk.Tests/HonuaMobileClientHttpTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/HonuaMobileClientHttpTests.cs
@@ -3,11 +3,24 @@ using System.Text;
 using System.Text.Json;
 using Honua.Mobile.Sdk;
 using Honua.Mobile.Sdk.Models;
+using Honua.Sdk.GeoServices.FeatureServer.Models;
+using Honua.Sdk.OgcFeatures.Models;
 
 namespace Honua.Mobile.Sdk.Tests;
 
 public sealed class HonuaMobileClientHttpTests
 {
+    [Fact]
+    public void HonuaMobileSdk_ReferencesSdkTransportPackages()
+    {
+        var references = typeof(HonuaMobileClient).Assembly.GetReferencedAssemblies()
+            .Select(reference => reference.Name)
+            .ToArray();
+
+        Assert.Contains("Honua.Sdk.GeoServices", references);
+        Assert.Contains("Honua.Sdk.OgcFeatures", references);
+    }
+
     [Fact]
     public async Task QueryFeaturesAsync_Success_ReturnsEsriJson()
     {
@@ -78,6 +91,60 @@ public sealed class HonuaMobileClientHttpTests
     }
 
     [Fact]
+    public async Task ApplyEditsAsync_WithSdkFeatureServerModels_SerializesEditForm()
+    {
+        string? capturedBody = null;
+        var handler = new StubHttpMessageHandler(async (request, ct) =>
+        {
+            capturedBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {
+                        "addResults": [{ "objectId": 42, "success": true }],
+                        "updateResults": [],
+                        "deleteResults": [{ "objectId": 7, "success": true }]
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"),
+            };
+        });
+
+        var client = CreateClient(handler);
+        using var result = await client.ApplyEditsAsync(new ApplyEditsRequest
+        {
+            ServiceId = "default",
+            LayerId = 0,
+            Adds =
+            [
+                new FeatureServerFeature
+                {
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["name"] = JsonSerializer.SerializeToElement("Test"),
+                    },
+                    Geometry = JsonSerializer.SerializeToElement(new { x = -157.8, y = 21.3 }),
+                },
+            ],
+            Deletes = [7],
+            RollbackOnFailure = true,
+        });
+
+        Assert.NotNull(capturedBody);
+        var form = ParseForm(capturedBody);
+        Assert.True(bool.Parse(form["rollbackOnFailure"]));
+        Assert.Equal("7", form["deletes"]);
+        Assert.Contains("\"name\":\"Test\"", form["adds"]);
+        Assert.Contains("\"geometry\"", form["adds"]);
+        Assert.True(result.RootElement.GetProperty("addResults")[0].GetProperty("success").GetBoolean());
+    }
+
+    [Fact]
     public async Task GetOgcCollectionsAsync_Success_ReturnsCollections()
     {
         var responseJson = """
@@ -139,6 +206,50 @@ public sealed class HonuaMobileClientHttpTests
         var features = result.RootElement.GetProperty("features");
         Assert.Equal(1, features.GetArrayLength());
         Assert.Equal("HQ", features[0].GetProperty("properties").GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task CreateOgcItemAsync_WithSdkOgcFeature_SendsGeoJsonContent()
+    {
+        string? capturedBody = null;
+        string? capturedMediaType = null;
+        var handler = new StubHttpMessageHandler(async (request, ct) =>
+        {
+            capturedMediaType = request.Content?.Headers.ContentType?.MediaType;
+            capturedBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"type":"Feature","id":"building-1"}""", Encoding.UTF8, "application/json"),
+            };
+        });
+
+        var client = CreateClient(handler);
+        using var result = await client.CreateOgcItemAsync(new OgcCreateItemRequest
+        {
+            CollectionId = "buildings",
+            Feature = new OgcFeature
+            {
+                Id = JsonSerializer.SerializeToElement("building-1"),
+                Properties = new Dictionary<string, JsonElement>
+                {
+                    ["name"] = JsonSerializer.SerializeToElement("HQ"),
+                },
+                Geometry = JsonSerializer.SerializeToElement(new
+                {
+                    type = "Point",
+                    coordinates = new[] { -157.8, 21.3 },
+                }),
+            },
+        });
+
+        Assert.Equal("application/geo+json", capturedMediaType);
+        Assert.NotNull(capturedBody);
+        Assert.Contains("\"type\":\"Feature\"", capturedBody);
+        Assert.Contains("\"name\":\"HQ\"", capturedBody);
+        Assert.Equal("building-1", result.RootElement.GetProperty("id").GetString());
     }
 
     [Fact]
@@ -325,6 +436,14 @@ public sealed class HonuaMobileClientHttpTests
             },
             options);
     }
+
+    private static IReadOnlyDictionary<string, string> ParseForm(string body)
+        => body
+            .Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => part.Split('=', 2))
+            .ToDictionary(
+                pair => Uri.UnescapeDataString(pair[0]),
+                pair => pair.Length == 2 ? Uri.UnescapeDataString(pair[1]).Replace("+", " ", StringComparison.Ordinal) : string.Empty);
 
     private sealed class StubHttpMessageHandler : HttpMessageHandler
     {

--- a/tests/Honua.Mobile.Sdk.Tests/HonuaMobileSdkFeatureClientTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/HonuaMobileSdkFeatureClientTests.cs
@@ -125,6 +125,32 @@ public sealed class HonuaMobileSdkFeatureClientTests
         Assert.Equal(7, result.DeleteResults[0].ObjectId);
     }
 
+    [Fact]
+    public async Task ApplyEditsAsync_OgcRequest_DeletesObjectIdsThroughSdkFeatureContract()
+    {
+        var capturedPaths = new List<string>();
+        var handler = new StubHttpMessageHandler((request, _) =>
+        {
+            capturedPaths.Add(request.RequestUri!.PathAndQuery);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+            });
+        });
+
+        var adapter = CreateAdapter(handler);
+        var result = await adapter.ApplyEditsAsync(new FeatureEditRequest
+        {
+            Source = new FeatureSource { CollectionId = "buildings" },
+            DeleteObjectIds = [42],
+        });
+
+        Assert.Contains("/ogc/features/collections/buildings/items/42", capturedPaths);
+        Assert.True(result.Succeeded);
+        Assert.Equal("42", result.DeleteResults[0].Id);
+        Assert.Equal(42, result.DeleteResults[0].ObjectId);
+    }
+
     private static HonuaMobileSdkFeatureClient CreateAdapter(HttpMessageHandler handler)
     {
         var options = new HonuaMobileClientOptions


### PR DESCRIPTION
## Summary
- add Honua.Sdk.GeoServices and Honua.Sdk.OgcFeatures package references to the mobile SDK transport layer
- route FeatureServer and OGC REST parameter/payload construction through SDK package models while preserving mobile auth and fallback behavior
- support typed SDK FeatureServer edit payloads in both REST and gRPC paths, and align Microsoft.Extensions package pins required by the SDK transport packages

Refs #54. This is the FeatureServer/OGC transport-package slice; proto/gRPC canonical package cleanup remains a separate geospatial-grpc/Sdk.Grpc boundary slice.

## Protocol compatibility
- no proto schema changes
- legacy raw JSON FeatureServer edit payloads still work
- typed SDK FeatureServer edit models now feed both REST and the existing gRPC translator
- canonical proto ownership remains unchanged in geospatial-grpc

## Validation
- dotnet restore Honua.Mobile.sln --configfile /tmp/honua-mobile-local-nuget.config
- dotnet test Honua.Mobile.sln --configuration Release --no-restore
- dotnet format Honua.Mobile.sln --verify-no-changes --verbosity minimal --no-restore
- git diff --check