### PR TITLE
sdk: consume attachment contracts

### DIFF
--- a/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
+++ b/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
@@ -6,7 +6,7 @@
   "compatibility": {
     "mobileBaseline": {
       "repository": "honua-io/honua-mobile",
-      "ref": "main after honua-mobile#65",
+      "ref": "main after honua-mobile#66 plus attachment package slice",
       "packageVersion": "unreleased-source"
     },
     "sdkBaseline": {
@@ -15,27 +15,27 @@
       "packages": [
         {
           "packageId": "Honua.Sdk.Abstractions",
-          "version": "0.1.3-alpha.1"
+          "version": "0.1.4-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.Offline.Abstractions",
-          "version": "0.1.3-alpha.1"
+          "version": "0.1.4-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.Offline",
-          "version": "0.1.3-alpha.1"
+          "version": "0.1.4-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.Grpc",
-          "version": "0.1.3-alpha.1"
+          "version": "0.1.4-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.GeoServices",
-          "version": "0.1.3-alpha.1"
+          "version": "0.1.4-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.OgcFeatures",
-          "version": "0.1.3-alpha.1"
+          "version": "0.1.4-alpha.1"
         }
       ]
     }
@@ -94,6 +94,30 @@
       "mobileDisposition": "adapter-required",
       "migrationIssue": "honua-mobile#54",
       "notes": "Offline queue rows keep mobile retry metadata, but uploaded payloads should map to FeatureEditRequest."
+    },
+    {
+      "id": "feature-attachments",
+      "displayName": "Feature attachment metadata and content operations",
+      "owner": "honua-sdk-dotnet",
+      "authoritativePackage": "Honua.Sdk.Abstractions",
+      "authoritativeTypes": [
+        "Honua.Sdk.Abstractions.Features.IHonuaFeatureAttachmentClient",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentCapabilities",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentInfo",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentListRequest",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentDownloadRequest",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentAddRequest",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentUpdateRequest",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentDeleteRequest",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentResult"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Sdk.Features.HonuaMobileSdkFeatureClient",
+        "Honua.Mobile.Offline.Sync.HonuaMobileSdkFeatureClient"
+      ],
+      "mobileDisposition": "adapter-only",
+      "migrationIssue": "honua-mobile#54",
+      "notes": "Mobile exposes attachment support through SDK contracts and keeps only runtime auth/DI adapters."
     },
     {
       "id": "geometry",

--- a/docs/guides/mobile-contract-harmonization.md
+++ b/docs/guides/mobile-contract-harmonization.md
@@ -12,7 +12,7 @@ the same ownership map without referencing mobile assemblies.
 
 | Mobile baseline | Shared SDK baseline | Status |
 |-----------------|---------------------|--------|
-| `honua-mobile` source packages from `main` after #65 | `Honua.Sdk.*` `0.1.3-alpha.1` | Fixture-level compatibility for shared feature, source, edit, and offline contracts |
+| `honua-mobile` source packages from `main` after #66 plus attachment adapter work | `Honua.Sdk.*` `0.1.4-alpha.1` | Fixture-level compatibility for shared feature, attachment, source, edit, and offline contracts |
 
 `honua-mobile` does not currently publish versioned NuGet packages. Until it
 does, compatibility is stated as source-baseline compatibility against the
@@ -25,6 +25,7 @@ published shared SDK package versions above. When mobile packages gain
 |--------------|-------|--------------------|
 | Feature query requests/results | `honua-sdk-dotnet` / `Honua.Sdk.Abstractions` | Mobile DTOs are transport shims; add adapters to `FeatureQueryRequest` and `FeatureQueryResult`. |
 | Feature edit envelopes/results | `honua-sdk-dotnet` / `Honua.Sdk.Abstractions` | Mobile edit DTOs and offline queue payloads should map to `FeatureEditRequest`. |
+| Feature attachment operations | `honua-sdk-dotnet` / `Honua.Sdk.Abstractions` | Mobile exposes `IHonuaFeatureAttachmentClient` through adapters only; no mobile-local attachment DTOs. |
 | Geometry and spatial references | Split pending SDK geometry package | Keep mobile coordinates at platform edges until SDK geometry contracts graduate. |
 | Offline sync state, journals, conflicts | `Honua.Sdk.Offline.Abstractions` plus mobile runtime adapters | Mobile owns native queue persistence, scheduling, and GeoPackage behavior; SDK owns portable manifests, journals, checkpoints, retry checkpoints, and conflict envelopes. |
 | Form-related feature schemas | Split | SDK source schema owns provider-neutral fields; mobile owns form rendering, validation, calculated fields, and record workflow. |
@@ -42,6 +43,9 @@ published shared SDK package versions above. When mobile packages gain
   `FeatureQueryResult`, `FeatureSource`, and `SourceDescriptor`.
 - New provider-neutral feature edit code should target
   `FeatureEditRequest`, `FeatureEditResponse`, and related edit result models.
+- New provider-neutral attachment code should target
+  `IHonuaFeatureAttachmentClient` and the SDK `FeatureAttachment*` request/result
+  contracts.
 - Mobile-only APIs may keep device, MAUI, GeoPackage, background execution,
   camera/location, route-location-provider, display, and offline file-system
   concerns.

--- a/src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
+++ b/src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
@@ -7,9 +7,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Honua.Sdk.Abstractions" Version="0.1.3-alpha.1" />
-    <PackageReference Include="Honua.Sdk.Offline" Version="0.1.3-alpha.1" />
-    <PackageReference Include="Honua.Sdk.Offline.Abstractions" Version="0.1.3-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Abstractions" Version="0.1.4-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Offline" Version="0.1.4-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Offline.Abstractions" Version="0.1.4-alpha.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
   </ItemGroup>

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -174,6 +174,7 @@ public static class HonuaMobileServiceCollectionExtensions
         services.AddSingleton<HonuaMobileSdkFeatureClient>();
         services.AddSingleton<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<SdkFeatureClient>());
         services.AddSingleton<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<SdkFeatureClient>());
+        services.AddSingleton<IHonuaFeatureAttachmentClient>(sp => sp.GetRequiredService<SdkFeatureClient>());
         services.AddSingleton<SdkOfflineFeatureStore>(sp => sp.GetRequiredService<GeoPackageSdkOfflineStoreAdapter>());
         services.AddSingleton<SdkOfflineChangeJournal>(sp => sp.GetRequiredService<GeoPackageSdkOfflineStoreAdapter>());
         services.AddSingleton<SdkOfflineCheckpointStore>(sp => sp.GetRequiredService<GeoPackageSdkOfflineStoreAdapter>());

--- a/src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj
+++ b/src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj
@@ -6,9 +6,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Honua.Sdk.Abstractions" Version="0.1.3-alpha.1" />
-    <PackageReference Include="Honua.Sdk.Offline" Version="0.1.3-alpha.1" />
-    <PackageReference Include="Honua.Sdk.Offline.Abstractions" Version="0.1.3-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Abstractions" Version="0.1.4-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Offline" Version="0.1.4-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Offline.Abstractions" Version="0.1.4-alpha.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
   </ItemGroup>

--- a/src/Honua.Mobile.Offline/Sync/HonuaMobileSdkFeatureClient.cs
+++ b/src/Honua.Mobile.Offline/Sync/HonuaMobileSdkFeatureClient.cs
@@ -8,7 +8,10 @@ namespace Honua.Mobile.Offline.Sync;
 /// <summary>
 /// Backward-compatible offline namespace shim for the SDK feature adapter.
 /// </summary>
-public sealed class HonuaMobileSdkFeatureClient : IHonuaFeatureQueryClient, IHonuaFeatureEditClient
+public sealed class HonuaMobileSdkFeatureClient :
+    IHonuaFeatureQueryClient,
+    IHonuaFeatureEditClient,
+    IHonuaFeatureAttachmentClient
 {
     private readonly SdkFeatureClient _inner;
 
@@ -28,6 +31,9 @@ public sealed class HonuaMobileSdkFeatureClient : IHonuaFeatureQueryClient, IHon
     public FeatureEditCapabilities EditCapabilities => _inner.EditCapabilities;
 
     /// <inheritdoc />
+    public FeatureAttachmentCapabilities AttachmentCapabilities => _inner.AttachmentCapabilities;
+
+    /// <inheritdoc />
     public Task<FeatureQueryResult> QueryAsync(FeatureQueryRequest request, CancellationToken ct = default)
         => _inner.QueryAsync(request, ct);
 
@@ -45,4 +51,34 @@ public sealed class HonuaMobileSdkFeatureClient : IHonuaFeatureQueryClient, IHon
     /// <inheritdoc />
     public Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken ct = default)
         => _inner.ApplyEditsAsync(request, ct);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<FeatureAttachmentInfo>> ListAttachmentsAsync(
+        FeatureAttachmentListRequest request,
+        CancellationToken ct = default)
+        => _inner.ListAttachmentsAsync(request, ct);
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentContent> DownloadAttachmentAsync(
+        FeatureAttachmentDownloadRequest request,
+        CancellationToken ct = default)
+        => _inner.DownloadAttachmentAsync(request, ct);
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentResult> AddAttachmentAsync(
+        FeatureAttachmentAddRequest request,
+        CancellationToken ct = default)
+        => _inner.AddAttachmentAsync(request, ct);
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentResult> UpdateAttachmentAsync(
+        FeatureAttachmentUpdateRequest request,
+        CancellationToken ct = default)
+        => _inner.UpdateAttachmentAsync(request, ct);
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentResult> DeleteAttachmentAsync(
+        FeatureAttachmentDeleteRequest request,
+        CancellationToken ct = default)
+        => _inner.DeleteAttachmentAsync(request, ct);
 }

--- a/src/Honua.Mobile.Sdk/Features/HonuaMobileSdkFeatureClient.cs
+++ b/src/Honua.Mobile.Sdk/Features/HonuaMobileSdkFeatureClient.cs
@@ -9,7 +9,10 @@ namespace Honua.Mobile.Sdk.Features;
 /// <summary>
 /// Adapts <see cref="HonuaMobileClient"/> to the SDK feature query and edit abstractions.
 /// </summary>
-public sealed class HonuaMobileSdkFeatureClient : IHonuaFeatureQueryClient, IHonuaFeatureEditClient
+public sealed class HonuaMobileSdkFeatureClient :
+    IHonuaFeatureQueryClient,
+    IHonuaFeatureEditClient,
+    IHonuaFeatureAttachmentClient
 {
     private readonly HonuaMobileClient _client;
 
@@ -33,6 +36,17 @@ public sealed class HonuaMobileSdkFeatureClient : IHonuaFeatureQueryClient, IHon
         SupportsDeletes = true,
         SupportsRollbackOnFailure = true,
         NativeSurface = "HonuaMobileClient",
+    };
+
+    /// <inheritdoc />
+    public FeatureAttachmentCapabilities AttachmentCapabilities { get; } = new()
+    {
+        SupportsList = true,
+        SupportsDownload = true,
+        SupportsAdd = true,
+        SupportsUpdate = true,
+        SupportsDelete = true,
+        NativeSurface = "HonuaMobileClient FeatureServer attachments",
     };
 
     /// <inheritdoc />
@@ -111,6 +125,80 @@ public sealed class HonuaMobileSdkFeatureClient : IHonuaFeatureQueryClient, IHon
             ProviderName = ProviderName,
             Error = new FeatureEditError { Message = "Feature edit requires either an OGC collection ID or FeatureServer service/layer identifiers." },
         };
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<FeatureAttachmentInfo>> ListAttachmentsAsync(
+        FeatureAttachmentListRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        EnsureFeatureServerAttachmentSource(request.Source);
+        return _client.ListAttachmentsAsync(request, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentContent> DownloadAttachmentAsync(
+        FeatureAttachmentDownloadRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        EnsureFeatureServerAttachmentSource(request.Source);
+        return _client.DownloadAttachmentAsync(request, ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<FeatureAttachmentResult> AddAttachmentAsync(
+        FeatureAttachmentAddRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        EnsureFeatureServerAttachmentSource(request.Source);
+
+        try
+        {
+            return await _client.AddAttachmentAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (HonuaMobileApiException ex)
+        {
+            return ToAttachmentErrorResult(ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<FeatureAttachmentResult> UpdateAttachmentAsync(
+        FeatureAttachmentUpdateRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        EnsureFeatureServerAttachmentSource(request.Source);
+
+        try
+        {
+            return await _client.UpdateAttachmentAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (HonuaMobileApiException ex)
+        {
+            return ToAttachmentErrorResult(ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<FeatureAttachmentResult> DeleteAttachmentAsync(
+        FeatureAttachmentDeleteRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        EnsureFeatureServerAttachmentSource(request.Source);
+
+        try
+        {
+            return await _client.DeleteAttachmentAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (HonuaMobileApiException ex)
+        {
+            return ToAttachmentErrorResult(ex);
+        }
     }
 
     private async Task<FeatureEditResponse> ApplyOgcEditsAsync(FeatureEditRequest request, CancellationToken ct)
@@ -220,6 +308,26 @@ public sealed class HonuaMobileSdkFeatureClient : IHonuaFeatureQueryClient, IHon
             Deletes = SdkFeatureTransportMappings.ToFeatureServerDeleteObjectIds(request),
             RollbackOnFailure = request.RollbackOnFailure,
             ForceWrite = request.ForceWrite,
+        };
+
+    private static void EnsureFeatureServerAttachmentSource(FeatureSource source)
+    {
+        if (string.IsNullOrWhiteSpace(source.ServiceId) || !source.LayerId.HasValue)
+        {
+            throw new InvalidOperationException(
+                "Mobile attachment operations currently require FeatureServer service and layer identifiers.");
+        }
+    }
+
+    private static FeatureAttachmentResult ToAttachmentErrorResult(HonuaMobileApiException exception)
+        => new()
+        {
+            Succeeded = false,
+            Error = new FeatureEditError
+            {
+                Code = (int)exception.StatusCode,
+                Message = exception.Message,
+            },
         };
 
     private static FeatureQueryResult ParseQueryResult(JsonElement root, FeatureQueryRequest request, string providerName)

--- a/src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj
+++ b/src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj
@@ -22,10 +22,10 @@
 
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-    <PackageReference Include="Honua.Sdk.Abstractions" Version="0.1.3-alpha.1" />
-    <PackageReference Include="Honua.Sdk.GeoServices" Version="0.1.3-alpha.1" />
-    <PackageReference Include="Honua.Sdk.Grpc" Version="0.1.3-alpha.1" />
-    <PackageReference Include="Honua.Sdk.OgcFeatures" Version="0.1.3-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Abstractions" Version="0.1.4-alpha.1" />
+    <PackageReference Include="Honua.Sdk.GeoServices" Version="0.1.4-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Grpc" Version="0.1.4-alpha.1" />
+    <PackageReference Include="Honua.Sdk.OgcFeatures" Version="0.1.4-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Honua.Mobile.Sdk.Models;
 using Honua.Mobile.Sdk.Routing;
 using Honua.Mobile.Sdk.Scenes;
+using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.GeoServices.FeatureServer;
 using Honua.Sdk.GeoServices.FeatureServer.Exceptions;
 using Honua.Sdk.Grpc;
@@ -174,6 +175,116 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
         }
 
         return await ApplyEditsRestAsync(request, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Lists FeatureServer attachments using the shared SDK attachment contract.
+    /// </summary>
+    /// <param name="request">SDK attachment list request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Attachment metadata for the requested feature.</returns>
+    public async Task<IReadOnlyList<FeatureAttachmentInfo>> ListAttachmentsAsync(
+        FeatureAttachmentListRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            return await _featureServerClient.ListAttachmentsAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (HonuaFeatureServerException ex)
+        {
+            throw ToMobileApiException("FeatureServer attachments", ex);
+        }
+    }
+
+    /// <summary>
+    /// Downloads one FeatureServer attachment using the shared SDK attachment contract.
+    /// </summary>
+    /// <param name="request">SDK attachment download request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Downloaded attachment content. Dispose the returned content stream when finished.</returns>
+    public async Task<FeatureAttachmentContent> DownloadAttachmentAsync(
+        FeatureAttachmentDownloadRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            return await _featureServerClient.DownloadAttachmentAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (HonuaFeatureServerException ex)
+        {
+            throw ToMobileApiException("FeatureServer attachments", ex);
+        }
+    }
+
+    /// <summary>
+    /// Adds one FeatureServer attachment using the shared SDK attachment contract.
+    /// </summary>
+    /// <param name="request">SDK attachment add request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Attachment edit result.</returns>
+    public async Task<FeatureAttachmentResult> AddAttachmentAsync(
+        FeatureAttachmentAddRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            return await _featureServerClient.AddAttachmentAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (HonuaFeatureServerException ex)
+        {
+            throw ToMobileApiException("FeatureServer attachments", ex);
+        }
+    }
+
+    /// <summary>
+    /// Updates one FeatureServer attachment using the shared SDK attachment contract.
+    /// </summary>
+    /// <param name="request">SDK attachment update request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Attachment edit result.</returns>
+    public async Task<FeatureAttachmentResult> UpdateAttachmentAsync(
+        FeatureAttachmentUpdateRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            return await _featureServerClient.UpdateAttachmentAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (HonuaFeatureServerException ex)
+        {
+            throw ToMobileApiException("FeatureServer attachments", ex);
+        }
+    }
+
+    /// <summary>
+    /// Deletes one FeatureServer attachment using the shared SDK attachment contract.
+    /// </summary>
+    /// <param name="request">SDK attachment delete request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Attachment edit result.</returns>
+    public async Task<FeatureAttachmentResult> DeleteAttachmentAsync(
+        FeatureAttachmentDeleteRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            return await _featureServerClient.DeleteAttachmentAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (HonuaFeatureServerException ex)
+        {
+            throw ToMobileApiException("FeatureServer attachments", ex);
+        }
     }
 
     /// <summary>

--- a/tests/Honua.Mobile.Maui.Tests/SdkOfflineRegistrationTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/SdkOfflineRegistrationTests.cs
@@ -36,6 +36,7 @@ public sealed class SdkOfflineRegistrationTests
             Assert.IsType<GeoPackageSdkOfflineStoreAdapter>(provider.GetRequiredService<SdkOfflineFeatureStore>());
             Assert.IsType<SdkFeatureClient>(provider.GetRequiredService<IHonuaFeatureQueryClient>());
             Assert.IsType<SdkFeatureClient>(provider.GetRequiredService<IHonuaFeatureEditClient>());
+            Assert.IsType<SdkFeatureClient>(provider.GetRequiredService<IHonuaFeatureAttachmentClient>());
             Assert.IsType<HonuaMobileSdkFeatureClient>(provider.GetRequiredService<HonuaMobileSdkFeatureClient>());
         }
         finally

--- a/tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj
+++ b/tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Honua.Sdk.Abstractions" Version="0.1.3-alpha.1" />
-    <PackageReference Include="Honua.Sdk.GeoServices" Version="0.1.3-alpha.1" />
-    <PackageReference Include="Honua.Sdk.Grpc" Version="0.1.3-alpha.1" />
-    <PackageReference Include="Honua.Sdk.OgcFeatures" Version="0.1.3-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Abstractions" Version="0.1.4-alpha.1" />
+    <PackageReference Include="Honua.Sdk.GeoServices" Version="0.1.4-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Grpc" Version="0.1.4-alpha.1" />
+    <PackageReference Include="Honua.Sdk.OgcFeatures" Version="0.1.4-alpha.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/tests/Honua.Mobile.Sdk.Tests/HonuaMobileSdkFeatureClientTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/HonuaMobileSdkFeatureClientTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using Honua.Mobile.Sdk.Features;
@@ -149,6 +150,167 @@ public sealed class HonuaMobileSdkFeatureClientTests
         Assert.True(result.Succeeded);
         Assert.Equal("42", result.DeleteResults[0].Id);
         Assert.Equal(42, result.DeleteResults[0].ObjectId);
+    }
+
+    [Fact]
+    public async Task AttachmentOperationsAsync_FeatureServerRequest_UsesSdkAttachmentContract()
+    {
+        var handler = new StubHttpMessageHandler(async (request, _) =>
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            if (request.Method == HttpMethod.Get &&
+                path == "/rest/services/assets/FeatureServer/0/42/attachments")
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """
+                        {
+                          "attachmentInfos": [
+                            {
+                              "id": 7,
+                              "parentObjectId": 42,
+                              "name": "photo.txt",
+                              "contentType": "text/plain",
+                              "size": 5,
+                              "keywords": "field"
+                            }
+                          ]
+                        }
+                        """,
+                        Encoding.UTF8,
+                        "application/json"),
+                };
+            }
+
+            if (request.Method == HttpMethod.Get &&
+                path == "/rest/services/assets/FeatureServer/0/42/attachments/7")
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(Encoding.UTF8.GetBytes("photo")),
+                };
+                response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+                response.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment")
+                {
+                    FileName = "\"photo.txt\"",
+                };
+                return response;
+            }
+
+            if (request.Method == HttpMethod.Post &&
+                path == "/rest/services/assets/FeatureServer/0/42/addAttachment")
+            {
+                var body = await request.Content!.ReadAsStringAsync().ConfigureAwait(false);
+                Assert.Contains("name=attachment", body);
+                Assert.Contains("filename=photo.txt", body);
+                Assert.Contains("field", body);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{ "addAttachmentResult": { "objectId": 8, "success": true } }""",
+                        Encoding.UTF8,
+                        "application/json"),
+                };
+            }
+
+            if (request.Method == HttpMethod.Post &&
+                path == "/rest/services/assets/FeatureServer/0/42/updateAttachment")
+            {
+                var body = await request.Content!.ReadAsStringAsync().ConfigureAwait(false);
+                Assert.Contains("name=attachmentId", body);
+                Assert.Contains("7", body);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{ "updateAttachmentResult": { "objectId": 7, "success": true } }""",
+                        Encoding.UTF8,
+                        "application/json"),
+                };
+            }
+
+            if (request.Method == HttpMethod.Post &&
+                path == "/rest/services/assets/FeatureServer/0/42/deleteAttachments")
+            {
+                var body = await request.Content!.ReadAsStringAsync().ConfigureAwait(false);
+                Assert.Contains("attachmentIds=7", body);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{ "deleteAttachmentResults": [{ "objectId": 7, "success": true }] }""",
+                        Encoding.UTF8,
+                        "application/json"),
+                };
+            }
+
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
+        });
+
+        var adapter = CreateAdapter(handler);
+        var attachments = (IHonuaFeatureAttachmentClient)adapter;
+        var source = new FeatureSource { ServiceId = "assets", LayerId = 0 };
+
+        Assert.True(attachments.AttachmentCapabilities.SupportsList);
+        Assert.True(attachments.AttachmentCapabilities.SupportsDownload);
+        Assert.True(attachments.AttachmentCapabilities.SupportsAdd);
+        Assert.True(attachments.AttachmentCapabilities.SupportsUpdate);
+        Assert.True(attachments.AttachmentCapabilities.SupportsDelete);
+
+        var listed = await attachments.ListAttachmentsAsync(new FeatureAttachmentListRequest
+        {
+            Source = source,
+            ObjectId = 42,
+        });
+        var info = Assert.Single(listed);
+        Assert.Equal(7, info.AttachmentId);
+        Assert.Equal("photo.txt", info.Name);
+
+        var downloaded = await attachments.DownloadAttachmentAsync(new FeatureAttachmentDownloadRequest
+        {
+            Source = source,
+            ObjectId = 42,
+            AttachmentId = 7,
+        });
+        using var reader = new StreamReader(downloaded.Content, Encoding.UTF8);
+        Assert.Equal("photo", await reader.ReadToEndAsync());
+        Assert.Equal("photo.txt", downloaded.Info.Name);
+
+        using var addContent = new MemoryStream(Encoding.UTF8.GetBytes("photo"));
+        var addResult = await attachments.AddAttachmentAsync(new FeatureAttachmentAddRequest
+        {
+            Source = source,
+            ObjectId = 42,
+            Name = "photo.txt",
+            ContentType = "text/plain",
+            Content = addContent,
+            Keywords = "field",
+        });
+        Assert.True(addResult.Succeeded);
+        Assert.Equal(8, addResult.AttachmentId);
+        Assert.True(addContent.CanRead);
+
+        using var updateContent = new MemoryStream(Encoding.UTF8.GetBytes("updated"));
+        var updateResult = await attachments.UpdateAttachmentAsync(new FeatureAttachmentUpdateRequest
+        {
+            Source = source,
+            ObjectId = 42,
+            AttachmentId = 7,
+            Name = "photo.txt",
+            ContentType = "text/plain",
+            Content = updateContent,
+        });
+        Assert.True(updateResult.Succeeded);
+        Assert.Equal(7, updateResult.AttachmentId);
+        Assert.True(updateContent.CanRead);
+
+        var deleteResult = await attachments.DeleteAttachmentAsync(new FeatureAttachmentDeleteRequest
+        {
+            Source = source,
+            ObjectId = 42,
+            AttachmentId = 7,
+        });
+        Assert.True(deleteResult.Succeeded);
+        Assert.Equal(7, deleteResult.AttachmentId);
     }
 
     private static HonuaMobileSdkFeatureClient CreateAdapter(HttpMessageHandler handler)

--- a/tests/Honua.Mobile.Sdk.Tests/MobileContractHarmonizationFixtureTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/MobileContractHarmonizationFixtureTests.cs
@@ -21,6 +21,7 @@ public sealed class MobileContractHarmonizationFixtureTests
         Assert.Equal(
         [
             "display-embed",
+            "feature-attachments",
             "feature-edit",
             "feature-query",
             "form-feature-schema",
@@ -58,6 +59,17 @@ public sealed class MobileContractHarmonizationFixtureTests
         Assert.Contains(
             "Honua.Mobile.Offline.GeoPackage.OfflineEditOperation",
             edits.MobileTypes);
+
+        var attachments = FindFamily(fixture, "feature-attachments");
+        Assert.Equal("honua-sdk-dotnet", attachments.Owner);
+        Assert.Equal("Honua.Sdk.Abstractions", attachments.AuthoritativePackage);
+        Assert.Contains(
+            "Honua.Sdk.Abstractions.Features.IHonuaFeatureAttachmentClient",
+            attachments.AuthoritativeTypes);
+        Assert.Contains(
+            "Honua.Mobile.Sdk.Features.HonuaMobileSdkFeatureClient",
+            attachments.MobileTypes);
+        Assert.Equal("adapter-only", attachments.MobileDisposition);
     }
 
     [Fact]
@@ -99,7 +111,7 @@ public sealed class MobileContractHarmonizationFixtureTests
 
         var abstractionsPackage = fixture.Compatibility.SdkBaseline.Packages.Single(package => package.PackageId == "Honua.Sdk.Abstractions");
         Assert.Equal("Honua.Sdk.Abstractions", abstractionsPackage.PackageId);
-        Assert.Equal("0.1.3-alpha.1", abstractionsPackage.Version);
+        Assert.Equal("0.1.4-alpha.1", abstractionsPackage.Version);
 
         Assert.Contains(fixture.Compatibility.SdkBaseline.Packages, package => package.PackageId == "Honua.Sdk.Offline.Abstractions");
         Assert.Contains(fixture.Compatibility.SdkBaseline.Packages, package => package.PackageId == "Honua.Sdk.Offline");


### PR DESCRIPTION
## Summary
- Bump mobile SDK package consumption to published `Honua.Sdk.*` `0.1.4-alpha.1`.
- Expose SDK feature attachment contracts through `HonuaMobileClient`, `HonuaMobileSdkFeatureClient`, and the offline namespace shim.
- Register `IHonuaFeatureAttachmentClient` in MAUI SDK offline DI.
- Update the contract harmonization fixture/docs to mark feature attachments as SDK-owned and mobile adapter-only.

Part of #54.
Depends on honua-sdk-dotnet#96 and the published `dotnet-sdk-v0.1.4-alpha.1` packages.

## Platform Impact
No native platform behavior changes. The MAUI impact is DI-only: apps that opt into the SDK offline registration can resolve `IHonuaFeatureAttachmentClient` from the existing mobile SDK adapter.

## Offline Impact
Offline sync behavior is unchanged. The offline namespace shim delegates the attachment contract to the SDK-backed mobile adapter for compatibility, but the offline engine still uses query/edit contracts only.

## Testing
- `dotnet restore Honua.Mobile.sln --configfile /tmp/honua-mobile-local-nuget.config`
- `dotnet test Honua.Mobile.sln --no-restore`
- `dotnet format --verify-no-changes --no-restore`
- `git diff --check`

Local note: direct restore from GitHub Packages failed with this shell token lacking `read:packages`, so validation used the successful honua-sdk-dotnet publish-run package artifact as a temporary local NuGet source. CI should restore from GitHub Packages using the workflow token.
