### PR TITLE
sdk: use SDK feature clients in mobile adapter

### DIFF
--- a/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
+++ b/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
@@ -2,11 +2,11 @@
   "schemaVersion": "honua.mobile-contract-harmonization.v1",
   "sdkIssue": "honua-sdk-dotnet#68",
   "mobileIssue": "honua-mobile#48",
-  "status": "baseline",
+  "status": "feature-adapter-sdk-native",
   "compatibility": {
     "mobileBaseline": {
       "repository": "honua-io/honua-mobile",
-      "ref": "main after honua-mobile#68 plus scene and field package slices",
+      "ref": "main after honua-mobile#68 plus scene, field, and feature adapter package slices",
       "packageVersion": "unreleased-source"
     },
     "sdkBaseline": {
@@ -73,11 +73,11 @@
       "mobileTypes": [
         "Honua.Mobile.Sdk.Models.QueryFeaturesRequest",
         "Honua.Mobile.Sdk.Models.OgcItemsRequest",
-        "Honua.Mobile.Sdk.SdkGrpcTransportMappings"
+        "Honua.Mobile.Sdk.Features.HonuaMobileSdkFeatureClient"
       ],
-      "mobileDisposition": "adapter-required",
+      "mobileDisposition": "compatibility-shim",
       "migrationIssue": "honua-mobile#54",
-      "notes": "Mobile request DTOs remain transport shims until callers construct Honua.Sdk.Abstractions feature queries directly."
+      "notes": "HonuaMobileSdkFeatureClient calls HonuaMobileClient SDK-native query paths with FeatureQueryRequest. Legacy JSON DTOs remain compatibility shims while remaining callers migrate."
     },
     {
       "id": "feature-edit",
@@ -99,9 +99,9 @@
         "Honua.Mobile.Sdk.Models.OgcDeleteItemRequest",
         "Honua.Mobile.Offline.GeoPackage.OfflineEditOperation"
       ],
-      "mobileDisposition": "adapter-required",
+      "mobileDisposition": "compatibility-shim-and-mobile-runtime-adapter",
       "migrationIssue": "honua-mobile#54",
-      "notes": "Offline queue rows keep mobile retry metadata, but uploaded payloads should map to FeatureEditRequest."
+      "notes": "HonuaMobileSdkFeatureClient calls HonuaMobileClient SDK-native edit paths with FeatureEditRequest. Offline queue rows keep mobile retry metadata; uploader payload migration remains in honua-mobile#54."
     },
     {
       "id": "feature-attachments",

--- a/docs/guides/mobile-contract-harmonization.md
+++ b/docs/guides/mobile-contract-harmonization.md
@@ -12,7 +12,7 @@ the same ownership map without referencing mobile assemblies.
 
 | Mobile baseline | Shared SDK baseline | Status |
 |-----------------|---------------------|--------|
-| `honua-mobile` source packages from `main` after #68 plus scene and field adapter work | `Honua.Sdk.*` `0.1.8-alpha.1` | Fixture-level compatibility for shared feature, attachment, source, edit, routing, scene, field, and offline contracts |
+| `honua-mobile` source packages from `main` after #68 plus scene, field, and feature adapter work | `Honua.Sdk.*` `0.1.8-alpha.1` | Fixture-level compatibility for shared feature, attachment, source, edit, routing, scene, field, and offline contracts |
 
 `honua-mobile` does not currently publish versioned NuGet packages. Until it
 does, compatibility is stated as source-baseline compatibility against the
@@ -23,8 +23,8 @@ published shared SDK package versions above. When mobile packages gain
 
 | Model family | Owner | Mobile disposition |
 |--------------|-------|--------------------|
-| Feature query requests/results | `honua-sdk-dotnet` / `Honua.Sdk.Abstractions` | Mobile DTOs are transport shims; add adapters to `FeatureQueryRequest` and `FeatureQueryResult`. |
-| Feature edit envelopes/results | `honua-sdk-dotnet` / `Honua.Sdk.Abstractions` | Mobile edit DTOs and offline queue payloads should map to `FeatureEditRequest`. |
+| Feature query requests/results | `honua-sdk-dotnet` / `Honua.Sdk.Abstractions` | `HonuaMobileSdkFeatureClient` uses SDK-native query paths; legacy mobile DTOs remain compatibility shims. |
+| Feature edit envelopes/results | `honua-sdk-dotnet` / `Honua.Sdk.Abstractions` | `HonuaMobileSdkFeatureClient` uses SDK-native edit paths; offline queue payloads still need migration to `FeatureEditRequest`. |
 | Feature attachment operations | `honua-sdk-dotnet` / `Honua.Sdk.Abstractions` | Mobile exposes `IHonuaFeatureAttachmentClient` through adapters only; no mobile-local attachment DTOs. |
 | Geometry and spatial references | Split pending SDK geometry package | Keep mobile coordinates at platform edges until SDK geometry contracts graduate. |
 | Offline sync state, journals, conflicts | `Honua.Sdk.Offline.Abstractions` plus mobile runtime adapters | Mobile owns native queue persistence, scheduling, and GeoPackage behavior; SDK owns portable manifests, journals, checkpoints, retry checkpoints, and conflict envelopes. |
@@ -83,6 +83,9 @@ published shared SDK package versions above. When mobile packages gain
 - `honua-sdk-dotnet#68` added the matching SDK-side fixture and tests.
 - #54 moves reusable `Honua.Mobile.Sdk` feature clients toward SDK contracts and
   package consumption.
+- #54 now routes `HonuaMobileSdkFeatureClient` through SDK-native
+  `FeatureQueryRequest` and `FeatureEditRequest` paths while preserving legacy
+  JSON compatibility methods for existing callers.
 - #54 now consumes SDK routing contracts and the `Honua.Sdk.GeoServices` routing
   client from `Honua.Sdk.*`; mobile keeps only
   location-provider helpers.

--- a/src/Honua.Mobile.Sdk/Features/HonuaMobileSdkFeatureClient.cs
+++ b/src/Honua.Mobile.Sdk/Features/HonuaMobileSdkFeatureClient.cs
@@ -1,7 +1,4 @@
-using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
-using System.Text.Json;
-using Honua.Mobile.Sdk.Models;
 using Honua.Sdk.Abstractions.Features;
 
 namespace Honua.Mobile.Sdk.Features;
@@ -53,20 +50,7 @@ public sealed class HonuaMobileSdkFeatureClient :
     public async Task<FeatureQueryResult> QueryAsync(FeatureQueryRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
-
-        if (!string.IsNullOrWhiteSpace(request.Source.CollectionId))
-        {
-            using var response = await _client.GetOgcItemsAsync(ToOgcRequest(request), ct).ConfigureAwait(false);
-            return ParseQueryResult(response.RootElement, request, "ogcfeatures");
-        }
-
-        if (!string.IsNullOrWhiteSpace(request.Source.ServiceId) && request.Source.LayerId.HasValue)
-        {
-            using var response = await _client.QueryFeaturesAsync(ToFeatureServerRequest(request), ct).ConfigureAwait(false);
-            return ParseQueryResult(response.RootElement, request, "featureserver");
-        }
-
-        throw new InvalidOperationException("Feature query requires either an OGC collection ID or FeatureServer service/layer identifiers.");
+        return await _client.QueryAsync(request, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -76,20 +60,9 @@ public sealed class HonuaMobileSdkFeatureClient :
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var offset = request.Offset ?? 0;
-        var limit = request.Limit;
-        while (true)
+        await foreach (var page in _client.QueryPagesAsync(request, ct).ConfigureAwait(false))
         {
-            ct.ThrowIfCancellationRequested();
-            var page = await QueryAsync(request with { Offset = offset, Limit = limit }, ct).ConfigureAwait(false);
             yield return page;
-
-            if (!page.HasMoreResults || limit is null || page.NumberReturned == 0)
-            {
-                yield break;
-            }
-
-            offset += page.NumberReturned;
         }
     }
 
@@ -100,16 +73,7 @@ public sealed class HonuaMobileSdkFeatureClient :
 
         try
         {
-            if (!string.IsNullOrWhiteSpace(request.Source.CollectionId))
-            {
-                return await ApplyOgcEditsAsync(request, ct).ConfigureAwait(false);
-            }
-
-            if (!string.IsNullOrWhiteSpace(request.Source.ServiceId) && request.Source.LayerId.HasValue)
-            {
-                using var response = await _client.ApplyEditsAsync(ToFeatureServerEditRequest(request), ct).ConfigureAwait(false);
-                return ParseEditResponse(response.RootElement, "featureserver");
-            }
+            return await _client.ApplyEditsAsync(request, ct).ConfigureAwait(false);
         }
         catch (HonuaMobileApiException ex)
         {
@@ -119,12 +83,6 @@ public sealed class HonuaMobileSdkFeatureClient :
                 Error = new FeatureEditError { Code = (int)ex.StatusCode, Message = ex.Message },
             };
         }
-
-        return new FeatureEditResponse
-        {
-            ProviderName = ProviderName,
-            Error = new FeatureEditError { Message = "Feature edit requires either an OGC collection ID or FeatureServer service/layer identifiers." },
-        };
     }
 
     /// <inheritdoc />
@@ -201,115 +159,6 @@ public sealed class HonuaMobileSdkFeatureClient :
         }
     }
 
-    private async Task<FeatureEditResponse> ApplyOgcEditsAsync(FeatureEditRequest request, CancellationToken ct)
-    {
-        var addResults = new List<FeatureEditResult>();
-        var updateResults = new List<FeatureEditResult>();
-        var deleteResults = new List<FeatureEditResult>();
-        var collectionId = request.Source.CollectionId ?? throw new InvalidOperationException("OGC edit request requires collection ID.");
-
-        foreach (var add in request.Adds)
-        {
-            using var response = await _client.CreateOgcItemAsync(new OgcCreateItemRequest
-            {
-                CollectionId = collectionId,
-                Feature = SdkFeatureTransportMappings.ToOgcFeature(add),
-            }, ct).ConfigureAwait(false);
-            addResults.Add(ToOgcSuccessResult(response.RootElement, add.Id, add.ObjectId));
-        }
-
-        foreach (var update in request.Updates)
-        {
-            if (string.IsNullOrWhiteSpace(update.Id))
-            {
-                updateResults.Add(new FeatureEditResult
-                {
-                    Succeeded = false,
-                    ObjectId = update.ObjectId,
-                    Error = new FeatureEditError { Message = "OGC update requires feature ID." },
-                });
-                continue;
-            }
-
-            using var response = await _client.ReplaceOgcItemAsync(new OgcReplaceItemRequest
-            {
-                CollectionId = collectionId,
-                FeatureId = update.Id,
-                Feature = SdkFeatureTransportMappings.ToOgcFeature(update, update.Id),
-            }, ct).ConfigureAwait(false);
-            updateResults.Add(ToOgcSuccessResult(response.RootElement, update.Id, update.ObjectId));
-        }
-
-        foreach (var deleteId in request.DeleteIds)
-        {
-            using var response = await _client.DeleteOgcItemAsync(new OgcDeleteItemRequest
-            {
-                CollectionId = collectionId,
-                FeatureId = deleteId,
-            }, ct).ConfigureAwait(false);
-            deleteResults.Add(ToOgcSuccessResult(response.RootElement, deleteId, null));
-        }
-
-        foreach (var deleteObjectId in request.DeleteObjectIds)
-        {
-            var deleteId = SdkFeatureTransportMappings.ToOgcFeatureId(deleteObjectId);
-            using var response = await _client.DeleteOgcItemAsync(new OgcDeleteItemRequest
-            {
-                CollectionId = collectionId,
-                FeatureId = deleteId,
-            }, ct).ConfigureAwait(false);
-            deleteResults.Add(ToOgcSuccessResult(response.RootElement, deleteId, deleteObjectId));
-        }
-
-        return new FeatureEditResponse
-        {
-            ProviderName = "ogcfeatures",
-            AddResults = addResults,
-            UpdateResults = updateResults,
-            DeleteResults = deleteResults,
-        };
-    }
-
-    private static QueryFeaturesRequest ToFeatureServerRequest(FeatureQueryRequest request)
-        => new()
-        {
-            ServiceId = request.Source.ServiceId ?? throw new InvalidOperationException("FeatureServer query requires service ID."),
-            LayerId = request.Source.LayerId ?? throw new InvalidOperationException("FeatureServer query requires layer ID."),
-            Where = request.Filter ?? "1=1",
-            ObjectIds = request.ObjectIds,
-            OutFields = request.OutFields,
-            ReturnGeometry = request.ReturnGeometry ?? true,
-            ResultOffset = request.Offset,
-            ResultRecordCount = request.Limit,
-            OrderBy = request.OrderBy,
-        };
-
-    private static OgcItemsRequest ToOgcRequest(FeatureQueryRequest request)
-        => new()
-        {
-            CollectionId = request.Source.CollectionId ?? throw new InvalidOperationException("OGC query requires collection ID."),
-            CqlFilter = request.Filter,
-            PropertyNames = request.OutFields,
-            Limit = request.Limit,
-            Offset = request.Offset,
-        };
-
-    private static ApplyEditsRequest ToFeatureServerEditRequest(FeatureEditRequest request)
-        => new()
-        {
-            ServiceId = request.Source.ServiceId ?? throw new InvalidOperationException("FeatureServer edit requires service ID."),
-            LayerId = request.Source.LayerId ?? throw new InvalidOperationException("FeatureServer edit requires layer ID."),
-            Adds = request.Adds.Count == 0
-                ? null
-                : request.Adds.Select(SdkFeatureTransportMappings.ToFeatureServerFeature).ToList(),
-            Updates = request.Updates.Count == 0
-                ? null
-                : request.Updates.Select(SdkFeatureTransportMappings.ToFeatureServerFeature).ToList(),
-            Deletes = SdkFeatureTransportMappings.ToFeatureServerDeleteObjectIds(request),
-            RollbackOnFailure = request.RollbackOnFailure,
-            ForceWrite = request.ForceWrite,
-        };
-
     private static void EnsureFeatureServerAttachmentSource(FeatureSource source)
     {
         if (string.IsNullOrWhiteSpace(source.ServiceId) || !source.LayerId.HasValue)
@@ -329,180 +178,4 @@ public sealed class HonuaMobileSdkFeatureClient :
                 Message = exception.Message,
             },
         };
-
-    private static FeatureQueryResult ParseQueryResult(JsonElement root, FeatureQueryRequest request, string providerName)
-    {
-        var features = root.TryGetProperty("features", out var featuresElement) && featuresElement.ValueKind == JsonValueKind.Array
-            ? featuresElement.EnumerateArray().Select(ParseFeatureRecord).ToArray()
-            : [];
-
-        var matched = ReadInt64(root, "numberMatched") ?? ReadInt64(root, "count");
-        var exceededTransferLimit = root.TryGetProperty("exceededTransferLimit", out var exceeded) && exceeded.ValueKind == JsonValueKind.True;
-        var hasNextLink = HasNextLink(root);
-        var inferredHasMore = matched.HasValue && request.Offset.HasValue && request.Limit.HasValue
-            ? request.Offset.Value + features.Length < matched.Value
-            : false;
-
-        return new FeatureQueryResult
-        {
-            ProviderName = providerName,
-            Features = features,
-            NumberMatched = matched,
-            NumberReturned = features.Length,
-            HasMoreResults = exceededTransferLimit || hasNextLink || inferredHasMore,
-            ObjectIdFieldName = root.TryGetProperty("objectIdFieldName", out var objectIdField) && objectIdField.ValueKind == JsonValueKind.String
-                ? objectIdField.GetString()
-                : null,
-        };
-    }
-
-    private static FeatureRecord ParseFeatureRecord(JsonElement feature)
-    {
-        var attributes = feature.TryGetProperty("attributes", out var featureServerAttributes)
-            ? ReadJsonObject(featureServerAttributes)
-            : feature.TryGetProperty("properties", out var geoJsonProperties)
-                ? ReadJsonObject(geoJsonProperties)
-                : new ReadOnlyDictionary<string, JsonElement>(new Dictionary<string, JsonElement>());
-
-        JsonElement? geometry = null;
-        if (feature.TryGetProperty("geometry", out var geometryElement) && geometryElement.ValueKind != JsonValueKind.Null)
-        {
-            geometry = geometryElement.Clone();
-        }
-
-        return new FeatureRecord
-        {
-            Id = ReadFeatureId(feature, attributes),
-            Attributes = attributes,
-            Geometry = geometry,
-        };
-    }
-
-    private static FeatureEditResponse ParseEditResponse(JsonElement root, string providerName)
-        => new()
-        {
-            ProviderName = providerName,
-            AddResults = ParseEditResults(root, "addResults"),
-            UpdateResults = ParseEditResults(root, "updateResults"),
-            DeleteResults = ParseEditResults(root, "deleteResults"),
-            Error = TryReadError(root, out var error) ? error : null,
-        };
-
-    private static IReadOnlyList<FeatureEditResult> ParseEditResults(JsonElement root, string propertyName)
-    {
-        if (!root.TryGetProperty(propertyName, out var results) || results.ValueKind != JsonValueKind.Array)
-        {
-            return [];
-        }
-
-        return results.EnumerateArray().Select(result => new FeatureEditResult
-        {
-            Id = ReadString(result, "id") ?? ReadString(result, "globalId"),
-            ObjectId = ReadInt64(result, "objectId"),
-            Succeeded = result.TryGetProperty("success", out var success) && success.ValueKind == JsonValueKind.True,
-            Error = TryReadError(result, out var error) ? error : null,
-        }).ToArray();
-    }
-
-    private static FeatureEditResult ToOgcSuccessResult(JsonElement root, string? fallbackId, long? objectId)
-    {
-        if (TryReadError(root, out var error))
-        {
-            return new FeatureEditResult
-            {
-                Id = fallbackId,
-                ObjectId = objectId,
-                Succeeded = false,
-                Error = error,
-            };
-        }
-
-        return new FeatureEditResult
-        {
-            Id = ReadString(root, "id") ?? fallbackId,
-            ObjectId = objectId,
-            Succeeded = true,
-        };
-    }
-
-    private static IReadOnlyDictionary<string, JsonElement> ReadJsonObject(JsonElement element)
-    {
-        if (element.ValueKind != JsonValueKind.Object)
-        {
-            return new ReadOnlyDictionary<string, JsonElement>(new Dictionary<string, JsonElement>());
-        }
-
-        return new ReadOnlyDictionary<string, JsonElement>(
-            element.EnumerateObject().ToDictionary(property => property.Name, property => property.Value.Clone()));
-    }
-
-    private static bool TryReadError(JsonElement element, out FeatureEditError? error)
-    {
-        error = null;
-        if (element.ValueKind == JsonValueKind.Object && element.TryGetProperty("error", out var nestedError))
-        {
-            return TryReadError(nestedError, out error);
-        }
-
-        if (element.ValueKind != JsonValueKind.Object)
-        {
-            return false;
-        }
-
-        var code = ReadInt32(element, "code");
-        var message = ReadString(element, "message");
-        if (code is null && string.IsNullOrWhiteSpace(message))
-        {
-            return false;
-        }
-
-        error = new FeatureEditError
-        {
-            Code = code,
-            Message = message ?? "Provider reported an edit error.",
-        };
-        return true;
-    }
-
-    private static string? ReadFeatureId(JsonElement feature, IReadOnlyDictionary<string, JsonElement> attributes)
-    {
-        if (feature.TryGetProperty("id", out var id))
-        {
-            return id.ValueKind == JsonValueKind.String ? id.GetString() : id.GetRawText();
-        }
-
-        foreach (var key in new[] { "OBJECTID", "objectid", "ObjectID", "FID" })
-        {
-            if (attributes.TryGetValue(key, out var objectId))
-            {
-                return objectId.ValueKind == JsonValueKind.String ? objectId.GetString() : objectId.GetRawText();
-            }
-        }
-
-        return null;
-    }
-
-    private static bool HasNextLink(JsonElement root)
-    {
-        if (!root.TryGetProperty("links", out var links) || links.ValueKind != JsonValueKind.Array)
-        {
-            return false;
-        }
-
-        return links.EnumerateArray().Any(link =>
-            link.TryGetProperty("rel", out var rel) &&
-            rel.ValueKind == JsonValueKind.String &&
-            string.Equals(rel.GetString(), "next", StringComparison.OrdinalIgnoreCase));
-    }
-
-    private static string? ReadString(JsonElement element, string propertyName)
-        => element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
-            ? value.GetString()
-            : null;
-
-    private static int? ReadInt32(JsonElement element, string propertyName)
-        => element.TryGetProperty(propertyName, out var value) && value.TryGetInt32(out var parsed) ? parsed : null;
-
-    private static long? ReadInt64(JsonElement element, string propertyName)
-        => element.TryGetProperty(propertyName, out var value) && value.TryGetInt64(out var parsed) ? parsed : null;
 }

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
@@ -76,6 +76,100 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
     public IHonuaSceneClient Scenes { get; }
 
     /// <summary>
+    /// Queries features through the SDK provider-neutral feature contract.
+    /// OGC collection sources are handled by <see cref="HonuaOgcFeaturesClient"/>;
+    /// FeatureServer sources prefer gRPC when configured and otherwise use <see cref="HonuaFeatureServerClient"/>.
+    /// </summary>
+    /// <param name="request">SDK feature query request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A provider-neutral feature query result.</returns>
+    public async Task<FeatureQueryResult> QueryAsync(FeatureQueryRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (HasOgcSource(request.Source))
+        {
+            return await QueryOgcFeaturesSdkAsync(request, ct).ConfigureAwait(false);
+        }
+
+        if (HasFeatureServerSource(request.Source))
+        {
+            return await QueryFeatureServerSdkAsync(request, ct).ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException(
+            "Feature query requires either an OGC collection ID or FeatureServer service/layer identifiers.");
+    }
+
+    /// <summary>
+    /// Streams feature query pages through the SDK provider-neutral feature contract.
+    /// </summary>
+    /// <param name="request">SDK feature query request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>An async sequence of provider-neutral feature query pages.</returns>
+    public async IAsyncEnumerable<FeatureQueryResult> QueryPagesAsync(
+        FeatureQueryRequest request,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (HasOgcSource(request.Source))
+        {
+            await foreach (var page in QueryOgcFeaturesSdkPagesAsync(request, ct).ConfigureAwait(false))
+            {
+                yield return page;
+            }
+
+            yield break;
+        }
+
+        if (HasFeatureServerSource(request.Source))
+        {
+            await foreach (var page in QueryFeatureServerSdkPagesAsync(request, ct).ConfigureAwait(false))
+            {
+                yield return page;
+            }
+
+            yield break;
+        }
+
+        throw new InvalidOperationException(
+            "Feature query requires either an OGC collection ID or FeatureServer service/layer identifiers.");
+    }
+
+    /// <summary>
+    /// Applies feature edits through the SDK provider-neutral feature contract.
+    /// OGC collection sources are handled by <see cref="HonuaOgcFeaturesClient"/>;
+    /// FeatureServer sources prefer gRPC when configured and otherwise use <see cref="HonuaFeatureServerClient"/>.
+    /// </summary>
+    /// <param name="request">SDK feature edit request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A provider-neutral feature edit response.</returns>
+    public async Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (HasOgcSource(request.Source))
+        {
+            return await ApplyOgcSdkEditsAsync(request, ct).ConfigureAwait(false);
+        }
+
+        if (HasFeatureServerSource(request.Source))
+        {
+            return await ApplyFeatureServerSdkEditsAsync(request, ct).ConfigureAwait(false);
+        }
+
+        return new FeatureEditResponse
+        {
+            ProviderName = "honua-mobile",
+            Error = new FeatureEditError
+            {
+                Message = "Feature edit requires either an OGC collection ID or FeatureServer service/layer identifiers.",
+            },
+        };
+    }
+
+    /// <summary>
     /// Queries features from a feature service layer, preferring gRPC when available.
     /// Falls back to REST if gRPC fails and <see cref="HonuaMobileClientOptions.AllowRestFallbackOnGrpcFailure"/> is enabled.
     /// </summary>
@@ -528,9 +622,171 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
         }
     }
 
+    private async Task<FeatureQueryResult> QueryOgcFeaturesSdkAsync(FeatureQueryRequest request, CancellationToken ct)
+    {
+        try
+        {
+            return await _ogcFeaturesClient.QueryAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (HonuaOgcFeaturesException ex)
+        {
+            throw ToMobileApiException("OGC Features", ex);
+        }
+    }
+
+    private async IAsyncEnumerable<FeatureQueryResult> QueryOgcFeaturesSdkPagesAsync(
+        FeatureQueryRequest request,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        await using var enumerator = _ogcFeaturesClient.QueryPagesAsync(request, ct).GetAsyncEnumerator(ct);
+        while (true)
+        {
+            FeatureQueryResult? page;
+            try
+            {
+                if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                {
+                    yield break;
+                }
+
+                page = enumerator.Current;
+            }
+            catch (HonuaOgcFeaturesException ex)
+            {
+                throw ToMobileApiException("OGC Features", ex);
+            }
+
+            yield return page;
+        }
+    }
+
+    private async Task<FeatureQueryResult> QueryFeatureServerSdkAsync(FeatureQueryRequest request, CancellationToken ct)
+    {
+        if (CanUseGrpcForQueries)
+        {
+            try
+            {
+                return await GetGrpcClient().QueryAsync(request, ct).ConfigureAwait(false);
+            }
+            catch (HonuaGrpcException) when (_options.AllowRestFallbackOnGrpcFailure)
+            {
+                // Fall through to REST transport.
+            }
+        }
+
+        try
+        {
+            return await _featureServerClient.QueryAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (HonuaFeatureServerException ex)
+        {
+            throw ToMobileApiException("FeatureServer", ex);
+        }
+    }
+
+    private async IAsyncEnumerable<FeatureQueryResult> QueryFeatureServerSdkPagesAsync(
+        FeatureQueryRequest request,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        if (CanUseGrpcForQueries)
+        {
+            var yieldedGrpcPage = false;
+            await using var grpcEnumerator = GetGrpcClient().QueryPagesAsync(request, ct).GetAsyncEnumerator(ct);
+
+            while (true)
+            {
+                FeatureQueryResult? nextPage = null;
+                try
+                {
+                    if (!await grpcEnumerator.MoveNextAsync().ConfigureAwait(false))
+                    {
+                        if (yieldedGrpcPage)
+                        {
+                            yield break;
+                        }
+
+                        break;
+                    }
+
+                    nextPage = grpcEnumerator.Current;
+                }
+                catch (HonuaGrpcException) when (_options.AllowRestFallbackOnGrpcFailure && !yieldedGrpcPage)
+                {
+                    break;
+                }
+
+                yieldedGrpcPage = true;
+                yield return nextPage!;
+            }
+        }
+
+        await using var restEnumerator = _featureServerClient.QueryPagesAsync(request, ct).GetAsyncEnumerator(ct);
+        while (true)
+        {
+            FeatureQueryResult? page;
+            try
+            {
+                if (!await restEnumerator.MoveNextAsync().ConfigureAwait(false))
+                {
+                    yield break;
+                }
+
+                page = restEnumerator.Current;
+            }
+            catch (HonuaFeatureServerException ex)
+            {
+                throw ToMobileApiException("FeatureServer", ex);
+            }
+
+            yield return page;
+        }
+    }
+
+    private async Task<FeatureEditResponse> ApplyOgcSdkEditsAsync(FeatureEditRequest request, CancellationToken ct)
+    {
+        try
+        {
+            return await _ogcFeaturesClient.ApplyEditsAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (HonuaOgcFeaturesException ex)
+        {
+            throw ToMobileApiException("OGC Features", ex);
+        }
+    }
+
+    private async Task<FeatureEditResponse> ApplyFeatureServerSdkEditsAsync(FeatureEditRequest request, CancellationToken ct)
+    {
+        if (CanUseGrpcForEdits)
+        {
+            try
+            {
+                return await GetGrpcClient().ApplyEditsAsync(request, ct).ConfigureAwait(false);
+            }
+            catch (HonuaGrpcException) when (_options.AllowRestFallbackOnGrpcFailure)
+            {
+                // Fall through to REST transport.
+            }
+        }
+
+        try
+        {
+            return await _featureServerClient.ApplyEditsAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (HonuaFeatureServerException ex)
+        {
+            throw ToMobileApiException("FeatureServer", ex);
+        }
+    }
+
     private static bool IsDefaultJsonResponseFormat(string? responseFormat)
         => string.IsNullOrWhiteSpace(responseFormat) ||
             string.Equals(responseFormat, "json", StringComparison.OrdinalIgnoreCase);
+
+    private static bool HasOgcSource(FeatureSource source)
+        => !string.IsNullOrWhiteSpace(source.CollectionId);
+
+    private static bool HasFeatureServerSource(FeatureSource source)
+        => !string.IsNullOrWhiteSpace(source.ServiceId) && source.LayerId.HasValue;
 
     internal async Task<JsonDocument> SendJsonAsync(
         HttpMethod method,

--- a/tests/Honua.Mobile.Sdk.Tests/HonuaMobileSdkFeatureClientTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/HonuaMobileSdkFeatureClientTests.cs
@@ -60,7 +60,7 @@ public sealed class HonuaMobileSdkFeatureClientTests
         Assert.Contains("resultOffset=10", pathAndQuery);
         Assert.Contains("resultRecordCount=20", pathAndQuery);
 
-        Assert.Equal("featureserver", result.ProviderName);
+        Assert.Equal("geoservices-featureserver", result.ProviderName);
         Assert.Equal(1, result.NumberMatched);
         Assert.Equal(1, result.NumberReturned);
         Assert.Equal("objectid", result.ObjectIdFieldName);
@@ -120,7 +120,7 @@ public sealed class HonuaMobileSdkFeatureClientTests
         Assert.Contains("\"name\":\"Pump Station\"", form["adds"]);
         Assert.Contains("\"geometry\"", form["adds"]);
 
-        Assert.Equal("featureserver", result.ProviderName);
+        Assert.Equal("geoservices-featureserver", result.ProviderName);
         Assert.True(result.Succeeded);
         Assert.Equal(42, result.AddResults[0].ObjectId);
         Assert.Equal(7, result.DeleteResults[0].ObjectId);
@@ -149,7 +149,6 @@ public sealed class HonuaMobileSdkFeatureClientTests
         Assert.Contains(capturedPaths, path => path.Contains("/ogc/features/collections/buildings/items/42", StringComparison.Ordinal));
         Assert.True(result.Succeeded);
         Assert.Equal("42", result.DeleteResults[0].Id);
-        Assert.Equal(42, result.DeleteResults[0].ObjectId);
     }
 
     [Fact]

--- a/tests/Honua.Mobile.Sdk.Tests/MobileContractHarmonizationFixtureTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/MobileContractHarmonizationFixtureTests.cs
@@ -49,7 +49,10 @@ public sealed class MobileContractHarmonizationFixtureTests
         Assert.Contains(
             "Honua.Mobile.Sdk.Models.QueryFeaturesRequest",
             query.MobileTypes);
-        Assert.Equal("adapter-required", query.MobileDisposition);
+        Assert.Contains(
+            "Honua.Mobile.Sdk.Features.HonuaMobileSdkFeatureClient",
+            query.MobileTypes);
+        Assert.Equal("compatibility-shim", query.MobileDisposition);
 
         var edits = FindFamily(fixture, "feature-edit");
         Assert.Equal("honua-sdk-dotnet", edits.Owner);
@@ -59,6 +62,7 @@ public sealed class MobileContractHarmonizationFixtureTests
         Assert.Contains(
             "Honua.Mobile.Offline.GeoPackage.OfflineEditOperation",
             edits.MobileTypes);
+        Assert.Equal("compatibility-shim-and-mobile-runtime-adapter", edits.MobileDisposition);
 
         var attachments = FindFamily(fixture, "feature-attachments");
         Assert.Equal("honua-sdk-dotnet", attachments.Owner);


### PR DESCRIPTION
## Summary
- add SDK-native feature query/edit paths on HonuaMobileClient for FeatureQueryRequest and FeatureEditRequest
- route HonuaMobileSdkFeatureClient through those SDK clients instead of local mobile DTO/JSON parsing shims
- update harmonization fixture/docs/tests to mark legacy query/edit DTOs as compatibility shims

## Platform Impact
No MAUI, Android, iOS, Windows, or native storage code changed. This is a shared .NET adapter/client change inside Honua.Mobile.Sdk plus docs and fixture updates.

## Platform Testing
Local validation covered the shared .NET solution. Device-specific platform smoke is left to CI because this PR does not touch platform runtime code.

## Offline Impact
This PR does not change offline queue storage, sync scheduling, GeoPackage adapters, or uploader behavior. The fixture notes that the remaining uploader payload migration is still tracked by #54.

## Testing
- dotnet restore Honua.Mobile.sln --configfile /tmp/honua-mobile-local-sdk-0.1.8.nuget.config
- dotnet build Honua.Mobile.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
- dotnet test Honua.Mobile.sln --configuration Release --no-build --no-restore
- dotnet format Honua.Mobile.sln --verify-no-changes --verbosity minimal --no-restore
- git diff --check

Related to #54