### PR TITLE
sdk: upload offline edits through SDK contracts

### DIFF
--- a/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
+++ b/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
@@ -101,7 +101,7 @@
       ],
       "mobileDisposition": "compatibility-shim-and-mobile-runtime-adapter",
       "migrationIssue": "honua-mobile#54",
-      "notes": "HonuaMobileSdkFeatureClient calls HonuaMobileClient SDK-native edit paths with FeatureEditRequest. Offline queue rows keep mobile retry metadata; uploader payload migration remains in honua-mobile#54."
+      "notes": "HonuaMobileSdkFeatureClient and HonuaApiOfflineOperationUploader call HonuaMobileClient SDK-native edit paths with FeatureEditRequest where the shared contract supports the operation. Offline queue rows keep mobile retry metadata; OGC merge-patch remains a compatibility shim until an SDK patch contract exists."
     },
     {
       "id": "feature-attachments",

--- a/docs/guides/mobile-contract-harmonization.md
+++ b/docs/guides/mobile-contract-harmonization.md
@@ -24,7 +24,7 @@ published shared SDK package versions above. When mobile packages gain
 | Model family | Owner | Mobile disposition |
 |--------------|-------|--------------------|
 | Feature query requests/results | `honua-sdk-dotnet` / `Honua.Sdk.Abstractions` | `HonuaMobileSdkFeatureClient` uses SDK-native query paths; legacy mobile DTOs remain compatibility shims. |
-| Feature edit envelopes/results | `honua-sdk-dotnet` / `Honua.Sdk.Abstractions` | `HonuaMobileSdkFeatureClient` uses SDK-native edit paths; offline queue payloads still need migration to `FeatureEditRequest`. |
+| Feature edit envelopes/results | `honua-sdk-dotnet` / `Honua.Sdk.Abstractions` | `HonuaMobileSdkFeatureClient` and offline uploads use SDK-native edit paths where supported; OGC merge-patch remains a compatibility shim. |
 | Feature attachment operations | `honua-sdk-dotnet` / `Honua.Sdk.Abstractions` | Mobile exposes `IHonuaFeatureAttachmentClient` through adapters only; no mobile-local attachment DTOs. |
 | Geometry and spatial references | Split pending SDK geometry package | Keep mobile coordinates at platform edges until SDK geometry contracts graduate. |
 | Offline sync state, journals, conflicts | `Honua.Sdk.Offline.Abstractions` plus mobile runtime adapters | Mobile owns native queue persistence, scheduling, and GeoPackage behavior; SDK owns portable manifests, journals, checkpoints, retry checkpoints, and conflict envelopes. |
@@ -86,6 +86,9 @@ published shared SDK package versions above. When mobile packages gain
 - #54 now routes `HonuaMobileSdkFeatureClient` through SDK-native
   `FeatureQueryRequest` and `FeatureEditRequest` paths while preserving legacy
   JSON compatibility methods for existing callers.
+- #54 now routes FeatureServer and OGC add/replace/delete offline uploads
+  through SDK-native `FeatureEditRequest`; OGC merge-patch remains on the
+  compatibility wrapper until the SDK owns that operation.
 - #54 now consumes SDK routing contracts and the `Honua.Sdk.GeoServices` routing
   client from `Honua.Sdk.*`; mobile keeps only
   location-provider helpers.

--- a/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
+++ b/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Honua.Mobile.Offline.GeoPackage;
 using Honua.Mobile.Sdk;
 using Honua.Mobile.Sdk.Models;
+using Honua.Sdk.Abstractions.Features;
 
 namespace Honua.Mobile.Offline.Sync;
 
@@ -62,6 +63,10 @@ public sealed class HonuaApiOfflineOperationUploader : IOfflineOperationUploader
         {
             return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = $"Invalid offline payload: {ex.Message}" };
         }
+        catch (ArgumentNullException ex) when (string.Equals(ex.ParamName, "source", StringComparison.Ordinal))
+        {
+            return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits response payload is malformed." };
+        }
         catch (ArgumentException ex)
         {
             return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = $"Invalid offline payload: {ex.Message}" };
@@ -99,39 +104,28 @@ public sealed class HonuaApiOfflineOperationUploader : IOfflineOperationUploader
             };
         }
 
-        var addsJson = payload.AddsJson;
-        var updatesJson = payload.UpdatesJson;
-        var deletesCsv = payload.DeletesCsv;
-
-        if (operation.OperationType == OfflineOperationType.Add && string.IsNullOrWhiteSpace(addsJson))
+        var request = new FeatureEditRequest
         {
-            addsJson = WrapSingleFeature(payload.Feature, "Add operation requires feature payload.");
-        }
-
-        if (operation.OperationType == OfflineOperationType.Update && string.IsNullOrWhiteSpace(updatesJson))
-        {
-            updatesJson = WrapSingleFeature(payload.Feature, "Update operation requires feature payload.");
-        }
-
-        if (operation.OperationType == OfflineOperationType.Delete && string.IsNullOrWhiteSpace(deletesCsv))
-        {
-            deletesCsv = payload.DeleteObjectIds is { Count: > 0 }
-                ? string.Join(',', payload.DeleteObjectIds)
-                : throw new InvalidOperationException("Delete operation requires deleteObjectIds or deletesCsv.");
-        }
-
-        using var response = await _client.ApplyEditsAsync(new ApplyEditsRequest
-        {
-            ServiceId = payload.ServiceId,
-            LayerId = payload.LayerId.Value,
-            AddsJson = addsJson,
-            UpdatesJson = updatesJson,
-            DeletesCsv = deletesCsv,
+            Source = new FeatureSource
+            {
+                ServiceId = payload.ServiceId,
+                LayerId = payload.LayerId,
+            },
+            Adds = operation.OperationType == OfflineOperationType.Add
+                ? ResolveFeatureServerFeatures(payload.AddsJson, payload.Feature, "Add operation requires feature payload.")
+                : [],
+            Updates = operation.OperationType == OfflineOperationType.Update
+                ? ResolveFeatureServerFeatures(payload.UpdatesJson, payload.Feature, "Update operation requires feature payload.")
+                : [],
+            DeleteObjectIds = operation.OperationType == OfflineOperationType.Delete
+                ? ResolveFeatureServerDeleteObjectIds(payload)
+                : [],
             RollbackOnFailure = false,
             ForceWrite = forceWrite,
-        }, ct).ConfigureAwait(false);
+        };
 
-        return ParseApplyEditsResponse(response.RootElement);
+        var response = await _client.ApplyEditsAsync(request, ct).ConfigureAwait(false);
+        return ToUploadResult(response);
     }
 
     private async Task<UploadResult> UploadOgcAsync(
@@ -148,125 +142,91 @@ public sealed class HonuaApiOfflineOperationUploader : IOfflineOperationUploader
             };
         }
 
-        JsonDocument response;
         switch (operation.OperationType)
         {
             case OfflineOperationType.Add:
-                response = await _client.CreateOgcItemAsync(new OgcCreateItemRequest
                 {
-                    CollectionId = payload.CollectionId,
-                    Feature = payload.Feature ?? throw new InvalidOperationException("Add operation requires feature payload."),
-                }, ct).ConfigureAwait(false);
-                break;
+                    var response = await _client.ApplyEditsAsync(new FeatureEditRequest
+                    {
+                        Source = new FeatureSource { CollectionId = payload.CollectionId },
+                        Adds = [ToOgcFeatureEditFeature(payload.Feature, null, "Add operation requires feature payload.")],
+                        RollbackOnFailure = false,
+                    }, ct).ConfigureAwait(false);
+                    return ToUploadResult(response);
+                }
 
             case OfflineOperationType.Update:
                 if (!string.IsNullOrWhiteSpace(payload.FeatureId) && payload.Patch is not null)
                 {
-                    response = await _client.PatchOgcItemAsync(new OgcPatchItemRequest
+                    using var patchResponse = await _client.PatchOgcItemAsync(new OgcPatchItemRequest
                     {
                         CollectionId = payload.CollectionId,
                         FeatureId = payload.FeatureId,
                         Patch = payload.Patch.Value,
                     }, ct).ConfigureAwait(false);
-                    break;
+
+                    if (TryReadError(patchResponse.RootElement, out var code, out var message))
+                    {
+                        return FromErrorCode(code, message);
+                    }
+
+                    return new UploadResult { Outcome = UploadOutcome.Success };
                 }
 
-                response = await _client.ReplaceOgcItemAsync(new OgcReplaceItemRequest
+                var updateResponse = await _client.ApplyEditsAsync(new FeatureEditRequest
                 {
-                    CollectionId = payload.CollectionId,
-                    FeatureId = payload.FeatureId ?? throw new InvalidOperationException("Update operation requires featureId."),
-                    Feature = payload.Feature ?? throw new InvalidOperationException("Update operation requires feature payload."),
+                    Source = new FeatureSource { CollectionId = payload.CollectionId },
+                    Updates =
+                    [
+                        ToOgcFeatureEditFeature(
+                            payload.Feature,
+                            payload.FeatureId ?? throw new InvalidOperationException("Update operation requires featureId."),
+                            "Update operation requires feature payload.")
+                    ],
+                    RollbackOnFailure = false,
                 }, ct).ConfigureAwait(false);
-                break;
+                return ToUploadResult(updateResponse);
 
             case OfflineOperationType.Delete:
-                response = await _client.DeleteOgcItemAsync(new OgcDeleteItemRequest
+                var deleteResponse = await _client.ApplyEditsAsync(new FeatureEditRequest
                 {
-                    CollectionId = payload.CollectionId,
-                    FeatureId = payload.FeatureId ?? throw new InvalidOperationException("Delete operation requires featureId."),
+                    Source = new FeatureSource { CollectionId = payload.CollectionId },
+                    DeleteIds = [payload.FeatureId ?? throw new InvalidOperationException("Delete operation requires featureId.")],
+                    RollbackOnFailure = false,
                 }, ct).ConfigureAwait(false);
-                break;
+                return ToUploadResult(deleteResponse);
 
             default:
                 return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "Unsupported OGC operation." };
         }
-
-        using (response)
-        {
-            if (TryReadError(response.RootElement, out var code, out var message))
-            {
-                return FromErrorCode(code, message);
-            }
-        }
-
-        return new UploadResult { Outcome = UploadOutcome.Success };
     }
 
-    private static UploadResult ParseApplyEditsResponse(JsonElement root)
+    private static UploadResult ToUploadResult(FeatureEditResponse response)
     {
-        if (root.ValueKind != JsonValueKind.Object)
+        if (response.Error is not null)
         {
-            return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits response payload is malformed." };
+            return FromErrorCode(response.Error.Code, response.Error.Message);
         }
 
-        if (TryReadError(root, out var topLevelCode, out var topLevelMessage))
-        {
-            return FromErrorCode(topLevelCode, topLevelMessage);
-        }
-
-        var resultArrays = new[] { "addResults", "updateResults", "deleteResults" };
-        var foundResultArray = false;
-        var foundResultEntry = false;
-
-        foreach (var propertyName in resultArrays)
-        {
-            if (!root.TryGetProperty(propertyName, out var results))
-            {
-                continue;
-            }
-
-            foundResultArray = true;
-            if (results.ValueKind != JsonValueKind.Array)
-            {
-                return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits response payload is malformed." };
-            }
-
-            foreach (var result in results.EnumerateArray())
-            {
-                foundResultEntry = true;
-
-                if (result.ValueKind != JsonValueKind.Object)
-                {
-                    return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits result payload is malformed." };
-                }
-
-                if (result.TryGetProperty("success", out var success) && success.ValueKind == JsonValueKind.True)
-                {
-                    continue;
-                }
-
-                if (result.TryGetProperty("error", out var error) && TryReadError(error, out var code, out var message))
-                {
-                    return FromErrorCode(code, message);
-                }
-
-                if (result.TryGetProperty("success", out success) && success.ValueKind == JsonValueKind.False)
-                {
-                    return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits result reported failure." };
-                }
-
-                return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits result payload is malformed." };
-            }
-        }
-
-        if (!foundResultArray)
+        var editResults = (response.AddResults ?? [])
+            .Concat(response.UpdateResults ?? [])
+            .Concat(response.DeleteResults ?? [])
+            .ToArray();
+        if (editResults.Length == 0)
         {
             return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits response is missing edit result arrays." };
         }
 
-        if (!foundResultEntry)
+        foreach (var result in editResults)
         {
-            return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits response contains no edit results." };
+            if (result.Succeeded)
+            {
+                continue;
+            }
+
+            return result.Error is not null
+                ? FromErrorCode(result.Error.Code, result.Error.Message)
+                : new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = "applyEdits result reported failure." };
         }
 
         return new UploadResult { Outcome = UploadOutcome.Success };
@@ -332,14 +292,120 @@ public sealed class HonuaApiOfflineOperationUploader : IOfflineOperationUploader
         return code.HasValue || !string.IsNullOrWhiteSpace(message);
     }
 
-    private static string WrapSingleFeature(JsonElement? feature, string errorMessage)
+    private static IReadOnlyList<FeatureEditFeature> ResolveFeatureServerFeatures(
+        string? featuresJson,
+        JsonElement? singleFeature,
+        string errorMessage)
+    {
+        if (!string.IsNullOrWhiteSpace(featuresJson))
+        {
+            return ReadFeatureServerFeatures(featuresJson);
+        }
+
+        return [ToFeatureServerFeatureEditFeature(singleFeature, errorMessage)];
+    }
+
+    private static IReadOnlyList<FeatureEditFeature> ReadFeatureServerFeatures(string featuresJson)
+    {
+        using var document = JsonDocument.Parse(featuresJson);
+        return document.RootElement.ValueKind == JsonValueKind.Array
+            ? document.RootElement.EnumerateArray().Select(feature => ToFeatureServerFeatureEditFeature(feature, "Feature payload is required.")).ToArray()
+            : [ToFeatureServerFeatureEditFeature(document.RootElement, "Feature payload is required.")];
+    }
+
+    private static IReadOnlyList<long> ResolveFeatureServerDeleteObjectIds(OfflineOperationPayload payload)
+    {
+        if (payload.DeleteObjectIds is { Count: > 0 })
+        {
+            return payload.DeleteObjectIds;
+        }
+
+        if (!string.IsNullOrWhiteSpace(payload.DeletesCsv))
+        {
+            return payload.DeletesCsv
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(value => long.Parse(value, System.Globalization.CultureInfo.InvariantCulture))
+                .ToArray();
+        }
+
+        throw new InvalidOperationException("Delete operation requires deleteObjectIds or deletesCsv.");
+    }
+
+    private static FeatureEditFeature ToFeatureServerFeatureEditFeature(JsonElement? feature, string errorMessage)
     {
         if (feature is null)
         {
             throw new InvalidOperationException(errorMessage);
         }
 
-        return JsonSerializer.Serialize(new[] { feature.Value });
+        return ToFeatureEditFeature(feature.Value, fallbackId: null, includeFeatureId: false, includeObjectId: true);
+    }
+
+    private static FeatureEditFeature ToOgcFeatureEditFeature(JsonElement? feature, string? fallbackId, string errorMessage)
+    {
+        if (feature is null)
+        {
+            throw new InvalidOperationException(errorMessage);
+        }
+
+        return ToFeatureEditFeature(feature.Value, fallbackId, includeFeatureId: true, includeObjectId: true);
+    }
+
+    private static FeatureEditFeature ToFeatureEditFeature(
+        JsonElement feature,
+        string? fallbackId,
+        bool includeFeatureId,
+        bool includeObjectId)
+    {
+        var id = fallbackId;
+        if (includeFeatureId && feature.TryGetProperty("id", out var idElement))
+        {
+            id = idElement.ValueKind == JsonValueKind.String ? idElement.GetString() : idElement.GetRawText();
+        }
+
+        var attributes = feature.TryGetProperty("attributes", out var featureServerAttributes)
+            ? ReadJsonObject(featureServerAttributes)
+            : feature.TryGetProperty("properties", out var geoJsonProperties)
+                ? ReadJsonObject(geoJsonProperties)
+                : new Dictionary<string, JsonElement>();
+        var objectId = includeObjectId ? TryReadObjectId(attributes) : null;
+
+        JsonElement? geometry = null;
+        if (feature.TryGetProperty("geometry", out var geometryElement) && geometryElement.ValueKind != JsonValueKind.Null)
+        {
+            geometry = geometryElement.Clone();
+        }
+
+        return new FeatureEditFeature
+        {
+            Id = id,
+            ObjectId = objectId,
+            Attributes = attributes,
+            Geometry = geometry,
+        };
+    }
+
+    private static long? TryReadObjectId(IReadOnlyDictionary<string, JsonElement> attributes)
+    {
+        foreach (var key in new[] { "OBJECTID", "objectid", "ObjectID", "FID" })
+        {
+            if (attributes.TryGetValue(key, out var objectId) && objectId.TryGetInt64(out var parsedObjectId))
+            {
+                return parsedObjectId;
+            }
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyDictionary<string, JsonElement> ReadJsonObject(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            return new Dictionary<string, JsonElement>();
+        }
+
+        return element.EnumerateObject().ToDictionary(property => property.Name, property => property.Value.Clone());
     }
 }
 

--- a/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
+++ b/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net;
 using System.Text.Json;
 using Honua.Mobile.Offline.GeoPackage;
@@ -322,10 +323,19 @@ public sealed class HonuaApiOfflineOperationUploader : IOfflineOperationUploader
 
         if (!string.IsNullOrWhiteSpace(payload.DeletesCsv))
         {
-            return payload.DeletesCsv
-                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Select(value => long.Parse(value, System.Globalization.CultureInfo.InvariantCulture))
-                .ToArray();
+            var values = payload.DeletesCsv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var objectIds = new long[values.Length];
+            for (var index = 0; index < values.Length; index++)
+            {
+                if (!long.TryParse(values[index], NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
+                {
+                    throw new InvalidOperationException($"Delete operation contains an invalid object id '{values[index]}'.");
+                }
+
+                objectIds[index] = objectId;
+            }
+
+            return objectIds;
         }
 
         throw new InvalidOperationException("Delete operation requires deleteObjectIds or deletesCsv.");

--- a/tests/Honua.Mobile.Offline.Tests/HonuaApiOfflineOperationUploaderTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/HonuaApiOfflineOperationUploaderTests.cs
@@ -272,6 +272,39 @@ public sealed class HonuaApiOfflineOperationUploaderTests
     }
 
     [Fact]
+    public async Task UploadAsync_MalformedDeleteCsv_ReturnsFatalFailure()
+    {
+        var requestCount = 0;
+        var uploader = CreateUploader((_, _) =>
+        {
+            requestCount++;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+            };
+        });
+
+        var result = await uploader.UploadAsync(new OfflineEditOperation
+        {
+            LayerKey = "assets",
+            TargetCollection = "assets",
+            OperationType = OfflineOperationType.Delete,
+            PayloadJson = """
+            {
+              "protocol": "FeatureServer",
+              "serviceId": "default",
+              "layerId": 0,
+              "deletesCsv": "1,not-an-id"
+            }
+            """,
+        }, forceWrite: false);
+
+        Assert.Equal(UploadOutcome.FatalFailure, result.Outcome);
+        Assert.Contains("invalid object id", result.Message, StringComparison.Ordinal);
+        Assert.Equal(0, requestCount);
+    }
+
+    [Fact]
     public async Task UploadAsync_WhenCanceled_ThrowsOperationCanceledException()
     {
         var uploader = CreateUploader((_, _) => throw new TaskCanceledException("request canceled"));

--- a/tests/Honua.Mobile.Offline.Tests/HonuaApiOfflineOperationUploaderTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/HonuaApiOfflineOperationUploaderTests.cs
@@ -15,7 +15,7 @@ public sealed class HonuaApiOfflineOperationUploaderTests
         var uploader = CreateUploader((request, _) =>
         {
             postedBody = request.Content is null ? null : request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-            var body = "{\"addResults\":[{\"success\":true,\"objectId\":1}]}";
+            var body = "{\"addResults\":[{\"success\":true,\"objectId\":1}],\"updateResults\":[],\"deleteResults\":[]}";
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(body, Encoding.UTF8, "application/json"),
@@ -37,16 +37,25 @@ public sealed class HonuaApiOfflineOperationUploaderTests
             """,
         }, forceWrite: false);
 
-        Assert.Equal(UploadOutcome.Success, result.Outcome);
+        Assert.True(result.Outcome == UploadOutcome.Success, result.Message);
         Assert.Contains("adds=", postedBody, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
     public async Task UploadAsync_FeatureServerConflict_ReturnsConflict()
     {
-        var uploader = CreateUploader((_, _) =>
+        var uploader = CreateUploader((request, _) =>
         {
-            var body = "{\"updateResults\":[{\"success\":false,\"error\":{\"code\":409,\"message\":\"conflict\"}}]}";
+            if (request.Method == HttpMethod.Get &&
+                request.RequestUri!.PathAndQuery.Contains("/rest/services/default/FeatureServer/0", StringComparison.Ordinal))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("""{"objectIdField":"objectid"}""", Encoding.UTF8, "application/json"),
+                };
+            }
+
+            var body = "{\"addResults\":[],\"updateResults\":[{\"success\":false,\"error\":{\"code\":409,\"message\":\"conflict\"}}],\"deleteResults\":[]}";
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(body, Encoding.UTF8, "application/json"),
@@ -68,7 +77,7 @@ public sealed class HonuaApiOfflineOperationUploaderTests
             """,
         }, forceWrite: false);
 
-        Assert.Equal(UploadOutcome.Conflict, result.Outcome);
+        Assert.True(result.Outcome == UploadOutcome.Conflict, result.Message);
     }
 
     [Fact]
@@ -95,7 +104,7 @@ public sealed class HonuaApiOfflineOperationUploaderTests
         }, forceWrite: false);
 
         Assert.Equal(UploadOutcome.FatalFailure, result.Outcome);
-        Assert.Contains("missing", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("malformed", result.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -103,7 +112,7 @@ public sealed class HonuaApiOfflineOperationUploaderTests
     {
         var uploader = CreateUploader((_, _) => new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new StringContent("""{"addResults":[{}]}""", Encoding.UTF8, "application/json"),
+            Content = new StringContent("""{"addResults":[{}],"updateResults":[],"deleteResults":[]}""", Encoding.UTF8, "application/json"),
         });
 
         var result = await uploader.UploadAsync(new OfflineEditOperation
@@ -149,6 +158,85 @@ public sealed class HonuaApiOfflineOperationUploaderTests
         }, forceWrite: false);
 
         Assert.Equal(UploadOutcome.RetryableFailure, result.Outcome);
+    }
+
+    [Fact]
+    public async Task UploadAsync_OgcAdd_UsesSdkFeatureEditRequest()
+    {
+        string? capturedPath = null;
+        string? capturedMediaType = null;
+        string? capturedBody = null;
+        var uploader = CreateUploader((request, _) =>
+        {
+            capturedPath = request.RequestUri!.PathAndQuery;
+            capturedMediaType = request.Content?.Headers.ContentType?.MediaType;
+            capturedBody = request.Content is null ? null : request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"type":"Feature","id":"building-1"}""", Encoding.UTF8, "application/json"),
+            };
+        });
+
+        var result = await uploader.UploadAsync(new OfflineEditOperation
+        {
+            LayerKey = "buildings",
+            TargetCollection = "buildings",
+            OperationType = OfflineOperationType.Add,
+            PayloadJson = """
+            {
+              "protocol": "ogcfeatures",
+              "collectionId": "buildings",
+              "feature": {
+                "type": "Feature",
+                "properties": { "name": "HQ" },
+                "geometry": { "type": "Point", "coordinates": [-157.8, 21.3] }
+              }
+            }
+            """,
+        }, forceWrite: false);
+
+        Assert.Equal(UploadOutcome.Success, result.Outcome);
+        Assert.Contains("/ogc/features/collections/buildings/items", capturedPath);
+        Assert.Equal("application/geo+json", capturedMediaType);
+        Assert.Contains("\"name\":\"HQ\"", capturedBody);
+    }
+
+    [Fact]
+    public async Task UploadAsync_OgcPatch_KeepsCompatibilityPatchPath()
+    {
+        HttpMethod? capturedMethod = null;
+        string? capturedPath = null;
+        string? capturedMediaType = null;
+        var uploader = CreateUploader((request, _) =>
+        {
+            capturedMethod = request.Method;
+            capturedPath = request.RequestUri!.PathAndQuery;
+            capturedMediaType = request.Content?.Headers.ContentType?.MediaType;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"type":"Feature","id":"building-1"}""", Encoding.UTF8, "application/json"),
+            };
+        });
+
+        var result = await uploader.UploadAsync(new OfflineEditOperation
+        {
+            LayerKey = "buildings",
+            TargetCollection = "buildings",
+            OperationType = OfflineOperationType.Update,
+            PayloadJson = """
+            {
+              "protocol": "ogcfeatures",
+              "collectionId": "buildings",
+              "featureId": "building-1",
+              "patch": { "properties": { "name": "HQ" } }
+            }
+            """,
+        }, forceWrite: false);
+
+        Assert.Equal(UploadOutcome.Success, result.Outcome);
+        Assert.Equal(HttpMethod.Patch, capturedMethod);
+        Assert.Contains("/ogc/features/collections/buildings/items/building-1", capturedPath);
+        Assert.Equal("application/merge-patch+json", capturedMediaType);
     }
 
     [Fact]
@@ -216,6 +304,7 @@ public sealed class HonuaApiOfflineOperationUploaderTests
             new HonuaMobileClientOptions
             {
                 BaseUri = new Uri("https://api.honua.test"),
+                PreferGrpcForFeatureEdits = false,
             });
 
         return new HonuaApiOfflineOperationUploader(client);


### PR DESCRIPTION
## Summary
- route FeatureServer offline uploads through HonuaMobileClient's SDK-native FeatureEditRequest path
- route OGC add/replace/delete offline uploads through SDK FeatureEditRequest while keeping OGC merge-patch on the compatibility wrapper
- update harmonization fixture/docs and offline uploader tests for the remaining compatibility boundary

## Platform Impact
No MAUI, Android, iOS, Windows, or native storage code changed. This changes shared offline sync upload composition and tests.

## Platform Testing
Local validation covered the shared .NET solution. Platform-specific app builds are left to CI because the change does not touch platform runtime code.

## Offline Impact
Offline queue storage, retry scheduling, GeoPackage adapters, and operation persistence are unchanged. The uploader now maps queued payloads into SDK edit contracts where the SDK owns the operation; OGC PATCH remains a compatibility path until the SDK exposes a patch edit contract.

## Testing
- dotnet restore Honua.Mobile.sln --configfile /tmp/honua-mobile-local-sdk-0.1.8.nuget.config
- dotnet build Honua.Mobile.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
- dotnet test Honua.Mobile.sln --configuration Release --no-build --no-restore
- dotnet format Honua.Mobile.sln --verify-no-changes --verbosity minimal --no-restore
- git diff --check

Related to #54