### PR TITLE
feat: harden mobile SDK auth and offline gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dotnet-mobile:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/src/Honua.Embed"
+    schedule:
+      interval: "weekly"
+    groups:
+      embed:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,11 +224,10 @@ jobs:
           retention-days: 7
 
   maui-android:
-    name: MAUI Android Build
+    name: MAUI Android Build & Trim Smoke
     runs-on: ubuntu-latest
     needs: [build, changes]
     if: needs.changes.outputs.src_changed == 'true'
-    continue-on-error: true
     permissions:
       contents: read
       packages: read
@@ -251,39 +250,143 @@ jobs:
 
       - name: Install MAUI workload
         run: |
-          dotnet workload install maui-android \
-            || echo "::warning::MAUI Android workload install failed; Android checks are advisory and do not block merge"
+          dotnet workload install maui-android
 
       - name: Restore
         run: |
-          status=0
-          dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj -p:TargetFramework=net10.0-android || status=$?
-          dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj -p:TargetFramework=net10.0-android || status=$?
-
-          if [ "$status" -ne 0 ]; then
-            echo "::warning::Android restore failed; Android checks are advisory and do not block merge"
-          fi
+          dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj -p:TargetFramework=net10.0-android
+          dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj -p:TargetFramework=net10.0-android
 
       - name: Build MAUI Components
         run: |
           dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
             --configuration Release \
-            || echo "::warning::MAUI component build failed in Android job; Android checks are advisory and do not block merge"
+            /p:TreatWarningsAsErrors=true
 
       - name: Build Android Apps
         run: |
-          status=0
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
-            --framework net10.0-android || status=$?
+            --framework net10.0-android \
+            /p:TreatWarningsAsErrors=true
 
           dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
             --configuration Release \
-            --framework net10.0-android || status=$?
+            --framework net10.0-android \
+            /p:TreatWarningsAsErrors=true
 
-          if [ "$status" -ne 0 ]; then
-            echo "::warning::Android app build failed; Android checks are advisory and do not block merge"
-          fi
+      - name: Android trim smoke
+        run: |
+          # Keep direct mobile-code trim warnings blocking, but do not fail on assembly-level
+          # summaries emitted by upstream NuGet packages during the baseline app smoke.
+          dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
+            --configuration Release \
+            --framework net10.0-android \
+            /p:PublishTrimmed=true \
+            /p:TrimMode=full \
+            /p:TreatWarningsAsErrors=true \
+            /p:WarningsNotAsErrors=IL2104 \
+            /p:AndroidPackageFormat=apk
+
+      - name: Android API 33 emulator smoke
+        uses: reactivecircus/android-emulator-runner@v2
+        env:
+          HONUA_MOBILE_SMOKE_BASE_URL: ${{ vars.HONUA_MOBILE_SMOKE_BASE_URL }}
+          HONUA_MOBILE_SMOKE_SERVICE_ID: ${{ vars.HONUA_MOBILE_SMOKE_SERVICE_ID }}
+          HONUA_MOBILE_SMOKE_LAYER_ID: ${{ vars.HONUA_MOBILE_SMOKE_LAYER_ID }}
+          HONUA_MOBILE_SMOKE_API_KEY: ${{ secrets.HONUA_MOBILE_SMOKE_API_KEY }}
+        with:
+          api-level: 33
+          target: google_apis
+          arch: x86_64
+          script: |
+            adb shell getprop ro.build.version.sdk
+            dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj \
+              --configuration Release \
+              --logger "console;verbosity=minimal"
+
+  maui-ios:
+    name: MAUI iOS Build & AOT Smoke
+    runs-on: macos-latest
+    needs: [build, changes]
+    if: needs.changes.outputs.src_changed == 'true'
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure GitHub Packages
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
+
+      - name: Select Xcode 26.3
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
+          xcodebuild -version
+
+      - name: Install MAUI workload
+        run: dotnet workload install maui
+
+      - name: Verify iOS 17+ simulator runtime
+        run: xcrun simctl list runtimes | grep -E "iOS (17|18|19|20)"
+
+      - name: Restore
+        run: |
+          dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj -p:TargetFramework=net10.0-ios
+          dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj -p:TargetFramework=net10.0-ios
+
+      - name: Build MAUI Components
+        run: |
+          dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
+            --configuration Release \
+            /p:TreatWarningsAsErrors=true
+
+      - name: Build iOS Apps
+        run: |
+          dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
+            --configuration Release \
+            --framework net10.0-ios \
+            /p:RuntimeIdentifier=iossimulator-x64 \
+            /p:TreatWarningsAsErrors=true
+
+          dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
+            --configuration Release \
+            --framework net10.0-ios \
+            /p:RuntimeIdentifier=iossimulator-x64 \
+            /p:TreatWarningsAsErrors=true
+
+      - name: iOS trim and NativeAOT smoke
+        run: |
+          # Keep direct mobile-code trim/AOT warnings blocking, but do not fail on assembly-level
+          # summaries emitted by upstream NuGet packages during the baseline app smoke.
+          dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
+            --configuration Release \
+            --framework net10.0-ios \
+            /p:RuntimeIdentifier=ios-arm64 \
+            /p:PublishTrimmed=true \
+            /p:TrimMode=full \
+            /p:PublishAot=true \
+            /p:PublishAotUsingRuntimePack=true \
+            /p:EnableCodeSigning=false \
+            /p:ArchiveOnBuild=false \
+            /p:TreatWarningsAsErrors=true \
+            /p:WarningsNotAsErrors=IL2104%3BIL3053
+
+      - name: iOS live query smoke
+        env:
+          HONUA_MOBILE_SMOKE_BASE_URL: ${{ vars.HONUA_MOBILE_SMOKE_BASE_URL }}
+          HONUA_MOBILE_SMOKE_SERVICE_ID: ${{ vars.HONUA_MOBILE_SMOKE_SERVICE_ID }}
+          HONUA_MOBILE_SMOKE_LAYER_ID: ${{ vars.HONUA_MOBILE_SMOKE_LAYER_ID }}
+          HONUA_MOBILE_SMOKE_API_KEY: ${{ secrets.HONUA_MOBILE_SMOKE_API_KEY }}
+        run: |
+          dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj \
+            --configuration Release \
+            --logger "console;verbosity=minimal"
 
   maui-windows:
     name: MAUI Windows Build
@@ -367,6 +470,21 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v6
+
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      - name: Upload Trivy SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
 
       - name: Run CodeQL Analysis
         uses: github/codeql-action/init@v4
@@ -506,7 +624,7 @@ jobs:
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [build, test, maui-android, maui-windows, grpc-validation, security, quality-gates]
+    needs: [build, test, maui-android, maui-ios, maui-windows, grpc-validation, security, quality-gates]
     if: always()
     steps:
       - name: Check all required jobs succeeded
@@ -541,10 +659,17 @@ jobs:
 
           # Platform builds (can be skipped if no source changes)
           android_result="${{ needs.maui-android.result }}"
+          ios_result="${{ needs.maui-ios.result }}"
           windows_result="${{ needs.maui-windows.result }}"
 
           if [[ "$android_result" == "failure" ]]; then
-            echo "⚠️ Android build failed, but it is advisory and does not block merge"
+            echo "❌ Android build failed"
+            exit 1
+          fi
+
+          if [[ "$ios_result" == "failure" ]]; then
+            echo "❌ iOS build failed"
+            exit 1
           fi
 
           if [[ "$windows_result" == "failure" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,13 @@ jobs:
             /p:WarningsNotAsErrors=IL2104 \
             /p:AndroidPackageFormat=apk
 
+      - name: Enable KVM for Android emulator
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+          ls -l /dev/kvm
+
       - name: Android API 33 emulator smoke
         uses: reactivecircus/android-emulator-runner@v2
         env:
@@ -299,11 +306,12 @@ jobs:
           api-level: 33
           target: google_apis
           arch: x86_64
+          disable-linux-hw-accel: false
+          emulator-boot-timeout: 600
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -no-metrics
           script: |
             adb shell getprop ro.build.version.sdk
-            dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj \
-              --configuration Release \
-              --logger "console;verbosity=minimal"
+            dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --configuration Release --logger "console;verbosity=minimal"
 
   maui-ios:
     name: MAUI iOS Build & AOT Smoke

--- a/.github/workflows/publish-dotnet-mobile.yml
+++ b/.github/workflows/publish-dotnet-mobile.yml
@@ -65,6 +65,20 @@ jobs:
 
           echo "PACKAGE_VERSION=${package_version}" >> "${GITHUB_ENV}"
 
+      - name: Verify signed release tag
+        if: ${{ github.event_name == 'push' }}
+        shell: bash
+        run: |
+          git fetch --force origin "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}"
+          git verify-tag "${GITHUB_REF_NAME}"
+
+      - name: Block manual publishing outside signed releases
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true' }}
+        shell: bash
+        run: |
+          echo "::error::Mobile .NET packages publish only from signed mobile-dotnet-v* release tags. Use dry_run=true for manual validation."
+          exit 1
+
       - name: Build mobile packages
         shell: bash
         run: |
@@ -250,7 +264,7 @@ jobs:
   publish:
     name: Publish to GitHub Packages
     needs: package-smoke
-    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 offline-first field data collection with GeoPackage storage, gRPC transport,
 dynamic forms, and background sync.
 
+Current mobile SDK roadmap coordination is tracked from
+[honua-server#811](https://github.com/honua-io/honua-server/issues/811) and the
+[mobile SDK roadmap](https://github.com/honua-io/honua-server/blob/trunk/docs/developer/mobile-sdk-roadmap.md).
+
 ## Packages
 
 | Package | Purpose |
@@ -24,6 +28,7 @@ using Honua.Mobile.Offline.Sync;
 using Honua.Mobile.Sdk;
 
 builder.Services
+    .AddHonuaMobileAuth()
     .AddHonuaMobileSdk(new HonuaMobileClientOptions
     {
         BaseUri = new Uri("https://your-honua-server.com"),
@@ -59,6 +64,7 @@ GeoPackage-backed offline storage with queue-based sync:
 - **Background sync** -- connectivity-aware with periodic timer and semaphore gating
 - **Map area download** -- offline basemap packages with path traversal protection
 - **Delta sync** -- replica-based incremental downloads with cursor persistence
+- **Cache governance** -- per-layer TTL eviction and R-tree-backed bbox lookups for replicated features
 
 ## Field Collection
 

--- a/apps/Honua.Mobile.FieldCollection/App.xaml.cs
+++ b/apps/Honua.Mobile.FieldCollection/App.xaml.cs
@@ -5,24 +5,19 @@ public partial class App : Application
     public App()
     {
         InitializeComponent();
-        MainPage = new AppShell();
     }
 
     protected override Window CreateWindow(IActivationState? activationState)
     {
-        var window = base.CreateWindow(activationState);
-
-        if (window != null)
+        var window = new Window(new AppShell())
         {
-            // Configure window properties
-            window.Title = "Honua Field Collection";
+            Title = "Honua Field Collection"
+        };
 
-            // Set minimum window size for desktop platforms
 #if WINDOWS || MACCATALYST
-            window.MinimumHeight = 600;
-            window.MinimumWidth = 800;
+        window.MinimumHeight = 600;
+        window.MinimumWidth = 800;
 #endif
-        }
 
         return window;
     }

--- a/apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj
+++ b/apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj
@@ -19,7 +19,7 @@
         <ApplicationVersion>1</ApplicationVersion>
 
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
         <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
@@ -63,7 +63,6 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
         <PackageReference Include="CommunityToolkit.Maui" Version="9.1.0" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
@@ -72,8 +71,7 @@
         <!-- SQLite and GeoPackage support -->
         <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
         <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.8" />
-        <PackageReference Include="System.Text.Json" Version="10.0.0" />
-        <PackageReference Include="NetTopologySuite" Version="2.5.0" />
+        <PackageReference Include="NetTopologySuite" Version="2.6.0" />
         <PackageReference Include="NetTopologySuite.IO.SqlServerBytes" Version="2.1.0" />
     </ItemGroup>
 

--- a/apps/Honua.Mobile.FieldCollection/Models/CoreModels.cs
+++ b/apps/Honua.Mobile.FieldCollection/Models/CoreModels.cs
@@ -18,6 +18,44 @@ public class Feature
     public string? UpdatedBy { get; set; }
     public bool IsPendingSync { get; set; }
     public List<AttachmentInfo> Attachments { get; set; } = new();
+
+    public string DisplayTitle
+    {
+        get
+        {
+            if (Attributes.TryGetValue("name", out var name) && !string.IsNullOrWhiteSpace(name?.ToString()))
+            {
+                return name.ToString()!;
+            }
+
+            if (Attributes.TryGetValue("title", out var title) && !string.IsNullOrWhiteSpace(title?.ToString()))
+            {
+                return title.ToString()!;
+            }
+
+            return string.IsNullOrWhiteSpace(Id) ? "Untitled feature" : Id;
+        }
+    }
+
+    public string AttributeSummary
+    {
+        get
+        {
+            if (Attributes.Count == 0)
+            {
+                return "No attributes";
+            }
+
+            return string.Join(", ", Attributes
+                .Where(attribute => attribute.Value is not null)
+                .Take(3)
+                .Select(attribute => $"{attribute.Key}: {attribute.Value}"));
+        }
+    }
+
+    public bool HasAttachments => Attachments.Count > 0;
+
+    public int AttachmentsCount => Attachments.Count;
 }
 
 public abstract class Geometry

--- a/apps/Honua.Mobile.FieldCollection/Platforms/Android/MainActivity.cs
+++ b/apps/Honua.Mobile.FieldCollection/Platforms/Android/MainActivity.cs
@@ -1,0 +1,18 @@
+using Android.App;
+using Android.Content.PM;
+
+namespace Honua.Mobile.FieldCollection;
+
+[Activity(
+    Theme = "@style/Maui.SplashTheme",
+    MainLauncher = true,
+    LaunchMode = LaunchMode.SingleTop,
+    ConfigurationChanges = ConfigChanges.ScreenSize
+        | ConfigChanges.Orientation
+        | ConfigChanges.UiMode
+        | ConfigChanges.ScreenLayout
+        | ConfigChanges.SmallestScreenSize
+        | ConfigChanges.Density)]
+public class MainActivity : MauiAppCompatActivity
+{
+}

--- a/apps/Honua.Mobile.FieldCollection/Platforms/Android/MainApplication.cs
+++ b/apps/Honua.Mobile.FieldCollection/Platforms/Android/MainApplication.cs
@@ -1,0 +1,15 @@
+using Android.App;
+using Android.Runtime;
+
+namespace Honua.Mobile.FieldCollection;
+
+[Application]
+public class MainApplication : MauiApplication
+{
+    public MainApplication(IntPtr handle, JniHandleOwnership ownership)
+        : base(handle, ownership)
+    {
+    }
+
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/apps/Honua.Mobile.FieldCollection/Platforms/iOS/AppDelegate.cs
+++ b/apps/Honua.Mobile.FieldCollection/Platforms/iOS/AppDelegate.cs
@@ -1,0 +1,9 @@
+using Foundation;
+
+namespace Honua.Mobile.FieldCollection;
+
+[Register("AppDelegate")]
+public class AppDelegate : MauiUIApplicationDelegate
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/apps/Honua.Mobile.FieldCollection/Platforms/iOS/Info.plist
+++ b/apps/Honua.Mobile.FieldCollection/Platforms/iOS/Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>1</integer>
+        <integer>2</integer>
+    </array>
+    <key>UIRequiredDeviceCapabilities</key>
+    <array>
+        <string>arm64</string>
+    </array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+</dict>
+</plist>

--- a/apps/Honua.Mobile.FieldCollection/Platforms/iOS/Program.cs
+++ b/apps/Honua.Mobile.FieldCollection/Platforms/iOS/Program.cs
@@ -1,0 +1,11 @@
+using UIKit;
+
+namespace Honua.Mobile.FieldCollection;
+
+public class Program
+{
+    private static void Main(string[] args)
+    {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/apps/Honua.Mobile.FieldCollection/Resources/Styles/Styles.xaml
+++ b/apps/Honua.Mobile.FieldCollection/Resources/Styles/Styles.xaml
@@ -66,7 +66,6 @@
         <Setter Property="PlaceholderColor" Value="{StaticResource Gray500}" />
         <Setter Property="TextColor" Value="{StaticResource OnSurface}" />
         <Setter Property="BackgroundColor" Value="{StaticResource Surface}" />
-        <Setter Property="Padding" Value="16,12" />
     </Style>
 
     <!-- Label Styles -->

--- a/apps/Honua.Mobile.FieldCollection/Services/CoreServices.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/CoreServices.cs
@@ -3,6 +3,7 @@ using Honua.Mobile.FieldCollection.Models;
 using Microsoft.Maui.Devices.Sensors;
 using Microsoft.Maui.Networking;
 using Microsoft.Maui.Storage;
+using FieldPoint = Honua.Mobile.FieldCollection.Models.Point;
 
 namespace Honua.Mobile.FieldCollection.Services;
 
@@ -152,7 +153,7 @@ public class FeatureService : IFeatureService
             {
                 Id = "1",
                 LayerId = layerId,
-                Geometry = new Point(37.7749, -122.4194),
+                Geometry = new FieldPoint(37.7749, -122.4194),
                 CreatedAt = DateTime.UtcNow.AddDays(-1),
                 ModifiedAt = DateTime.UtcNow.AddDays(-1),
                 Attributes = new Dictionary<string, object>
@@ -166,7 +167,7 @@ public class FeatureService : IFeatureService
             {
                 Id = "2",
                 LayerId = layerId,
-                Geometry = new Point(37.7849, -122.4094),
+                Geometry = new FieldPoint(37.7849, -122.4094),
                 CreatedAt = DateTime.UtcNow.AddHours(-2),
                 ModifiedAt = DateTime.UtcNow.AddHours(-2),
                 Attributes = new Dictionary<string, object>

--- a/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/DiagnosticService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/DiagnosticService.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Networking;
+using System.Runtime.InteropServices;
 
 namespace Honua.Mobile.FieldCollection.Services.Diagnostics;
 
@@ -38,7 +39,7 @@ public class DiagnosticService
             Platform = DeviceInfo.Platform.ToString(),
             DeviceModel = DeviceInfo.Model,
             OperatingSystem = $"{DeviceInfo.Platform} {DeviceInfo.VersionString}",
-            Architecture = DeviceInfo.Architecture.ToString(),
+            Architecture = RuntimeInformation.ProcessArchitecture.ToString(),
             Manufacturer = DeviceInfo.Manufacturer,
             DeviceName = DeviceInfo.Name,
             DeviceType = DeviceInfo.DeviceType.ToString(),

--- a/apps/Honua.Mobile.FieldCollection/Services/INavigationService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/INavigationService.cs
@@ -43,17 +43,17 @@ public class NavigationService : INavigationService
 
     public async Task DisplayAlert(string title, string message, string cancel)
     {
-        await Shell.Current.DisplayAlert(title, message, cancel);
+        await Shell.Current.DisplayAlertAsync(title, message, cancel);
     }
 
     public async Task<bool> DisplayAlert(string title, string message, string accept, string cancel)
     {
-        return await Shell.Current.DisplayAlert(title, message, accept, cancel);
+        return await Shell.Current.DisplayAlertAsync(title, message, accept, cancel);
     }
 
     public async Task<string> DisplayActionSheet(string title, string cancel, string destruction, params string[] buttons)
     {
-        return await Shell.Current.DisplayActionSheet(title, cancel, destruction, buttons);
+        return await Shell.Current.DisplayActionSheetAsync(title, cancel, destruction, buttons);
     }
 
     public async Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = "", int maxLength = -1, Keyboard? keyboard = null, string initialValue = "")

--- a/apps/Honua.Mobile.FieldCollection/Services/ISyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/ISyncService.cs
@@ -62,6 +62,15 @@ public class ConflictInfo
     public DateTime DetectedAt { get; set; }
     public object? LocalVersion { get; set; }
     public object? ServerVersion { get; set; }
+
+    public string ConflictDescription => Type switch
+    {
+        ConflictType.UpdateUpdate => "Local and server versions were both updated.",
+        ConflictType.UpdateDelete => "Local changes conflict with a server delete.",
+        ConflictType.DeleteUpdate => "A local delete conflicts with server changes.",
+        ConflictType.GeometryOverlap => "Geometry overlaps with an existing feature.",
+        _ => "Sync conflict requires review."
+    };
 }
 
 public enum ConflictType

--- a/apps/Honua.Mobile.FieldCollection/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Storage/GeoPackageStorageService.cs
@@ -5,6 +5,7 @@ using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services.Storage.Models;
 using ChangeOperation = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeOperation;
 using CoreModels = Honua.Mobile.FieldCollection.Models;
+using StorageSpatialRelationship = Honua.Mobile.FieldCollection.Services.Storage.Models.SpatialRelationship;
 using StorageSyncStatus = Honua.Mobile.FieldCollection.Services.Storage.Models.SyncStatus;
 using NtsEnvelope = NetTopologySuite.Geometries.Envelope;
 using NtsGeometry = NetTopologySuite.Geometries.Geometry;
@@ -472,12 +473,12 @@ public class GeoPackageStorageService : IDisposable
 
         return spatialQuery.Relationship switch
         {
-            SpatialRelationship.Intersects => geometry.Intersects(queryGeometry),
-            SpatialRelationship.Contains => geometry.Contains(queryGeometry),
-            SpatialRelationship.Within => geometry.Within(queryGeometry),
-            SpatialRelationship.Overlaps => geometry.Overlaps(queryGeometry),
-            SpatialRelationship.Touches => geometry.Touches(queryGeometry),
-            SpatialRelationship.Crosses => geometry.Crosses(queryGeometry),
+            StorageSpatialRelationship.Intersects => geometry.Intersects(queryGeometry),
+            StorageSpatialRelationship.Contains => geometry.Contains(queryGeometry),
+            StorageSpatialRelationship.Within => geometry.Within(queryGeometry),
+            StorageSpatialRelationship.Overlaps => geometry.Overlaps(queryGeometry),
+            StorageSpatialRelationship.Touches => geometry.Touches(queryGeometry),
+            StorageSpatialRelationship.Crosses => geometry.Crosses(queryGeometry),
             _ => geometry.Intersects(queryGeometry)
         };
     }

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/MapViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/MapViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services;
 using System.Collections.ObjectModel;
+using FieldPoint = Honua.Mobile.FieldCollection.Models.Point;
 
 namespace Honua.Mobile.FieldCollection.ViewModels;
 
@@ -28,7 +29,7 @@ public partial class MapViewModel : BaseViewModel
     private bool isAddingFeature;
 
     [ObservableProperty]
-    private Point? newFeatureLocation;
+    private FieldPoint? newFeatureLocation;
 
     public ObservableCollection<LayerInfo> AvailableLayers { get; } = new();
     public ObservableCollection<Feature> MapFeatures { get; } = new();
@@ -175,7 +176,7 @@ public partial class MapViewModel : BaseViewModel
     }
 
     [RelayCommand]
-    private async Task AddFeatureAtLocation(Point location)
+    private async Task AddFeatureAtLocation(FieldPoint location)
     {
         if (!IsAddingFeature || SelectedLayer == null)
             return;

--- a/apps/Honua.Mobile.FieldCollection/Views/MapPage.xaml.cs
+++ b/apps/Honua.Mobile.FieldCollection/Views/MapPage.xaml.cs
@@ -1,5 +1,7 @@
 using Honua.Mobile.FieldCollection.ViewModels;
+using Microsoft.Maui.Controls.Maps;
 using Microsoft.Maui.Maps;
+using FieldPoint = Honua.Mobile.FieldCollection.Models.Point;
 
 namespace Honua.Mobile.FieldCollection.Views;
 
@@ -38,7 +40,7 @@ public partial class MapPage : ContentPage
         // Handle map clicks for adding new features
         if (_viewModel.IsAddingFeature)
         {
-            var point = new Models.Point
+            var point = new FieldPoint
             {
                 Latitude = e.Location.Latitude,
                 Longitude = e.Location.Longitude

--- a/apps/Honua.Mobile.FieldCollection/Views/RecordsPage.xaml
+++ b/apps/Honua.Mobile.FieldCollection/Views/RecordsPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:models="clr-namespace:Honua.Mobile.FieldCollection.Models"
              xmlns:vm="clr-namespace:Honua.Mobile.FieldCollection.ViewModels"
              x:Class="Honua.Mobile.FieldCollection.Views.RecordsPage"
              Title="{Binding Title}"
@@ -130,7 +131,7 @@
                 </CollectionView.EmptyView>
 
                 <CollectionView.ItemTemplate>
-                    <DataTemplate>
+                    <DataTemplate x:DataType="models:Feature">
                         <Frame Style="{StaticResource CardFrameStyle}" Margin="0,5">
                             <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
 

--- a/apps/Honua.Mobile.FieldCollection/Views/SyncCenterPage.xaml
+++ b/apps/Honua.Mobile.FieldCollection/Views/SyncCenterPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:services="clr-namespace:Honua.Mobile.FieldCollection.Services"
              xmlns:vm="clr-namespace:Honua.Mobile.FieldCollection.ViewModels"
              x:Class="Honua.Mobile.FieldCollection.Views.SyncCenterPage"
              Title="{Binding Title}"
@@ -141,7 +142,7 @@
 
                         <CollectionView ItemsSource="{Binding ActiveConflicts}">
                             <CollectionView.ItemTemplate>
-                                <DataTemplate>
+                                <DataTemplate x:DataType="services:ConflictInfo">
                                     <Grid ColumnDefinitions="*,Auto" Padding="10" ColumnSpacing="10">
                                         <StackLayout Grid.Column="0">
                                             <Label Text="{Binding LayerName}"
@@ -179,7 +180,7 @@
                         <CollectionView ItemsSource="{Binding SyncHistory}"
                                        MaximumHeightRequest="200">
                             <CollectionView.ItemTemplate>
-                                <DataTemplate>
+                                <DataTemplate x:DataType="vm:SyncHistoryItem">
                                     <Grid ColumnDefinitions="Auto,*,Auto" Padding="5" ColumnSpacing="10">
                                         <Label Grid.Column="0"
                                                Text="{Binding Status, Converter={StaticResource SyncStatusToEmojiConverter}}"

--- a/docs/guides/offline-sync.md
+++ b/docs/guides/offline-sync.md
@@ -79,6 +79,31 @@ builder.Services
 
 The adapter partitions cached features and queued edits by SDK package ID and source ID, so multiple offline packages can safely include the same source without overwriting feature rows or claiming each other's pending edits.
 
+## Cache Policy And Spatial Indexing
+
+`GeoPackageSyncStoreOptions` supports per-layer TTL policy for replicated feature caches:
+
+```csharp
+new GeoPackageSyncStoreOptions
+{
+    DatabasePath = "fielddata.gpkg",
+    DefaultFeatureCacheTtl = TimeSpan.FromDays(7),
+    LayerFeatureCacheTtls = new Dictionary<string, TimeSpan>
+    {
+        ["inspection-districts"] = TimeSpan.FromDays(30),
+        ["weather-alerts"] = TimeSpan.FromHours(6),
+    },
+};
+```
+
+`EvictExpiredFeaturesAsync` removes expired feature rows and their R-tree index records. Point and envelope geometries are indexed on insert in `rtree_honua_features`, and bbox queries use that finite spatial index before returning cached feature JSON. The GeoPackage SRS table keeps the OGC GeoPackage 1.3 built-in records, including EPSG:4326 as the default WGS-84 SRS for Honua-managed cache tables.
+
+SpatiaLite is not bundled for the baseline mobile cache path. Current feature-cache lookups only require SQLite R-tree envelope filtering, so SQLite-PCL-raw plus the platform SQLite provider is sufficient. If future work needs exact topology, CRS transforms, or SpatiaLite SQL functions on-device, add platform native binaries for iOS and Android in a separate packaging PR and gate them with AOT/trim smoke tests.
+
+## Lifecycle-Aware Prefetch
+
+`BackgroundPrefetchScheduler` runs optional cache-warming work with bounded concurrency. Call `CancelForLifecycleEventAsync(PrefetchLifecycleEvent.Suspend)` from app suspend handlers and `PrefetchLifecycleEvent.LowMemory` from platform memory-pressure hooks so downloads and cache fills observe cancellation before the OS reclaims resources.
+
 ## Configuration
 
 ### Basic Setup

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -107,6 +107,30 @@ public class SecureApiKeyManager
 }
 ```
 
+### Mobile Auth Token Provider
+
+For SDK code, prefer `IAuthTokenProvider` over passing static secrets through `HonuaMobileClientOptions`. The provider supports API-key and bearer-token modes, refreshes bearer tokens through a mockable `HttpClient`, and maps storage or refresh failures to `HonuaMobileAuthException` so raw platform exceptions are not exposed to consumers.
+
+```csharp
+using Honua.Mobile.Maui;
+using Honua.Mobile.Maui.Auth;
+using Honua.Mobile.Sdk.Auth;
+
+builder.Services
+    .AddHonuaMobileAuth(
+        new MauiSecureAuthTokenStore(new PlatformMauiSecureStorage()),
+        new RefreshingAuthTokenProviderOptions
+        {
+            RefreshEndpoint = new Uri("https://api.example.com/auth/refresh"),
+        })
+    .AddHonuaMobileSdk(new HonuaMobileClientOptions
+    {
+        BaseUri = new Uri("https://api.example.com"),
+    });
+```
+
+`PlatformMauiSecureStorage` uses MAUI Essentials secure storage on platform targets: iOS Keychain on Apple platforms and encrypted Android storage backed by the Android Keystore provider. For unit tests, use `InMemoryAuthTokenStore` and a stub `HttpMessageHandler` to exercise refresh logic without a live server.
+
 ### Certificate Pinning
 
 Implement certificate pinning for production:

--- a/quality/release-checklist.md
+++ b/quality/release-checklist.md
@@ -10,7 +10,9 @@ quality check; link the evidence (CI run URL, review comment, etc.) in the Notes
 - [ ] All CI gates pass (build, test, gRPC validation, security)
 - [ ] Performance budgets within thresholds (`quality/performance-budget.json`)
 - [ ] Smoke tests pass (`tests/Honua.Mobile.Smoke.Tests`)
-- [ ] No CodeQL or dependency-audit findings above accepted risk level
+- [ ] MAUI Android API 33 emulator smoke and trim publish pass; direct mobile-code trim warnings remain blocking
+- [ ] MAUI iOS 17+ simulator build plus trim/NativeAOT publish pass; direct mobile-code trim/AOT warnings remain blocking
+- [ ] No CodeQL, Trivy, or dependency-audit findings above accepted risk level
 
 ## Quality Review
 
@@ -24,12 +26,16 @@ quality check; link the evidence (CI run URL, review comment, etc.) in the Notes
 - [ ] Version number bumped in `Directory.Build.props` / `.csproj` files
 - [ ] Migration notes documented for breaking API changes (if any)
 - [ ] NuGet package metadata reviewed (description, tags, license)
+- [ ] NuGet publish release tag is signed and matches `mobile-dotnet-v*`
+- [ ] `trunk` branch protection confirmed: required reviews, required status checks, and force-push disabled
 
 ## Platform-Specific Validation
 
 - [ ] Android build and smoke test pass on CI
+- [ ] Android `PublishTrimmed=true; TrimMode=full` publish has no new direct mobile-code trim warnings; upstream package assembly-summary warnings are reviewed before release
 - [ ] Windows MAUI build passes on CI
-- [ ] iOS build verified (manual or Mac-hosted agent)
+- [ ] iOS simulator build verified on Mac-hosted CI
+- [ ] iOS `ios-arm64; PublishTrimmed=true; TrimMode=full; PublishAot=true; PublishAotUsingRuntimePack=true` publish has no new direct mobile-code trim/AOT warnings; upstream package assembly-summary warnings are reviewed before release
 
 ## Final Approval
 

--- a/src/Honua.Mobile.Maui/Auth/MauiSecureAuthTokenStore.cs
+++ b/src/Honua.Mobile.Maui/Auth/MauiSecureAuthTokenStore.cs
@@ -1,0 +1,106 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Mobile.Sdk.Auth;
+
+namespace Honua.Mobile.Maui.Auth;
+
+/// <summary>
+/// Minimal secure key-value storage contract used by <see cref="MauiSecureAuthTokenStore"/>.
+/// </summary>
+public interface IMauiSecureStorage
+{
+    /// <summary>
+    /// Gets a stored secure value.
+    /// </summary>
+    /// <param name="key">Storage key.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The stored value, or <see langword="null"/> when absent.</returns>
+    ValueTask<string?> GetAsync(string key, CancellationToken ct = default);
+
+    /// <summary>
+    /// Sets a secure value.
+    /// </summary>
+    /// <param name="key">Storage key.</param>
+    /// <param name="value">Value to store.</param>
+    /// <param name="ct">Cancellation token.</param>
+    ValueTask SetAsync(string key, string value, CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes a secure value.
+    /// </summary>
+    /// <param name="key">Storage key.</param>
+    /// <param name="ct">Cancellation token.</param>
+    ValueTask RemoveAsync(string key, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Auth token store backed by MAUI secure storage. On iOS this maps to Keychain, and on Android it maps to
+/// encrypted SharedPreferences protected by the Android Keystore provider.
+/// </summary>
+public sealed class MauiSecureAuthTokenStore : IAuthTokenStore
+{
+    private const string DefaultStorageKey = "honua.mobile.auth.token";
+
+    private readonly IMauiSecureStorage _storage;
+    private readonly string _storageKey;
+
+    /// <summary>
+    /// Initializes a new <see cref="MauiSecureAuthTokenStore"/>.
+    /// </summary>
+    /// <param name="storage">Platform secure storage adapter.</param>
+    /// <param name="storageKey">Storage key. Defaults to a Honua SDK key.</param>
+    public MauiSecureAuthTokenStore(IMauiSecureStorage storage, string storageKey = DefaultStorageKey)
+    {
+        _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+        _storageKey = string.IsNullOrWhiteSpace(storageKey) ? DefaultStorageKey : storageKey;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<HonuaAuthToken?> ReadAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var payload = await _storage.GetAsync(_storageKey, ct).ConfigureAwait(false);
+            return string.IsNullOrWhiteSpace(payload)
+                ? null
+                : JsonSerializer.Deserialize(payload, HonuaMobileMauiAuthJsonContext.Default.HonuaAuthToken);
+        }
+        catch (Exception ex)
+        {
+            throw new HonuaMobileAuthException("Honua auth token secure-storage read failed.", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask WriteAsync(HonuaAuthToken token, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(token);
+
+        try
+        {
+            var payload = JsonSerializer.Serialize(token, HonuaMobileMauiAuthJsonContext.Default.HonuaAuthToken);
+            await _storage.SetAsync(_storageKey, payload, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new HonuaMobileAuthException("Honua auth token secure-storage write failed.", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask ClearAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            await _storage.RemoveAsync(_storageKey, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new HonuaMobileAuthException("Honua auth token secure-storage clear failed.", ex);
+        }
+    }
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(HonuaAuthToken))]
+internal sealed partial class HonuaMobileMauiAuthJsonContext : JsonSerializerContext;

--- a/src/Honua.Mobile.Maui/Auth/PlatformMauiSecureStorage.cs
+++ b/src/Honua.Mobile.Maui/Auth/PlatformMauiSecureStorage.cs
@@ -1,0 +1,28 @@
+#if IOS || ANDROID || MACCATALYST
+using Microsoft.Maui.Storage;
+
+namespace Honua.Mobile.Maui.Auth;
+
+/// <summary>
+/// Platform secure-storage adapter backed by MAUI Essentials. iOS uses Keychain and Android uses
+/// encrypted SharedPreferences protected by the Android Keystore provider.
+/// </summary>
+public sealed class PlatformMauiSecureStorage : IMauiSecureStorage
+{
+    /// <inheritdoc />
+    public async ValueTask<string?> GetAsync(string key, CancellationToken ct = default)
+        => await SecureStorage.Default.GetAsync(key).WaitAsync(ct).ConfigureAwait(false);
+
+    /// <inheritdoc />
+    public async ValueTask SetAsync(string key, string value, CancellationToken ct = default)
+        => await SecureStorage.Default.SetAsync(key, value).WaitAsync(ct).ConfigureAwait(false);
+
+    /// <inheritdoc />
+    public ValueTask RemoveAsync(string key, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        SecureStorage.Default.Remove(key);
+        return ValueTask.CompletedTask;
+    }
+}
+#endif

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -1,10 +1,12 @@
 using Honua.Mobile.Field.Capture;
+using Honua.Mobile.Maui.Auth;
 using Honua.Mobile.Maui.Annotations;
 using Honua.Mobile.Offline.GeoPackage;
 using Honua.Mobile.Offline.MapAreas;
 using Honua.Mobile.Offline.ScenePackages;
 using Honua.Mobile.Offline.Sync;
 using Honua.Mobile.Sdk;
+using Honua.Mobile.Sdk.Auth;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Abstractions.Routing;
 using Honua.Sdk.Abstractions.Scenes;
@@ -48,8 +50,46 @@ public static class HonuaMobileServiceCollectionExtensions
         {
             var factory = sp.GetRequiredService<IHttpClientFactory>();
             var httpClient = factory.CreateClient("HonuaMobile");
-            return new HonuaMobileClient(httpClient, clientOptions);
+            var authTokenProvider = sp.GetService<IAuthTokenProvider>();
+            return new HonuaMobileClient(httpClient, clientOptions, authTokenProvider);
         });
+        return services;
+    }
+
+    /// <summary>
+    /// Registers mobile auth token storage and refresh services.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="tokenStore">Optional secure token store. When omitted, an in-memory store is registered.</param>
+    /// <param name="options">Optional token refresh options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaMobileAuth(
+        this IServiceCollection services,
+        IAuthTokenStore? tokenStore = null,
+        RefreshingAuthTokenProviderOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        if (tokenStore is null)
+        {
+            services.AddSingleton<IAuthTokenStore, InMemoryAuthTokenStore>();
+        }
+        else
+        {
+            services.AddSingleton<IAuthTokenStore>(tokenStore);
+        }
+
+        services.AddSingleton(options ?? new RefreshingAuthTokenProviderOptions());
+        services.AddHttpClient("HonuaMobileAuth");
+        services.AddSingleton<IAuthTokenProvider>(sp =>
+        {
+            var factory = sp.GetRequiredService<IHttpClientFactory>();
+            return new RefreshingAuthTokenProvider(
+                sp.GetRequiredService<IAuthTokenStore>(),
+                factory.CreateClient("HonuaMobileAuth"),
+                sp.GetRequiredService<RefreshingAuthTokenProviderOptions>());
+        });
+
         return services;
     }
 
@@ -216,6 +256,25 @@ public static class HonuaMobileServiceCollectionExtensions
             var logger = sp.GetRequiredService<ILogger<BackgroundSyncOrchestrator>>();
             return new BackgroundSyncOrchestrator(runner, connectivity, orchestratorOptions, logger: logger);
         });
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the cancellable background prefetch scheduler used for lifecycle-aware cache warming.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="options">Scheduler options; defaults are used when <see langword="null"/>.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaBackgroundPrefetch(
+        this IServiceCollection services,
+        BackgroundPrefetchSchedulerOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton(options ?? new BackgroundPrefetchSchedulerOptions());
+        services.AddSingleton<BackgroundPrefetchScheduler>(sp => new BackgroundPrefetchScheduler(
+            sp.GetRequiredService<BackgroundPrefetchSchedulerOptions>(),
+            sp.GetService<ILogger<BackgroundPrefetchScheduler>>()));
         return services;
     }
 

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageModels.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageModels.cs
@@ -21,6 +21,22 @@ public sealed class GeoPackageSyncStoreOptions
     /// Duration after which an in-progress operation claim is considered stale and can be reclaimed. Defaults to 5 minutes.
     /// </summary>
     public TimeSpan InProgressLeaseTimeout { get; init; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Default TTL for cached replicated features. When <see langword="null"/>, cached features do not expire by default.
+    /// </summary>
+    public TimeSpan? DefaultFeatureCacheTtl { get; init; }
+
+    /// <summary>
+    /// Per-layer TTL policy keyed by layer key. Values override <see cref="DefaultFeatureCacheTtl"/>.
+    /// </summary>
+    public IReadOnlyDictionary<string, TimeSpan> LayerFeatureCacheTtls { get; init; } =
+        new Dictionary<string, TimeSpan>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Clock used for TTL calculation. Defaults to <see cref="TimeProvider.System"/>.
+    /// </summary>
+    public TimeProvider TimeProvider { get; init; } = TimeProvider.System;
 }
 
 /// <summary>

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSdkOfflineStoreAdapter.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSdkOfflineStoreAdapter.cs
@@ -1,5 +1,7 @@
 using System.Globalization;
+using System.Text;
 using System.Text.Json;
+using Honua.Mobile.Offline;
 using Honua.Mobile.Offline.Sync;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Offline.Abstractions;
@@ -15,11 +17,6 @@ public sealed class GeoPackageSdkOfflineStoreAdapter :
     IOfflineSyncCheckpointStore,
     IOfflineSyncStateStore
 {
-    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
-    {
-        PropertyNameCaseInsensitive = true,
-    };
-
     private readonly IGeoPackageSyncStore _store;
 
     /// <summary>
@@ -136,7 +133,7 @@ public sealed class GeoPackageSdkOfflineStoreAdapter :
         var value = await _store.GetSyncCursorAsync(GetCheckpointKey(packageId, sourceId), ct).ConfigureAwait(false);
         return string.IsNullOrWhiteSpace(value)
             ? null
-            : JsonSerializer.Deserialize<OfflineSyncCheckpoint>(value, JsonOptions);
+            : HonuaMobileOfflineJson.Deserialize<OfflineSyncCheckpoint>(value);
     }
 
     /// <inheritdoc />
@@ -147,7 +144,7 @@ public sealed class GeoPackageSdkOfflineStoreAdapter :
         await _store.InitializeAsync(ct).ConfigureAwait(false);
         await _store.SetSyncCursorAsync(
             GetCheckpointKey(checkpoint.PackageId, checkpoint.SourceId),
-            JsonSerializer.Serialize(checkpoint, JsonOptions),
+            HonuaMobileOfflineJson.Serialize(checkpoint),
             ct).ConfigureAwait(false);
     }
 
@@ -160,7 +157,7 @@ public sealed class GeoPackageSdkOfflineStoreAdapter :
         var value = await _store.GetSyncCursorAsync(GetStateKey(packageId, sourceId), ct).ConfigureAwait(false);
         return string.IsNullOrWhiteSpace(value)
             ? null
-            : JsonSerializer.Deserialize<OfflineSyncState>(value, JsonOptions);
+            : HonuaMobileOfflineJson.Deserialize<OfflineSyncState>(value);
     }
 
     /// <inheritdoc />
@@ -171,7 +168,7 @@ public sealed class GeoPackageSdkOfflineStoreAdapter :
         await _store.InitializeAsync(ct).ConfigureAwait(false);
         await _store.SetSyncCursorAsync(
             GetStateKey(state.PackageId, state.SourceId),
-            JsonSerializer.Serialize(state, JsonOptions),
+            HonuaMobileOfflineJson.Serialize(state),
             ct).ConfigureAwait(false);
     }
 
@@ -190,7 +187,7 @@ public sealed class GeoPackageSdkOfflineStoreAdapter :
                 OfflineEditOperationKind.Delete => OfflineOperationType.Delete,
                 _ => throw new InvalidOperationException($"Unsupported SDK offline operation kind '{entry.OperationKind}'."),
             },
-            PayloadJson = JsonSerializer.Serialize(payload, JsonOptions),
+            PayloadJson = HonuaMobileOfflineJson.Serialize(payload),
             CreatedAtUtc = entry.CreatedAtUtc,
             AttemptCount = entry.AttemptCount,
         };
@@ -252,7 +249,7 @@ public sealed class GeoPackageSdkOfflineStoreAdapter :
     }
 
     private static OfflineOperationPayload DeserializePayload(string payloadJson)
-        => JsonSerializer.Deserialize<OfflineOperationPayload>(payloadJson, JsonOptions)
+        => HonuaMobileOfflineJson.Deserialize<OfflineOperationPayload>(payloadJson)
            ?? throw new InvalidOperationException("Offline operation payload cannot be null.");
 
     private static FeatureEditFeature? ToFeatureEditFeature(OfflineOperationPayload payload, OfflineOperationType operationType)
@@ -362,37 +359,106 @@ public sealed class GeoPackageSdkOfflineStoreAdapter :
             !attributes.ContainsKey("OBJECTID") &&
             long.TryParse(feature.Id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
         {
-            attributes[objectIdField] = JsonSerializer.SerializeToElement(objectId);
+            attributes[objectIdField] = ToJsonElement(objectId);
         }
 
-        var payload = new Dictionary<string, object?>
+        return SerializeJson(writer =>
         {
-            ["attributes"] = attributes,
-        };
+            writer.WriteStartObject();
+            writer.WritePropertyName("attributes");
+            WriteJsonObject(writer, attributes);
 
-        if (feature.Geometry is not null)
-        {
-            payload["geometry"] = feature.Geometry.Value;
-        }
+            if (feature.Geometry is { } geometry)
+            {
+                writer.WritePropertyName("geometry");
+                geometry.WriteTo(writer);
+            }
 
-        return JsonSerializer.Serialize(payload, JsonOptions);
+            writer.WriteEndObject();
+        });
     }
 
     private static JsonElement ToFeatureServerFeature(FeatureEditFeature feature)
-        => JsonSerializer.SerializeToElement(new Dictionary<string, object?>
+        => ToJsonElement(writer =>
         {
-            ["attributes"] = feature.Attributes,
-            ["geometry"] = feature.Geometry,
-        }, JsonOptions);
+            writer.WriteStartObject();
+            writer.WritePropertyName("attributes");
+            WriteJsonObject(writer, feature.Attributes);
+            writer.WritePropertyName("geometry");
+            WriteJsonElementOrNull(writer, feature.Geometry);
+            writer.WriteEndObject();
+        });
 
     private static JsonElement ToGeoJsonFeature(FeatureEditFeature feature)
-        => JsonSerializer.SerializeToElement(new Dictionary<string, object?>
+        => ToJsonElement(writer =>
         {
-            ["type"] = "Feature",
-            ["id"] = feature.Id,
-            ["properties"] = feature.Attributes,
-            ["geometry"] = feature.Geometry,
-        }, JsonOptions);
+            writer.WriteStartObject();
+            writer.WriteString("type", "Feature");
+            if (feature.Id is null)
+            {
+                writer.WriteNull("id");
+            }
+            else
+            {
+                writer.WriteString("id", feature.Id);
+            }
+
+            writer.WritePropertyName("properties");
+            WriteJsonObject(writer, feature.Attributes);
+            writer.WritePropertyName("geometry");
+            WriteJsonElementOrNull(writer, feature.Geometry);
+            writer.WriteEndObject();
+        });
+
+    private static string SerializeJson(Action<Utf8JsonWriter> writeJson)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writeJson(writer);
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static JsonElement ToJsonElement(long value)
+    {
+        using var document = JsonDocument.Parse(value.ToString(CultureInfo.InvariantCulture));
+        return document.RootElement.Clone();
+    }
+
+    private static JsonElement ToJsonElement(Action<Utf8JsonWriter> writeJson)
+    {
+        var json = SerializeJson(writeJson);
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private static void WriteJsonObject(Utf8JsonWriter writer, IReadOnlyDictionary<string, JsonElement>? values)
+    {
+        writer.WriteStartObject();
+        if (values is not null)
+        {
+            foreach (var (key, value) in values)
+            {
+                writer.WritePropertyName(key);
+                value.WriteTo(writer);
+            }
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static void WriteJsonElementOrNull(Utf8JsonWriter writer, JsonElement? value)
+    {
+        if (value is { } element)
+        {
+            element.WriteTo(writer);
+            return;
+        }
+
+        writer.WriteNullValue();
+    }
 
     private static string GetCheckpointKey(string packageId, string sourceId)
         => $"sdk-checkpoint:{packageId}:{sourceId}";

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageStorageException.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageStorageException.cs
@@ -1,0 +1,26 @@
+namespace Honua.Mobile.Offline.GeoPackage;
+
+/// <summary>
+/// Exception raised when GeoPackage storage operations fail with provider-specific errors.
+/// </summary>
+public sealed class GeoPackageStorageException : Exception
+{
+    /// <summary>
+    /// Initializes a new <see cref="GeoPackageStorageException"/>.
+    /// </summary>
+    /// <param name="message">Redacted error message safe for SDK consumers.</param>
+    public GeoPackageStorageException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="GeoPackageStorageException"/>.
+    /// </summary>
+    /// <param name="message">Redacted error message safe for SDK consumers.</param>
+    /// <param name="innerException">Original exception retained for diagnostics.</param>
+    public GeoPackageStorageException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
@@ -1,6 +1,8 @@
 using System.Globalization;
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Honua.Mobile.Offline;
 using Honua.Sdk.Abstractions.Scenes;
 using Microsoft.Data.Sqlite;
 
@@ -140,8 +142,30 @@ CREATE TABLE IF NOT EXISTS honua_features (
     object_id INTEGER NOT NULL,
     feature_json TEXT NOT NULL,
     updated_at_utc TEXT NOT NULL,
+    expires_at_utc TEXT,
+    min_x DOUBLE,
+    min_y DOUBLE,
+    max_x DOUBLE,
+    max_y DOUBLE,
     PRIMARY KEY (layer_key, object_id)
 );
+
+CREATE TABLE IF NOT EXISTS honua_feature_index_keys (
+    index_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    layer_key TEXT NOT NULL,
+    object_id INTEGER NOT NULL,
+    UNIQUE(layer_key, object_id)
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS rtree_honua_features USING rtree(
+    index_id,
+    min_x,
+    max_x,
+    min_y,
+    max_y
+);
+
+CREATE INDEX IF NOT EXISTS idx_honua_features_layer_expires ON honua_features(layer_key, expires_at_utc);
 
 INSERT OR IGNORE INTO gpkg_contents (table_name, data_type, identifier, description, srs_id)
 VALUES ('honua_features', 'attributes', 'honua_features', 'Replicated feature cache for delta sync', 4326);
@@ -158,6 +182,11 @@ VALUES ('honua_features', 'attributes', 'honua_features', 'Replicated feature ca
             "missing_optional_asset_keys_json",
             "TEXT NOT NULL DEFAULT '[]'",
             ct).ConfigureAwait(false);
+        await EnsureColumnExistsAsync(connection, "honua_features", "expires_at_utc", "TEXT", ct).ConfigureAwait(false);
+        await EnsureColumnExistsAsync(connection, "honua_features", "min_x", "DOUBLE", ct).ConfigureAwait(false);
+        await EnsureColumnExistsAsync(connection, "honua_features", "min_y", "DOUBLE", ct).ConfigureAwait(false);
+        await EnsureColumnExistsAsync(connection, "honua_features", "max_x", "DOUBLE", ct).ConfigureAwait(false);
+        await EnsureColumnExistsAsync(connection, "honua_features", "max_y", "DOUBLE", ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -403,7 +432,7 @@ ON CONFLICT(cursor_key) DO UPDATE SET
         await using var connection = OpenConnection();
         await connection.OpenAsync(ct).ConfigureAwait(false);
 
-        var bbox = JsonSerializer.Serialize(mapArea.BoundingBox);
+        var bbox = HonuaMobileOfflineJson.Serialize(mapArea.BoundingBox);
 
         await using var command = connection.CreateCommand();
         command.CommandText = @"
@@ -442,7 +471,7 @@ ON CONFLICT(area_id) DO UPDATE SET
         await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
         while (await reader.ReadAsync(ct).ConfigureAwait(false))
         {
-            var bbox = JsonSerializer.Deserialize<BoundingBox>(reader.GetString(2))
+            var bbox = HonuaMobileOfflineJson.Deserialize<BoundingBox>(reader.GetString(2))
                 ?? throw new InvalidOperationException("Invalid bbox payload in honua_map_areas.");
 
             items.Add(new MapAreaPackage
@@ -470,8 +499,8 @@ ON CONFLICT(area_id) DO UPDATE SET
 
         var extent = scenePackage.Extent is null
             ? null
-            : JsonSerializer.Serialize(scenePackage.Extent);
-        var missingOptionalAssetKeysJson = JsonSerializer.Serialize(scenePackage.MissingOptionalAssetKeys);
+            : HonuaMobileOfflineJson.Serialize(scenePackage.Extent);
+        var missingOptionalAssetKeysJson = HonuaMobileOfflineJson.Serialize(scenePackage.MissingOptionalAssetKeys.ToArray());
 
         await using var command = connection.CreateCommand();
         command.CommandText = @"
@@ -617,26 +646,61 @@ ORDER BY scene_id ASC, package_id ASC;
         ArgumentException.ThrowIfNullOrWhiteSpace(layerKey);
         ArgumentException.ThrowIfNullOrWhiteSpace(featureJson);
 
+        using var activity = MobileStorageTelemetry.ActivitySource.StartActivity("honua.mobile.storage.feature.upsert", ActivityKind.Internal);
+        activity?.SetTag("layer_key", layerKey);
+
         var objectId = ExtractObjectId(featureJson);
+        var extent = ExtractFeatureExtent(featureJson);
+        var expiresAtUtc = ResolveFeatureExpiresAtUtc(layerKey);
 
         await using var connection = OpenConnection();
         await connection.OpenAsync(ct).ConfigureAwait(false);
 
-        await using var command = connection.CreateCommand();
-        command.CommandText = @"
-INSERT INTO honua_features (layer_key, object_id, feature_json, updated_at_utc)
-VALUES ($layer_key, $object_id, $feature_json, $updated_at_utc)
+        await ExecuteTransactionCommandAsync(connection, "BEGIN IMMEDIATE;", ct).ConfigureAwait(false);
+        try
+        {
+            await using (var command = connection.CreateCommand())
+            {
+                command.CommandText = @"
+INSERT INTO honua_features (layer_key, object_id, feature_json, updated_at_utc, expires_at_utc, min_x, min_y, max_x, max_y)
+VALUES ($layer_key, $object_id, $feature_json, $updated_at_utc, $expires_at_utc, $min_x, $min_y, $max_x, $max_y)
 ON CONFLICT(layer_key, object_id) DO UPDATE SET
   feature_json = excluded.feature_json,
-  updated_at_utc = excluded.updated_at_utc;
+  updated_at_utc = excluded.updated_at_utc,
+  expires_at_utc = excluded.expires_at_utc,
+  min_x = excluded.min_x,
+  min_y = excluded.min_y,
+  max_x = excluded.max_x,
+  max_y = excluded.max_y;
 ";
 
-        command.Parameters.AddWithValue("$layer_key", layerKey);
-        command.Parameters.AddWithValue("$object_id", objectId);
-        command.Parameters.AddWithValue("$feature_json", featureJson);
-        command.Parameters.AddWithValue("$updated_at_utc", DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture));
+                command.Parameters.AddWithValue("$layer_key", layerKey);
+                command.Parameters.AddWithValue("$object_id", objectId);
+                command.Parameters.AddWithValue("$feature_json", featureJson);
+                command.Parameters.AddWithValue("$updated_at_utc", _options.TimeProvider.GetUtcNow().ToString("O", CultureInfo.InvariantCulture));
+                command.Parameters.AddWithValue("$expires_at_utc", ToDbValue(expiresAtUtc));
+                command.Parameters.AddWithValue("$min_x", ToDbValue(extent?.MinX));
+                command.Parameters.AddWithValue("$min_y", ToDbValue(extent?.MinY));
+                command.Parameters.AddWithValue("$max_x", ToDbValue(extent?.MaxX));
+                command.Parameters.AddWithValue("$max_y", ToDbValue(extent?.MaxY));
 
-        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+                await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            }
+
+            await UpsertFeatureIndexAsync(connection, layerKey, objectId, extent, ct).ConfigureAwait(false);
+            await ExecuteTransactionCommandAsync(connection, "COMMIT;", ct).ConfigureAwait(false);
+        }
+        catch (SqliteException ex)
+        {
+            await RollbackQuietlyAsync(connection).ConfigureAwait(false);
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw new GeoPackageStorageException("GeoPackage feature cache write failed.", ex);
+        }
+        catch
+        {
+            await RollbackQuietlyAsync(connection).ConfigureAwait(false);
+            throw;
+        }
     }
 
     /// <inheritdoc />
@@ -647,12 +711,33 @@ ON CONFLICT(layer_key, object_id) DO UPDATE SET
         await using var connection = OpenConnection();
         await connection.OpenAsync(ct).ConfigureAwait(false);
 
-        await using var command = connection.CreateCommand();
-        command.CommandText = "DELETE FROM honua_features WHERE layer_key = $layer_key AND object_id = $object_id;";
-        command.Parameters.AddWithValue("$layer_key", layerKey);
-        command.Parameters.AddWithValue("$object_id", objectId);
+        await ExecuteTransactionCommandAsync(connection, "BEGIN IMMEDIATE;", ct).ConfigureAwait(false);
+        try
+        {
+            var indexId = await GetFeatureIndexIdAsync(connection, layerKey, objectId, ct).ConfigureAwait(false);
+            if (indexId.HasValue)
+            {
+                await DeleteFeatureIndexAsync(connection, indexId.Value, ct).ConfigureAwait(false);
+            }
 
-        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            await using var command = connection.CreateCommand();
+            command.CommandText = "DELETE FROM honua_features WHERE layer_key = $layer_key AND object_id = $object_id;";
+            command.Parameters.AddWithValue("$layer_key", layerKey);
+            command.Parameters.AddWithValue("$object_id", objectId);
+
+            await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            await ExecuteTransactionCommandAsync(connection, "COMMIT;", ct).ConfigureAwait(false);
+        }
+        catch (SqliteException ex)
+        {
+            await RollbackQuietlyAsync(connection).ConfigureAwait(false);
+            throw new GeoPackageStorageException("GeoPackage feature cache delete failed.", ex);
+        }
+        catch
+        {
+            await RollbackQuietlyAsync(connection).ConfigureAwait(false);
+            throw;
+        }
     }
 
     /// <inheritdoc />
@@ -660,21 +745,225 @@ ON CONFLICT(layer_key, object_id) DO UPDATE SET
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(layerKey);
 
+        using var activity = MobileStorageTelemetry.ActivitySource.StartActivity("honua.mobile.storage.feature.query", ActivityKind.Internal);
+        activity?.SetTag("layer_key", layerKey);
+
         await using var connection = OpenConnection();
         await connection.OpenAsync(ct).ConfigureAwait(false);
 
         await using var command = connection.CreateCommand();
-        command.CommandText = "SELECT feature_json FROM honua_features WHERE layer_key = $layer_key ORDER BY object_id ASC;";
+        command.CommandText = @"
+SELECT feature_json
+FROM honua_features
+WHERE layer_key = $layer_key
+  AND (expires_at_utc IS NULL OR expires_at_utc > $now_utc)
+ORDER BY object_id ASC;
+";
         command.Parameters.AddWithValue("$layer_key", layerKey);
+        command.Parameters.AddWithValue("$now_utc", _options.TimeProvider.GetUtcNow().ToString("O", CultureInfo.InvariantCulture));
 
         var items = new List<string>();
-        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
-        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        try
         {
-            items.Add(reader.GetString(0));
+            await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                items.Add(reader.GetString(0));
+            }
+
+            MobileStorageTelemetry.RecordQuery("success");
+            return items;
+        }
+        catch (SqliteException ex)
+        {
+            MobileStorageTelemetry.RecordQuery("failure");
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw new GeoPackageStorageException("GeoPackage feature cache query failed.", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<string>> GetFeaturesAsync(string layerKey, BoundingBox boundingBox, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(layerKey);
+
+        using var activity = MobileStorageTelemetry.ActivitySource.StartActivity("honua.mobile.storage.feature.query_bbox", ActivityKind.Internal);
+        activity?.SetTag("layer_key", layerKey);
+
+        await using var connection = OpenConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = @"
+SELECT f.feature_json
+FROM honua_features f
+JOIN honua_feature_index_keys k
+  ON k.layer_key = f.layer_key
+ AND k.object_id = f.object_id
+JOIN rtree_honua_features r
+  ON r.index_id = k.index_id
+WHERE f.layer_key = $layer_key
+  AND (f.expires_at_utc IS NULL OR f.expires_at_utc > $now_utc)
+  AND r.min_x <= $max_x
+  AND r.max_x >= $min_x
+  AND r.min_y <= $max_y
+  AND r.max_y >= $min_y
+ORDER BY f.object_id ASC;
+";
+        command.Parameters.AddWithValue("$layer_key", layerKey);
+        command.Parameters.AddWithValue("$now_utc", _options.TimeProvider.GetUtcNow().ToString("O", CultureInfo.InvariantCulture));
+        command.Parameters.AddWithValue("$min_x", boundingBox.MinLongitude);
+        command.Parameters.AddWithValue("$min_y", boundingBox.MinLatitude);
+        command.Parameters.AddWithValue("$max_x", boundingBox.MaxLongitude);
+        command.Parameters.AddWithValue("$max_y", boundingBox.MaxLatitude);
+
+        var items = new List<string>();
+        try
+        {
+            await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                items.Add(reader.GetString(0));
+            }
+
+            MobileStorageTelemetry.RecordQuery("success");
+            return items;
+        }
+        catch (SqliteException ex)
+        {
+            MobileStorageTelemetry.RecordQuery("failure");
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw new GeoPackageStorageException("GeoPackage feature cache query failed.", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<int> EvictExpiredFeaturesAsync(CancellationToken ct = default)
+    {
+        var nowUtc = _options.TimeProvider.GetUtcNow().ToString("O", CultureInfo.InvariantCulture);
+
+        await using var connection = OpenConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+
+        await ExecuteTransactionCommandAsync(connection, "BEGIN IMMEDIATE;", ct).ConfigureAwait(false);
+        try
+        {
+            var expiredIndexIds = await ReadExpiredFeatureIndexIdsAsync(connection, nowUtc, ct).ConfigureAwait(false);
+            if (expiredIndexIds.Count > 0)
+            {
+                await DeleteFeatureIndexesAsync(connection, expiredIndexIds, ct).ConfigureAwait(false);
+            }
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = "DELETE FROM honua_features WHERE expires_at_utc IS NOT NULL AND expires_at_utc <= $now_utc;";
+            command.Parameters.AddWithValue("$now_utc", nowUtc);
+            var evicted = await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+            await ExecuteTransactionCommandAsync(connection, "COMMIT;", ct).ConfigureAwait(false);
+            MobileStorageTelemetry.RecordEvictions(evicted);
+            return evicted;
+        }
+        catch (SqliteException ex)
+        {
+            await RollbackQuietlyAsync(connection).ConfigureAwait(false);
+            throw new GeoPackageStorageException("GeoPackage feature cache eviction failed.", ex);
+        }
+        catch
+        {
+            await RollbackQuietlyAsync(connection).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<long> GetStorageSizeBytesAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        var bytes = File.Exists(_options.DatabasePath)
+            ? new FileInfo(_options.DatabasePath).Length
+            : 0L;
+        MobileStorageTelemetry.RecordSizeBytes(bytes);
+        return Task.FromResult(bytes);
+    }
+
+    private DateTimeOffset? ResolveFeatureExpiresAtUtc(string layerKey)
+    {
+        TimeSpan? ttl = null;
+        if (_options.LayerFeatureCacheTtls.TryGetValue(layerKey, out var layerTtl))
+        {
+            ttl = layerTtl;
+        }
+        else
+        {
+            ttl = _options.DefaultFeatureCacheTtl;
         }
 
-        return items;
+        if (!ttl.HasValue || ttl.Value <= TimeSpan.Zero)
+        {
+            return null;
+        }
+
+        return _options.TimeProvider.GetUtcNow().Add(ttl.Value);
+    }
+
+    private static FeatureExtent? ExtractFeatureExtent(string featureJson)
+    {
+        using var doc = JsonDocument.Parse(featureJson);
+        var root = doc.RootElement;
+        var geometry = root.TryGetProperty("geometry", out var geometryElement)
+            ? geometryElement
+            : root;
+
+        if (TryReadPointExtent(geometry, out var pointExtent))
+        {
+            return pointExtent;
+        }
+
+        if (TryReadEnvelopeExtent(geometry, out var envelopeExtent))
+        {
+            return envelopeExtent;
+        }
+
+        return null;
+    }
+
+    private static bool TryReadPointExtent(JsonElement geometry, out FeatureExtent extent)
+    {
+        if (TryGetDouble(geometry, "x", out var x) && TryGetDouble(geometry, "y", out var y))
+        {
+            extent = new FeatureExtent(x, y, x, y);
+            return true;
+        }
+
+        extent = default;
+        return false;
+    }
+
+    private static bool TryReadEnvelopeExtent(JsonElement geometry, out FeatureExtent extent)
+    {
+        if (TryGetDouble(geometry, "xmin", out var minX) &&
+            TryGetDouble(geometry, "ymin", out var minY) &&
+            TryGetDouble(geometry, "xmax", out var maxX) &&
+            TryGetDouble(geometry, "ymax", out var maxY))
+        {
+            extent = new FeatureExtent(minX, minY, maxX, maxY);
+            return true;
+        }
+
+        extent = default;
+        return false;
+    }
+
+    private static bool TryGetDouble(JsonElement element, string propertyName, out double value)
+    {
+        if (element.TryGetProperty(propertyName, out var property) && property.TryGetDouble(out value))
+        {
+            return true;
+        }
+
+        value = 0;
+        return false;
     }
 
     private static long ExtractObjectId(string featureJson)
@@ -733,6 +1022,153 @@ ON CONFLICT(layer_key, object_id) DO UPDATE SET
         await using var command = connection.CreateCommand();
         command.CommandText = sql;
         await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    private static async Task RollbackQuietlyAsync(SqliteConnection connection)
+    {
+        try
+        {
+            await ExecuteTransactionCommandAsync(connection, "ROLLBACK;", CancellationToken.None).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Preserve the original exception.
+        }
+    }
+
+    private static async Task UpsertFeatureIndexAsync(
+        SqliteConnection connection,
+        string layerKey,
+        long objectId,
+        FeatureExtent? extent,
+        CancellationToken ct)
+    {
+        var indexId = await EnsureFeatureIndexIdAsync(connection, layerKey, objectId, ct).ConfigureAwait(false);
+        if (extent is null)
+        {
+            await DeleteFeatureIndexAsync(connection, indexId, ct).ConfigureAwait(false);
+            return;
+        }
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = @"
+INSERT OR REPLACE INTO rtree_honua_features (index_id, min_x, max_x, min_y, max_y)
+VALUES ($index_id, $min_x, $max_x, $min_y, $max_y);
+";
+        command.Parameters.AddWithValue("$index_id", indexId);
+        command.Parameters.AddWithValue("$min_x", extent.Value.MinX);
+        command.Parameters.AddWithValue("$max_x", extent.Value.MaxX);
+        command.Parameters.AddWithValue("$min_y", extent.Value.MinY);
+        command.Parameters.AddWithValue("$max_y", extent.Value.MaxY);
+
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    private static async Task<long> EnsureFeatureIndexIdAsync(
+        SqliteConnection connection,
+        string layerKey,
+        long objectId,
+        CancellationToken ct)
+    {
+        await using (var insertCommand = connection.CreateCommand())
+        {
+            insertCommand.CommandText = @"
+INSERT INTO honua_feature_index_keys (layer_key, object_id)
+VALUES ($layer_key, $object_id)
+ON CONFLICT(layer_key, object_id) DO NOTHING;
+";
+            insertCommand.Parameters.AddWithValue("$layer_key", layerKey);
+            insertCommand.Parameters.AddWithValue("$object_id", objectId);
+            await insertCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+
+        return await GetFeatureIndexIdAsync(connection, layerKey, objectId, ct).ConfigureAwait(false)
+            ?? throw new GeoPackageStorageException("GeoPackage feature index key was not created.");
+    }
+
+    private static async Task<long?> GetFeatureIndexIdAsync(
+        SqliteConnection connection,
+        string layerKey,
+        long objectId,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = @"
+SELECT index_id
+FROM honua_feature_index_keys
+WHERE layer_key = $layer_key
+  AND object_id = $object_id
+LIMIT 1;
+";
+        command.Parameters.AddWithValue("$layer_key", layerKey);
+        command.Parameters.AddWithValue("$object_id", objectId);
+        var value = await command.ExecuteScalarAsync(ct).ConfigureAwait(false);
+        return value is null or DBNull ? null : Convert.ToInt64(value, CultureInfo.InvariantCulture);
+    }
+
+    private static async Task DeleteFeatureIndexAsync(SqliteConnection connection, long indexId, CancellationToken ct)
+    {
+        await using (var rtreeCommand = connection.CreateCommand())
+        {
+            rtreeCommand.CommandText = "DELETE FROM rtree_honua_features WHERE index_id = $index_id;";
+            rtreeCommand.Parameters.AddWithValue("$index_id", indexId);
+            await rtreeCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+
+        await using var keyCommand = connection.CreateCommand();
+        keyCommand.CommandText = "DELETE FROM honua_feature_index_keys WHERE index_id = $index_id;";
+        keyCommand.Parameters.AddWithValue("$index_id", indexId);
+        await keyCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    private static async Task<IReadOnlyList<long>> ReadExpiredFeatureIndexIdsAsync(
+        SqliteConnection connection,
+        string nowUtc,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = @"
+SELECT k.index_id
+FROM honua_feature_index_keys k
+JOIN honua_features f
+  ON f.layer_key = k.layer_key
+ AND f.object_id = k.object_id
+WHERE f.expires_at_utc IS NOT NULL
+  AND f.expires_at_utc <= $now_utc;
+";
+        command.Parameters.AddWithValue("$now_utc", nowUtc);
+
+        var indexIds = new List<long>();
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            indexIds.Add(reader.GetInt64(0));
+        }
+
+        return indexIds;
+    }
+
+    private static async Task DeleteFeatureIndexesAsync(
+        SqliteConnection connection,
+        IReadOnlyList<long> indexIds,
+        CancellationToken ct)
+    {
+        if (indexIds.Count == 0)
+        {
+            return;
+        }
+
+        await using (var rtreeCommand = connection.CreateCommand())
+        {
+            var parameters = AddIndexIdParameters(rtreeCommand, indexIds);
+            rtreeCommand.CommandText = $"DELETE FROM rtree_honua_features WHERE index_id IN ({parameters});";
+            await rtreeCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+
+        await using var keyCommand = connection.CreateCommand();
+        var keyParameters = AddIndexIdParameters(keyCommand, indexIds);
+        keyCommand.CommandText = $"DELETE FROM honua_feature_index_keys WHERE index_id IN ({keyParameters});";
+        await keyCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
 
     private static async Task<IReadOnlyList<string>> ReadPendingOperationIdsAsync(
@@ -803,7 +1239,7 @@ LIMIT $limit;
         var extentJson = reader.IsDBNull(5) ? null : reader.GetString(5);
         var extent = string.IsNullOrWhiteSpace(extentJson)
             ? null
-            : JsonSerializer.Deserialize<HonuaSceneBounds>(extentJson)
+            : HonuaMobileOfflineJson.Deserialize<HonuaSceneBounds>(extentJson)
                 ?? throw new InvalidOperationException("Invalid extent payload in honua_scene_packages.");
 
         return new ScenePackageRecord
@@ -830,7 +1266,7 @@ LIMIT $limit;
     }
 
     private static IReadOnlyList<string> ReadStringArrayJson(string json)
-        => JsonSerializer.Deserialize<List<string>>(json) ?? [];
+        => HonuaMobileOfflineJson.Deserialize<string[]>(json) ?? [];
 
     private static DateTimeOffset? ReadNullableDateTimeOffset(SqliteDataReader reader, int ordinal)
         => reader.IsDBNull(ordinal)
@@ -845,6 +1281,9 @@ LIMIT $limit;
             ? value.Value.ToString("O", CultureInfo.InvariantCulture)
             : DBNull.Value;
 
+    private static object ToDbValue(double? value)
+        => value.HasValue ? value.Value : DBNull.Value;
+
     private static string AddOperationIdParameters(SqliteCommand command, IReadOnlyList<string> operationIds)
     {
         var parameterNames = new string[operationIds.Count];
@@ -857,6 +1296,21 @@ LIMIT $limit;
 
         return string.Join(", ", parameterNames);
     }
+
+    private static string AddIndexIdParameters(SqliteCommand command, IReadOnlyList<long> indexIds)
+    {
+        var parameterNames = new string[indexIds.Count];
+        for (var i = 0; i < indexIds.Count; i++)
+        {
+            var parameterName = $"$index_id_{i}";
+            command.Parameters.AddWithValue(parameterName, indexIds[i]);
+            parameterNames[i] = parameterName;
+        }
+
+        return string.Join(", ", parameterNames);
+    }
+
+    private readonly record struct FeatureExtent(double MinX, double MinY, double MaxX, double MaxY);
 
     private static void ValidateSqlIdentifier(string identifier, string parameterName)
     {

--- a/src/Honua.Mobile.Offline/GeoPackage/IGeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/IGeoPackageSyncStore.cs
@@ -144,4 +144,30 @@ public interface IGeoPackageSyncStore
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Feature JSON strings for the specified layer.</returns>
     Task<IReadOnlyList<string>> GetFeaturesAsync(string layerKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Retrieves cached feature JSON payloads whose stored feature envelope intersects <paramref name="boundingBox"/>.
+    /// </summary>
+    /// <param name="layerKey">The layer identifier.</param>
+    /// <param name="boundingBox">Bounding box used for R-tree candidate lookup.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Feature JSON strings for the specified layer and extent.</returns>
+    Task<IReadOnlyList<string>> GetFeaturesAsync(string layerKey, BoundingBox boundingBox, CancellationToken ct = default)
+        => throw new NotSupportedException("This GeoPackage sync store does not support spatial feature queries.");
+
+    /// <summary>
+    /// Evicts expired cached features according to the configured per-layer TTL policy.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Number of cached features removed.</returns>
+    Task<int> EvictExpiredFeaturesAsync(CancellationToken ct = default)
+        => Task.FromResult(0);
+
+    /// <summary>
+    /// Returns the current GeoPackage database file size in bytes.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Database size in bytes, or 0 when the file does not exist.</returns>
+    Task<long> GetStorageSizeBytesAsync(CancellationToken ct = default)
+        => Task.FromResult(0L);
 }

--- a/src/Honua.Mobile.Offline/GeoPackage/MobileStorageTelemetry.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/MobileStorageTelemetry.cs
@@ -1,0 +1,58 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Honua.Mobile.Offline.GeoPackage;
+
+/// <summary>
+/// Telemetry sources emitted by the Honua mobile storage layer.
+/// </summary>
+public static class MobileStorageTelemetry
+{
+    /// <summary>
+    /// Activity source name for storage operations.
+    /// </summary>
+    public const string ActivitySourceName = "Honua.Mobile.Storage";
+
+    /// <summary>
+    /// Meter name for storage metrics.
+    /// </summary>
+    public const string MeterName = "Honua.Mobile.Storage";
+
+    /// <summary>
+    /// Activity source for local GeoPackage operations.
+    /// </summary>
+    public static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+
+    private static readonly Meter Meter = new(MeterName);
+    private static readonly Counter<long> Queries = Meter.CreateCounter<long>(
+        "mobile_storage_queries_total",
+        description: "Number of local mobile storage feature queries.");
+    private static readonly Counter<long> Evictions = Meter.CreateCounter<long>(
+        "mobile_storage_evictions_total",
+        description: "Number of cached features evicted from mobile storage.");
+    private static readonly UpDownCounter<long> SizeBytes = Meter.CreateUpDownCounter<long>(
+        "mobile_storage_size_bytes",
+        unit: "bytes",
+        description: "Observed mobile storage size in bytes.");
+
+    /// <summary>
+    /// Records a local feature query.
+    /// </summary>
+    /// <param name="result">Query outcome.</param>
+    public static void RecordQuery(string result)
+        => Queries.Add(1, new KeyValuePair<string, object?>("result", result));
+
+    /// <summary>
+    /// Records evicted feature rows.
+    /// </summary>
+    /// <param name="count">Number of rows evicted.</param>
+    public static void RecordEvictions(long count)
+        => Evictions.Add(count);
+
+    /// <summary>
+    /// Records an observed storage size.
+    /// </summary>
+    /// <param name="bytes">Storage size in bytes.</param>
+    public static void RecordSizeBytes(long bytes)
+        => SizeBytes.Add(bytes);
+}

--- a/src/Honua.Mobile.Offline/HonuaMobileOfflineJsonContext.cs
+++ b/src/Honua.Mobile.Offline/HonuaMobileOfflineJsonContext.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Mobile.Offline.GeoPackage;
+using Honua.Mobile.Offline.Sync;
+using Honua.Sdk.Abstractions.Scenes;
+using Honua.Sdk.Offline.Abstractions;
+
+namespace Honua.Mobile.Offline;
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(BoundingBox))]
+[JsonSerializable(typeof(HonuaSceneBounds))]
+[JsonSerializable(typeof(OfflineOperationPayload))]
+[JsonSerializable(typeof(OfflineSyncCheckpoint))]
+[JsonSerializable(typeof(OfflineSyncState))]
+[JsonSerializable(typeof(string[]))]
+internal sealed partial class HonuaMobileOfflineJsonContext : JsonSerializerContext;
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
+[JsonSerializable(typeof(HonuaScenePackageAsset))]
+[JsonSerializable(typeof(HonuaScenePackageByteBudget))]
+[JsonSerializable(typeof(HonuaScenePackageLod))]
+[JsonSerializable(typeof(HonuaScenePackageManifest))]
+internal sealed partial class HonuaMobileScenePackageJsonContext : JsonSerializerContext;
+
+internal static class HonuaMobileOfflineJson
+{
+    public static string Serialize<T>(T value)
+        => JsonSerializer.Serialize(value, typeof(T), HonuaMobileOfflineJsonContext.Default);
+
+    public static T? Deserialize<T>(string json)
+        => (T?)JsonSerializer.Deserialize(json, typeof(T), HonuaMobileOfflineJsonContext.Default);
+}

--- a/src/Honua.Mobile.Offline/ScenePackages/ScenePackageDownloader.cs
+++ b/src/Honua.Mobile.Offline/ScenePackages/ScenePackageDownloader.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using Honua.Mobile.Offline;
 using Honua.Mobile.Offline.GeoPackage;
 using Honua.Sdk.Abstractions.Scenes;
 
@@ -15,12 +16,6 @@ namespace Honua.Mobile.Offline.ScenePackages;
 /// </summary>
 public sealed class ScenePackageDownloader : IHonuaScenePackageDownloader
 {
-    private static readonly JsonSerializerOptions ManifestJsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = true,
-    };
-
     private readonly HttpClient _httpClient;
     private readonly IGeoPackageSyncStore _syncStore;
 
@@ -373,7 +368,11 @@ public sealed class ScenePackageDownloader : IHonuaScenePackageDownloader
     {
         var manifestPath = Path.Combine(stagingDirectory, "manifest.json");
         await using var stream = File.Create(manifestPath);
-        await JsonSerializer.SerializeAsync(stream, manifest, ManifestJsonOptions, ct).ConfigureAwait(false);
+        await JsonSerializer.SerializeAsync(
+            stream,
+            manifest,
+            HonuaMobileScenePackageJsonContext.Default.HonuaScenePackageManifest,
+            ct).ConfigureAwait(false);
         return manifestPath;
     }
 

--- a/src/Honua.Mobile.Offline/Sync/BackgroundPrefetchScheduler.cs
+++ b/src/Honua.Mobile.Offline/Sync/BackgroundPrefetchScheduler.cs
@@ -1,0 +1,151 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Mobile.Offline.Sync;
+
+/// <summary>
+/// Runs bounded background prefetch work and cooperatively cancels it on mobile lifecycle events.
+/// </summary>
+public sealed class BackgroundPrefetchScheduler : IAsyncDisposable
+{
+    private readonly BackgroundPrefetchSchedulerOptions _options;
+    private readonly ILogger<BackgroundPrefetchScheduler> _logger;
+    private readonly SemaphoreSlim _concurrency;
+    private readonly object _sync = new();
+    private readonly List<Task> _runningTasks = [];
+    private CancellationTokenSource _lifetimeCts = new();
+
+    /// <summary>
+    /// Initializes a new <see cref="BackgroundPrefetchScheduler"/>.
+    /// </summary>
+    /// <param name="options">Scheduler options. Defaults are used when omitted.</param>
+    /// <param name="logger">Optional logger.</param>
+    public BackgroundPrefetchScheduler(
+        BackgroundPrefetchSchedulerOptions? options = null,
+        ILogger<BackgroundPrefetchScheduler>? logger = null)
+    {
+        _options = options ?? new BackgroundPrefetchSchedulerOptions();
+        _logger = logger ?? NullLogger<BackgroundPrefetchScheduler>.Instance;
+        _concurrency = new SemaphoreSlim(Math.Max(1, _options.MaxConcurrency));
+    }
+
+    /// <summary>
+    /// Number of prefetch tasks currently tracked by the scheduler.
+    /// </summary>
+    public int RunningCount
+    {
+        get
+        {
+            lock (_sync)
+            {
+                PruneCompletedTasks();
+                return _runningTasks.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Starts a background prefetch item.
+    /// </summary>
+    /// <param name="workItem">Work item to run.</param>
+    /// <param name="ct">Cancellation token linked to this specific item.</param>
+    /// <returns>The scheduled task.</returns>
+    public Task ScheduleAsync(IBackgroundPrefetchWorkItem workItem, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(workItem);
+
+        CancellationTokenSource linkedCts;
+        lock (_sync)
+        {
+            PruneCompletedTasks();
+            linkedCts = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeCts.Token, ct);
+        }
+
+        var task = Task.Run(async () =>
+        {
+            using (linkedCts)
+            {
+                await RunWorkItemAsync(workItem, linkedCts.Token).ConfigureAwait(false);
+            }
+        }, CancellationToken.None);
+        lock (_sync)
+        {
+            _runningTasks.Add(task);
+        }
+
+        return task;
+    }
+
+    /// <summary>
+    /// Cancels in-flight prefetch work because the host app received a lifecycle pressure event.
+    /// </summary>
+    /// <param name="reason">Lifecycle reason for cancellation.</param>
+    /// <param name="ct">Cancellation token used while waiting for work to observe cancellation.</param>
+    public async Task CancelForLifecycleEventAsync(PrefetchLifecycleEvent reason, CancellationToken ct = default)
+    {
+        Task[] tasks;
+        lock (_sync)
+        {
+            _logger.LogInformation("Cancelling mobile prefetch work because of lifecycle event {LifecycleEvent}.", reason);
+            _lifetimeCts.Cancel();
+            tasks = _runningTasks.ToArray();
+        }
+
+        try
+        {
+            await Task.WhenAll(tasks).WaitAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            // Individual task errors are logged in RunWorkItemAsync; cancellation should not fail lifecycle handling.
+        }
+        finally
+        {
+            lock (_sync)
+            {
+                _lifetimeCts.Dispose();
+                _lifetimeCts = new CancellationTokenSource();
+                PruneCompletedTasks();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await CancelForLifecycleEventAsync(PrefetchLifecycleEvent.Shutdown).ConfigureAwait(false);
+        _lifetimeCts.Dispose();
+        _concurrency.Dispose();
+    }
+
+    private async Task RunWorkItemAsync(IBackgroundPrefetchWorkItem workItem, CancellationToken ct)
+    {
+        try
+        {
+            await _concurrency.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                await workItem.ExecuteAsync(ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                _concurrency.Release();
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Cooperative lifecycle cancellation.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Background prefetch item {PrefetchItemId} failed.", workItem.ItemId);
+        }
+    }
+
+    private void PruneCompletedTasks()
+        => _runningTasks.RemoveAll(static task => task.IsCompleted);
+}

--- a/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
+++ b/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Net;
 using System.Text.Json;
+using Honua.Mobile.Offline;
 using Honua.Mobile.Offline.GeoPackage;
 using Honua.Mobile.Sdk;
 using Honua.Mobile.Sdk.Models;
@@ -14,11 +15,6 @@ namespace Honua.Mobile.Offline.Sync;
 /// </summary>
 public sealed class HonuaApiOfflineOperationUploader : IOfflineOperationUploader
 {
-    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
-    {
-        PropertyNameCaseInsensitive = true,
-    };
-
     private readonly HonuaMobileClient _client;
 
     /// <summary>
@@ -39,7 +35,7 @@ public sealed class HonuaApiOfflineOperationUploader : IOfflineOperationUploader
         OfflineOperationPayload payload;
         try
         {
-            payload = JsonSerializer.Deserialize<OfflineOperationPayload>(operation.PayloadJson, JsonOptions)
+            payload = HonuaMobileOfflineJson.Deserialize<OfflineOperationPayload>(operation.PayloadJson)
                       ?? throw new InvalidOperationException("Payload cannot be null.");
         }
         catch (Exception ex)

--- a/src/Honua.Mobile.Offline/Sync/ReplicaSyncClient.cs
+++ b/src/Honua.Mobile.Offline/Sync/ReplicaSyncClient.cs
@@ -9,11 +9,6 @@ namespace Honua.Mobile.Offline.Sync;
 /// </summary>
 public sealed class ReplicaSyncClient : IReplicaSyncClient
 {
-    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
-    {
-        PropertyNameCaseInsensitive = true,
-    };
-
     private readonly HttpClient _httpClient;
 
     /// <summary>

--- a/src/Honua.Mobile.Offline/Sync/SyncContracts.cs
+++ b/src/Honua.Mobile.Offline/Sync/SyncContracts.cs
@@ -123,6 +123,55 @@ public sealed class BackgroundSyncOrchestratorOptions
 }
 
 /// <summary>
+/// Lifecycle event that should cancel optional background prefetch work.
+/// </summary>
+public enum PrefetchLifecycleEvent
+{
+    /// <summary>
+    /// The app is entering the background or suspended state.
+    /// </summary>
+    Suspend,
+
+    /// <summary>
+    /// The platform reported memory pressure.
+    /// </summary>
+    LowMemory,
+
+    /// <summary>
+    /// The scheduler is shutting down.
+    /// </summary>
+    Shutdown,
+}
+
+/// <summary>
+/// Configuration options for <see cref="BackgroundPrefetchScheduler"/>.
+/// </summary>
+public sealed class BackgroundPrefetchSchedulerOptions
+{
+    /// <summary>
+    /// Maximum number of prefetch items allowed to run at the same time.
+    /// </summary>
+    public int MaxConcurrency { get; init; } = 2;
+}
+
+/// <summary>
+/// Represents a cancellable background prefetch task.
+/// </summary>
+public interface IBackgroundPrefetchWorkItem
+{
+    /// <summary>
+    /// Stable identifier used for diagnostics.
+    /// </summary>
+    string ItemId { get; }
+
+    /// <summary>
+    /// Executes the prefetch work.
+    /// </summary>
+    /// <param name="ct">Cancellation token that is triggered for app suspend, low memory, or shutdown.</param>
+    Task ExecuteAsync(CancellationToken ct = default);
+}
+
+/// <summary>
 /// Summary of a single offline sync cycle.
 /// </summary>
 public sealed class SyncRunResult

--- a/src/Honua.Mobile.Sdk/Auth/HonuaAuthToken.cs
+++ b/src/Honua.Mobile.Sdk/Auth/HonuaAuthToken.cs
@@ -1,0 +1,76 @@
+namespace Honua.Mobile.Sdk.Auth;
+
+/// <summary>
+/// Authentication scheme represented by a mobile auth token.
+/// </summary>
+public enum HonuaAuthScheme
+{
+    /// <summary>
+    /// Token is sent through the <c>X-API-Key</c> header.
+    /// </summary>
+    ApiKey,
+
+    /// <summary>
+    /// Token is sent through the HTTP bearer-token authorization convention.
+    /// </summary>
+    Bearer,
+}
+
+/// <summary>
+/// Mobile authentication material resolved by an <see cref="IAuthTokenProvider"/>.
+/// </summary>
+public sealed record HonuaAuthToken
+{
+    /// <summary>
+    /// Initializes a new <see cref="HonuaAuthToken"/>.
+    /// </summary>
+    /// <param name="scheme">Authentication scheme used for the token.</param>
+    /// <param name="accessToken">API key or bearer access token value.</param>
+    /// <param name="refreshToken">Optional refresh token used to obtain a new bearer token.</param>
+    /// <param name="expiresAtUtc">Optional access token expiration time in UTC.</param>
+    public HonuaAuthToken(
+        HonuaAuthScheme scheme,
+        string accessToken,
+        string? refreshToken = null,
+        DateTimeOffset? expiresAtUtc = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(accessToken);
+
+        Scheme = scheme;
+        AccessToken = accessToken;
+        RefreshToken = refreshToken;
+        ExpiresAtUtc = expiresAtUtc;
+    }
+
+    /// <summary>
+    /// Authentication scheme used for the token.
+    /// </summary>
+    public HonuaAuthScheme Scheme { get; }
+
+    /// <summary>
+    /// API key or bearer access token value.
+    /// </summary>
+    public string AccessToken { get; }
+
+    /// <summary>
+    /// Optional refresh token used to obtain a new bearer token.
+    /// </summary>
+    public string? RefreshToken { get; }
+
+    /// <summary>
+    /// Optional access token expiration time in UTC.
+    /// </summary>
+    public DateTimeOffset? ExpiresAtUtc { get; }
+
+    /// <summary>
+    /// Determines whether the token should be refreshed before use.
+    /// </summary>
+    /// <param name="nowUtc">Current UTC time.</param>
+    /// <param name="refreshSkew">Clock skew applied before expiration.</param>
+    /// <returns><see langword="true"/> when a refresh should be attempted.</returns>
+    public bool ShouldRefresh(DateTimeOffset nowUtc, TimeSpan refreshSkew)
+        => Scheme == HonuaAuthScheme.Bearer &&
+            !string.IsNullOrWhiteSpace(RefreshToken) &&
+            ExpiresAtUtc.HasValue &&
+            ExpiresAtUtc.Value <= nowUtc.Add(refreshSkew);
+}

--- a/src/Honua.Mobile.Sdk/Auth/HonuaMobileAuthException.cs
+++ b/src/Honua.Mobile.Sdk/Auth/HonuaMobileAuthException.cs
@@ -1,0 +1,26 @@
+namespace Honua.Mobile.Sdk.Auth;
+
+/// <summary>
+/// Exception raised when mobile authentication cannot resolve, refresh, or persist tokens.
+/// </summary>
+public sealed class HonuaMobileAuthException : Exception
+{
+    /// <summary>
+    /// Initializes a new <see cref="HonuaMobileAuthException"/>.
+    /// </summary>
+    /// <param name="message">Redacted error message safe for SDK consumers.</param>
+    public HonuaMobileAuthException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="HonuaMobileAuthException"/>.
+    /// </summary>
+    /// <param name="message">Redacted error message safe for SDK consumers.</param>
+    /// <param name="innerException">Original exception retained for diagnostics.</param>
+    public HonuaMobileAuthException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Honua.Mobile.Sdk/Auth/IAuthTokenProvider.cs
+++ b/src/Honua.Mobile.Sdk/Auth/IAuthTokenProvider.cs
@@ -1,0 +1,60 @@
+namespace Honua.Mobile.Sdk.Auth;
+
+/// <summary>
+/// Resolves and refreshes mobile authentication tokens used by Honua clients.
+/// </summary>
+public interface IAuthTokenProvider
+{
+    /// <summary>
+    /// Returns the current token, refreshing it first when the provider supports refresh and the token is near expiry.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The current token, or <see langword="null"/> when no token is available.</returns>
+    ValueTask<HonuaAuthToken?> GetTokenAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Attempts to refresh the current token.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The refreshed token, the existing token when refresh is not possible, or <see langword="null"/> when no token exists.</returns>
+    ValueTask<HonuaAuthToken?> RefreshTokenAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Stores new authentication material.
+    /// </summary>
+    /// <param name="token">Token to store.</param>
+    /// <param name="ct">Cancellation token.</param>
+    ValueTask StoreTokenAsync(HonuaAuthToken token, CancellationToken ct = default);
+
+    /// <summary>
+    /// Clears stored authentication material.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    ValueTask ClearTokenAsync(CancellationToken ct = default);
+}
+
+/// <summary>
+/// Secure storage abstraction used by auth token providers.
+/// </summary>
+public interface IAuthTokenStore
+{
+    /// <summary>
+    /// Reads stored authentication material.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The stored token, or <see langword="null"/> when no token is stored.</returns>
+    ValueTask<HonuaAuthToken?> ReadAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Writes authentication material to storage.
+    /// </summary>
+    /// <param name="token">Token to persist.</param>
+    /// <param name="ct">Cancellation token.</param>
+    ValueTask WriteAsync(HonuaAuthToken token, CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes authentication material from storage.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    ValueTask ClearAsync(CancellationToken ct = default);
+}

--- a/src/Honua.Mobile.Sdk/Auth/InMemoryAuthTokenStore.cs
+++ b/src/Honua.Mobile.Sdk/Auth/InMemoryAuthTokenStore.cs
@@ -1,0 +1,54 @@
+namespace Honua.Mobile.Sdk.Auth;
+
+/// <summary>
+/// In-memory token store intended for tests, local development, and custom provider composition.
+/// </summary>
+public sealed class InMemoryAuthTokenStore : IAuthTokenStore
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private HonuaAuthToken? _token;
+
+    /// <inheritdoc />
+    public async ValueTask<HonuaAuthToken?> ReadAsync(CancellationToken ct = default)
+    {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            return _token;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask WriteAsync(HonuaAuthToken token, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(token);
+
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            _token = token;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask ClearAsync(CancellationToken ct = default)
+    {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            _token = null;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}

--- a/src/Honua.Mobile.Sdk/Auth/MobileAuthTelemetry.cs
+++ b/src/Honua.Mobile.Sdk/Auth/MobileAuthTelemetry.cs
@@ -1,0 +1,37 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Honua.Mobile.Sdk.Auth;
+
+/// <summary>
+/// Telemetry sources emitted by the Honua mobile auth layer.
+/// </summary>
+public static class MobileAuthTelemetry
+{
+    /// <summary>
+    /// Activity source name for auth operations.
+    /// </summary>
+    public const string ActivitySourceName = "Honua.Mobile.Auth";
+
+    /// <summary>
+    /// Meter name for auth metrics.
+    /// </summary>
+    public const string MeterName = "Honua.Mobile.Auth";
+
+    /// <summary>
+    /// Activity source for token resolution and refresh operations.
+    /// </summary>
+    public static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+
+    private static readonly Meter Meter = new(MeterName);
+    private static readonly Counter<long> TokenRefreshes = Meter.CreateCounter<long>(
+        "mobile_auth_token_refreshes_total",
+        description: "Number of mobile auth token refresh attempts.");
+
+    /// <summary>
+    /// Records a token refresh attempt.
+    /// </summary>
+    /// <param name="result">Refresh outcome such as <c>success</c>, <c>skipped</c>, or <c>failure</c>.</param>
+    public static void RecordTokenRefresh(string result)
+        => TokenRefreshes.Add(1, new KeyValuePair<string, object?>("result", result));
+}

--- a/src/Honua.Mobile.Sdk/Auth/RefreshingAuthTokenProvider.cs
+++ b/src/Honua.Mobile.Sdk/Auth/RefreshingAuthTokenProvider.cs
@@ -74,6 +74,10 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
         {
             throw;
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             throw new HonuaMobileAuthException("Honua auth token resolution failed.", ex);
@@ -124,6 +128,10 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
         {
             throw;
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             MobileAuthTelemetry.RecordTokenRefresh("failure");
@@ -141,6 +149,10 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
         {
             await _store.WriteAsync(token, ct).ConfigureAwait(false);
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             throw new HonuaMobileAuthException("Honua auth token persistence failed.", ex);
@@ -153,6 +165,10 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
         try
         {
             await _store.ClearAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/Honua.Mobile.Sdk/Auth/RefreshingAuthTokenProvider.cs
+++ b/src/Honua.Mobile.Sdk/Auth/RefreshingAuthTokenProvider.cs
@@ -1,0 +1,219 @@
+using System.Diagnostics;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Honua.Mobile.Sdk.Auth;
+
+/// <summary>
+/// Options for <see cref="RefreshingAuthTokenProvider"/>.
+/// </summary>
+public sealed class RefreshingAuthTokenProviderOptions
+{
+    /// <summary>
+    /// Token refresh endpoint. When unset, refresh attempts return the current stored token.
+    /// </summary>
+    public Uri? RefreshEndpoint { get; init; }
+
+    /// <summary>
+    /// Clock used for expiration checks. Defaults to <see cref="TimeProvider.System"/>.
+    /// </summary>
+    public TimeProvider TimeProvider { get; init; } = TimeProvider.System;
+
+    /// <summary>
+    /// Time before expiration when a bearer token should be refreshed. Defaults to 2 minutes.
+    /// </summary>
+    public TimeSpan RefreshSkew { get; init; } = TimeSpan.FromMinutes(2);
+}
+
+/// <summary>
+/// Token provider that stores tokens locally and can refresh bearer tokens through a mockable HTTP endpoint.
+/// </summary>
+public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
+{
+    private readonly IAuthTokenStore _store;
+    private readonly HttpClient _http;
+    private readonly RefreshingAuthTokenProviderOptions _options;
+
+    /// <summary>
+    /// Initializes a new <see cref="RefreshingAuthTokenProvider"/>.
+    /// </summary>
+    /// <param name="store">Secure token store.</param>
+    /// <param name="http">HTTP client used for refresh requests.</param>
+    /// <param name="options">Provider options.</param>
+    public RefreshingAuthTokenProvider(
+        IAuthTokenStore store,
+        HttpClient http,
+        RefreshingAuthTokenProviderOptions? options = null)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _options = options ?? new RefreshingAuthTokenProviderOptions();
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<HonuaAuthToken?> GetTokenAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var token = await _store.ReadAsync(ct).ConfigureAwait(false);
+            if (token is null)
+            {
+                return null;
+            }
+
+            var now = _options.TimeProvider.GetUtcNow();
+            if (!token.ShouldRefresh(now, _options.RefreshSkew))
+            {
+                return token;
+            }
+
+            return await RefreshTokenAsync(ct).ConfigureAwait(false);
+        }
+        catch (HonuaMobileAuthException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new HonuaMobileAuthException("Honua auth token resolution failed.", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<HonuaAuthToken?> RefreshTokenAsync(CancellationToken ct = default)
+    {
+        using var activity = MobileAuthTelemetry.ActivitySource.StartActivity("honua.mobile.auth.refresh", ActivityKind.Client);
+        activity?.SetTag("auth.scheme", "bearer");
+
+        try
+        {
+            var current = await _store.ReadAsync(ct).ConfigureAwait(false);
+            if (current is null || string.IsNullOrWhiteSpace(current.RefreshToken) || _options.RefreshEndpoint is null)
+            {
+                MobileAuthTelemetry.RecordTokenRefresh("skipped");
+                activity?.SetTag("auth.refresh.result", "skipped");
+                return current;
+            }
+
+            using var content = JsonContent.Create(
+                new RefreshTokenRequest(current.RefreshToken),
+                HonuaMobileAuthJsonContext.Default.RefreshTokenRequest);
+            using var response = await _http.PostAsync(_options.RefreshEndpoint, content, ct).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                MobileAuthTelemetry.RecordTokenRefresh("failure");
+                activity?.SetStatus(ActivityStatusCode.Error);
+                throw new HonuaMobileAuthException("Honua auth token refresh failed.");
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+            var payload = await JsonSerializer.DeserializeAsync(
+                stream,
+                HonuaMobileAuthJsonContext.Default.JsonElement,
+                ct).ConfigureAwait(false);
+            var refreshed = ParseRefreshResponse(payload, current);
+            await _store.WriteAsync(refreshed, ct).ConfigureAwait(false);
+
+            MobileAuthTelemetry.RecordTokenRefresh("success");
+            activity?.SetTag("auth.refresh.result", "success");
+            return refreshed;
+        }
+        catch (HonuaMobileAuthException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            MobileAuthTelemetry.RecordTokenRefresh("failure");
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw new HonuaMobileAuthException("Honua auth token refresh failed.", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask StoreTokenAsync(HonuaAuthToken token, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(token);
+
+        try
+        {
+            await _store.WriteAsync(token, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new HonuaMobileAuthException("Honua auth token persistence failed.", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask ClearTokenAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            await _store.ClearAsync(ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new HonuaMobileAuthException("Honua auth token clearing failed.", ex);
+        }
+    }
+
+    private static HonuaAuthToken ParseRefreshResponse(JsonElement payload, HonuaAuthToken current)
+    {
+        var accessToken = ReadString(payload, "accessToken", "access_token")
+            ?? throw new HonuaMobileAuthException("Honua auth token refresh returned no access token.");
+        var refreshToken = ReadString(payload, "refreshToken", "refresh_token") ?? current.RefreshToken;
+        var tokenType = ReadString(payload, "tokenType", "token_type");
+        var scheme = string.Equals(tokenType, "api_key", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(tokenType, "apiKey", StringComparison.OrdinalIgnoreCase)
+                ? HonuaAuthScheme.ApiKey
+                : HonuaAuthScheme.Bearer;
+        var expiresAtUtc = ReadExpiresAt(payload);
+
+        return new HonuaAuthToken(scheme, accessToken, refreshToken, expiresAtUtc);
+    }
+
+    private static string? ReadString(JsonElement payload, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (payload.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String)
+            {
+                return value.GetString();
+            }
+        }
+
+        return null;
+    }
+
+    private static DateTimeOffset? ReadExpiresAt(JsonElement payload)
+    {
+        var expiresAt = ReadString(payload, "expiresAtUtc", "expires_at_utc", "expiresAt", "expires_at");
+        if (DateTimeOffset.TryParse(expiresAt, out var parsed))
+        {
+            return parsed.ToUniversalTime();
+        }
+
+        if (payload.TryGetProperty("expiresIn", out var expiresIn) || payload.TryGetProperty("expires_in", out expiresIn))
+        {
+            if (expiresIn.TryGetInt64(out var seconds))
+            {
+                return DateTimeOffset.UtcNow.AddSeconds(seconds);
+            }
+        }
+
+        return null;
+    }
+}
+
+internal sealed record RefreshTokenRequest(
+    [property: JsonPropertyName("refreshToken")] string RefreshToken);
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(RefreshTokenRequest))]
+[JsonSerializable(typeof(JsonElement))]
+internal sealed partial class HonuaMobileAuthJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using Honua.Mobile.Sdk.Auth;
 using Honua.Mobile.Sdk.Models;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Abstractions.Scenes;
@@ -28,6 +29,7 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
     private readonly HonuaFeatureServerClient _featureServerClient;
     private readonly HonuaOgcFeaturesClient _ogcFeaturesClient;
     private readonly HonuaMobileClientOptions _options;
+    private readonly IAuthTokenProvider? _authTokenProvider;
     private readonly object _grpcClientSync = new();
     private readonly bool _canUseGrpcEndpoint;
     private HonuaGrpcClient? _grpcClient;
@@ -39,9 +41,22 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
     /// <param name="options">Configuration controlling endpoints, authentication, and transport preferences.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="httpClient"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     public HonuaMobileClient(HttpClient httpClient, HonuaMobileClientOptions options)
+        : this(httpClient, options, authTokenProvider: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="HonuaMobileClient"/> with the supplied HTTP client, options, and auth token provider.
+    /// </summary>
+    /// <param name="httpClient">The <see cref="HttpClient"/> used for REST requests.</param>
+    /// <param name="options">Configuration controlling endpoints, authentication, and transport preferences.</param>
+    /// <param name="authTokenProvider">Optional provider that resolves API-key or bearer-token credentials.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="httpClient"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
+    public HonuaMobileClient(HttpClient httpClient, HonuaMobileClientOptions options, IAuthTokenProvider? authTokenProvider)
     {
         _http = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _options = options ?? throw new ArgumentNullException(nameof(options));
+        _authTokenProvider = authTokenProvider ?? options.AuthTokenProvider;
         _http.BaseAddress = options.BaseUri;
         _http.Timeout = options.Timeout;
         _http.DefaultRequestHeaders.UserAgent.Clear();
@@ -822,8 +837,19 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
 
     private async ValueTask ApplyHttpAuthenticationAsync(HttpRequestMessage request, CancellationToken ct)
     {
+        var apiKey = _options.ApiKey;
         var token = await ResolveBearerTokenAsync(ct).ConfigureAwait(false);
-        var hasApiKey = !string.IsNullOrWhiteSpace(_options.ApiKey);
+        var providerToken = await ResolveProviderTokenAsync(ct).ConfigureAwait(false);
+        if (providerToken is { Scheme: HonuaAuthScheme.ApiKey })
+        {
+            apiKey = providerToken.AccessToken;
+        }
+        else if (providerToken is { Scheme: HonuaAuthScheme.Bearer })
+        {
+            token = providerToken.AccessToken;
+        }
+
+        var hasApiKey = !string.IsNullOrWhiteSpace(apiKey);
         var hasBearerToken = !string.IsNullOrWhiteSpace(token);
 
         if (hasApiKey || hasBearerToken)
@@ -833,7 +859,7 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
 
         if (hasApiKey)
         {
-            request.Headers.TryAddWithoutValidation("X-API-Key", _options.ApiKey);
+            request.Headers.TryAddWithoutValidation("X-API-Key", apiKey);
         }
 
         if (!string.IsNullOrWhiteSpace(token))
@@ -852,6 +878,11 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
 
         return token;
     }
+
+    private async ValueTask<HonuaAuthToken?> ResolveProviderTokenAsync(CancellationToken ct)
+        => _authTokenProvider is null
+            ? null
+            : await _authTokenProvider.GetTokenAsync(ct).ConfigureAwait(false);
 
     internal HonuaGrpcClient GetGrpcClient()
     {
@@ -873,12 +904,48 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
         {
             Address = address.ToString(),
             ApiKey = _options.ApiKey,
+            ApiKeyProvider = BuildGrpcApiKeyProvider(),
             BearerToken = _options.BearerToken,
-            BearerTokenProvider = _options.AccessTokenProvider is null
-                ? null
-                : async ct => await _options.AccessTokenProvider(ct).ConfigureAwait(false) ?? _options.BearerToken,
+            BearerTokenProvider = BuildGrpcBearerTokenProvider(),
             Timeout = _options.Timeout,
         };
+    }
+
+    private Func<CancellationToken, Task<string?>>? BuildGrpcApiKeyProvider()
+    {
+        if (_authTokenProvider is null)
+        {
+            return null;
+        }
+
+        return async ct =>
+        {
+            var token = await _authTokenProvider.GetTokenAsync(ct).ConfigureAwait(false);
+            return token is { Scheme: HonuaAuthScheme.ApiKey }
+                ? token.AccessToken
+                : _options.ApiKey;
+        };
+    }
+
+    private Func<CancellationToken, Task<string?>>? BuildGrpcBearerTokenProvider()
+    {
+        if (_authTokenProvider is not null)
+        {
+            return async ct =>
+            {
+                var token = await _authTokenProvider.GetTokenAsync(ct).ConfigureAwait(false);
+                if (token is { Scheme: HonuaAuthScheme.Bearer })
+                {
+                    return token.AccessToken;
+                }
+
+                return await ResolveBearerTokenAsync(ct).ConfigureAwait(false);
+            };
+        }
+
+        return _options.AccessTokenProvider is null
+            ? null
+            : async ct => await _options.AccessTokenProvider(ct).ConfigureAwait(false) ?? _options.BearerToken;
     }
 
     internal static HonuaSceneClientOptions BuildSceneClientOptions(HonuaMobileClientOptions options)
@@ -892,7 +959,8 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
     private bool HasConfiguredGrpcAuthentication =>
         !string.IsNullOrWhiteSpace(_options.ApiKey) ||
         !string.IsNullOrWhiteSpace(_options.BearerToken) ||
-        _options.AccessTokenProvider is not null;
+        _options.AccessTokenProvider is not null ||
+        _authTokenProvider is not null;
 
     private Uri ResolveAbsoluteRequestUri(HttpRequestMessage request)
     {

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
@@ -838,7 +838,7 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
     private async ValueTask ApplyHttpAuthenticationAsync(HttpRequestMessage request, CancellationToken ct)
     {
         var apiKey = _options.ApiKey;
-        var token = await ResolveBearerTokenAsync(ct).ConfigureAwait(false);
+        var token = _options.BearerToken;
         var providerToken = await ResolveProviderTokenAsync(ct).ConfigureAwait(false);
         if (providerToken is { Scheme: HonuaAuthScheme.ApiKey })
         {
@@ -847,6 +847,10 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
         else if (providerToken is { Scheme: HonuaAuthScheme.Bearer })
         {
             token = providerToken.AccessToken;
+        }
+        else
+        {
+            token = await ResolveBearerTokenAsync(ct).ConfigureAwait(false);
         }
 
         var hasApiKey = !string.IsNullOrWhiteSpace(apiKey);
@@ -939,7 +943,9 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
                     return token.AccessToken;
                 }
 
-                return await ResolveBearerTokenAsync(ct).ConfigureAwait(false);
+                return token is null
+                    ? await ResolveBearerTokenAsync(ct).ConfigureAwait(false)
+                    : _options.BearerToken;
             };
         }
 

--- a/src/Honua.Mobile.Sdk/HonuaMobileClientOptions.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClientOptions.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Headers;
+using Honua.Mobile.Sdk.Auth;
 
 namespace Honua.Mobile.Sdk;
 
@@ -46,6 +47,12 @@ public sealed class HonuaMobileClientOptions
     /// Async callback that resolves a fresh bearer token on each request. Takes precedence over <see cref="BearerToken"/>.
     /// </summary>
     public Func<CancellationToken, ValueTask<string?>>? AccessTokenProvider { get; init; }
+
+    /// <summary>
+    /// Optional first-class auth token provider. When set, the provider can supply API-key or bearer-token credentials
+    /// and can refresh bearer tokens before requests.
+    /// </summary>
+    public IAuthTokenProvider? AuthTokenProvider { get; init; }
 
     /// <summary>
     /// When <see langword="true"/>, authentication credentials are allowed over plain HTTP.

--- a/src/Honua.Mobile.Sdk/SdkFeatureTransportMappings.cs
+++ b/src/Honua.Mobile.Sdk/SdkFeatureTransportMappings.cs
@@ -76,7 +76,9 @@ internal static class SdkFeatureTransportMappings
         var id = featureId ?? ResolveOptionalFeatureId(feature);
         return new OgcFeature
         {
-            Id = id is null ? null : JsonSerializer.SerializeToElement(id),
+            Id = id is null
+                ? null
+                : JsonSerializer.SerializeToElement(id, HonuaMobileSdkTransportJsonContext.Default.String),
             Geometry = feature.Geometry.HasValue ? feature.Geometry.Value.Clone() : null,
             Properties = feature.Attributes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone()),
         };
@@ -125,7 +127,10 @@ internal static class SdkFeatureTransportMappings
         {
             JsonElement element => element.GetRawText(),
             JsonDocument document => document.RootElement.GetRawText(),
-            _ => JsonSerializer.Serialize(feature),
+            FeatureEditFeature editFeature => JsonSerializer.Serialize(
+                ToOgcFeature(editFeature),
+                HonuaMobileSdkTransportJsonContext.Default.OgcFeature),
+            _ => SerializeWithContext(feature),
         };
 
         return JsonSerializer.Deserialize(json, HonuaMobileSdkTransportJsonContext.Default.OgcFeature)
@@ -140,7 +145,7 @@ internal static class SdkFeatureTransportMappings
         {
             JsonElement element => element.Clone(),
             JsonDocument document => document.RootElement.Clone(),
-            _ => JsonSerializer.SerializeToElement(value),
+            _ => SerializeToElementWithContext(value),
         };
     }
 
@@ -225,6 +230,38 @@ internal static class SdkFeatureTransportMappings
             features.ToArray(),
             HonuaMobileSdkTransportJsonContext.Default.FeatureServerFeatureArray);
 
+    private static string SerializeWithContext(object value)
+    {
+        try
+        {
+            return JsonSerializer.Serialize(value, value.GetType(), HonuaMobileSdkTransportJsonContext.Default);
+        }
+        catch (NotSupportedException ex)
+        {
+            throw new ArgumentException(
+                "OGC feature payload must be an OgcFeature, FeatureEditFeature, JsonElement, JsonDocument, or a source-generated JSON type.",
+                nameof(value),
+                ex);
+        }
+    }
+
+    private static JsonElement SerializeToElementWithContext(object value)
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(value, value.GetType(), HonuaMobileSdkTransportJsonContext.Default);
+            using var document = JsonDocument.Parse(json);
+            return document.RootElement.Clone();
+        }
+        catch (NotSupportedException ex)
+        {
+            throw new ArgumentException(
+                "OGC patch payload must be a JsonElement, JsonDocument, or a source-generated JSON type.",
+                nameof(value),
+                ex);
+        }
+    }
+
     private static string JoinInvariant(IEnumerable<long> values)
         => string.Join(',', values.Select(value => value.ToString(CultureInfo.InvariantCulture)));
 
@@ -274,6 +311,7 @@ internal sealed class OgcCollectionsEnvelope
 [JsonSerializable(typeof(OgcFeatureCollection))]
 [JsonSerializable(typeof(OgcFeature))]
 [JsonSerializable(typeof(JsonElement))]
+[JsonSerializable(typeof(string))]
 internal sealed partial class HonuaMobileSdkTransportJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Mobile.Sdk/SdkGrpcTransportMappings.cs
+++ b/src/Honua.Mobile.Sdk/SdkGrpcTransportMappings.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Globalization;
 using System.Text.Json;
 using Honua.Mobile.Sdk.Models;
@@ -53,7 +54,7 @@ internal static class SdkGrpcTransportMappings
             ["extent"] = ToExtent(response.Extent),
         };
 
-        return JsonSerializer.SerializeToDocument(payload);
+        return SerializePayload(payload);
     }
 
     public static JsonDocument ToJsonDocument(GrpcModels.FeaturePage page)
@@ -68,7 +69,7 @@ internal static class SdkGrpcTransportMappings
             ["isLastPage"] = page.IsLastPage,
         };
 
-        return JsonSerializer.SerializeToDocument(payload);
+        return SerializePayload(payload);
     }
 
     public static JsonDocument ToJsonDocument(GrpcModels.ApplyEditsResponse response)
@@ -81,7 +82,7 @@ internal static class SdkGrpcTransportMappings
             ["error"] = response.Error is null ? null : ToEditError(response.Error),
         };
 
-        return JsonSerializer.SerializeToDocument(payload);
+        return SerializePayload(payload);
     }
 
     private static IReadOnlyList<GrpcModels.Feature>? ToGrpcFeatures(
@@ -325,4 +326,76 @@ internal static class SdkGrpcTransportMappings
             ["code"] = source.Code,
             ["message"] = source.Message,
         };
+
+    private static JsonDocument SerializePayload(IReadOnlyDictionary<string, object?> payload)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            WriteObject(writer, payload);
+        }
+
+        return JsonDocument.Parse(stream.ToArray());
+    }
+
+    private static void WriteObject(Utf8JsonWriter writer, IReadOnlyDictionary<string, object?> values)
+    {
+        writer.WriteStartObject();
+        foreach (var (name, value) in values)
+        {
+            writer.WritePropertyName(name);
+            WriteValue(writer, value);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static void WriteValue(Utf8JsonWriter writer, object? value)
+    {
+        switch (value)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case string stringValue:
+                writer.WriteStringValue(stringValue);
+                break;
+            case bool boolValue:
+                writer.WriteBooleanValue(boolValue);
+                break;
+            case int intValue:
+                writer.WriteNumberValue(intValue);
+                break;
+            case long longValue:
+                writer.WriteNumberValue(longValue);
+                break;
+            case float floatValue:
+                writer.WriteNumberValue(floatValue);
+                break;
+            case double doubleValue:
+                writer.WriteNumberValue(doubleValue);
+                break;
+            case decimal decimalValue:
+                writer.WriteNumberValue(decimalValue);
+                break;
+            case JsonElement element:
+                element.WriteTo(writer);
+                break;
+            case IReadOnlyDictionary<string, object?> objectDictionary:
+                WriteObject(writer, objectDictionary);
+                break;
+            case IEnumerable enumerable:
+                writer.WriteStartArray();
+                foreach (var item in enumerable)
+                {
+                    WriteValue(writer, item);
+                }
+
+                writer.WriteEndArray();
+                break;
+            default:
+                writer.WriteStringValue(value.ToString());
+                break;
+        }
+    }
 }

--- a/tests/Honua.Mobile.Maui.Tests/MauiAuthRegistrationTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/MauiAuthRegistrationTests.cs
@@ -1,0 +1,69 @@
+using Honua.Mobile.Maui;
+using Honua.Mobile.Maui.Auth;
+using Honua.Mobile.Sdk;
+using Honua.Mobile.Sdk.Auth;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Mobile.Maui.Tests;
+
+public sealed class MauiAuthRegistrationTests
+{
+    [Fact]
+    public void AddHonuaMobileAuth_RegistersProviderAndWiresClient()
+    {
+        var store = new InMemoryAuthTokenStore();
+
+        using var provider = new ServiceCollection()
+            .AddHonuaMobileAuth(store)
+            .AddHonuaMobileSdk(new HonuaMobileClientOptions
+            {
+                BaseUri = new Uri("https://api.honua.test"),
+                PreferGrpcForFeatureQueries = false,
+            })
+            .BuildServiceProvider();
+
+        Assert.Same(store, provider.GetRequiredService<IAuthTokenStore>());
+        Assert.IsType<RefreshingAuthTokenProvider>(provider.GetRequiredService<IAuthTokenProvider>());
+        Assert.NotNull(provider.GetRequiredService<HonuaMobileClient>());
+    }
+
+    [Fact]
+    public async Task MauiSecureAuthTokenStore_RoundTripsToken()
+    {
+        var storage = new FakeSecureStorage();
+        var store = new MauiSecureAuthTokenStore(storage);
+
+        await store.WriteAsync(new HonuaAuthToken(
+            HonuaAuthScheme.Bearer,
+            "access-token",
+            "refresh-token",
+            DateTimeOffset.UtcNow.AddHours(1)));
+
+        var token = await store.ReadAsync();
+
+        Assert.NotNull(token);
+        Assert.Equal(HonuaAuthScheme.Bearer, token.Scheme);
+        Assert.Equal("access-token", token.AccessToken);
+        Assert.Equal("refresh-token", token.RefreshToken);
+    }
+
+    private sealed class FakeSecureStorage : IMauiSecureStorage
+    {
+        private string? _value;
+
+        public ValueTask<string?> GetAsync(string key, CancellationToken ct = default)
+            => ValueTask.FromResult(_value);
+
+        public ValueTask SetAsync(string key, string value, CancellationToken ct = default)
+        {
+            _value = value;
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask RemoveAsync(string key, CancellationToken ct = default)
+        {
+            _value = null;
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/Honua.Mobile.Offline.Tests/BackgroundPrefetchSchedulerTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/BackgroundPrefetchSchedulerTests.cs
@@ -1,0 +1,48 @@
+using Honua.Mobile.Offline.Sync;
+
+namespace Honua.Mobile.Offline.Tests;
+
+public sealed class BackgroundPrefetchSchedulerTests
+{
+    [Fact]
+    public async Task CancelForLifecycleEventAsync_CancelsRunningPrefetchWork()
+    {
+        await using var scheduler = new BackgroundPrefetchScheduler(new BackgroundPrefetchSchedulerOptions
+        {
+            MaxConcurrency = 1,
+        });
+        var workItem = new CancellableWorkItem();
+
+        var task = scheduler.ScheduleAsync(workItem);
+        await workItem.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await scheduler.CancelForLifecycleEventAsync(PrefetchLifecycleEvent.LowMemory);
+        await task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(workItem.WasCancelled);
+        Assert.Equal(0, scheduler.RunningCount);
+    }
+
+    private sealed class CancellableWorkItem : IBackgroundPrefetchWorkItem
+    {
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool WasCancelled { get; private set; }
+
+        public string ItemId => "test-prefetch";
+
+        public async Task ExecuteAsync(CancellationToken ct = default)
+        {
+            Started.SetResult();
+            try
+            {
+                await Task.Delay(TimeSpan.FromMinutes(5), ct);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                WasCancelled = true;
+                throw;
+            }
+        }
+    }
+}

--- a/tests/Honua.Mobile.Offline.Tests/BackgroundSyncOrchestratorTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/BackgroundSyncOrchestratorTests.cs
@@ -32,7 +32,7 @@ public sealed class BackgroundSyncOrchestratorTests
             });
 
         await orchestrator.StartAsync();
-        await Task.Delay(120);
+        await runner.FirstRun.WaitAsync(TimeSpan.FromSeconds(5));
         await orchestrator.StopAsync();
 
         Assert.True(runner.CallCount >= 1);
@@ -53,7 +53,7 @@ public sealed class BackgroundSyncOrchestratorTests
             });
 
         await orchestrator.StartAsync();
-        await Task.Delay(150);
+        await runner.FirstSuccess.WaitAsync(TimeSpan.FromSeconds(5));
         await orchestrator.StopAsync();
 
         Assert.True(runner.CallCount >= 2);
@@ -62,11 +62,19 @@ public sealed class BackgroundSyncOrchestratorTests
 
     private sealed class FakeSyncRunner : IOfflineSyncRunner
     {
-        public int CallCount { get; private set; }
+        private int _callCount;
+
+        public Task FirstRun => _firstRun.Task;
+
+        public int CallCount => Volatile.Read(ref _callCount);
+
+        private readonly TaskCompletionSource _firstRun = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public Task<SyncRunResult> SyncAsync(CancellationToken ct = default)
         {
-            CallCount++;
+            Interlocked.Increment(ref _callCount);
+            _firstRun.TrySetResult();
+
             return Task.FromResult(new SyncRunResult
             {
                 Loaded = 0,
@@ -84,27 +92,34 @@ public sealed class BackgroundSyncOrchestratorTests
     private sealed class FlakySyncRunner : IOfflineSyncRunner
     {
         private int _remainingFailures;
+        private int _callCount;
+        private int _successCount;
 
         public FlakySyncRunner(int initialFailures)
         {
             _remainingFailures = initialFailures;
         }
 
-        public int CallCount { get; private set; }
+        public Task FirstSuccess => _firstSuccess.Task;
 
-        public int SuccessCount { get; private set; }
+        public int CallCount => Volatile.Read(ref _callCount);
+
+        public int SuccessCount => Volatile.Read(ref _successCount);
+
+        private readonly TaskCompletionSource _firstSuccess = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public Task<SyncRunResult> SyncAsync(CancellationToken ct = default)
         {
-            CallCount++;
+            Interlocked.Increment(ref _callCount);
 
-            if (_remainingFailures > 0)
+            if (Interlocked.Decrement(ref _remainingFailures) >= 0)
             {
-                _remainingFailures--;
                 throw new InvalidOperationException("transient sync error");
             }
 
-            SuccessCount++;
+            Interlocked.Increment(ref _successCount);
+            _firstSuccess.TrySetResult();
+
             return Task.FromResult(new SyncRunResult
             {
                 Loaded = 0,

--- a/tests/Honua.Mobile.Offline.Tests/GeoPackageSyncStoreTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/GeoPackageSyncStoreTests.cs
@@ -168,6 +168,55 @@ public sealed class GeoPackageSyncStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task UpsertFeatureAsync_WithPointGeometry_CreatesRTreeIndexAndSupportsBboxQuery()
+    {
+        var store = CreateStore();
+        await store.InitializeAsync();
+
+        await store.UpsertFeatureAsync(
+            "parks",
+            """{"attributes":{"OBJECTID":1,"name":"Inside"},"geometry":{"x":-157.8,"y":21.3}}""");
+        await store.UpsertFeatureAsync(
+            "parks",
+            """{"attributes":{"OBJECTID":2,"name":"Outside"},"geometry":{"x":-158.2,"y":21.9}}""");
+
+        var hits = await store.GetFeaturesAsync("parks", new BoundingBox(-157.9, 21.2, -157.7, 21.4));
+        var indexedRows = await CountRowsAsync("rtree_honua_features");
+
+        Assert.Single(hits);
+        Assert.Contains("Inside", hits[0], StringComparison.Ordinal);
+        Assert.Equal(2, indexedRows);
+    }
+
+    [Fact]
+    public async Task EvictExpiredFeaturesAsync_RemovesExpiredLayerCacheEntries()
+    {
+        var timeProvider = new MutableTimeProvider(DateTimeOffset.Parse("2026-05-01T00:00:00Z", CultureInfo.InvariantCulture));
+        var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions
+        {
+            DatabasePath = _databasePath,
+            TimeProvider = timeProvider,
+            LayerFeatureCacheTtls = new Dictionary<string, TimeSpan>
+            {
+                ["parks"] = TimeSpan.FromMinutes(5),
+            },
+        });
+        await store.InitializeAsync();
+
+        await store.UpsertFeatureAsync(
+            "parks",
+            """{"attributes":{"OBJECTID":1},"geometry":{"x":-157.8,"y":21.3}}""");
+        Assert.Single(await store.GetFeaturesAsync("parks"));
+
+        timeProvider.Advance(TimeSpan.FromMinutes(6));
+        var evicted = await store.EvictExpiredFeaturesAsync();
+
+        Assert.Equal(1, evicted);
+        Assert.Empty(await store.GetFeaturesAsync("parks"));
+        Assert.Equal(0, await CountRowsAsync("rtree_honua_features"));
+    }
+
+    [Fact]
     public async Task InitializeAsync_HandlesDatabasePathsWithConnectionStringCharacters()
     {
         var databasePath = Path.Combine(Path.GetTempPath(), $"honua-mobile-{Guid.NewGuid():N};Mode=Memory.gpkg");
@@ -232,5 +281,35 @@ WHERE operation_id = $operation_id;
         command.Parameters.AddWithValue("$operation_id", operationId);
 
         await command.ExecuteNonQueryAsync();
+    }
+
+    private async Task<long> CountRowsAsync(string tableName)
+    {
+        await using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = _databasePath,
+        }.ToString());
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT COUNT(*) FROM {tableName};";
+        return (long)(await command.ExecuteScalarAsync() ?? 0L);
+    }
+
+    private sealed class MutableTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now;
+
+        public MutableTimeProvider(DateTimeOffset now)
+        {
+            _now = now;
+        }
+
+        public override DateTimeOffset GetUtcNow() => _now;
+
+        public void Advance(TimeSpan duration)
+        {
+            _now = _now.Add(duration);
+        }
     }
 }

--- a/tests/Honua.Mobile.Sdk.Tests/AuthTokenProviderTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/AuthTokenProviderTests.cs
@@ -38,6 +38,80 @@ public sealed class AuthTokenProviderTests
     }
 
     [Fact]
+    public async Task QueryFeaturesAsync_WithAuthTokenProviderAndThrowingLegacyProvider_UsesProviderToken()
+    {
+        var legacyProviderCalls = 0;
+        string? capturedApiKey = null;
+        var store = new InMemoryAuthTokenStore();
+        await store.WriteAsync(new HonuaAuthToken(HonuaAuthScheme.ApiKey, "provider-api-key"));
+
+        var client = CreateClient(request =>
+        {
+            if (request.Headers.TryGetValues("X-API-Key", out var values))
+            {
+                capturedApiKey = values.FirstOrDefault();
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"features":[]}""", Encoding.UTF8, "application/json"),
+            };
+        }, new RefreshingAuthTokenProvider(
+            store,
+            new HttpClient(new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)))),
+        new HonuaMobileClientOptions
+        {
+            BaseUri = new Uri("https://api.honua.test"),
+            AccessTokenProvider = _ =>
+            {
+                legacyProviderCalls++;
+                throw new InvalidOperationException("Legacy provider should not be invoked when an auth token provider resolves a token.");
+            },
+            PreferGrpcForFeatureQueries = false,
+            PreferGrpcForFeatureEdits = false,
+        });
+
+        using var result = await client.QueryFeaturesAsync(new QueryFeaturesRequest
+        {
+            ServiceId = "assets",
+            LayerId = 0,
+        });
+
+        Assert.Equal("provider-api-key", capturedApiKey);
+        Assert.Equal(0, legacyProviderCalls);
+    }
+
+    [Fact]
+    public async Task BuildGrpcClientOptions_WithAuthTokenProviderApiKey_DoesNotInvokeLegacyBearerProvider()
+    {
+        var legacyProviderCalls = 0;
+        var store = new InMemoryAuthTokenStore();
+        await store.WriteAsync(new HonuaAuthToken(HonuaAuthScheme.ApiKey, "provider-api-key"));
+        var client = CreateClient(_ => new HttpResponseMessage(HttpStatusCode.OK), new RefreshingAuthTokenProvider(
+            store,
+            new HttpClient(new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)))),
+        new HonuaMobileClientOptions
+        {
+            BaseUri = new Uri("https://api.honua.test"),
+            AccessTokenProvider = _ =>
+            {
+                legacyProviderCalls++;
+                throw new InvalidOperationException("Legacy provider should not be invoked when an auth token provider resolves a token.");
+            },
+            PreferGrpcForFeatureQueries = false,
+            PreferGrpcForFeatureEdits = false,
+        });
+
+        var options = client.BuildGrpcClientOptions();
+
+        Assert.NotNull(options.ApiKeyProvider);
+        Assert.Equal("provider-api-key", await options.ApiKeyProvider!(CancellationToken.None));
+        Assert.NotNull(options.BearerTokenProvider);
+        Assert.Null(await options.BearerTokenProvider!(CancellationToken.None));
+        Assert.Equal(0, legacyProviderCalls);
+    }
+
+    [Fact]
     public async Task QueryFeaturesAsync_WithExpiredBearerToken_RefreshesBeforeSending()
     {
         string? capturedAuthHeader = null;
@@ -88,9 +162,24 @@ public sealed class AuthTokenProviderTests
         Assert.Equal("next-refresh-token", stored?.RefreshToken);
     }
 
-    private static HonuaMobileClient CreateClient(Func<HttpRequestMessage, HttpResponseMessage> handler, IAuthTokenProvider provider)
+    [Fact]
+    public async Task GetTokenAsync_WhenCanceled_ThrowsOperationCanceledException()
     {
-        var options = new HonuaMobileClientOptions
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var provider = new RefreshingAuthTokenProvider(
+            new InMemoryAuthTokenStore(),
+            new HttpClient(new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK))));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await provider.GetTokenAsync(cts.Token));
+    }
+
+    private static HonuaMobileClient CreateClient(
+        Func<HttpRequestMessage, HttpResponseMessage> handler,
+        IAuthTokenProvider provider,
+        HonuaMobileClientOptions? options = null)
+    {
+        options ??= new HonuaMobileClientOptions
         {
             BaseUri = new Uri("https://api.honua.test"),
             PreferGrpcForFeatureQueries = false,

--- a/tests/Honua.Mobile.Sdk.Tests/AuthTokenProviderTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/AuthTokenProviderTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using System.Text;
+using Honua.Mobile.Sdk;
+using Honua.Mobile.Sdk.Auth;
+using Honua.Mobile.Sdk.Models;
+
+namespace Honua.Mobile.Sdk.Tests;
+
+public sealed class AuthTokenProviderTests
+{
+    [Fact]
+    public async Task QueryFeaturesAsync_WithAuthTokenProviderApiKey_SendsApiKeyHeader()
+    {
+        string? capturedApiKey = null;
+        var store = new InMemoryAuthTokenStore();
+        await store.WriteAsync(new HonuaAuthToken(HonuaAuthScheme.ApiKey, "provider-api-key"));
+
+        var client = CreateClient(request =>
+        {
+            if (request.Headers.TryGetValues("X-API-Key", out var values))
+            {
+                capturedApiKey = values.FirstOrDefault();
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"features":[]}""", Encoding.UTF8, "application/json"),
+            };
+        }, new RefreshingAuthTokenProvider(store, new HttpClient(new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)))));
+
+        using var result = await client.QueryFeaturesAsync(new QueryFeaturesRequest
+        {
+            ServiceId = "assets",
+            LayerId = 0,
+        });
+
+        Assert.Equal("provider-api-key", capturedApiKey);
+    }
+
+    [Fact]
+    public async Task QueryFeaturesAsync_WithExpiredBearerToken_RefreshesBeforeSending()
+    {
+        string? capturedAuthHeader = null;
+        var store = new InMemoryAuthTokenStore();
+        await store.WriteAsync(new HonuaAuthToken(
+            HonuaAuthScheme.Bearer,
+            "expired-token",
+            "refresh-token",
+            DateTimeOffset.UtcNow.AddMinutes(-5)));
+
+        var refreshHandler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """
+                {
+                    "accessToken": "fresh-token",
+                    "refreshToken": "next-refresh-token",
+                    "expiresIn": 3600
+                }
+                """,
+                Encoding.UTF8,
+                "application/json"),
+        });
+        var provider = new RefreshingAuthTokenProvider(
+            store,
+            new HttpClient(refreshHandler),
+            new RefreshingAuthTokenProviderOptions
+            {
+                RefreshEndpoint = new Uri("https://auth.honua.test/token/refresh"),
+            });
+        var client = CreateClient(request =>
+        {
+            capturedAuthHeader = request.Headers.Authorization?.ToString();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"features":[]}""", Encoding.UTF8, "application/json"),
+            };
+        }, provider);
+
+        using var result = await client.QueryFeaturesAsync(new QueryFeaturesRequest
+        {
+            ServiceId = "assets",
+            LayerId = 0,
+        });
+
+        var stored = await store.ReadAsync();
+        Assert.Equal("Bearer fresh-token", capturedAuthHeader);
+        Assert.Equal("next-refresh-token", stored?.RefreshToken);
+    }
+
+    private static HonuaMobileClient CreateClient(Func<HttpRequestMessage, HttpResponseMessage> handler, IAuthTokenProvider provider)
+    {
+        var options = new HonuaMobileClientOptions
+        {
+            BaseUri = new Uri("https://api.honua.test"),
+            PreferGrpcForFeatureQueries = false,
+            PreferGrpcForFeatureEdits = false,
+        };
+
+        return new HonuaMobileClient(
+            new HttpClient(new StubHttpMessageHandler(handler))
+            {
+                BaseAddress = options.BaseUri,
+            },
+            options,
+            provider);
+    }
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+        public StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_handler(request));
+    }
+}

--- a/tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj
+++ b/tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Honua.Mobile.Offline\Honua.Mobile.Offline.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Mobile.Sdk\Honua.Mobile.Sdk.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Honua.Mobile.Smoke.Tests/SmokeTests.cs
+++ b/tests/Honua.Mobile.Smoke.Tests/SmokeTests.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics;
 using Honua.Mobile.Offline.GeoPackage;
 using Honua.Mobile.Offline.Sync;
+using Honua.Mobile.Sdk;
+using Honua.Mobile.Sdk.Models;
 
 namespace Honua.Mobile.Smoke.Tests;
 
@@ -169,6 +172,46 @@ public sealed class SmokeTests : IDisposable
         // A cursor that was never set should return null.
         var missing = await store.GetSyncCursorAsync("nonexistent-key");
         Assert.Null(missing);
+    }
+
+    // ---------------------------------------------------------------
+    // 7. Optional live server smoke for platform CI
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task LiveFeatureQuery_WhenConfigured_CompletesUnderOneSecond()
+    {
+        var baseUrl = Environment.GetEnvironmentVariable("HONUA_MOBILE_SMOKE_BASE_URL");
+        var serviceId = Environment.GetEnvironmentVariable("HONUA_MOBILE_SMOKE_SERVICE_ID");
+        var layerIdValue = Environment.GetEnvironmentVariable("HONUA_MOBILE_SMOKE_LAYER_ID");
+        if (string.IsNullOrWhiteSpace(baseUrl) ||
+            string.IsNullOrWhiteSpace(serviceId) ||
+            !int.TryParse(layerIdValue, out var layerId))
+        {
+            return;
+        }
+
+        using var http = new HttpClient();
+        var client = new HonuaMobileClient(http, new HonuaMobileClientOptions
+        {
+            BaseUri = new Uri(baseUrl),
+            ApiKey = Environment.GetEnvironmentVariable("HONUA_MOBILE_SMOKE_API_KEY"),
+            PreferGrpcForFeatureQueries = false,
+            PreferGrpcForFeatureEdits = false,
+        });
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        var stopwatch = Stopwatch.StartNew();
+        using var result = await client.QueryFeaturesAsync(new QueryFeaturesRequest
+        {
+            ServiceId = serviceId,
+            LayerId = layerId,
+            ResultRecordCount = 1,
+        }, timeout.Token);
+        stopwatch.Stop();
+
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(1), $"Live query took {stopwatch.Elapsed}.");
+        Assert.True(result.RootElement.ValueKind == System.Text.Json.JsonValueKind.Object);
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Bundles implementation work for the mobile SDK tracking tickets in honua-io/honua-server#826, #827, #828, #829, and #830.

- Adds first-class mobile auth token provider APIs with API-key and bearer-token modes, refresh support, secure-store adapters, telemetry, and client wiring for REST and gRPC.
- Hardens GeoPackage offline storage with per-layer TTL eviction, R-tree-backed bbox lookups, storage telemetry, redacted storage exceptions, and lifecycle-aware background prefetch cancellation.
- Tightens mobile CI/release scaffolding with Dependabot, Trivy, Android API 33 emulator smoke, Android trim publish, iOS simulator build, iOS trim/NativeAOT publish, signed-tag NuGet publishing, and release checklist updates.
- Documents roadmap links, auth secure storage, offline cache policy, R-tree indexing, and the SpatiaLite non-bundling decision.

## Tracking issues

Refs honua-io/honua-server#826
Refs honua-io/honua-server#827
Refs honua-io/honua-server#828
Refs honua-io/honua-server#829
Refs honua-io/honua-server#830

## Validation

- `dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --configuration Release`
- `dotnet test tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj --configuration Release`
- `dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --configuration Release`
- `dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --configuration Release`
- `dotnet test tests/Honua.Mobile.Field.Tests/Honua.Mobile.Field.Tests.csproj --configuration Release`
- `dotnet build src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet build src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet format Honua.Mobile.sln --verify-no-changes --verbosity minimal`
- YAML parsed locally with PyYAML for `.github/workflows/ci.yml`, `.github/workflows/publish-dotnet-mobile.yml`, and `.github/dependabot.yml`.

## Repository setting note

Checked `honua-mobile/main` branch protection on May 1, 2026. Required status checks are enabled for `CI Gate` and `Validate Mobile SDK PR`, and force pushes are disabled. Required pull request reviews are not currently enabled; that must be configured in repository settings outside this code PR if the team wants the #826 acceptance item fully enforced.