### PR TITLE
feat(embed): implement non-Flutter embed backlog slices

### DIFF
--- a/docs/guides/3d-scene-embed.md
+++ b/docs/guides/3d-scene-embed.md
@@ -66,6 +66,58 @@ scene.addEventListener('honua-scene-identify', (event) => {
 
 The package build copies Cesium `Assets`, `Workers`, `ThirdParty`, and `Widgets` into `dist/cesium`. By default, `<honua-scene>` resolves Cesium runtime assets relative to the built `dist` module. Use `cesium-base-url` when hosting those assets from a CDN or another static path.
 
+## Offline Package Resolver
+
+Browser and WebView hosts can load package-local scene assets without public
+network URLs by assigning a package asset resolver. The SDK owns scene package
+manifest contracts and validation; the embed component only receives a
+SDK-validated package ID, package-local asset paths, and the offline-use expiry
+date.
+
+```js
+import {
+  createCacheStorageScenePackageResolver,
+  HonuaScenePackageCacheError,
+} from '@honua-io/embed';
+
+const scene = document.querySelector('honua-scene');
+const resolver = createCacheStorageScenePackageResolver({
+  cacheName: 'honua-scene-packages',
+  urlPrefix: '/honua-scene-packages/',
+});
+
+scene.packageAssetResolver = resolver;
+scene.setAttribute('package-id', manifest.packageId);
+scene.setAttribute('tileset-asset', primaryTileset.path);
+scene.setAttribute('terrain-asset', terrainLayer?.path ?? '');
+scene.setAttribute('package-expires-at', manifest.offlineUseExpiresAtUtc);
+
+scene.addEventListener('honua-scene-load-error', (event) => {
+  if (event.detail.source !== 'package-cache') {
+    return;
+  }
+
+  switch (event.detail.code) {
+    case 'cache-miss':
+      queuePackageRefresh(manifest.packageId);
+      break;
+    case 'expired-package':
+      blockProtectedSceneUse(manifest.packageId);
+      break;
+    case 'unsupported-browser-storage':
+      fallBackToOnlineScene();
+      break;
+  }
+});
+```
+
+The resolver API is intentionally host-controlled so MAUI WebView bridges,
+service workers, Cache Storage, IndexedDB, and caller-provided object URLs can
+share the same `<honua-scene>` surface. When using object URLs for `tileset.json`,
+ensure nested 3D Tiles references are also rewritten or served through a stable
+package-local URL prefix. Call `resolver.dispose?.()` when a host tears down a
+Cache Storage resolver that created object URLs.
+
 ## Current Scope
 
 This first slice proves client-side 3D Tiles loading, scene events, and typed SDK scene discovery. Honua-hosted scene registry, terrain tiles, elevation APIs, 3D Tiles generation, and I3S compatibility are tracked in the linked server backlog.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -14,6 +14,7 @@ In-depth guides for building with the Honua Mobile SDK.
 | [Offline 3D Scene Packages](offline-3d-scene-packages.md) | Package manifest, cache, expiry, and platform policy for offline 3D scenes |
 | [Offline Sync](offline-sync.md) | GeoPackage storage, sync engine configuration, and conflict resolution |
 | [Performance](performance.md) | Optimizing startup time, memory usage, and sync throughput |
+| [Plugin and Host Extension Boundary](plugin-extension-api.md) | Web embed extension APIs and the SDK/mobile ownership split for plugin work |
 | [Protected 3D Scene Auth](protected-3d-scene-auth.md) | Signed URL, proxy, header, CORS, cache, and revocation policy for protected scene assets |
 | [Security](security.md) | Authentication, transport security, and secure storage best practices |
 | [Troubleshooting](troubleshooting.md) | Common issues and solutions for development and production |

--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -1,10 +1,10 @@
 # Embeddable Map Component
 
-`@honua/embed` provides a framework-agnostic `<honua-map>` custom element for ISV and SaaS integrations.
+`@honua-io/embed` provides a framework-agnostic `<honua-map>` custom element for ISV and SaaS integrations.
 
 ```html
 <script type="module">
-  import '@honua/embed';
+  import '@honua-io/embed';
 </script>
 
 <honua-map
@@ -19,6 +19,53 @@
 ```
 
 The component is white-label by default: it does not render Honua branding unless an integrator provides their own attribution. Host applications can style it with CSS custom properties without leaking styles into the map internals.
+
+## Generated Snippets
+
+ISV portals can generate embed markup from the typed helper instead of assembling
+attribute strings by hand.
+
+```js
+import { createHonuaMapSnippet } from '@honua-io/embed';
+
+const snippet = createHonuaMapSnippet({
+  serviceUrl: 'https://services.honua.example/FeatureServer',
+  layerIds: ['assets', 'work-orders'],
+  center: { latitude: 21.3069, longitude: -157.8583 },
+  zoom: 12,
+  interactive: true,
+  search: true,
+  identify: true,
+  attribution: 'City GIS',
+  label: 'City asset map',
+  style: {
+    accent: '#0f766e',
+    fontFamily: 'Aptos, sans-serif',
+  },
+}, {
+  elementName: 'city-asset-map',
+});
+```
+
+When `elementName` is not `honua-map`, the generated module script calls
+`defineHonuaMapElement('city-asset-map')` so the host can expose a branded tag
+name while still using the same implementation. `apiKey` is omitted from
+generated snippets unless `includeCredentials: true` is passed; generated markup
+should only contain renderer-safe public credentials.
+
+Runtime hosts can apply the same configuration shape to an existing element:
+
+```js
+import { applyHonuaMapOptions } from '@honua-io/embed';
+
+applyHonuaMapOptions(document.querySelector('honua-map'), {
+  basemap: 'satellite',
+  search: true,
+  style: {
+    accent: '#334155',
+  },
+});
+```
 
 ## Integration Events
 
@@ -82,11 +129,52 @@ const layer = createHonuaGeoJsonLayer(featureCollection, {
 });
 ```
 
+## Host Extensions
+
+Host applications can register lightweight runtime extensions that mount
+white-label controls into `<honua-map>` or `<honua-scene>` and react to config
+changes. These are host UI/runtime extensions, not SDK-owned plugin manifests.
+
+```js
+import { registerHonuaEmbedExtension } from '@honua-io/embed';
+
+const registration = registerHonuaEmbedExtension({
+  id: 'isv-locate',
+  target: 'map',
+  activate(context) {
+    context.addControl({
+      id: 'locate',
+      label: 'Locate asset',
+      text: 'L',
+      onClick: (_event, clickContext) => {
+        clickContext.dispatch('isv-locate', {
+          zoom: clickContext.config.zoom,
+        });
+      },
+    });
+  },
+  configChanged(context) {
+    console.debug('map config changed', context.config);
+  },
+});
+
+// Later, for teardown or tenant switch:
+registration.unregister();
+```
+
+Extensions can set CSS custom properties through `context.setCssVariable(...)`,
+dispatch composed DOM events through `context.dispatch(...)`, and return a
+cleanup callback from `activate`. If an extension throws, the element emits
+`honua-embed-extension-error` with the extension id, target, lifecycle, and
+original error.
+
 ## Current Scope
 
-`<honua-map>` still provides the declarative, white-label web component shell,
-Shadow DOM encapsulation, theme hooks, accessible controls, search events, and
-identify events. Production map rendering should use the MapLibre/deck.gl
-adapter above until the custom element owns a full renderer lifecycle.
+`<honua-map>` provides the declarative, white-label web component shell, Shadow
+DOM encapsulation, theme hooks, generated snippets, host extension controls,
+accessible controls, search events, and identify events. Production map
+rendering should use the MapLibre/deck.gl adapter above until the custom element
+owns a full renderer lifecycle. Follow-on work can add feature loading,
+analytics, binary deck.gl attribute batches, and framework-specific wrappers.
 
 For 3D Tiles and CesiumJS-based scenes, use the [`<honua-scene>` guide](3d-scene-embed.md).

--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -34,8 +34,59 @@ map.addEventListener('honua-map-identify', (event) => {
 });
 ```
 
-## First Slice Scope
+## Web Display Adapter
 
-This initial package establishes the web component API, Shadow DOM encapsulation, declarative attributes, theme hooks, accessible controls, and test coverage. Follow-on work can add a production map renderer, feature loading, generated embed snippets, analytics, and framework-specific wrappers.
+For production map rendering, host the base map with MapLibre GL JS and attach
+Honua feature overlays through deck.gl. The adapter consumes renderer-neutral SDK
+source descriptors and `FeatureQueryResult` pages; it does not define new query
+contracts in this repository.
+
+```js
+import maplibregl from 'maplibre-gl';
+import {
+  HonuaWebDisplayAdapter,
+  createHonuaGeoJsonLayer,
+  featureQueryResultToGeoJson,
+} from '@honua-io/embed';
+
+const map = new maplibregl.Map({
+  container: 'map',
+  style: 'https://tiles.example/styles/streets.json',
+  center: [-157.8583, 21.3069],
+  zoom: 12,
+});
+
+const display = new HonuaWebDisplayAdapter(map);
+const page = await sdk.features.queryFeatures(sourceDescriptor.id, query);
+
+display.setFeatureQueryResult(page, {
+  source: sourceDescriptor,
+  onClick: ({ object }) => {
+    console.log(object?.properties);
+  },
+});
+```
+
+Use MapLibre GL JS for base map, style, camera, vector-tile styles, and normal
+map controls. Use deck.gl layers for high-volume overlays, picking,
+highlighting, paths, polygons, point clouds, heatmaps, temporal animation, and
+GPU aggregation. The initial implementation is a GeoJSON flow; binary deck.gl
+attribute batches should be added only when feature volume requires them.
+
+The pure converter is also exported when a host app owns the overlay lifecycle:
+
+```js
+const featureCollection = featureQueryResultToGeoJson(page);
+const layer = createHonuaGeoJsonLayer(featureCollection, {
+  id: 'honua-work-orders',
+});
+```
+
+## Current Scope
+
+`<honua-map>` still provides the declarative, white-label web component shell,
+Shadow DOM encapsulation, theme hooks, accessible controls, search events, and
+identify events. Production map rendering should use the MapLibre/deck.gl
+adapter above until the custom element owns a full renderer lifecycle.
 
 For 3D Tiles and CesiumJS-based scenes, use the [`<honua-scene>` guide](3d-scene-embed.md).

--- a/docs/guides/plugin-extension-api.md
+++ b/docs/guides/plugin-extension-api.md
@@ -1,0 +1,106 @@
+# Plugin and Host Extension Boundary
+
+Honua mobile and embed hosts can expose extension points for runtime behavior,
+but shared plugin contracts and manifests belong in `honua-sdk-dotnet` packages.
+This repo should stay focused on host wiring, UI integration, renderer adapters,
+storage, permissions, and lifecycle concerns.
+
+## Ownership
+
+| Surface | Owner | Notes |
+| --- | --- | --- |
+| Plugin manifest schema, source descriptors, shared DTOs, validation rules | `honua-sdk-dotnet` | Publish as versioned `Honua.Sdk.*` packages and consume them here. |
+| Web component controls, DOM events, white-label themes, snippet generation | `honua-mobile` / `@honua-io/embed` | Runtime integration for browser and WebView hosts. |
+| MAUI dependency injection, platform permissions, storage, camera, GPS, sensors | `honua-mobile` | Plugin packages should provide mobile registration glue instead of new neutral clients. |
+| Server capabilities needed by plugins | `honua-server` | Link server dependency issues from the mobile issue. |
+
+## Web Host Extensions
+
+`@honua-io/embed` exposes a runtime registry for lightweight host extensions:
+
+```ts
+import { registerHonuaEmbedExtension } from '@honua-io/embed';
+
+const registration = registerHonuaEmbedExtension({
+  id: 'tenant-tools',
+  target: 'map',
+  priority: 10,
+  activate(context) {
+    const control = context.addControl({
+      id: 'tenant-action',
+      label: 'Open tenant action',
+      text: 'T',
+      onClick: (_event, clickContext) => {
+        clickContext.dispatch('tenant-action', {
+          config: clickContext.config,
+        });
+      },
+    });
+
+    context.setCssVariable('--honua-map-accent', '#0f766e');
+    return () => control.remove();
+  },
+});
+```
+
+Extension lifecycle:
+
+| Hook | When it runs |
+| --- | --- |
+| `activate(context)` | When a matching `<honua-map>` or `<honua-scene>` connects, or when the extension is registered after elements already exist. |
+| `configChanged(context)` | After a connected element emits its config-change event. |
+| `registration.unregister()` | Removes mounted extension controls from active elements and runs cleanup callbacks. |
+
+The context intentionally exposes host runtime capabilities only: the target
+element, open shadow root, current config, control mounting, CSS variables, and
+composed DOM event dispatch. It does not define plugin manifests, data schemas,
+source contracts, auth contracts, or feature query/edit APIs.
+
+## MAUI Host Extensions
+
+Mobile extension packages should follow the existing `IServiceCollection`
+pattern in `Honua.Mobile.Maui`:
+
+```csharp
+public static IServiceCollection AddTenantFieldTools(
+    this IServiceCollection services,
+    TenantFieldToolOptions options)
+{
+    ArgumentNullException.ThrowIfNull(services);
+    ArgumentNullException.ThrowIfNull(options);
+
+    services.AddSingleton(options);
+    services.AddSingleton<TenantFieldToolViewModel>();
+    return services;
+}
+```
+
+Registration code may compose existing mobile-owned services such as map
+annotations, offline storage adapters, camera workflows, and background sync.
+When an extension needs portable contracts, feature clients, routing, scenes,
+field schemas, validation, or plugin manifests, add or consume versioned
+`Honua.Sdk.*` packages rather than adding platform-neutral models here.
+
+## Embed Snippet Generation
+
+Use `createHonuaMapSnippet` for white-label map embeds and tenant-specific tag
+names:
+
+```ts
+import { createHonuaMapSnippet } from '@honua-io/embed';
+
+const snippet = createHonuaMapSnippet({
+  serviceUrl: 'https://services.honua.example/FeatureServer',
+  layerIds: ['assets'],
+  label: 'Tenant asset map',
+  style: {
+    accent: '#334155',
+    fontFamily: 'Aptos, sans-serif',
+  },
+}, {
+  elementName: 'tenant-asset-map',
+});
+```
+
+Generated snippets omit `apiKey` unless `includeCredentials: true` is supplied.
+Only browser-safe public credentials should be emitted into tenant-facing markup.

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -28,6 +28,25 @@ npm install @honua-io/embed
 </honua-map>
 ```
 
+For production display, pair MapLibre GL JS with the deck.gl adapter:
+
+```js
+import maplibregl from 'maplibre-gl';
+import { HonuaWebDisplayAdapter } from '@honua-io/embed';
+
+const map = new maplibregl.Map({
+  container: 'map',
+  style: 'https://tiles.example/styles/streets.json',
+  center: [-157.8583, 21.3069],
+  zoom: 12,
+});
+const display = new HonuaWebDisplayAdapter(map);
+
+display.setFeatureQueryResult(featureQueryResultPage, {
+  source: sourceDescriptor,
+});
+```
+
 ## Scene Use
 
 ```html
@@ -45,6 +64,20 @@ npm install @honua-io/embed
 ```
 
 `<honua-scene>` uses CesiumJS from npm and the package build copies Cesium runtime assets into `dist/cesium`. CesiumJS is Apache-2.0 open source; Cesium ion is optional and only needed when an integrator chooses ion-hosted assets or services.
+
+Offline browser/WebView packages can assign a host-controlled resolver:
+
+```js
+import { createCacheStorageScenePackageResolver } from '@honua-io/embed';
+
+const scene = document.querySelector('honua-scene');
+scene.packageAssetResolver = createCacheStorageScenePackageResolver({
+  cacheName: 'honua-scene-packages',
+});
+scene.setAttribute('package-id', manifest.packageId);
+scene.setAttribute('tileset-asset', primaryTileset.path);
+scene.setAttribute('package-expires-at', manifest.offlineUseExpiresAtUtc);
+```
 
 ## Map Attributes
 
@@ -69,6 +102,10 @@ npm install @honua-io/embed
 | --- | --- |
 | `tileset-url` | External or Honua-hosted 3D Tiles `tileset.json` URL. |
 | `terrain-url` | Optional Cesium terrain provider URL. |
+| `package-id` | SDK-validated offline scene package identifier. |
+| `tileset-asset` | Package-local `tileset.json` path resolved by `packageAssetResolver`. |
+| `terrain-asset` | Optional package-local terrain asset path resolved by `packageAssetResolver`. |
+| `package-expires-at` | Offline-use expiry timestamp. Expired packages emit `expired-package`. |
 | `ion-token` | Optional Cesium ion token. It is not rendered. |
 | `cesium-base-url` | Optional URL for hosted Cesium `Assets`, `Workers`, `ThirdParty`, and `Widgets`. |
 | `center` | Initial latitude/longitude pair, for example `21.3069,-157.8583`. |
@@ -89,7 +126,7 @@ npm install @honua-io/embed
 | `honua-map-identify` | `{ x, y, config }`. |
 | `honua-scene-ready` | `{ config, widget, tileset }`. |
 | `honua-scene-config-change` | Current `HonuaSceneConfig`. |
-| `honua-scene-load-error` | `{ source, message, config, error }`. |
+| `honua-scene-load-error` | `{ source, code, message, config, error }`. |
 | `honua-scene-camera-change` | `{ center, height, orientation, config }`. |
 | `honua-scene-identify` | `{ x, y, picked, config }`. |
 

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -95,6 +95,7 @@ scene.setAttribute('package-expires-at', manifest.offlineUseExpiresAtUtc);
 | `identify` | Enables click/identify events and emits `honua-map-identify`. |
 | `attribution` | Optional attribution text. No Honua branding is shown by default. |
 | `theme` | `light` or `dark`. |
+| `label` | Accessible map label, defaulting to `Embedded map`. |
 
 ## Scene Attributes
 
@@ -129,6 +130,63 @@ scene.setAttribute('package-expires-at', manifest.offlineUseExpiresAtUtc);
 | `honua-scene-load-error` | `{ source, code, message, config, error }`. |
 | `honua-scene-camera-change` | `{ center, height, orientation, config }`. |
 | `honua-scene-identify` | `{ x, y, picked, config }`. |
+| `honua-embed-extension-error` | `{ extensionId, target, lifecycle, error }`. |
+
+## Generated Map Snippets
+
+```ts
+import { createHonuaMapSnippet } from '@honua-io/embed';
+
+const snippet = createHonuaMapSnippet({
+  serviceUrl: 'https://services.honua.example/FeatureServer',
+  layerIds: ['assets', 'work-orders'],
+  center: { latitude: 21.3069, longitude: -157.8583 },
+  zoom: 12,
+  interactive: true,
+  search: true,
+  identify: true,
+  label: 'City asset map',
+  style: {
+    accent: '#0f766e',
+    fontFamily: 'Aptos, sans-serif',
+  },
+}, {
+  elementName: 'city-asset-map',
+});
+```
+
+Custom element names generate a script that calls `defineHonuaMapElement(...)`.
+`apiKey` is omitted unless `includeCredentials: true` is passed.
+
+Use `applyHonuaMapOptions(element, options)` to apply the same options shape to
+an existing map element at runtime.
+
+## Host Extensions
+
+```ts
+import { registerHonuaEmbedExtension } from '@honua-io/embed';
+
+const registration = registerHonuaEmbedExtension({
+  id: 'isv-locate',
+  target: 'map',
+  activate(context) {
+    context.addControl({
+      id: 'locate',
+      label: 'Locate asset',
+      text: 'L',
+      onClick: (_event, clickContext) => {
+        clickContext.dispatch('isv-locate', {
+          zoom: clickContext.config.zoom,
+        });
+      },
+    });
+  },
+});
+```
+
+Extensions are runtime host hooks for controls, CSS variables, and DOM events.
+Shared plugin manifests, source descriptors, and data contracts should come from
+versioned `Honua.Sdk.*` packages.
 
 ## Styling
 

--- a/src/Honua.Embed/package-lock.json
+++ b/src/Honua.Embed/package-lock.json
@@ -9,7 +9,11 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "cesium": "^1.140.0"
+        "@deck.gl/core": "^9.3.2",
+        "@deck.gl/layers": "^9.3.2",
+        "@deck.gl/mapbox": "^9.3.2",
+        "cesium": "^1.140.0",
+        "maplibre-gl": "^5.24.0"
       },
       "devDependencies": {
         "happy-dom": "^20.0.10",
@@ -69,6 +73,72 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@deck.gl/core": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.3.2.tgz",
+      "integrity": "sha512-32Va3np0Zdlz/LBNtDWCs4EkKqdHmXcbGmVp4+7i1Cpdza8y8CFmJs2VPOmSX1fwHvNCGkAZV/SFZOfDb2INsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/core": "^4.4.1",
+        "@loaders.gl/images": "^4.4.1",
+        "@luma.gl/core": "^9.3.3",
+        "@luma.gl/engine": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.3",
+        "@luma.gl/webgl": "^9.3.3",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/sun": "^4.1.0",
+        "@math.gl/types": "^4.1.0",
+        "@math.gl/web-mercator": "^4.1.0",
+        "@probe.gl/env": "^4.1.1",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1",
+        "@types/offscreencanvas": "^2019.6.4",
+        "gl-matrix": "^3.0.0",
+        "mjolnir.js": "^3.0.0"
+      }
+    },
+    "node_modules/@deck.gl/layers": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.3.2.tgz",
+      "integrity": "sha512-TeVfhQ/cQU1oTlTn16mCp7268d1uBJ6dwfgmKXThe2TzW9hql3iJaxbYTKg2phDg5YSiGmeEOpXbeBh59jyUcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/images": "^4.4.1",
+        "@loaders.gl/schema": "^4.4.1",
+        "@luma.gl/shadertools": "^9.3.3",
+        "@mapbox/tiny-sdf": "^2.0.5",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/polygon": "^4.1.0",
+        "@math.gl/web-mercator": "^4.1.0",
+        "earcut": "^2.2.4"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "~9.3.0",
+        "@loaders.gl/core": "^4.4.1",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
+      }
+    },
+    "node_modules/@deck.gl/layers/node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "license": "ISC"
+    },
+    "node_modules/@deck.gl/mapbox": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-9.3.2.tgz",
+      "integrity": "sha512-+T9pJwsOXwjUxyGN6oiBMfIs28VtDIG1V1Rqz4qqn4TjjNEFFw+xO0olJIg8FO5IAqw2OtePdsrMj0tX8tHdGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/web-mercator": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "~9.3.0",
+        "@luma.gl/core": "~9.3.3",
+        "@math.gl/web-mercator": "^4.1.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -110,6 +180,275 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@loaders.gl/core": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-4.4.1.tgz",
+      "integrity": "sha512-/s4IuvCCQUepvhjLnmePwQppGko2d1pxRS+sp7lyExU0uiqo5dVsAKaCZ2VnddBkFWgDVb/wvcZUBmv/dWcj0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/schema-utils": "4.4.1",
+        "@loaders.gl/worker-utils": "4.4.1",
+        "@probe.gl/log": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/images": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-4.4.1.tgz",
+      "integrity": "sha512-v9A4BliEKGxhLuEbh0Ke8ElUlp04KxpKIknUtXXWoEaszAMTSrHI3YhaL/JdRlHraC1VUF/sjzbSBFkKh7nxJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.4.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/loader-utils": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.1.tgz",
+      "integrity": "sha512-waosL7VtVRfXsNOXtAM3rOjZyNQD0lQBlhuB5/oY+E+lNzYNFlzgiGXiDOwBpcs7dK7kW2Vv8+KcxyIGIyXOtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/worker-utils": "4.4.1",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/schema": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.1.tgz",
+      "integrity": "sha512-s7NjEnyK6jZvJJSWj/mHq+S9mHRHVzIYtFP+C7sMf1gVCQbdkt6OSAMUWRzwPr9+whQNVWjZ9pbLsI/IPW3zvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/schema-utils": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema-utils/-/schema-utils-4.4.1.tgz",
+      "integrity": "sha512-4upip2O6MFaWzk68/lnna7P2uRj9NQ8MIk/ff3CLbciP5/9lKl1qyuzObz5JrJRYzfGB6I81vpOn6FSVQ6m6KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/schema": "4.4.1",
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/worker-utils": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.1.tgz",
+      "integrity": "sha512-ovMyIyj9dlChuHuD64Bel7Mir2UYlmLqlZ9MMzVxzTTLvaudJoNAXi6Disp0ooxwF62ZqjNXXutaSbS6UDeuIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@luma.gl/core": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-9.3.3.tgz",
+      "integrity": "sha512-jCFm2htvrVpcXIy85TBTF1ROgMfknKnfw2OH+Vydr41hiCFd6nqr79gM3f2uhaNkal0BghFNqF3qDioKiUWtew==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/types": "^4.1.0",
+        "@probe.gl/env": "^4.1.1",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1",
+        "@types/offscreencanvas": "^2019.7.3"
+      }
+    },
+    "node_modules/@luma.gl/engine": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.3.3.tgz",
+      "integrity": "sha512-StmMTzUcUlpKMU3wvWU48A6OQyphptD9zVGBsSkK6iHIBdtBKlOcmqRkyfvRouo8JHtlrnoJDHLVKhxorwhGAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/types": "^4.1.0",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      },
+      "peerDependencies": {
+        "@luma.gl/core": "~9.3.0",
+        "@luma.gl/shadertools": "~9.3.0"
+      }
+    },
+    "node_modules/@luma.gl/shadertools": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.3.3.tgz",
+      "integrity": "sha512-4ZfG4/Utix951vqyiG/JIx+Eg+GMNwOxgr/07/i0gf7bK1gJZIEQ5BxVcDw4MCQfdoVlGPGzl0cQKbdqBvaCAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/types": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@luma.gl/core": "~9.3.0"
+      }
+    },
+    "node_modules/@luma.gl/webgl": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-9.3.3.tgz",
+      "integrity": "sha512-X+aavdP5o6VFHSA0es9gKZTT145jfcFbhKJt/gwJrptnKNoIW4+Y37ZEpCo1AzAnr+FQCxjgcM2kOCpoWMfSVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/types": "^4.1.0",
+        "@probe.gl/env": "^4.1.1"
+      },
+      "peerDependencies": {
+        "@luma.gl/core": "~9.3.0"
+      }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.1.0.tgz",
+      "integrity": "sha512-uFJhNh36BR4OCuWIEiWaEix9CA2WzT6CAIcqVjWYpnx8+QDtS+oC4QehRrx5cX4mgWs37MmKnwUejeHxVymzNg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.1"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.0.tgz",
+      "integrity": "sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "24.8.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.1.tgz",
+      "integrity": "sha512-zxa92qF96ZNojLxeAjnaRpjVCy+swoUNJvDhtpC90k7u5F0TMr4GmvNqMKvYrMoPB8d7gRSXbMG1hBbmgESIsw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "rw": "^1.3.3",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/mlt": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.9.tgz",
+      "integrity": "sha512-g/tD8EYJB97udq33ipuJ9a4Q7fcbZnTEnUrgnEc/tLMmEL+zaCbR+X5fkDBO2dgpaAMsLH179qE3UXg2N0Nc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
+      "integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@maplibre/geojson-vt": "^5.0.4",
+        "@types/geojson": "^7946.0.16",
+        "@types/supercluster": "^7.1.3",
+        "pbf": "^4.0.1",
+        "supercluster": "^8.0.1"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf/node_modules/@maplibre/geojson-vt": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
+      "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
+      "license": "ISC"
+    },
+    "node_modules/@math.gl/core": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-4.1.0.tgz",
+      "integrity": "sha512-FrdHBCVG3QdrworwrUSzXIaK+/9OCRLscxI2OUy6sLOHyHgBMyfnEGs99/m3KNvs+95BsnQLWklVfpKfQzfwKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/types": "4.1.0"
+      }
+    },
+    "node_modules/@math.gl/polygon": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-4.1.0.tgz",
+      "integrity": "sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/core": "4.1.0"
+      }
+    },
+    "node_modules/@math.gl/sun": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/sun/-/sun-4.1.0.tgz",
+      "integrity": "sha512-i3q6OCBLSZ5wgZVhXg+X7gsjY/TUtuFW/2KBiq/U1ypLso3S4sEykoU/MGjxUv1xiiGtr+v8TeMbO1OBIh/HmA==",
+      "license": "MIT"
+    },
+    "node_modules/@math.gl/types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-clYZdHcmRvMzVK5fjeDkQlHUzXQSNdZ7s4xOqC3nJPgz4C/TZkUecTo9YS4PruZqtDda/ag4erndP0MIn40dGA==",
+      "license": "MIT"
+    },
+    "node_modules/@math.gl/web-mercator": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-4.1.0.tgz",
+      "integrity": "sha512-HZo3vO5GCMkXJThxRJ5/QYUYRr3XumfT8CzNNCwoJfinxy5NtKUd7dusNTXn7yJ40UoB8FMIwkVwNlqaiRZZAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/core": "4.1.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -138,6 +477,27 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@probe.gl/env": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@probe.gl/env/-/env-4.1.1.tgz",
+      "integrity": "sha512-+68seNDMVsEegRB47pFA/Ws1Fjy8agcFYXxzorKToyPcD6zd+gZ5uhwoLd7TzsSw6Ydns//2KEszWn+EnNHTbA==",
+      "license": "MIT"
+    },
+    "node_modules/@probe.gl/log": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-4.1.1.tgz",
+      "integrity": "sha512-kcZs9BT44pL7hS1OkRGKYRXI/SN9KejUlPD+BY40DguRLzdC5tLG/28WGMyfKdn/51GT4a0p+0P8xvDn1Ez+Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@probe.gl/env": "4.1.1"
+      }
+    },
+    "node_modules/@probe.gl/stats": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.1.1.tgz",
+      "integrity": "sha512-4VpAyMHOqydSvPlEyHwXaE+AkIdR03nX+Qhlxsk2D/IW4OVmDZgIsvJB1cDzyEEtcfKcnaEbfXeiPgejBceT6g==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
@@ -438,6 +798,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
@@ -466,6 +835,18 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -480,6 +861,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -487,6 +874,21 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -637,6 +1039,65 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/apache-arrow": {
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
+      "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^24.0.3",
+        "command-line-args": "^6.0.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^25.1.24",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
+    "node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -691,6 +1152,93 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/command-line-args": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
+      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.3",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/commander": {
@@ -795,6 +1343,29 @@
         }
       }
     },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -809,6 +1380,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -834,6 +1411,15 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jsep": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
@@ -842,6 +1428,20 @@
       "engines": {
         "node": ">= 10.16.0"
       }
+    },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
     },
     "node_modules/kdbush": {
       "version": "4.0.2",
@@ -1134,6 +1734,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -1150,6 +1756,40 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/maplibre-gl": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
+      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.1.0",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/geojson-vt": "^6.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
+        "@maplibre/mlt": "^1.1.8",
+        "@maplibre/vt-pbf": "^4.3.0",
+        "@types/geojson": "^7946.0.16",
+        "earcut": "^3.0.2",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^4.0.1",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
     "node_modules/mersenne-twister": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mersenne-twister/-/mersenne-twister-1.1.0.tgz",
@@ -1160,6 +1800,27 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
       "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mjolnir.js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mjolnir.js/-/mjolnir.js-3.0.0.tgz",
+      "integrity": "sha512-siX3YCG7N2HnmN1xMH3cK4JkUZJhbkhRFJL+G5N1vH0mh1t5088rJknIoqDFWDIU6NPGvRRgLnYW3ZHjSMEBLA==",
+      "license": "MIT"
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -1211,6 +1872,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1260,6 +1933,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
     "node_modules/protobufjs": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.3.tgz",
@@ -1274,6 +1953,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
     "node_modules/quickselect": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
@@ -1287,6 +1972,15 @@
       "license": "MIT",
       "dependencies": {
         "quickselect": "^3.0.0"
+      }
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "node_modules/rolldown": {
@@ -1323,6 +2017,12 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -1353,6 +2053,40 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1387,6 +2121,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
@@ -1430,6 +2170,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/undici-types": {
@@ -1637,6 +2386,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/ws": {

--- a/src/Honua.Embed/package.json
+++ b/src/Honua.Embed/package.json
@@ -46,6 +46,10 @@
     "vitest": "^4.0.15"
   },
   "dependencies": {
-    "cesium": "^1.140.0"
+    "@deck.gl/core": "^9.3.2",
+    "@deck.gl/layers": "^9.3.2",
+    "@deck.gl/mapbox": "^9.3.2",
+    "cesium": "^1.140.0",
+    "maplibre-gl": "^5.24.0"
   }
 }

--- a/src/Honua.Embed/src/display-adapter.ts
+++ b/src/Honua.Embed/src/display-adapter.ts
@@ -1,0 +1,241 @@
+import type { Layer } from '@deck.gl/core';
+import { GeoJsonLayer, type GeoJsonLayerProps } from '@deck.gl/layers';
+import { MapboxOverlay, type MapboxOverlayProps } from '@deck.gl/mapbox';
+import type {
+  Feature,
+  FeatureCollection,
+  GeoJsonProperties,
+  Geometry,
+} from 'geojson';
+
+export interface HonuaDisplayBounds {
+  minLongitude: number;
+  minLatitude: number;
+  maxLongitude: number;
+  maxLatitude: number;
+}
+
+export interface HonuaDisplaySpatialReference {
+  authority?: string;
+  code?: string | number;
+  wkid?: number;
+  latestWkid?: number;
+  wkt?: string;
+}
+
+export interface HonuaDisplaySourceDescriptor {
+  id: string;
+  title?: string;
+  geometryType?: string;
+  extent?: HonuaDisplayBounds | null;
+  spatialReference?: HonuaDisplaySpatialReference | null;
+  schema?: unknown;
+  queryCapabilities?: unknown;
+  tileUrl?: string | null;
+  feedUrl?: string | null;
+}
+
+export interface HonuaFeatureRecord {
+  id?: string | number;
+  objectId?: string | number;
+  geometry?: Geometry | null;
+  geoJson?: Geometry | Feature<Geometry, GeoJsonProperties> | null;
+  geoJsonGeometry?: Geometry | null;
+  attributes?: Record<string, unknown> | null;
+  properties?: Record<string, unknown> | null;
+}
+
+export interface HonuaFeatureQueryResult {
+  source?: HonuaDisplaySourceDescriptor | null;
+  features?: HonuaFeatureRecord[] | null;
+  items?: HonuaFeatureRecord[] | null;
+  spatialReference?: HonuaDisplaySpatialReference | null;
+  nextPageToken?: string | null;
+  totalCount?: number | null;
+}
+
+export interface HonuaGeoJsonLayerOptions
+  extends Omit<GeoJsonLayerProps<Record<string, unknown>>, 'data' | 'id'> {
+  id?: string;
+  source?: HonuaDisplaySourceDescriptor | null;
+}
+
+export interface HonuaDeckOverlayOptions
+  extends Omit<MapboxOverlayProps, 'layers'> {
+  layers?: Layer[];
+}
+
+export interface HonuaMapLibreLike {
+  addControl(control: unknown, position?: string): unknown;
+  removeControl?(control: unknown): unknown;
+}
+
+export interface HonuaWebDisplayAdapterOptions
+  extends HonuaDeckOverlayOptions {
+  controlPosition?: string;
+}
+
+export class HonuaWebDisplayAdapter {
+  readonly #map: HonuaMapLibreLike;
+  readonly #overlay: MapboxOverlay;
+  #layers: Layer[];
+
+  constructor(map: HonuaMapLibreLike, options: HonuaWebDisplayAdapterOptions = {}) {
+    const { controlPosition, layers = [], ...overlayOptions } = options;
+    this.#map = map;
+    this.#layers = [...layers];
+    this.#overlay = createHonuaDeckOverlay(this.#layers, overlayOptions);
+    this.#map.addControl(this.#overlay, controlPosition);
+  }
+
+  get overlay(): MapboxOverlay {
+    return this.#overlay;
+  }
+
+  get layers(): readonly Layer[] {
+    return this.#layers;
+  }
+
+  setLayers(layers: Layer[]): void {
+    this.#layers = [...layers];
+    this.#overlay.setProps({ layers: this.#layers });
+  }
+
+  setFeatureQueryResult(
+    result: HonuaFeatureQueryResult | HonuaFeatureRecord[] | FeatureCollection<Geometry, GeoJsonProperties>,
+    options: HonuaGeoJsonLayerOptions = {},
+  ): Layer {
+    const layer = createHonuaGeoJsonLayer(result, options);
+    this.setLayers([
+      ...this.#layers.filter((existing) => existing.id !== layer.id),
+      layer,
+    ]);
+
+    return layer;
+  }
+
+  destroy(): void {
+    this.#map.removeControl?.(this.#overlay);
+    this.#overlay.finalize();
+    this.#layers = [];
+  }
+}
+
+export function featureQueryResultToGeoJson(
+  result: HonuaFeatureQueryResult | HonuaFeatureRecord[] | FeatureCollection<Geometry, GeoJsonProperties>,
+): FeatureCollection<Geometry, GeoJsonProperties> {
+  if (isFeatureCollection(result)) {
+    return result;
+  }
+
+  const records = Array.isArray(result)
+    ? result
+    : result.features ?? result.items ?? [];
+
+  return {
+    type: 'FeatureCollection',
+    features: records
+      .map(recordToFeature)
+      .filter((feature): feature is Feature<Geometry, GeoJsonProperties> => feature !== null),
+  };
+}
+
+export function createHonuaGeoJsonLayer(
+  result: HonuaFeatureQueryResult | HonuaFeatureRecord[] | FeatureCollection<Geometry, GeoJsonProperties>,
+  options: HonuaGeoJsonLayerOptions = {},
+): Layer {
+  const source = options.source ?? (!Array.isArray(result) && !isFeatureCollection(result)
+    ? result.source
+    : null);
+  const id = options.id ?? buildLayerId(source);
+  const featureCollection = featureQueryResultToGeoJson(result);
+  const { source: _source, ...layerOptions } = options;
+
+  return new GeoJsonLayer<Record<string, unknown>>({
+    id,
+    data: featureCollection,
+    pickable: true,
+    autoHighlight: true,
+    stroked: true,
+    filled: true,
+    pointType: 'circle',
+    lineWidthMinPixels: 1,
+    getFillColor: [31, 122, 140, 168],
+    getLineColor: [19, 33, 44, 220],
+    getLineWidth: 1,
+    getPointRadius: 6,
+    pointRadiusUnits: 'pixels',
+    ...layerOptions,
+  });
+}
+
+export function createHonuaDeckOverlay(
+  layers: Layer[] = [],
+  options: Omit<MapboxOverlayProps, 'layers'> = {},
+): MapboxOverlay {
+  return new MapboxOverlay({
+    interleaved: true,
+    ...options,
+    layers,
+  });
+}
+
+function recordToFeature(record: HonuaFeatureRecord): Feature<Geometry, GeoJsonProperties> | null {
+  const geometryOrFeature = record.geoJson ?? record.geoJsonGeometry ?? record.geometry ?? null;
+  if (geometryOrFeature === null) {
+    return null;
+  }
+
+  if (isFeature(geometryOrFeature)) {
+    return {
+      ...geometryOrFeature,
+      properties: {
+        ...record.attributes,
+        ...geometryOrFeature.properties,
+        ...record.properties,
+      },
+    };
+  }
+
+  if (!isGeometry(geometryOrFeature)) {
+    return null;
+  }
+
+  return {
+    type: 'Feature',
+    id: record.id ?? record.objectId,
+    geometry: geometryOrFeature,
+    properties: {
+      ...record.attributes,
+      ...record.properties,
+    },
+  };
+}
+
+function buildLayerId(source: HonuaDisplaySourceDescriptor | null | undefined): string {
+  if (!source?.id) {
+    return 'honua-features';
+  }
+
+  return `honua-${source.id.trim().replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '') || 'features'}`;
+}
+
+function isFeatureCollection(
+  value: unknown,
+): value is FeatureCollection<Geometry, GeoJsonProperties> {
+  return isRecord(value) && value.type === 'FeatureCollection' && Array.isArray(value.features);
+}
+
+function isFeature(value: unknown): value is Feature<Geometry, GeoJsonProperties> {
+  return isRecord(value) && value.type === 'Feature' && isGeometry(value.geometry);
+}
+
+function isGeometry(value: unknown): value is Geometry {
+  return isRecord(value) &&
+    typeof value.type === 'string' &&
+    ('coordinates' in value || 'geometries' in value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/src/Honua.Embed/src/extensions.ts
+++ b/src/Honua.Embed/src/extensions.ts
@@ -1,0 +1,376 @@
+import type { HonuaMapConfig } from './map';
+import type { HonuaSceneConfig } from './scene';
+
+export type HonuaEmbedTarget = 'map' | 'scene';
+
+export interface HonuaEmbedConfigByTarget {
+  map: HonuaMapConfig;
+  scene: HonuaSceneConfig;
+}
+
+export type HonuaEmbedExtensionCleanup = () => void;
+
+export interface HonuaEmbedExtensionContext<TTarget extends HonuaEmbedTarget = HonuaEmbedTarget> {
+  readonly target: TTarget;
+  readonly element: HTMLElement;
+  readonly shadowRoot: ShadowRoot;
+  readonly config: HonuaEmbedConfigByTarget[TTarget];
+  addControl(options: HonuaEmbedControlOptions<TTarget>): HonuaEmbedContribution;
+  setCssVariable(name: string, value: string | null): void;
+  dispatch(type: string, detail?: unknown, init?: Omit<CustomEventInit, 'detail'>): boolean;
+}
+
+export interface HonuaEmbedControlOptions<TTarget extends HonuaEmbedTarget = HonuaEmbedTarget> {
+  id?: string;
+  label: string;
+  title?: string;
+  text?: string;
+  disabled?: boolean;
+  part?: string;
+  onClick?: (event: MouseEvent, context: HonuaEmbedExtensionContext<TTarget>) => void;
+}
+
+export interface HonuaEmbedContribution {
+  readonly element: HTMLElement;
+  remove(): void;
+}
+
+export interface HonuaEmbedExtension<TTarget extends HonuaEmbedTarget = HonuaEmbedTarget> {
+  id: string;
+  target?: TTarget | readonly TTarget[];
+  priority?: number;
+  activate(context: HonuaEmbedExtensionContext<TTarget>): HonuaEmbedExtensionCleanup | void;
+  configChanged?(context: HonuaEmbedExtensionContext<TTarget>): void;
+}
+
+export interface HonuaEmbedExtensionRegistration {
+  readonly id: string;
+  unregister(): void;
+}
+
+export interface HonuaEmbedExtensionDescriptor {
+  readonly id: string;
+  readonly target: readonly HonuaEmbedTarget[];
+  readonly priority: number;
+}
+
+export interface HonuaEmbedExtensionErrorDetail {
+  extensionId: string;
+  target: HonuaEmbedTarget;
+  lifecycle: 'activate' | 'configChanged' | 'deactivate';
+  error: unknown;
+}
+
+interface HonuaEmbedExtensionHostOptions<TTarget extends HonuaEmbedTarget> {
+  target: TTarget;
+  element: HTMLElement;
+  getConfig: () => HonuaEmbedConfigByTarget[TTarget];
+  controlsSelector?: string;
+}
+
+interface ActiveExtension {
+  extension: HonuaEmbedExtension;
+  cleanup?: HonuaEmbedExtensionCleanup;
+  contributions: HonuaEmbedContribution[];
+}
+
+const DEFAULT_CONTROLS_SELECTOR = '[data-honua-extension-controls]';
+const extensions = new Map<string, HonuaEmbedExtension>();
+const hosts = new Set<HonuaEmbedExtensionHost<HonuaEmbedTarget>>();
+
+export function registerHonuaEmbedExtension<TTarget extends HonuaEmbedTarget>(
+  extension: HonuaEmbedExtension<TTarget>,
+): HonuaEmbedExtensionRegistration {
+  const id = extension.id.trim();
+  if (!id) {
+    throw new Error('Honua embed extensions require a non-empty id.');
+  }
+
+  if (extensions.has(id)) {
+    throw new Error(`A Honua embed extension is already registered with id "${id}".`);
+  }
+
+  const normalized = { ...extension, id } as HonuaEmbedExtension;
+  extensions.set(id, normalized);
+  for (const host of hosts) {
+    host.activate(normalized);
+  }
+
+  let registered = true;
+  return {
+    id,
+    unregister() {
+      if (!registered) {
+        return;
+      }
+
+      registered = false;
+      extensions.delete(id);
+      for (const host of hosts) {
+        host.deactivate(id);
+      }
+    },
+  };
+}
+
+export function listHonuaEmbedExtensions(target?: HonuaEmbedTarget): HonuaEmbedExtensionDescriptor[] {
+  return sortedExtensions()
+    .filter((extension) => !target || extensionTargets(extension).includes(target))
+    .map((extension) => ({
+      id: extension.id,
+      target: extensionTargets(extension),
+      priority: extension.priority ?? 0,
+    }));
+}
+
+export class HonuaEmbedExtensionHost<TTarget extends HonuaEmbedTarget> {
+  readonly #target: TTarget;
+  readonly #element: HTMLElement;
+  readonly #getConfig: () => HonuaEmbedConfigByTarget[TTarget];
+  readonly #controlsSelector: string;
+  readonly #active = new Map<string, ActiveExtension>();
+  #connected = false;
+
+  constructor(options: HonuaEmbedExtensionHostOptions<TTarget>) {
+    this.#target = options.target;
+    this.#element = options.element;
+    this.#getConfig = options.getConfig;
+    this.#controlsSelector = options.controlsSelector ?? DEFAULT_CONTROLS_SELECTOR;
+  }
+
+  connect(): void {
+    if (this.#connected) {
+      return;
+    }
+
+    this.#connected = true;
+    hosts.add(this as HonuaEmbedExtensionHost<HonuaEmbedTarget>);
+    for (const extension of sortedExtensions()) {
+      this.activate(extension);
+    }
+  }
+
+  disconnect(): void {
+    if (!this.#connected) {
+      return;
+    }
+
+    for (const id of [...this.#active.keys()]) {
+      this.deactivate(id);
+    }
+
+    hosts.delete(this as HonuaEmbedExtensionHost<HonuaEmbedTarget>);
+    this.#connected = false;
+  }
+
+  configChanged(): void {
+    if (!this.#connected) {
+      return;
+    }
+
+    for (const active of this.#active.values()) {
+      try {
+        active.extension.configChanged?.(this.#context(active.extension.id) as HonuaEmbedExtensionContext);
+      } catch (error) {
+        this.#emitError(active.extension.id, 'configChanged', error);
+      }
+    }
+  }
+
+  activate(extension: HonuaEmbedExtension): void {
+    if (!this.#connected || this.#active.has(extension.id) || !extensionTargets(extension).includes(this.#target)) {
+      return;
+    }
+
+    const active: ActiveExtension = { extension, contributions: [] };
+    this.#active.set(extension.id, active);
+
+    try {
+      const cleanup = extension.activate(this.#context(extension.id) as HonuaEmbedExtensionContext);
+      if (cleanup) {
+        active.cleanup = cleanup;
+      }
+    } catch (error) {
+      this.deactivate(extension.id);
+      this.#emitError(extension.id, 'activate', error);
+    }
+  }
+
+  deactivate(id: string): void {
+    const active = this.#active.get(id);
+    if (!active) {
+      return;
+    }
+
+    this.#active.delete(id);
+    for (const contribution of active.contributions.splice(0)) {
+      contribution.remove();
+    }
+
+    try {
+      active.cleanup?.();
+    } catch (error) {
+      this.#emitError(id, 'deactivate', error);
+    }
+  }
+
+  #context(extensionId: string): HonuaEmbedExtensionContext<TTarget> {
+    const thisHost = this;
+
+    return {
+      get target() {
+        return thisHost.#target;
+      },
+      get element() {
+        return thisHost.#element;
+      },
+      get shadowRoot() {
+        return thisHost.#root();
+      },
+      get config() {
+        return thisHost.#getConfig();
+      },
+      addControl(options) {
+        return thisHost.#addControl(extensionId, options);
+      },
+      setCssVariable(name, value) {
+        thisHost.#setCssVariable(name, value);
+      },
+      dispatch(type, detail, init) {
+        return thisHost.#element.dispatchEvent(new CustomEvent(type, {
+          bubbles: true,
+          composed: true,
+          ...init,
+          detail,
+        }));
+      },
+    };
+  }
+
+  #addControl(
+    extensionId: string,
+    options: HonuaEmbedControlOptions<TTarget>,
+  ): HonuaEmbedContribution {
+    if (!this.#active.has(extensionId)) {
+      throw new Error(`Honua embed extension "${extensionId}" is not active.`);
+    }
+
+    const label = options.label.trim();
+    if (!label) {
+      throw new Error('Honua embed extension controls require a non-empty label.');
+    }
+
+    const outlet = this.#root().querySelector<HTMLElement>(this.#controlsSelector);
+    if (!outlet) {
+      throw new Error(`Missing Honua embed extension outlet: ${this.#controlsSelector}`);
+    }
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'extension-control';
+    button.setAttribute('part', ['extension-control', options.part].filter(Boolean).join(' '));
+    button.setAttribute('aria-label', label);
+    button.title = options.title ?? label;
+    button.disabled = options.disabled ?? false;
+    button.textContent = options.text ?? label;
+
+    if (options.id?.trim()) {
+      button.dataset.honuaExtensionControl = options.id.trim();
+    }
+
+    button.addEventListener('click', (event) => {
+      options.onClick?.(event, this.#context(extensionId));
+    });
+
+    outlet.append(button);
+    setOutletActive(outlet);
+
+    let removed = false;
+    const contribution: HonuaEmbedContribution = {
+      element: button,
+      remove() {
+        if (removed) {
+          return;
+        }
+
+        removed = true;
+        button.remove();
+        setOutletActive(outlet);
+      },
+    };
+
+    this.#active.get(extensionId)?.contributions.push(contribution);
+    return contribution;
+  }
+
+  #setCssVariable(name: string, value: string | null): void {
+    if (!name.startsWith('--')) {
+      throw new Error(`Honua embed CSS variables must start with "--": ${name}`);
+    }
+
+    if (value === null) {
+      this.#element.style.removeProperty(name);
+      return;
+    }
+
+    this.#element.style.setProperty(name, value);
+  }
+
+  #root(): ShadowRoot {
+    const root = this.#element.shadowRoot;
+    if (!root) {
+      throw new Error('Honua embed extensions require an open shadow root.');
+    }
+
+    return root;
+  }
+
+  #emitError(
+    extensionId: string,
+    lifecycle: HonuaEmbedExtensionErrorDetail['lifecycle'],
+    error: unknown,
+  ): void {
+    this.#element.dispatchEvent(new CustomEvent<HonuaEmbedExtensionErrorDetail>('honua-embed-extension-error', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        extensionId,
+        target: this.#target,
+        lifecycle,
+        error,
+      },
+    }));
+  }
+}
+
+export function createHonuaEmbedExtensionHost<TTarget extends HonuaEmbedTarget>(
+  options: HonuaEmbedExtensionHostOptions<TTarget>,
+): HonuaEmbedExtensionHost<TTarget> {
+  return new HonuaEmbedExtensionHost(options);
+}
+
+function sortedExtensions(): HonuaEmbedExtension[] {
+  return [...extensions.values()].sort((left, right) => {
+    const priority = (left.priority ?? 0) - (right.priority ?? 0);
+    return priority === 0 ? left.id.localeCompare(right.id) : priority;
+  });
+}
+
+function extensionTargets(extension: HonuaEmbedExtension): readonly HonuaEmbedTarget[] {
+  const target = extension.target;
+  if (!target) {
+    return ['map', 'scene'];
+  }
+
+  return typeof target === 'string' ? [target] : [...target];
+}
+
+function setOutletActive(outlet: HTMLElement): void {
+  const active = outlet.childElementCount > 0 ? 'true' : 'false';
+  outlet.dataset.honuaExtensionActive = active;
+
+  const parent = outlet.parentElement;
+  if (parent?.classList.contains('controls')) {
+    parent.dataset.honuaExtensionActive = active;
+  }
+}

--- a/src/Honua.Embed/src/index.ts
+++ b/src/Honua.Embed/src/index.ts
@@ -1,5 +1,7 @@
 export * from './map';
 export * from './scene';
+export * from './scene-package-cache';
+export * from './display-adapter';
 
 import { defineHonuaMapElement } from './map';
 import { defineHonuaSceneElement } from './scene';

--- a/src/Honua.Embed/src/index.ts
+++ b/src/Honua.Embed/src/index.ts
@@ -2,6 +2,23 @@ export * from './map';
 export * from './scene';
 export * from './scene-package-cache';
 export * from './display-adapter';
+export type {
+  HonuaEmbedConfigByTarget,
+  HonuaEmbedContribution,
+  HonuaEmbedControlOptions,
+  HonuaEmbedExtension,
+  HonuaEmbedExtensionCleanup,
+  HonuaEmbedExtensionContext,
+  HonuaEmbedExtensionDescriptor,
+  HonuaEmbedExtensionErrorDetail,
+  HonuaEmbedExtensionRegistration,
+  HonuaEmbedTarget,
+} from './extensions';
+export {
+  listHonuaEmbedExtensions,
+  registerHonuaEmbedExtension,
+} from './extensions';
+export * from './snippets';
 
 import { defineHonuaMapElement } from './map';
 import { defineHonuaSceneElement } from './scene';

--- a/src/Honua.Embed/src/map.ts
+++ b/src/Honua.Embed/src/map.ts
@@ -1,3 +1,8 @@
+import {
+  createHonuaEmbedExtensionHost,
+  type HonuaEmbedExtensionHost,
+} from './extensions';
+
 export interface HonuaMapCoordinate {
   latitude: number;
   longitude: number;
@@ -23,6 +28,7 @@ export interface HonuaMapConfig {
   identify: boolean;
   attribution: string | null;
   theme: 'light' | 'dark';
+  label: string;
 }
 
 export interface HonuaMapIdentifyDetail {
@@ -203,12 +209,25 @@ template.innerHTML = `
       flex-direction: column;
     }
 
+    .controls > button[data-action] {
+      display: none;
+    }
+
+    .controls[data-honua-extension-active="true"],
     :host([interactive]:not([interactive="false"]):not([interactive="0"]):not([interactive="no"])) .controls {
       display: flex;
     }
 
+    :host([interactive]:not([interactive="false"]):not([interactive="0"]):not([interactive="no"])) .controls > button[data-action] {
+      display: block;
+    }
+
     :host([search]:not([search="false"]):not([search="0"]):not([search="no"])) .controls {
       top: 62px;
+    }
+
+    .extension-controls {
+      display: contents;
     }
 
     .layers {
@@ -299,6 +318,7 @@ template.innerHTML = `
     <div class="controls" part="controls">
       <button type="button" data-action="zoom-in" aria-label="Zoom in">+</button>
       <button type="button" data-action="zoom-out" aria-label="Zoom out">&minus;</button>
+      <div class="extension-controls" part="extension-controls" data-honua-extension-controls></div>
     </div>
     <div class="layers" part="layers"></div>
     <output class="popup" part="popup"></output>
@@ -321,16 +341,23 @@ export class HonuaMapElement extends HTMLElement {
       'identify',
       'attribution',
       'theme',
+      'label',
     ];
   }
 
   readonly #root: ShadowRoot;
+  readonly #extensionHost: HonuaEmbedExtensionHost<'map'>;
   #readyDispatched = false;
 
   constructor() {
     super();
     this.#root = this.attachShadow({ mode: 'open' });
     this.#root.append(template.content.cloneNode(true));
+    this.#extensionHost = createHonuaEmbedExtensionHost({
+      target: 'map',
+      element: this,
+      getConfig: () => this.config,
+    });
   }
 
   get config(): HonuaMapConfig {
@@ -342,6 +369,7 @@ export class HonuaMapElement extends HTMLElement {
     this.#upgradeProperty('zoom');
     this.#render();
     this.#bindEvents();
+    this.#extensionHost.connect();
 
     if (!this.#readyDispatched) {
       this.#readyDispatched = true;
@@ -353,6 +381,10 @@ export class HonuaMapElement extends HTMLElement {
     }
   }
 
+  disconnectedCallback(): void {
+    this.#extensionHost.disconnect();
+  }
+
   attributeChangedCallback(): void {
     this.#render();
     this.dispatchEvent(new CustomEvent('honua-map-config-change', {
@@ -360,6 +392,7 @@ export class HonuaMapElement extends HTMLElement {
       composed: true,
       detail: this.config,
     }));
+    this.#extensionHost.configChanged();
   }
 
   setView(center: HonuaMapCoordinate, zoom = this.config.zoom): void {
@@ -458,6 +491,7 @@ export class HonuaMapElement extends HTMLElement {
     const meta = this.#query<HTMLElement>('.meta');
 
     map.tabIndex = config.interactive ? 0 : -1;
+    map.setAttribute('aria-label', config.label);
     surface.dataset.basemap = config.basemap;
     layers.replaceChildren(...config.layerIds.map((layerId) => {
       const chip = document.createElement('span');
@@ -513,6 +547,7 @@ function readConfig(element: HTMLElement): HonuaMapConfig {
     identify: parseBooleanAttribute(element, 'identify'),
     attribution: emptyToNull(element.getAttribute('attribution')),
     theme: element.getAttribute('theme') === 'dark' ? 'dark' : 'light',
+    label: emptyToNull(element.getAttribute('label')) ?? 'Embedded map',
   };
 }
 

--- a/src/Honua.Embed/src/scene-package-cache.ts
+++ b/src/Honua.Embed/src/scene-package-cache.ts
@@ -1,0 +1,162 @@
+import type { HonuaSceneConfig } from './scene';
+
+export type HonuaScenePackageAssetKind = 'tileset' | 'terrain' | 'metadata' | 'asset';
+
+export type HonuaScenePackageCacheErrorCode =
+  | 'cache-miss'
+  | 'unsupported-browser-storage'
+  | 'expired-package'
+  | 'invalid-package';
+
+export interface HonuaScenePackageAssetResolverRequest {
+  packageId: string;
+  path: string;
+  kind: HonuaScenePackageAssetKind;
+  config: HonuaSceneConfig;
+}
+
+export interface HonuaScenePackageAssetResolver {
+  resolveAsset(
+    request: HonuaScenePackageAssetResolverRequest,
+  ): Promise<string | URL> | string | URL;
+  dispose?(): void;
+}
+
+export type HonuaScenePackageAssetResolverInput =
+  | HonuaScenePackageAssetResolver
+  | ((request: HonuaScenePackageAssetResolverRequest) => Promise<string | URL> | string | URL);
+
+export interface CacheStorageScenePackageResolverOptions {
+  cacheName: string;
+  urlPrefix?: string;
+  createObjectUrls?: boolean;
+}
+
+export class HonuaScenePackageCacheError extends Error {
+  readonly code: HonuaScenePackageCacheErrorCode;
+
+  constructor(code: HonuaScenePackageCacheErrorCode, message: string) {
+    super(message);
+    this.name = 'HonuaScenePackageCacheError';
+    this.code = code;
+  }
+}
+
+export async function resolveScenePackageAsset(
+  resolver: HonuaScenePackageAssetResolverInput,
+  request: HonuaScenePackageAssetResolverRequest,
+): Promise<string> {
+  const result = typeof resolver === 'function'
+    ? await resolver(request)
+    : await resolver.resolveAsset(request);
+  const url = result instanceof URL ? result.toString() : result.trim();
+
+  if (url.length === 0) {
+    throw new HonuaScenePackageCacheError(
+      'cache-miss',
+      `Scene package asset '${request.path}' was not found in the browser cache.`,
+    );
+  }
+
+  return url;
+}
+
+export function createCacheStorageScenePackageResolver(
+  options: CacheStorageScenePackageResolverOptions,
+): HonuaScenePackageAssetResolver {
+  if (!options.cacheName.trim()) {
+    throw new HonuaScenePackageCacheError(
+      'invalid-package',
+      'A Cache Storage cache name is required.',
+    );
+  }
+
+  const objectUrls = new Set<string>();
+  const createObjectUrls = options.createObjectUrls ?? true;
+
+  return {
+    async resolveAsset(request) {
+      if (!('caches' in globalThis)) {
+        throw new HonuaScenePackageCacheError(
+          'unsupported-browser-storage',
+          'Cache Storage is not available in this browser or WebView.',
+        );
+      }
+
+      const path = normalizeScenePackageAssetPath(request.path);
+      const cache = await globalThis.caches.open(options.cacheName);
+      const cacheUrl = buildCacheStorageAssetUrl(
+        options.urlPrefix ?? '/honua-scene-packages/',
+        request.packageId,
+        path,
+      );
+      const response = await cache.match(cacheUrl);
+      if (!response) {
+        throw new HonuaScenePackageCacheError(
+          'cache-miss',
+          `Scene package asset '${path}' was not found in cache '${options.cacheName}'.`,
+        );
+      }
+
+      if (!createObjectUrls) {
+        return cacheUrl;
+      }
+
+      if (!URL.createObjectURL) {
+        throw new HonuaScenePackageCacheError(
+          'unsupported-browser-storage',
+          'Object URLs are not available in this browser or WebView.',
+        );
+      }
+
+      const objectUrl = URL.createObjectURL(await response.blob());
+      objectUrls.add(objectUrl);
+      return objectUrl;
+    },
+    dispose() {
+      for (const objectUrl of objectUrls) {
+        URL.revokeObjectURL(objectUrl);
+      }
+
+      objectUrls.clear();
+    },
+  };
+}
+
+export function normalizeScenePackageAssetPath(path: string): string {
+  const trimmed = path.trim();
+  if (
+    trimmed.length === 0 ||
+    trimmed.startsWith('/') ||
+    trimmed.includes('\\') ||
+    /^[a-z][a-z0-9+.-]*:/i.test(trimmed)
+  ) {
+    throw new HonuaScenePackageCacheError(
+      'invalid-package',
+      `Scene package asset path '${path}' must be package-local and relative.`,
+    );
+  }
+
+  const segments = trimmed
+    .split('/')
+    .filter((segment) => segment.length > 0);
+
+  if (segments.some((segment) => segment === '.' || segment === '..')) {
+    throw new HonuaScenePackageCacheError(
+      'invalid-package',
+      `Scene package asset path '${path}' must stay under the package root.`,
+    );
+  }
+
+  return segments.join('/');
+}
+
+function buildCacheStorageAssetUrl(
+  urlPrefix: string,
+  packageId: string,
+  path: string,
+): string {
+  const origin = typeof location === 'undefined' ? 'http://localhost' : location.origin;
+  const prefix = urlPrefix.trim().replace(/^\/?/, '/').replace(/\/?$/, '/');
+  return new URL(`${prefix}${encodeURIComponent(packageId)}/${path}`, origin).toString();
+}

--- a/src/Honua.Embed/src/scene.ts
+++ b/src/Honua.Embed/src/scene.ts
@@ -4,6 +4,13 @@ import type {
   Event as CesiumEvent,
   ScreenSpaceEventHandler,
 } from 'cesium';
+import {
+  HonuaScenePackageCacheError,
+  type HonuaScenePackageAssetResolverInput,
+  type HonuaScenePackageAssetKind,
+  type HonuaScenePackageCacheErrorCode,
+  resolveScenePackageAsset,
+} from './scene-package-cache';
 
 export interface HonuaSceneCoordinate {
   latitude: number;
@@ -19,6 +26,10 @@ export interface HonuaSceneOrientation {
 export interface HonuaSceneConfig {
   tilesetUrl: string | null;
   terrainUrl: string | null;
+  packageId: string | null;
+  tilesetAssetPath: string | null;
+  terrainAssetPath: string | null;
+  packageExpiresAtUtc: string | null;
   ionToken: string | null;
   cesiumBaseUrl: string | null;
   center: HonuaSceneCoordinate | null;
@@ -36,7 +47,8 @@ export interface HonuaSceneReadyDetail {
 
 export interface HonuaSceneLoadErrorDetail {
   config: HonuaSceneConfig;
-  source: 'webgl' | 'cesium' | 'terrain' | 'tileset';
+  source: 'webgl' | 'cesium' | 'terrain' | 'tileset' | 'package-cache';
+  code?: HonuaScenePackageCacheErrorCode;
   message: string;
   error?: unknown;
 }
@@ -148,6 +160,10 @@ export class HonuaSceneElement extends HTMLElement {
     return [
       'tileset-url',
       'terrain-url',
+      'package-id',
+      'tileset-asset',
+      'terrain-asset',
+      'package-expires-at',
       'ion-token',
       'cesium-base-url',
       'center',
@@ -166,6 +182,7 @@ export class HonuaSceneElement extends HTMLElement {
   #tileset: Cesium3DTileset | null = null;
   #handler: ScreenSpaceEventHandler | null = null;
   #removeCameraListener: CesiumEvent.RemoveCallback | null = null;
+  #assetResolver: HonuaScenePackageAssetResolverInput | null = null;
   #loadVersion = 0;
 
   constructor() {
@@ -186,12 +203,21 @@ export class HonuaSceneElement extends HTMLElement {
     return this.#tileset;
   }
 
+  get packageAssetResolver(): HonuaScenePackageAssetResolverInput | null {
+    return this.#assetResolver;
+  }
+
+  set packageAssetResolver(resolver: HonuaScenePackageAssetResolverInput | null) {
+    this.setPackageAssetResolver(resolver);
+  }
+
   connectedCallback(): void {
     this.#upgradeProperty('center');
+    this.#upgradeProperty('packageAssetResolver');
     this.#render();
 
     const config = this.config;
-    if (config.autoload && (config.tilesetUrl || config.terrainUrl)) {
+    if (config.autoload && hasSceneData(config)) {
       void this.load();
     }
   }
@@ -222,7 +248,20 @@ export class HonuaSceneElement extends HTMLElement {
       return;
     }
 
-    if (this.config.autoload && ['tileset-url', 'terrain-url', 'ion-token', 'cesium-base-url', 'autoload'].includes(name)) {
+    if (
+      this.config.autoload &&
+      [
+        'tileset-url',
+        'terrain-url',
+        'package-id',
+        'tileset-asset',
+        'terrain-asset',
+        'package-expires-at',
+        'ion-token',
+        'cesium-base-url',
+        'autoload',
+      ].includes(name)
+    ) {
       void this.load();
     }
   }
@@ -252,13 +291,26 @@ export class HonuaSceneElement extends HTMLElement {
     await this.load();
   }
 
+  setPackageAssetResolver(resolver: HonuaScenePackageAssetResolverInput | null): void {
+    this.#assetResolver = resolver;
+
+    if (this.isConnected && this.config.autoload && hasSceneData(this.config)) {
+      void this.load();
+    }
+  }
+
   async load(): Promise<void> {
     const version = ++this.#loadVersion;
     const config = this.config;
+    const dataUrls = await this.#resolveSceneDataUrls(config);
 
-    if (!config.tilesetUrl && !config.terrainUrl) {
+    if (version !== this.#loadVersion || dataUrls === null) {
+      return;
+    }
+
+    if (!dataUrls.tilesetUrl && !dataUrls.terrainUrl) {
       this.#destroyCesium();
-      this.#setStatus('Set a 3D Tiles URL to load a scene.');
+      this.#setStatus('Set a 3D Tiles URL or package asset to load a scene.');
       return;
     }
 
@@ -290,8 +342,8 @@ export class HonuaSceneElement extends HTMLElement {
     this.#appendCesiumStyles(config);
 
     try {
-      const terrainProvider = config.terrainUrl
-        ? await cesium.CesiumTerrainProvider.fromUrl(config.terrainUrl)
+      const terrainProvider = dataUrls.terrainUrl
+        ? await cesium.CesiumTerrainProvider.fromUrl(dataUrls.terrainUrl!)
         : undefined;
 
       if (version !== this.#loadVersion) {
@@ -313,8 +365,8 @@ export class HonuaSceneElement extends HTMLElement {
     }
 
     try {
-      if (config.tilesetUrl) {
-        this.#tileset = await cesium.Cesium3DTileset.fromUrl(config.tilesetUrl);
+      if (dataUrls.tilesetUrl) {
+        this.#tileset = await cesium.Cesium3DTileset.fromUrl(dataUrls.tilesetUrl);
 
         if (version !== this.#loadVersion || !this.#widget) {
           return;
@@ -342,6 +394,62 @@ export class HonuaSceneElement extends HTMLElement {
     } catch (error) {
       this.#emitLoadError('tileset', 'Unable to load the 3D Tiles dataset.', error);
     }
+  }
+
+  async #resolveSceneDataUrls(config: HonuaSceneConfig): Promise<{
+    tilesetUrl: string | null;
+    terrainUrl: string | null;
+  } | null> {
+    if (!config.packageId) {
+      return {
+        tilesetUrl: config.tilesetUrl,
+        terrainUrl: config.terrainUrl,
+      };
+    }
+
+    if (isExpired(config.packageExpiresAtUtc)) {
+      this.#emitLoadError(
+        'package-cache',
+        'The offline scene package has expired and must be refreshed before rendering.',
+        undefined,
+        'expired-package',
+      );
+      return null;
+    }
+
+    try {
+      return {
+        tilesetUrl: config.tilesetAssetPath
+          ? await this.#resolvePackageAssetUrl(config, config.tilesetAssetPath, 'tileset')
+          : config.tilesetUrl,
+        terrainUrl: config.terrainAssetPath
+          ? await this.#resolvePackageAssetUrl(config, config.terrainAssetPath, 'terrain')
+          : config.terrainUrl,
+      };
+    } catch (error) {
+      this.#emitPackageCacheError(error);
+      return null;
+    }
+  }
+
+  async #resolvePackageAssetUrl(
+    config: HonuaSceneConfig,
+    path: string,
+    kind: HonuaScenePackageAssetKind,
+  ): Promise<string> {
+    if (!this.#assetResolver) {
+      throw new HonuaScenePackageCacheError(
+        'unsupported-browser-storage',
+        'No scene package asset resolver is configured for this browser or WebView host.',
+      );
+    }
+
+    return await resolveScenePackageAsset(this.#assetResolver, {
+      packageId: config.packageId!,
+      path,
+      kind,
+      config,
+    });
   }
 
   #bindCesiumEvents(cesium: CesiumModule): void {
@@ -462,9 +570,9 @@ export class HonuaSceneElement extends HTMLElement {
       return;
     }
 
-    this.#setStatus(this.config.tilesetUrl || this.config.terrainUrl
+    this.#setStatus(hasSceneData(this.config)
       ? '3D scene ready to load.'
-      : 'Set a 3D Tiles URL to load a scene.');
+      : 'Set a 3D Tiles URL or package asset to load a scene.');
   }
 
   #destroyCesium(): void {
@@ -485,7 +593,26 @@ export class HonuaSceneElement extends HTMLElement {
     this.#widget = null;
   }
 
-  #emitLoadError(source: HonuaSceneLoadErrorDetail['source'], message: string, error?: unknown): void {
+  #emitPackageCacheError(error: unknown): void {
+    if (error instanceof HonuaScenePackageCacheError) {
+      this.#emitLoadError('package-cache', error.message, error, error.code);
+      return;
+    }
+
+    this.#emitLoadError(
+      'package-cache',
+      'Unable to resolve the offline scene package asset.',
+      error,
+      'cache-miss',
+    );
+  }
+
+  #emitLoadError(
+    source: HonuaSceneLoadErrorDetail['source'],
+    message: string,
+    error?: unknown,
+    code?: HonuaScenePackageCacheErrorCode,
+  ): void {
     this.#setStatus(message);
     this.dispatchEvent(new CustomEvent<HonuaSceneLoadErrorDetail>('honua-scene-load-error', {
       bubbles: true,
@@ -493,6 +620,7 @@ export class HonuaSceneElement extends HTMLElement {
       detail: {
         config: this.config,
         source,
+        code,
         message,
         error,
       },
@@ -540,6 +668,10 @@ function readSceneConfig(element: HTMLElement): HonuaSceneConfig {
   return {
     tilesetUrl: emptyToNull(element.getAttribute('tileset-url')),
     terrainUrl: emptyToNull(element.getAttribute('terrain-url')),
+    packageId: emptyToNull(element.getAttribute('package-id')),
+    tilesetAssetPath: emptyToNull(element.getAttribute('tileset-asset')),
+    terrainAssetPath: emptyToNull(element.getAttribute('terrain-asset')),
+    packageExpiresAtUtc: emptyToNull(element.getAttribute('package-expires-at')),
     ionToken: emptyToNull(element.getAttribute('ion-token')),
     cesiumBaseUrl: normalizeBaseUrl(element.getAttribute('cesium-base-url')),
     center: parseCoordinate(element.getAttribute('center')),
@@ -552,6 +684,23 @@ function readSceneConfig(element: HTMLElement): HonuaSceneConfig {
     theme: element.getAttribute('theme') === 'light' ? 'light' : 'dark',
     autoload: parseBooleanAttribute(element, 'autoload', true),
   };
+}
+
+function hasSceneData(config: HonuaSceneConfig): boolean {
+  return Boolean(
+    config.tilesetUrl ||
+    config.terrainUrl ||
+    (config.packageId && (config.tilesetAssetPath || config.terrainAssetPath)),
+  );
+}
+
+function isExpired(expiresAtUtc: string | null): boolean {
+  if (!expiresAtUtc) {
+    return false;
+  }
+
+  const expiresAt = Date.parse(expiresAtUtc);
+  return Number.isFinite(expiresAt) && expiresAt <= Date.now();
 }
 
 function emptyToNull(value: string | null): string | null {

--- a/src/Honua.Embed/src/scene.ts
+++ b/src/Honua.Embed/src/scene.ts
@@ -347,7 +347,12 @@ export class HonuaSceneElement extends HTMLElement {
     const config = this.config;
     const dataUrls = await this.#resolveSceneDataUrls(config);
 
-    if (version !== this.#loadVersion || dataUrls === null) {
+    if (version !== this.#loadVersion) {
+      return;
+    }
+
+    if (dataUrls === null) {
+      this.#destroyCesium();
       return;
     }
 

--- a/src/Honua.Embed/src/scene.ts
+++ b/src/Honua.Embed/src/scene.ts
@@ -5,6 +5,10 @@ import type {
   ScreenSpaceEventHandler,
 } from 'cesium';
 import {
+  createHonuaEmbedExtensionHost,
+  type HonuaEmbedExtensionHost,
+} from './extensions';
+import {
   HonuaScenePackageCacheError,
   type HonuaScenePackageAssetResolverInput,
   type HonuaScenePackageAssetKind,
@@ -148,9 +152,39 @@ sceneTemplate.innerHTML = `
     .status[data-hidden="true"] {
       display: none;
     }
+
+    .extension-controls {
+      position: absolute;
+      right: 12px;
+      top: 12px;
+      z-index: 1;
+      display: none;
+      gap: 6px;
+      flex-direction: column;
+    }
+
+    .extension-controls[data-honua-extension-active="true"] {
+      display: flex;
+    }
+
+    .extension-controls > button {
+      width: 36px;
+      height: 36px;
+      color: var(--honua-scene-foreground);
+      background: color-mix(in srgb, var(--honua-scene-background) 78%, transparent);
+      border: 1px solid var(--honua-scene-border);
+      border-radius: 6px;
+      font: inherit;
+      cursor: pointer;
+    }
+
+    .extension-controls > button:hover {
+      border-color: var(--honua-scene-accent);
+    }
   </style>
   <section class="scene" role="application" aria-label="Embedded 3D scene">
     <div class="viewport" part="viewport"></div>
+    <div class="extension-controls" part="extension-controls" data-honua-extension-controls></div>
     <output class="status" part="status"></output>
   </section>
 `;
@@ -183,12 +217,18 @@ export class HonuaSceneElement extends HTMLElement {
   #handler: ScreenSpaceEventHandler | null = null;
   #removeCameraListener: CesiumEvent.RemoveCallback | null = null;
   #assetResolver: HonuaScenePackageAssetResolverInput | null = null;
+  readonly #extensionHost: HonuaEmbedExtensionHost<'scene'>;
   #loadVersion = 0;
 
   constructor() {
     super();
     this.#root = this.attachShadow({ mode: 'open' });
     this.#root.append(sceneTemplate.content.cloneNode(true));
+    this.#extensionHost = createHonuaEmbedExtensionHost({
+      target: 'scene',
+      element: this,
+      getConfig: () => this.config,
+    });
   }
 
   get config(): HonuaSceneConfig {
@@ -215,6 +255,7 @@ export class HonuaSceneElement extends HTMLElement {
     this.#upgradeProperty('center');
     this.#upgradeProperty('packageAssetResolver');
     this.#render();
+    this.#extensionHost.connect();
 
     const config = this.config;
     if (config.autoload && hasSceneData(config)) {
@@ -224,6 +265,7 @@ export class HonuaSceneElement extends HTMLElement {
 
   disconnectedCallback(): void {
     this.#loadVersion += 1;
+    this.#extensionHost.disconnect();
     this.#destroyCesium();
   }
 
@@ -238,6 +280,7 @@ export class HonuaSceneElement extends HTMLElement {
       composed: true,
       detail: this.config,
     }));
+    this.#extensionHost.configChanged();
 
     if (!this.isConnected) {
       return;

--- a/src/Honua.Embed/src/snippets.ts
+++ b/src/Honua.Embed/src/snippets.ts
@@ -1,0 +1,287 @@
+import type { HonuaMapBounds, HonuaMapCoordinate } from './map';
+
+export interface HonuaMapThemeOptions {
+  accent?: string | null;
+  background?: string | null;
+  foreground?: string | null;
+  muted?: string | null;
+  surface?: string | null;
+  border?: string | null;
+  fontFamily?: string | null;
+  controlSize?: string | null;
+}
+
+export interface HonuaMapEmbedOptions {
+  serviceUrl?: string | null;
+  layerIds?: readonly string[] | null;
+  apiKey?: string | null;
+  center?: HonuaMapCoordinate | null;
+  zoom?: number | null;
+  bounds?: HonuaMapBounds | null;
+  basemap?: string | null;
+  interactive?: boolean | null;
+  search?: boolean | null;
+  identify?: boolean | null;
+  attribution?: string | null;
+  theme?: 'light' | 'dark' | null;
+  label?: string | null;
+  style?: HonuaMapThemeOptions | null;
+}
+
+export interface HonuaMapSnippetOptions {
+  packageName?: string;
+  elementName?: string;
+  includeScript?: boolean;
+  includeCredentials?: boolean;
+  indent?: string;
+}
+
+export function applyHonuaMapOptions(
+  element: HTMLElement,
+  options: HonuaMapEmbedOptions,
+): void {
+  setOptionalAttribute(element, 'service-url', options.serviceUrl);
+  setOptionalAttribute(element, 'layer-ids', serializeList(options.layerIds));
+  setOptionalAttribute(element, 'api-key', options.apiKey);
+  setOptionalAttribute(element, 'center', serializeCoordinate(options.center));
+  setOptionalAttribute(element, 'zoom', serializeNumber(options.zoom));
+  setOptionalAttribute(element, 'bbox', serializeBounds(options.bounds));
+  setOptionalAttribute(element, 'basemap', options.basemap);
+  setBooleanAttribute(element, 'interactive', options.interactive);
+  setBooleanAttribute(element, 'search', options.search);
+  setBooleanAttribute(element, 'identify', options.identify);
+  setOptionalAttribute(element, 'attribution', options.attribution);
+  setOptionalAttribute(element, 'theme', options.theme);
+  setOptionalAttribute(element, 'label', options.label);
+
+  if (options.style !== undefined) {
+    applyHonuaMapTheme(element, options.style);
+  }
+}
+
+export function applyHonuaMapTheme(element: HTMLElement, theme: HonuaMapThemeOptions | null): void {
+  for (const [property, value] of Object.entries(mapThemeVariables(theme))) {
+    if (value === undefined) {
+      continue;
+    }
+
+    if (value === null) {
+      element.style.removeProperty(property);
+      continue;
+    }
+
+    element.style.setProperty(property, value);
+  }
+}
+
+export function createHonuaMapSnippet(
+  options: HonuaMapEmbedOptions,
+  snippetOptions: HonuaMapSnippetOptions = {},
+): string {
+  const elementName = snippetOptions.elementName ?? 'honua-map';
+  assertCustomElementName(elementName);
+
+  const includeScript = snippetOptions.includeScript ?? true;
+  const packageName = snippetOptions.packageName ?? '@honua-io/embed';
+  const indent = snippetOptions.indent ?? '  ';
+  const element = createElementMarkup(elementName, options, {
+    includeCredentials: snippetOptions.includeCredentials ?? false,
+    indent,
+  });
+
+  if (!includeScript) {
+    return element;
+  }
+
+  const script = elementName === 'honua-map'
+    ? [
+      '<script type="module">',
+      `${indent}import '${escapeJsString(packageName)}';`,
+      '</script>',
+    ].join('\n')
+    : [
+      '<script type="module">',
+      `${indent}import { defineHonuaMapElement } from '${escapeJsString(packageName)}';`,
+      `${indent}defineHonuaMapElement('${escapeJsString(elementName)}');`,
+      '</script>',
+    ].join('\n');
+
+  return `${script}\n\n${element}`;
+}
+
+function createElementMarkup(
+  elementName: string,
+  options: HonuaMapEmbedOptions,
+  config: Required<Pick<HonuaMapSnippetOptions, 'includeCredentials' | 'indent'>>,
+): string {
+  const attributes = mapAttributes(options, config.includeCredentials);
+  const style = serializeTheme(options.style);
+  if (style) {
+    attributes.push(['style', style]);
+  }
+
+  if (attributes.length === 0) {
+    return `<${elementName}></${elementName}>`;
+  }
+
+  const lines = attributes.map(([name, value]) => value === true
+    ? `${config.indent}${name}`
+    : `${config.indent}${name}="${escapeHtmlAttribute(value)}"`);
+
+  return `<${elementName}\n${lines.join('\n')}>\n</${elementName}>`;
+}
+
+function mapAttributes(
+  options: HonuaMapEmbedOptions,
+  includeCredentials: boolean,
+): Array<[string, string | true]> {
+  return [
+    ['service-url', options.serviceUrl],
+    ['layer-ids', serializeList(options.layerIds)],
+    ['api-key', includeCredentials ? options.apiKey : undefined],
+    ['center', serializeCoordinate(options.center)],
+    ['zoom', serializeNumber(options.zoom)],
+    ['bbox', serializeBounds(options.bounds)],
+    ['basemap', options.basemap],
+    ['interactive', serializeBoolean(options.interactive)],
+    ['search', serializeBoolean(options.search)],
+    ['identify', serializeBoolean(options.identify)],
+    ['attribution', options.attribution],
+    ['theme', options.theme],
+    ['label', options.label],
+  ].filter((entry): entry is [string, string | true] => {
+    const value = entry[1];
+    return value !== undefined && value !== null && value !== '';
+  });
+}
+
+function serializeTheme(theme: HonuaMapThemeOptions | null | undefined): string | null {
+  const declarations = Object.entries(mapThemeVariables(theme))
+    .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+    .map(([property, value]) => `${property}: ${value}`);
+
+  return declarations.length === 0 ? null : declarations.join('; ');
+}
+
+function mapThemeVariables(theme: HonuaMapThemeOptions | null | undefined): Record<string, string | null | undefined> {
+  if (theme === null) {
+    return {
+      '--honua-map-accent': null,
+      '--honua-map-background': null,
+      '--honua-map-foreground': null,
+      '--honua-map-muted': null,
+      '--honua-map-surface': null,
+      '--honua-map-border': null,
+      '--honua-map-font-family': null,
+      '--honua-map-control-size': null,
+    };
+  }
+
+  return {
+    '--honua-map-accent': theme?.accent,
+    '--honua-map-background': theme?.background,
+    '--honua-map-foreground': theme?.foreground,
+    '--honua-map-muted': theme?.muted,
+    '--honua-map-surface': theme?.surface,
+    '--honua-map-border': theme?.border,
+    '--honua-map-font-family': theme?.fontFamily,
+    '--honua-map-control-size': theme?.controlSize,
+  };
+}
+
+function setOptionalAttribute(element: HTMLElement, name: string, value: string | null | undefined): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (value === null || value === '') {
+    element.removeAttribute(name);
+    return;
+  }
+
+  element.setAttribute(name, value);
+}
+
+function setBooleanAttribute(element: HTMLElement, name: string, value: boolean | null | undefined): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (value) {
+    element.setAttribute(name, '');
+    return;
+  }
+
+  element.removeAttribute(name);
+}
+
+function serializeBoolean(value: boolean | null | undefined): true | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return value ? true : null;
+}
+
+function serializeList(value: readonly string[] | null | undefined): string | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  const serialized = value
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .join(',');
+  return serialized || null;
+}
+
+function serializeCoordinate(value: HonuaMapCoordinate | null | undefined): string | null | undefined {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  return `${value.latitude},${value.longitude}`;
+}
+
+function serializeBounds(value: HonuaMapBounds | null | undefined): string | null | undefined {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  return `${value.minLongitude},${value.minLatitude},${value.maxLongitude},${value.maxLatitude}`;
+}
+
+function serializeNumber(value: number | null | undefined): string | null | undefined {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  return String(value);
+}
+
+function escapeHtmlAttribute(value: string | true): string {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function escapeJsString(value: string): string {
+  return value
+    .replaceAll('\\', '\\\\')
+    .replaceAll('\'', '\\\'')
+    .replaceAll('<', '\\x3C')
+    .replaceAll('\n', '\\n')
+    .replaceAll('\r', '\\r');
+}
+
+function assertCustomElementName(name: string): void {
+  if (!/^[a-z][.0-9_a-z-]*-[.0-9_a-z-]*$/.test(name)) {
+    throw new Error(`Invalid custom element name: ${name}`);
+  }
+}

--- a/src/Honua.Embed/tests/display-adapter.test.ts
+++ b/src/Honua.Embed/tests/display-adapter.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createHonuaGeoJsonLayer,
+  featureQueryResultToGeoJson,
+  HonuaWebDisplayAdapter,
+} from '../src/index';
+
+describe('display adapter', () => {
+  it('converts feature query results into deck.gl-ready GeoJSON', () => {
+    const geoJson = featureQueryResultToGeoJson({
+      source: {
+        id: 'field-assets',
+        spatialReference: { wkid: 4326 },
+      },
+      features: [
+        {
+          id: 42,
+          geometry: {
+            type: 'Point',
+            coordinates: [-157.8583, 21.3069],
+          },
+          attributes: {
+            assetType: 'hydrant',
+          },
+          properties: {
+            status: 'active',
+          },
+        },
+        {
+          id: 43,
+          geometry: null,
+          attributes: {
+            status: 'missing geometry',
+          },
+        },
+      ],
+    });
+
+    expect(geoJson).toEqual({
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          id: 42,
+          geometry: {
+            type: 'Point',
+            coordinates: [-157.8583, 21.3069],
+          },
+          properties: {
+            assetType: 'hydrant',
+            status: 'active',
+          },
+        },
+      ],
+    });
+  });
+
+  it('creates a GeoJsonLayer with stable Honua defaults', () => {
+    const layer = createHonuaGeoJsonLayer({
+      source: { id: 'utility lines' },
+      features: [
+        {
+          geometry: {
+            type: 'LineString',
+            coordinates: [
+              [-157.86, 21.3],
+              [-157.85, 21.31],
+            ],
+          },
+          attributes: {
+            material: 'ductile iron',
+          },
+        },
+      ],
+    });
+
+    expect(layer.id).toBe('honua-utility-lines');
+    expect(layer.props.pickable).toBe(true);
+    expect(layer.props.autoHighlight).toBe(true);
+    expect(layer.props.data).toMatchObject({
+      type: 'FeatureCollection',
+      features: [
+        {
+          geometry: {
+            type: 'LineString',
+          },
+        },
+      ],
+    });
+  });
+
+  it('attaches and updates deck.gl overlays on a MapLibre-compatible map', () => {
+    const controls: unknown[] = [];
+    const map = {
+      addControl: vi.fn((control: unknown) => {
+        controls.push(control);
+      }),
+      removeControl: vi.fn((control: unknown) => {
+        const index = controls.indexOf(control);
+        if (index >= 0) {
+          controls.splice(index, 1);
+        }
+      }),
+    };
+    const adapter = new HonuaWebDisplayAdapter(map);
+
+    const layer = adapter.setFeatureQueryResult([
+      {
+        geometry: {
+          type: 'Point',
+          coordinates: [-157.8583, 21.3069],
+        },
+      },
+    ]);
+
+    expect(map.addControl).toHaveBeenCalledOnce();
+    expect(adapter.layers).toEqual([layer]);
+
+    adapter.destroy();
+
+    expect(map.removeControl).toHaveBeenCalledWith(adapter.overlay);
+    expect(controls).toHaveLength(0);
+  });
+});

--- a/src/Honua.Embed/tests/honua-extensions.test.ts
+++ b/src/Honua.Embed/tests/honua-extensions.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  defineHonuaMapElement,
+  defineHonuaSceneElement,
+  listHonuaEmbedExtensions,
+  registerHonuaEmbedExtension,
+  type HonuaEmbedExtensionRegistration,
+} from '../src/index';
+
+const registrations: HonuaEmbedExtensionRegistration[] = [];
+
+describe('honua embed extensions', () => {
+  beforeEach(() => {
+    defineHonuaMapElement();
+    defineHonuaSceneElement();
+    document.body.replaceChildren();
+  });
+
+  afterEach(() => {
+    for (const registration of registrations.splice(0)) {
+      registration.unregister();
+    }
+    document.body.replaceChildren();
+  });
+
+  it('mounts registered map controls and removes them on unregister', () => {
+    const registration = registerHonuaEmbedExtension({
+      id: 'isv-locate',
+      target: 'map',
+      activate(context) {
+        context.setCssVariable('--honua-map-accent', '#0f766e');
+        context.addControl({
+          id: 'locate',
+          label: 'Locate asset',
+          text: 'L',
+          onClick: (_event, clickContext) => {
+            clickContext.dispatch('isv-locate', { zoom: clickContext.config.zoom });
+          },
+        });
+      },
+    });
+    registrations.push(registration);
+
+    const element = document.createElement('honua-map');
+    element.setAttribute('zoom', '8');
+    document.body.append(element);
+    const listener = vi.fn();
+    element.addEventListener('isv-locate', listener);
+
+    const button = element.shadowRoot!.querySelector<HTMLButtonElement>('[data-honua-extension-control="locate"]')!;
+    button.click();
+
+    expect(button.textContent).toBe('L');
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail).toEqual({ zoom: 8 });
+    expect(element.style.getPropertyValue('--honua-map-accent')).toBe('#0f766e');
+    expect(element.shadowRoot!.querySelector<HTMLElement>('.controls')!.dataset.honuaExtensionActive).toBe('true');
+
+    registration.unregister();
+
+    expect(button.isConnected).toBe(false);
+    expect(element.shadowRoot!.querySelector<HTMLElement>('.controls')!.dataset.honuaExtensionActive).toBe('false');
+  });
+
+  it('notifies active extensions when element config changes', () => {
+    const configChanges: string[] = [];
+    const registration = registerHonuaEmbedExtension({
+      id: 'isv-config-watch',
+      target: 'map',
+      activate: vi.fn(),
+      configChanged(context) {
+        configChanges.push(context.config.basemap);
+      },
+    });
+    registrations.push(registration);
+
+    const element = document.createElement('honua-map');
+    document.body.append(element);
+
+    element.setAttribute('basemap', 'satellite');
+    element.setAttribute('basemap', 'dark');
+
+    expect(configChanges).toEqual(['satellite', 'dark']);
+  });
+
+  it('keeps target-specific extensions scoped to their embed type', () => {
+    const registration = registerHonuaEmbedExtension({
+      id: 'scene-reset',
+      target: 'scene',
+      activate(context) {
+        context.addControl({
+          id: 'reset',
+          label: 'Reset view',
+          text: 'R',
+        });
+      },
+    });
+    registrations.push(registration);
+
+    const map = document.createElement('honua-map');
+    const scene = document.createElement('honua-scene');
+    document.body.append(map, scene);
+
+    expect(map.shadowRoot!.querySelector('[data-honua-extension-control="reset"]')).toBeNull();
+    expect(scene.shadowRoot!.querySelector('[data-honua-extension-control="reset"]')).not.toBeNull();
+    expect(listHonuaEmbedExtensions('scene')).toMatchObject([
+      { id: 'scene-reset', target: ['scene'], priority: 0 },
+    ]);
+  });
+
+  it('rejects duplicate extension ids', () => {
+    const registration = registerHonuaEmbedExtension({
+      id: 'duplicate-extension',
+      activate: vi.fn(),
+    });
+    registrations.push(registration);
+
+    expect(() => registerHonuaEmbedExtension({
+      id: 'duplicate-extension',
+      activate: vi.fn(),
+    })).toThrow(/already registered/);
+  });
+
+  it('emits extension lifecycle errors on the host element', () => {
+    const error = new Error('failed to activate');
+    const registration = registerHonuaEmbedExtension({
+      id: 'broken-extension',
+      target: 'map',
+      activate() {
+        throw error;
+      },
+    });
+    registrations.push(registration);
+
+    const element = document.createElement('honua-map');
+    const listener = vi.fn();
+    element.addEventListener('honua-embed-extension-error', listener);
+    document.body.append(element);
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail).toMatchObject({
+      extensionId: 'broken-extension',
+      target: 'map',
+      lifecycle: 'activate',
+      error,
+    });
+  });
+});

--- a/src/Honua.Embed/tests/honua-scene.test.ts
+++ b/src/Honua.Embed/tests/honua-scene.test.ts
@@ -333,6 +333,33 @@ describe('honua-scene', () => {
     webgl.mockRestore();
   });
 
+  it('tears down the existing scene when package resolution fails', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('package-id', 'pkg-downtown');
+    element.setAttribute('tileset-asset', 'tilesets/buildings/tileset.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    element.packageAssetResolver = () => 'https://cache.example.test/tileset.json';
+    document.body.append(element);
+
+    await element.load();
+    expect(cesium.__mock.widgets).toHaveLength(1);
+
+    const listener = vi.fn();
+    element.addEventListener('honua-scene-load-error', listener);
+    element.setAttribute('package-expires-at', '2000-01-01T00:00:00Z');
+    await element.load();
+
+    expect(listener.mock.calls[0][0].detail).toMatchObject({
+      source: 'package-cache',
+      code: 'expired-package',
+    });
+    expect(cesium.__mock.widgets[0].destroy).toHaveBeenCalledOnce();
+    expect(element.cesiumWidget).toBeNull();
+    webgl.mockRestore();
+  });
+
   it('cancels in-flight loads when disconnected', async () => {
     const webgl = mockWebGl();
     let resolveTerrain!: (value: unknown) => void;

--- a/src/Honua.Embed/tests/honua-scene.test.ts
+++ b/src/Honua.Embed/tests/honua-scene.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { defineHonuaSceneElement, HonuaSceneElement } from '../src/index';
+import {
+  defineHonuaSceneElement,
+  HonuaSceneElement,
+  HonuaScenePackageCacheError,
+} from '../src/index';
 
 interface MockCesiumModule {
   CesiumTerrainProvider: {
@@ -134,6 +138,10 @@ describe('honua-scene', () => {
     const element = document.createElement('honua-scene');
     element.setAttribute('tileset-url', 'https://data.example.test/tileset.json');
     element.setAttribute('terrain-url', 'https://data.example.test/terrain');
+    element.setAttribute('package-id', 'pkg-downtown');
+    element.setAttribute('tileset-asset', 'tilesets/buildings/tileset.json');
+    element.setAttribute('terrain-asset', 'terrain/layer.json');
+    element.setAttribute('package-expires-at', '2026-06-27T00:00:00Z');
     element.setAttribute('ion-token', 'secret-ion-token');
     element.setAttribute('cesium-base-url', '/assets/cesium');
     element.setAttribute('center', '21.3069,-157.8583');
@@ -149,6 +157,10 @@ describe('honua-scene', () => {
     expect(element.config).toMatchObject({
       tilesetUrl: 'https://data.example.test/tileset.json',
       terrainUrl: 'https://data.example.test/terrain',
+      packageId: 'pkg-downtown',
+      tilesetAssetPath: 'tilesets/buildings/tileset.json',
+      terrainAssetPath: 'terrain/layer.json',
+      packageExpiresAtUtc: '2026-06-27T00:00:00Z',
       ionToken: 'secret-ion-token',
       cesiumBaseUrl: '/assets/cesium/',
       center: { latitude: 21.3069, longitude: -157.8583 },
@@ -195,6 +207,98 @@ describe('honua-scene', () => {
       source: 'webgl',
       message: '3D scenes require WebGL support in the host browser.',
     });
+  });
+
+  it('resolves package-local scene assets through a host-provided resolver', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('package-id', 'pkg-downtown');
+    element.setAttribute('tileset-asset', 'tilesets/buildings/tileset.json');
+    element.setAttribute('terrain-asset', 'terrain/layer.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    const resolver = vi.fn((request) => `https://cache.example.test/${request.packageId}/${request.path}`);
+    element.packageAssetResolver = resolver;
+    document.body.append(element);
+
+    await element.load();
+
+    expect(resolver).toHaveBeenCalledWith(expect.objectContaining({
+      packageId: 'pkg-downtown',
+      path: 'tilesets/buildings/tileset.json',
+      kind: 'tileset',
+    }));
+    expect(resolver).toHaveBeenCalledWith(expect.objectContaining({
+      packageId: 'pkg-downtown',
+      path: 'terrain/layer.json',
+      kind: 'terrain',
+    }));
+    expect(cesium.CesiumTerrainProvider.fromUrl).toHaveBeenCalledWith(
+      'https://cache.example.test/pkg-downtown/terrain/layer.json',
+    );
+    webgl.mockRestore();
+  });
+
+  it('surfaces unsupported browser storage when package assets have no resolver', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('package-id', 'pkg-downtown');
+    element.setAttribute('tileset-asset', 'tilesets/buildings/tileset.json');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+    const listener = vi.fn();
+    element.addEventListener('honua-scene-load-error', listener);
+
+    await element.load();
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail).toMatchObject({
+      source: 'package-cache',
+      code: 'unsupported-browser-storage',
+    });
+    webgl.mockRestore();
+  });
+
+  it('surfaces cache misses and expired package grants before Cesium loads', async () => {
+    const webgl = mockWebGl();
+    const missing = document.createElement('honua-scene');
+    missing.setAttribute('package-id', 'pkg-downtown');
+    missing.setAttribute('tileset-asset', 'tilesets/missing/tileset.json');
+    missing.setAttribute('autoload', 'false');
+    missing.packageAssetResolver = () => {
+      throw new HonuaScenePackageCacheError('cache-miss', 'missing tileset');
+    };
+    document.body.append(missing);
+    const missingListener = vi.fn();
+    missing.addEventListener('honua-scene-load-error', missingListener);
+
+    await missing.load();
+
+    expect(missingListener.mock.calls[0][0].detail).toMatchObject({
+      source: 'package-cache',
+      code: 'cache-miss',
+      message: 'missing tileset',
+    });
+
+    const expired = document.createElement('honua-scene');
+    expired.setAttribute('package-id', 'pkg-expired');
+    expired.setAttribute('tileset-asset', 'tilesets/buildings/tileset.json');
+    expired.setAttribute('package-expires-at', '2000-01-01T00:00:00Z');
+    expired.setAttribute('autoload', 'false');
+    const expiredResolver = vi.fn(() => 'https://cache.example.test/tileset.json');
+    expired.packageAssetResolver = expiredResolver;
+    document.body.append(expired);
+    const expiredListener = vi.fn();
+    expired.addEventListener('honua-scene-load-error', expiredListener);
+
+    await expired.load();
+
+    expect(expiredListener.mock.calls[0][0].detail).toMatchObject({
+      source: 'package-cache',
+      code: 'expired-package',
+    });
+    expect(expiredResolver).not.toHaveBeenCalled();
+    webgl.mockRestore();
   });
 
   it('does not render access tokens or Honua branding by default', () => {

--- a/src/Honua.Embed/tests/honua-snippets.test.ts
+++ b/src/Honua.Embed/tests/honua-snippets.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  applyHonuaMapOptions,
+  createHonuaMapSnippet,
+  defineHonuaMapElement,
+} from '../src/index';
+
+describe('honua map snippets', () => {
+  beforeEach(() => {
+    defineHonuaMapElement();
+    document.body.replaceChildren();
+  });
+
+  it('generates a white-label custom-element snippet without credentials by default', () => {
+    const snippet = createHonuaMapSnippet({
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      layerIds: ['assets', 'work-orders'],
+      apiKey: 'secret-key',
+      center: { latitude: 21.3069, longitude: -157.8583 },
+      zoom: 12,
+      bounds: {
+        minLongitude: -158.3,
+        minLatitude: 21.2,
+        maxLongitude: -157.6,
+        maxLatitude: 21.6,
+      },
+      basemap: 'streets',
+      interactive: true,
+      search: true,
+      identify: true,
+      attribution: 'City GIS',
+      theme: 'dark',
+      label: 'City asset map',
+      style: {
+        accent: '#0f766e',
+        fontFamily: 'Aptos, sans-serif',
+      },
+    }, {
+      elementName: 'city-asset-map',
+    });
+
+    expect(snippet).toContain('defineHonuaMapElement(\'city-asset-map\')');
+    expect(snippet).toContain('<city-asset-map');
+    expect(snippet).toContain('service-url="https://services.example.test/FeatureServer"');
+    expect(snippet).toContain('layer-ids="assets,work-orders"');
+    expect(snippet).toContain('bbox="-158.3,21.2,-157.6,21.6"');
+    expect(snippet).toContain('interactive');
+    expect(snippet).toContain('label="City asset map"');
+    expect(snippet).toContain('style="--honua-map-accent: #0f766e; --honua-map-font-family: Aptos, sans-serif"');
+    expect(snippet).not.toContain('secret-key');
+  });
+
+  it('includes credentials only when explicitly requested', () => {
+    const snippet = createHonuaMapSnippet({
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      apiKey: 'public-browser-key',
+    }, {
+      includeCredentials: true,
+      includeScript: false,
+    });
+
+    expect(snippet).toContain('api-key="public-browser-key"');
+    expect(snippet).not.toContain('<script');
+  });
+
+  it('applies map options to an existing element and removes null values', () => {
+    const element = document.createElement('honua-map');
+    element.setAttribute('service-url', 'https://old.example.test');
+    element.setAttribute('interactive', '');
+    element.style.setProperty('--honua-map-accent', '#123456');
+    element.style.setProperty('--honua-map-background', '#eeeeee');
+    document.body.append(element);
+
+    applyHonuaMapOptions(element, {
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      layerIds: ['assets', ''],
+      interactive: false,
+      search: true,
+      style: {
+        accent: null,
+        surface: '#ffffff',
+      },
+    });
+
+    expect(element.getAttribute('service-url')).toBe('https://services.example.test/FeatureServer');
+    expect(element.getAttribute('layer-ids')).toBe('assets');
+    expect(element.hasAttribute('interactive')).toBe(false);
+    expect(element.hasAttribute('search')).toBe(true);
+    expect(element.style.getPropertyValue('--honua-map-accent')).toBe('');
+    expect(element.style.getPropertyValue('--honua-map-background')).toBe('#eeeeee');
+    expect(element.style.getPropertyValue('--honua-map-surface')).toBe('#ffffff');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the embed/web portions of the non-Flutter backlog:

- #50: adds a MapLibre/deck.gl web display adapter, GeoJSON conversion helpers, and deck.gl overlay wiring for SDK feature query results.
- #42: adds an experimental browser/WebView offline scene package resolver for `<honua-scene>`, including Cache Storage support and cache-miss/expired/unsupported-storage events.
- #16: adds host extension APIs for `<honua-map>` and `<honua-scene>` runtime controls and lifecycle hooks without duplicating SDK-owned plugin manifests.
- #10: adds white-label map snippet/config helpers with credential omission by default.

The plugin/snippet work was intentionally combined with the display/cache embed work because both touched `src/Honua.Embed` and the same docs.

## Validation

- `npm run typecheck`
- `npm test -- --run` (5 files, 31 tests)
- `npm run build`
