### PR TITLE
mobile: add native display and location adapter boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ dynamic forms, and background sync.
 | **Honua.Mobile.Sdk** | Transport, auth, gRPC-first client, REST fallback, routing, and SDK scene metadata adapter |
 | **Honua.Mobile.Field** | Mobile adapters for SDK-owned field forms, validation, media capture metadata, and workflow |
 | **Honua.Mobile.Offline** | GeoPackage storage, sync queue, map area download, conflict resolution |
-| **Honua.Mobile.Maui** | MAUI service registration and DI extensions |
+| **Honua.Mobile.Maui** | MAUI service registration, DI extensions, native display boundaries, and device location orchestration |
 | **@honua/embed** | Framework-agnostic `<honua-map>` and `<honua-scene>` web components for ISV embeds |
 
 ## Quick Start
@@ -150,7 +150,7 @@ tests/
   Honua.Mobile.Sdk.Tests/     HTTP client, transport security, gRPC translation, routing, scenes (36 tests)
   Honua.Mobile.Field.Tests/   SDK field adapter validation, calculated fields, workflow (11 tests)
   Honua.Mobile.Offline.Tests/ Sync engine, conflicts, map download, GeoPackage (59 tests)
-  Honua.Mobile.Maui.Tests/    MAUI integration helpers, map annotations (16 tests)
+  Honua.Mobile.Maui.Tests/    MAUI integration helpers, map annotations, native display, location (24 tests)
   Honua.Mobile.Smoke.Tests/   End-to-end smoke paths (6 tests)
 proto/
   honua/v1/                   gRPC protocol definitions

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -11,6 +11,7 @@ In-depth guides for building with the Honua Mobile SDK.
 | [Migration Guide](migration-guide.md) | Migrating from other field collection platforms to Honua |
 | [Mobile 3D and AR Dependency Matrix](mobile-3d-ar-dependency-matrix.md) | Server, SDK, platform, offline, and edition dependencies for scene and AR work |
 | [Mobile Contract Harmonization](mobile-contract-harmonization.md) | Ownership and compatibility baseline between `honua-mobile` and `honua-sdk-dotnet` contracts |
+| [Native Display and Location Integration](native-display-and-location.md) | Native .NET display adapter boundary, Mapsui evaluation, and device location/geofencing lifecycle |
 | [Offline 3D Scene Packages](offline-3d-scene-packages.md) | Package manifest, cache, expiry, and platform policy for offline 3D scenes |
 | [Offline Sync](offline-sync.md) | GeoPackage storage, sync engine configuration, and conflict resolution |
 | [Performance](performance.md) | Optimizing startup time, memory usage, and sync throughput |

--- a/docs/guides/native-display-and-location.md
+++ b/docs/guides/native-display-and-location.md
@@ -1,0 +1,168 @@
+# Native Display and Location Integration
+
+This guide covers the mobile-owned surfaces for native .NET map display and
+device location behavior.
+
+## Native Display Adapter
+
+`Honua.Mobile.Maui.Display` provides a dependency-free adapter boundary for a
+native map renderer:
+
+- `HonuaNativeMapLayer` wraps an SDK `SourceDescriptor` with mobile rendering
+  state such as visibility, z-index, filter, output fields, and projection.
+- `HonuaNativeMapProjection` declares source and display CRS values. The mobile
+  renderer performs projection; this package does not add geometry transforms.
+- `HonuaNativeMapDisplayController` turns visible feature layers into SDK
+  `FeatureQueryRequest` instances using the current `FeatureBoundingBox`.
+- `IHonuaNativeMapAdapter` is the platform renderer boundary for Mapsui,
+  platform maps, or a custom native view.
+
+```csharp
+using Honua.Mobile.Maui;
+using Honua.Mobile.Maui.Display;
+using Honua.Sdk.Abstractions.Features;
+
+builder.Services
+    .AddHonuaMobileSdk(clientOptions)
+    .AddHonuaSdkGeoPackageOfflineSync(storeOptions, offlineManifest)
+    .AddHonuaNativeDisplay();
+
+builder.Services.AddSingleton<IHonuaNativeMapAdapter, MapsuiHonuaMapAdapter>();
+```
+
+```csharp
+var scene = new HonuaNativeMapScene
+{
+    Layers =
+    [
+        new HonuaNativeMapLayer
+        {
+            Id = "parks",
+            Source = new SourceDescriptor
+            {
+                Id = "parks",
+                Protocol = FeatureProtocolIds.OgcFeatures,
+                Locator = new SourceLocator { CollectionId = "parks" },
+            },
+            Projection = new HonuaNativeMapProjection
+            {
+                SourceCrs = HonuaNativeMapProjection.Wgs84,
+                DisplayCrs = HonuaNativeMapProjection.WebMercator,
+            },
+            OutFields = ["objectid", "name", "status"],
+        },
+    ],
+};
+
+await display.RefreshAsync(scene, currentView, ct);
+```
+
+### Mapsui Evaluation
+
+Mapsui is a reasonable candidate for issue #57 because its model lines up with
+the boundary above: data providers feed layers, layers are ordered and styled
+independently, and projection can stay in the renderer adapter instead of the
+SDK packages.
+
+The repo does not add Mapsui directly yet. Pulling it into
+`Honua.Mobile.Maui` would commit every consumer to the display dependency,
+platform handler lifecycle, renderer asset packaging, and projection stack
+before the SDK geometry contracts have graduated. The safer shape is:
+
+- keep `Honua.Mobile.Maui` dependency-free and source-descriptor based;
+- implement `MapsuiHonuaMapAdapter` in an app or future renderer package;
+- translate SDK `FeatureQueryResult` records into Mapsui provider features at
+  the adapter edge;
+- use Mapsui projection support only inside that adapter;
+- benchmark pan/zoom refresh, offline GeoPackage layer loading, and annotation
+  redraw before making Mapsui the default renderer.
+
+## Device Location and Geofencing
+
+`Honua.Mobile.Maui.Location` owns mobile runtime acquisition behavior while
+leaving platform APIs behind app-provided adapters:
+
+- `IHonuaDeviceLocationPermissionService` checks and requests foreground or
+  background location permission.
+- `IHonuaDeviceLocationProvider` acquires a one-shot foreground or background
+  location fix.
+- `IHonuaBackgroundLocationProvider` starts native background updates and
+  returns an async-disposable session.
+- `IHonuaGeofenceMonitor` delegates geofence registration and transitions to
+  OS geofencing facilities.
+- `HonuaDeviceLocationCoordinator` enforces permission order and validates
+  request options before invoking the platform adapters.
+
+```csharp
+builder.Services
+    .AddSingleton<IHonuaDeviceLocationPermissionService, MauiLocationPermissions>()
+    .AddSingleton<IHonuaDeviceLocationProvider, MauiDeviceLocationProvider>()
+    .AddSingleton<IHonuaBackgroundLocationProvider, MauiBackgroundLocationProvider>()
+    .AddSingleton<IHonuaGeofenceMonitor, MauiGeofenceMonitor>()
+    .AddHonuaDeviceLocation();
+```
+
+Foreground capture:
+
+```csharp
+var location = await locations.AcquireCurrentLocationAsync(
+    new HonuaDeviceLocationRequest
+    {
+        RequiredAccess = HonuaLocationAccess.Foreground,
+        Accuracy = HonuaLocationAccuracy.High,
+        Timeout = TimeSpan.FromSeconds(20),
+    },
+    ct);
+```
+
+Background acquisition:
+
+```csharp
+await using var session = await locations.StartBackgroundUpdatesAsync(
+    new HonuaBackgroundLocationOptions
+    {
+        Accuracy = HonuaLocationAccuracy.Balanced,
+        MinimumInterval = TimeSpan.FromMinutes(5),
+        MinimumDistanceMeters = 25,
+        AllowBatterySaverDeferral = true,
+        Purpose = "offline field workflow updates",
+    },
+    ct);
+```
+
+Geofence registration:
+
+```csharp
+await locations.StartGeofencingAsync(
+    new HonuaGeofenceMonitoringRequest
+    {
+        Regions =
+        [
+            new HonuaGeofenceRegion
+            {
+                Id = "job-site",
+                Center = new HonuaMapCoordinate(21.3069, -157.8583),
+                RadiusMeters = 100,
+                NotifyOnEntry = true,
+                NotifyOnExit = true,
+                NotifyOnDwell = true,
+                DwellTime = TimeSpan.FromMinutes(2),
+            },
+        ],
+    },
+    ct);
+```
+
+### Lifecycle Rules
+
+- Request foreground permission before one-shot foreground capture.
+- Request background permission separately before background updates or
+  geofencing. Foreground permission is not treated as sufficient background
+  access.
+- Keep platform-specific permission copy, manifest entries, foreground service
+  notifications, and background mode declarations in the app layer.
+- Use OS geofencing APIs for enter, exit, and dwell detection. This package does
+  not implement geometry predicates or distance checks.
+- Dispose the background session when the workflow no longer needs updates.
+- Map `HonuaDeviceLocation` into SDK field, routing, or future geometry
+  contracts at the adapter edge when those SDK contracts are available.

--- a/src/Honua.Mobile.Maui/Display/HonuaNativeMapDisplayController.cs
+++ b/src/Honua.Mobile.Maui/Display/HonuaNativeMapDisplayController.cs
@@ -1,0 +1,80 @@
+using Honua.Sdk.Abstractions.Features;
+
+namespace Honua.Mobile.Maui.Display;
+
+/// <summary>
+/// Coordinates SDK feature queries with a native map adapter.
+/// </summary>
+public sealed class HonuaNativeMapDisplayController
+{
+    private readonly IHonuaNativeMapAdapter _adapter;
+    private readonly IHonuaFeatureQueryClient _featureQueryClient;
+
+    public HonuaNativeMapDisplayController(
+        IHonuaNativeMapAdapter adapter,
+        IHonuaFeatureQueryClient featureQueryClient)
+    {
+        _adapter = adapter ?? throw new ArgumentNullException(nameof(adapter));
+        _featureQueryClient = featureQueryClient ?? throw new ArgumentNullException(nameof(featureQueryClient));
+    }
+
+    /// <summary>
+    /// Applies the scene, sets the viewport, queries visible feature layers, and forwards results to the adapter.
+    /// </summary>
+    /// <param name="scene">Layer and annotation scene to render.</param>
+    /// <param name="view">Current map viewport.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task RefreshAsync(
+        HonuaNativeMapScene scene,
+        HonuaNativeMapViewState view,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+        ArgumentNullException.ThrowIfNull(view);
+
+        scene.Validate();
+        view.Validate();
+
+        await _adapter.ApplySceneAsync(scene, ct).ConfigureAwait(false);
+        await _adapter.SetViewAsync(view, ct).ConfigureAwait(false);
+
+        foreach (var layer in scene.Layers
+            .Where(layer => layer.IsVisible && layer.Kind == HonuaNativeMapLayerKind.Feature)
+            .OrderBy(layer => layer.ZIndex))
+        {
+            var query = CreateFeatureQuery(layer, view);
+            var features = await _featureQueryClient.QueryAsync(query, ct).ConfigureAwait(false);
+            await _adapter.RenderFeaturesAsync(layer, features, ct).ConfigureAwait(false);
+        }
+
+        await _adapter.RenderAnnotationsAsync(scene.Annotations, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Creates the SDK feature query for a visible native feature layer.
+    /// </summary>
+    /// <param name="layer">Layer to query.</param>
+    /// <param name="view">Viewport bounds and output CRS.</param>
+    /// <returns>SDK feature query request for the layer and view.</returns>
+    public static FeatureQueryRequest CreateFeatureQuery(
+        HonuaNativeMapLayer layer,
+        HonuaNativeMapViewState view)
+    {
+        ArgumentNullException.ThrowIfNull(layer);
+        ArgumentNullException.ThrowIfNull(view);
+
+        layer.Validate();
+        view.Validate();
+
+        return new FeatureQueryRequest
+        {
+            Source = layer.Source.ToFeatureSource(),
+            Filter = layer.Filter,
+            FilterLanguage = layer.FilterLanguage,
+            OutFields = layer.OutFields.ToArray(),
+            ReturnGeometry = true,
+            Bbox = view.Extent,
+            OutputCrs = view.DisplayCrs,
+        };
+    }
+}

--- a/src/Honua.Mobile.Maui/Display/NativeDisplayContracts.cs
+++ b/src/Honua.Mobile.Maui/Display/NativeDisplayContracts.cs
@@ -121,6 +121,14 @@ public sealed record HonuaNativeMapViewState
         ArgumentNullException.ThrowIfNull(Extent);
         ArgumentException.ThrowIfNullOrWhiteSpace(DisplayCrs);
 
+        if (!double.IsFinite(Extent.MinX)
+            || !double.IsFinite(Extent.MinY)
+            || !double.IsFinite(Extent.MaxX)
+            || !double.IsFinite(Extent.MaxY))
+        {
+            throw new ArgumentException("View extent coordinates must be finite.", nameof(Extent));
+        }
+
         if (Extent.MaxX < Extent.MinX)
         {
             throw new ArgumentException("View extent MaxX must be greater than or equal to MinX.", nameof(Extent));

--- a/src/Honua.Mobile.Maui/Display/NativeDisplayContracts.cs
+++ b/src/Honua.Mobile.Maui/Display/NativeDisplayContracts.cs
@@ -1,0 +1,156 @@
+using Honua.Mobile.Maui.Annotations;
+using Honua.Sdk.Abstractions.Features;
+
+namespace Honua.Mobile.Maui.Display;
+
+/// <summary>
+/// Source-backed layer categories a native map renderer can bind to.
+/// </summary>
+public enum HonuaNativeMapLayerKind
+{
+    /// <summary>Feature records queried through SDK feature abstractions.</summary>
+    Feature,
+    /// <summary>Vector tiles provided by the source descriptor.</summary>
+    VectorTile,
+    /// <summary>Raster tiles provided by the source descriptor.</summary>
+    RasterTile,
+}
+
+/// <summary>
+/// Projection declaration for a native map layer. Projection execution belongs to the renderer.
+/// </summary>
+public sealed record HonuaNativeMapProjection
+{
+    public const string Wgs84 = "EPSG:4326";
+    public const string WebMercator = "EPSG:3857";
+
+    public string SourceCrs { get; init; } = Wgs84;
+
+    public string DisplayCrs { get; init; } = WebMercator;
+
+    public bool RequiresProjection =>
+        !string.Equals(SourceCrs, DisplayCrs, StringComparison.OrdinalIgnoreCase);
+
+    public void Validate()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(SourceCrs);
+        ArgumentException.ThrowIfNullOrWhiteSpace(DisplayCrs);
+    }
+}
+
+/// <summary>
+/// SDK source descriptor plus mobile rendering metadata for a native map layer.
+/// </summary>
+public sealed record HonuaNativeMapLayer
+{
+    public required string Id { get; init; }
+
+    public HonuaNativeMapLayerKind Kind { get; init; } = HonuaNativeMapLayerKind.Feature;
+
+    public required SourceDescriptor Source { get; init; }
+
+    public HonuaNativeMapProjection Projection { get; init; } = new();
+
+    public bool IsVisible { get; init; } = true;
+
+    public int ZIndex { get; init; }
+
+    public string? Filter { get; init; }
+
+    public FeatureFilterLanguage FilterLanguage { get; init; } = FeatureFilterLanguage.ProviderDefault;
+
+    public IReadOnlyList<string> OutFields { get; init; } = ["*"];
+
+    public IReadOnlyDictionary<string, object?> RendererHints { get; init; } = new Dictionary<string, object?>();
+
+    public void Validate()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(Id);
+        ArgumentNullException.ThrowIfNull(Source);
+        ArgumentException.ThrowIfNullOrWhiteSpace(Source.Id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(Source.Protocol);
+        ArgumentNullException.ThrowIfNull(Source.Locator);
+        ArgumentNullException.ThrowIfNull(OutFields);
+        Projection.Validate();
+    }
+}
+
+/// <summary>
+/// Native map scene definition consumed by a platform-specific map adapter.
+/// </summary>
+public sealed record HonuaNativeMapScene
+{
+    public IReadOnlyList<HonuaNativeMapLayer> Layers { get; init; } = [];
+
+    public IReadOnlyList<HonuaAnnotation> Annotations { get; init; } = [];
+
+    public void Validate()
+    {
+        ArgumentNullException.ThrowIfNull(Layers);
+        ArgumentNullException.ThrowIfNull(Annotations);
+
+        var layerIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var layer in Layers)
+        {
+            ArgumentNullException.ThrowIfNull(layer);
+            layer.Validate();
+
+            if (!layerIds.Add(layer.Id))
+            {
+                throw new InvalidOperationException($"Native map layer '{layer.Id}' is defined more than once.");
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Native map viewport expressed with SDK feature query bounds.
+/// </summary>
+public sealed record HonuaNativeMapViewState
+{
+    public required FeatureBoundingBox Extent { get; init; }
+
+    public string DisplayCrs { get; init; } = HonuaNativeMapProjection.WebMercator;
+
+    public double? RotationDegrees { get; init; }
+
+    public double? ScaleDenominator { get; init; }
+
+    public void Validate()
+    {
+        ArgumentNullException.ThrowIfNull(Extent);
+        ArgumentException.ThrowIfNullOrWhiteSpace(DisplayCrs);
+
+        if (Extent.MaxX < Extent.MinX)
+        {
+            throw new ArgumentException("View extent MaxX must be greater than or equal to MinX.", nameof(Extent));
+        }
+
+        if (Extent.MaxY < Extent.MinY)
+        {
+            throw new ArgumentException("View extent MaxY must be greater than or equal to MinY.", nameof(Extent));
+        }
+
+        if (ScaleDenominator is <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(ScaleDenominator), "Scale denominator must be positive.");
+        }
+    }
+}
+
+/// <summary>
+/// Platform renderer boundary for native .NET map display implementations.
+/// </summary>
+public interface IHonuaNativeMapAdapter
+{
+    Task ApplySceneAsync(HonuaNativeMapScene scene, CancellationToken ct = default);
+
+    Task SetViewAsync(HonuaNativeMapViewState view, CancellationToken ct = default);
+
+    Task RenderFeaturesAsync(
+        HonuaNativeMapLayer layer,
+        FeatureQueryResult features,
+        CancellationToken ct = default);
+
+    Task RenderAnnotationsAsync(IReadOnlyList<HonuaAnnotation> annotations, CancellationToken ct = default);
+}

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using Honua.Mobile.Field.Capture;
 using Honua.Mobile.Maui.Annotations;
+using Honua.Mobile.Maui.Display;
+using Honua.Mobile.Maui.Location;
 using Honua.Mobile.Offline.GeoPackage;
 using Honua.Mobile.Offline.MapAreas;
 using Honua.Mobile.Offline.ScenePackages;
@@ -273,6 +275,38 @@ public static class HonuaMobileServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddTransient<HonuaAnnotationLayer>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the dependency-free native map display controller.
+    /// Applications must also register an <see cref="IHonuaNativeMapAdapter"/> and an SDK
+    /// <see cref="IHonuaFeatureQueryClient"/> for feature-backed layers.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaNativeDisplay(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddTransient<HonuaNativeMapDisplayController>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers device location orchestration over app-provided native permission and location adapters.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaDeviceLocation(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton(sp => new HonuaDeviceLocationCoordinator(
+            sp.GetRequiredService<IHonuaDeviceLocationPermissionService>(),
+            sp.GetRequiredService<IHonuaDeviceLocationProvider>(),
+            sp.GetService<IHonuaBackgroundLocationProvider>(),
+            sp.GetService<IHonuaGeofenceMonitor>()));
         return services;
     }
 }

--- a/src/Honua.Mobile.Maui/Location/DeviceLocationContracts.cs
+++ b/src/Honua.Mobile.Maui/Location/DeviceLocationContracts.cs
@@ -162,9 +162,9 @@ public sealed record HonuaGeofenceRegion
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(Id);
 
-        if (RadiusMeters <= 0)
+        if (RadiusMeters <= 0 || double.IsNaN(RadiusMeters) || double.IsInfinity(RadiusMeters))
         {
-            throw new ArgumentOutOfRangeException(nameof(RadiusMeters), "Geofence radius must be positive.");
+            throw new ArgumentOutOfRangeException(nameof(RadiusMeters), "Geofence radius must be finite and positive.");
         }
 
         if (!NotifyOnEntry && !NotifyOnExit && !NotifyOnDwell)

--- a/src/Honua.Mobile.Maui/Location/DeviceLocationContracts.cs
+++ b/src/Honua.Mobile.Maui/Location/DeviceLocationContracts.cs
@@ -1,0 +1,296 @@
+using Honua.Mobile.Maui.Annotations;
+
+namespace Honua.Mobile.Maui.Location;
+
+/// <summary>
+/// Permission scope needed for a mobile location workflow.
+/// </summary>
+public enum HonuaLocationAccess
+{
+    Foreground,
+    Background,
+}
+
+/// <summary>
+/// Current location permission state reported by the platform.
+/// </summary>
+public enum HonuaLocationPermissionStatus
+{
+    Unknown,
+    Denied,
+    Foreground,
+    Background,
+}
+
+/// <summary>
+/// Requested device location precision.
+/// </summary>
+public enum HonuaLocationAccuracy
+{
+    Reduced,
+    Balanced,
+    High,
+    Best,
+}
+
+/// <summary>
+/// Device location fix acquired from a native platform provider.
+/// </summary>
+public sealed record HonuaDeviceLocation
+{
+    public required HonuaMapCoordinate Coordinate { get; init; }
+
+    public double? AccuracyMeters { get; init; }
+
+    public double? AltitudeMeters { get; init; }
+
+    public double? SpeedMetersPerSecond { get; init; }
+
+    public double? HeadingDegrees { get; init; }
+
+    public DateTimeOffset CapturedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    public bool IsBackground { get; init; }
+
+    public string? Provider { get; init; }
+
+    public IReadOnlyDictionary<string, object?> Metadata { get; init; } = new Dictionary<string, object?>();
+
+    public void Validate()
+    {
+        if (AccuracyMeters is < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(AccuracyMeters), "Location accuracy must be non-negative.");
+        }
+
+        if (SpeedMetersPerSecond is < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(SpeedMetersPerSecond), "Location speed must be non-negative.");
+        }
+
+        if (HeadingDegrees is < 0 or >= 360)
+        {
+            throw new ArgumentOutOfRangeException(nameof(HeadingDegrees), "Location heading must be in [0, 360).");
+        }
+    }
+}
+
+/// <summary>
+/// Options for a one-shot current-location acquisition.
+/// </summary>
+public sealed record HonuaDeviceLocationRequest
+{
+    public HonuaLocationAccess RequiredAccess { get; init; } = HonuaLocationAccess.Foreground;
+
+    public HonuaLocationAccuracy Accuracy { get; init; } = HonuaLocationAccuracy.Balanced;
+
+    public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(15);
+
+    public TimeSpan? MaxCacheAge { get; init; } = TimeSpan.FromMinutes(2);
+
+    public bool AllowReducedAccuracy { get; init; } = true;
+
+    public void Validate()
+    {
+        if (Timeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(Timeout), "Location timeout must be positive.");
+        }
+
+        if (MaxCacheAge.HasValue && MaxCacheAge.Value <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(MaxCacheAge), "Location cache age must be positive.");
+        }
+    }
+}
+
+/// <summary>
+/// Options for continuous background location acquisition.
+/// </summary>
+public sealed record HonuaBackgroundLocationOptions
+{
+    public HonuaLocationAccuracy Accuracy { get; init; } = HonuaLocationAccuracy.Balanced;
+
+    public TimeSpan MinimumInterval { get; init; } = TimeSpan.FromMinutes(5);
+
+    public double MinimumDistanceMeters { get; init; } = 25;
+
+    public bool AllowBatterySaverDeferral { get; init; } = true;
+
+    public string Purpose { get; init; } = "Honua background location";
+
+    public IReadOnlyDictionary<string, object?> Metadata { get; init; } = new Dictionary<string, object?>();
+
+    public void Validate()
+    {
+        if (MinimumInterval <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(MinimumInterval), "Background location interval must be positive.");
+        }
+
+        if (MinimumDistanceMeters < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(MinimumDistanceMeters), "Background location distance must be non-negative.");
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(Purpose);
+    }
+}
+
+/// <summary>
+/// Region delegated to native OS geofencing facilities.
+/// </summary>
+public sealed record HonuaGeofenceRegion
+{
+    public required string Id { get; init; }
+
+    public required HonuaMapCoordinate Center { get; init; }
+
+    public required double RadiusMeters { get; init; }
+
+    public bool NotifyOnEntry { get; init; } = true;
+
+    public bool NotifyOnExit { get; init; } = true;
+
+    public bool NotifyOnDwell { get; init; }
+
+    public TimeSpan? DwellTime { get; init; }
+
+    public IReadOnlyDictionary<string, object?> Metadata { get; init; } = new Dictionary<string, object?>();
+
+    public void Validate()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(Id);
+
+        if (RadiusMeters <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(RadiusMeters), "Geofence radius must be positive.");
+        }
+
+        if (!NotifyOnEntry && !NotifyOnExit && !NotifyOnDwell)
+        {
+            throw new ArgumentException("A geofence region must notify on entry, exit, or dwell.", nameof(HonuaGeofenceRegion));
+        }
+
+        if (DwellTime.HasValue && DwellTime.Value <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(DwellTime), "Geofence dwell time must be positive.");
+        }
+    }
+}
+
+/// <summary>
+/// Options for starting native OS geofence monitoring.
+/// </summary>
+public sealed record HonuaGeofenceMonitoringRequest
+{
+    public IReadOnlyList<HonuaGeofenceRegion> Regions { get; init; } = [];
+
+    public HonuaLocationAccess RequiredAccess { get; init; } = HonuaLocationAccess.Background;
+
+    public bool ReplaceExisting { get; init; } = true;
+
+    public void Validate()
+    {
+        ArgumentNullException.ThrowIfNull(Regions);
+
+        if (Regions.Count == 0)
+        {
+            throw new ArgumentException("At least one geofence region is required.", nameof(Regions));
+        }
+
+        var regionIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var region in Regions)
+        {
+            ArgumentNullException.ThrowIfNull(region);
+            region.Validate();
+
+            if (!regionIds.Add(region.Id))
+            {
+                throw new InvalidOperationException($"Geofence region '{region.Id}' is defined more than once.");
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Native geofence transition kind.
+/// </summary>
+public enum HonuaGeofenceTransitionKind
+{
+    Enter,
+    Exit,
+    Dwell,
+}
+
+/// <summary>
+/// Native geofence transition emitted by a platform monitor.
+/// </summary>
+public sealed record HonuaGeofenceTransition
+{
+    public required string RegionId { get; init; }
+
+    public required HonuaGeofenceTransitionKind Kind { get; init; }
+
+    public HonuaDeviceLocation? Location { get; init; }
+
+    public DateTimeOffset OccurredAt { get; init; } = DateTimeOffset.UtcNow;
+}
+
+/// <summary>
+/// Platform permission adapter for foreground and background location access.
+/// </summary>
+public interface IHonuaDeviceLocationPermissionService
+{
+    ValueTask<HonuaLocationPermissionStatus> CheckPermissionAsync(
+        HonuaLocationAccess access,
+        CancellationToken ct = default);
+
+    ValueTask<HonuaLocationPermissionStatus> RequestPermissionAsync(
+        HonuaLocationAccess access,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Platform adapter for one-shot device location acquisition.
+/// </summary>
+public interface IHonuaDeviceLocationProvider
+{
+    ValueTask<HonuaDeviceLocation?> GetCurrentLocationAsync(
+        HonuaDeviceLocationRequest request,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Active native background location session.
+/// </summary>
+public interface IHonuaBackgroundLocationSession : IAsyncDisposable
+{
+    string SessionId { get; }
+}
+
+/// <summary>
+/// Platform adapter for continuous background location acquisition.
+/// </summary>
+public interface IHonuaBackgroundLocationProvider
+{
+    ValueTask<IHonuaBackgroundLocationSession> StartUpdatesAsync(
+        HonuaBackgroundLocationOptions options,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Platform adapter for OS-backed geofence monitoring.
+/// </summary>
+public interface IHonuaGeofenceMonitor
+{
+    event EventHandler<HonuaGeofenceTransition>? Transitioned;
+
+    ValueTask StartMonitoringAsync(
+        HonuaGeofenceMonitoringRequest request,
+        CancellationToken ct = default);
+
+    ValueTask StopMonitoringAsync(
+        IReadOnlyList<string> regionIds,
+        CancellationToken ct = default);
+}

--- a/src/Honua.Mobile.Maui/Location/HonuaDeviceLocationCoordinator.cs
+++ b/src/Honua.Mobile.Maui/Location/HonuaDeviceLocationCoordinator.cs
@@ -1,0 +1,116 @@
+namespace Honua.Mobile.Maui.Location;
+
+/// <summary>
+/// Coordinates permission checks with foreground, background, and geofence location adapters.
+/// </summary>
+public sealed class HonuaDeviceLocationCoordinator
+{
+    private readonly IHonuaDeviceLocationPermissionService _permissions;
+    private readonly IHonuaDeviceLocationProvider _locationProvider;
+    private readonly IHonuaBackgroundLocationProvider? _backgroundProvider;
+    private readonly IHonuaGeofenceMonitor? _geofenceMonitor;
+
+    public HonuaDeviceLocationCoordinator(
+        IHonuaDeviceLocationPermissionService permissions,
+        IHonuaDeviceLocationProvider locationProvider,
+        IHonuaBackgroundLocationProvider? backgroundProvider = null,
+        IHonuaGeofenceMonitor? geofenceMonitor = null)
+    {
+        _permissions = permissions ?? throw new ArgumentNullException(nameof(permissions));
+        _locationProvider = locationProvider ?? throw new ArgumentNullException(nameof(locationProvider));
+        _backgroundProvider = backgroundProvider;
+        _geofenceMonitor = geofenceMonitor;
+    }
+
+    /// <summary>
+    /// Acquires a single device location after ensuring the requested permission scope is granted.
+    /// </summary>
+    /// <param name="request">Acquisition options; defaults are used when <see langword="null"/>.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The current location fix.</returns>
+    public async ValueTask<HonuaDeviceLocation> AcquireCurrentLocationAsync(
+        HonuaDeviceLocationRequest? request = null,
+        CancellationToken ct = default)
+    {
+        request ??= new HonuaDeviceLocationRequest();
+        request.Validate();
+
+        await EnsurePermissionAsync(request.RequiredAccess, ct).ConfigureAwait(false);
+
+        var location = await _locationProvider.GetCurrentLocationAsync(request, ct).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("The device location provider did not return a location fix.");
+
+        location.Validate();
+        return location;
+    }
+
+    /// <summary>
+    /// Starts a native background location session after ensuring background permission is granted.
+    /// </summary>
+    /// <param name="options">Background acquisition options; defaults are used when <see langword="null"/>.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The active background location session.</returns>
+    public async ValueTask<IHonuaBackgroundLocationSession> StartBackgroundUpdatesAsync(
+        HonuaBackgroundLocationOptions? options = null,
+        CancellationToken ct = default)
+    {
+        if (_backgroundProvider is null)
+        {
+            throw new InvalidOperationException("No background location provider is registered.");
+        }
+
+        options ??= new HonuaBackgroundLocationOptions();
+        options.Validate();
+
+        await EnsurePermissionAsync(HonuaLocationAccess.Background, ct).ConfigureAwait(false);
+        return await _backgroundProvider.StartUpdatesAsync(options, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Starts native OS geofence monitoring after ensuring the request's permission scope is granted.
+    /// </summary>
+    /// <param name="request">Geofence monitoring request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async ValueTask StartGeofencingAsync(
+        HonuaGeofenceMonitoringRequest request,
+        CancellationToken ct = default)
+    {
+        if (_geofenceMonitor is null)
+        {
+            throw new InvalidOperationException("No geofence monitor is registered.");
+        }
+
+        ArgumentNullException.ThrowIfNull(request);
+        request.Validate();
+
+        await EnsurePermissionAsync(request.RequiredAccess, ct).ConfigureAwait(false);
+        await _geofenceMonitor.StartMonitoringAsync(request, ct).ConfigureAwait(false);
+    }
+
+    public static bool PermissionAllows(
+        HonuaLocationPermissionStatus status,
+        HonuaLocationAccess access)
+    {
+        return access switch
+        {
+            HonuaLocationAccess.Foreground => status is HonuaLocationPermissionStatus.Foreground
+                or HonuaLocationPermissionStatus.Background,
+            HonuaLocationAccess.Background => status is HonuaLocationPermissionStatus.Background,
+            _ => false,
+        };
+    }
+
+    private async ValueTask EnsurePermissionAsync(HonuaLocationAccess access, CancellationToken ct)
+    {
+        var status = await _permissions.CheckPermissionAsync(access, ct).ConfigureAwait(false);
+        if (!PermissionAllows(status, access))
+        {
+            status = await _permissions.RequestPermissionAsync(access, ct).ConfigureAwait(false);
+        }
+
+        if (!PermissionAllows(status, access))
+        {
+            throw new UnauthorizedAccessException($"Location permission '{access}' was not granted.");
+        }
+    }
+}

--- a/tests/Honua.Mobile.Maui.Tests/HonuaDeviceLocationTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaDeviceLocationTests.cs
@@ -1,0 +1,224 @@
+using Honua.Mobile.Maui;
+using Honua.Mobile.Maui.Annotations;
+using Honua.Mobile.Maui.Location;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Mobile.Maui.Tests;
+
+public sealed class HonuaDeviceLocationTests
+{
+    [Fact]
+    public async Task AcquireCurrentLocationAsync_RequestsForegroundPermissionBeforeProviderCall()
+    {
+        var permissions = new RecordingPermissionService
+        {
+            CheckStatus = HonuaLocationPermissionStatus.Denied,
+            RequestStatus = HonuaLocationPermissionStatus.Foreground,
+        };
+        var provider = new RecordingLocationProvider
+        {
+            Location = new HonuaDeviceLocation
+            {
+                Coordinate = new HonuaMapCoordinate(21.3069, -157.8583),
+                AccuracyMeters = 4,
+                Provider = "test",
+            },
+        };
+        var coordinator = new HonuaDeviceLocationCoordinator(permissions, provider);
+
+        var location = await coordinator.AcquireCurrentLocationAsync(new HonuaDeviceLocationRequest
+        {
+            Accuracy = HonuaLocationAccuracy.High,
+            RequiredAccess = HonuaLocationAccess.Foreground,
+        });
+
+        Assert.Equal(new HonuaMapCoordinate(21.3069, -157.8583), location.Coordinate);
+        Assert.Equal([HonuaLocationAccess.Foreground], permissions.CheckedAccesses);
+        Assert.Equal([HonuaLocationAccess.Foreground], permissions.RequestedAccesses);
+        Assert.Equal(HonuaLocationAccuracy.High, provider.Requests.Single().Accuracy);
+    }
+
+    [Fact]
+    public async Task StartBackgroundUpdatesAsync_RequiresBackgroundPermission()
+    {
+        var permissions = new RecordingPermissionService
+        {
+            CheckStatus = HonuaLocationPermissionStatus.Foreground,
+            RequestStatus = HonuaLocationPermissionStatus.Background,
+        };
+        var backgroundProvider = new RecordingBackgroundLocationProvider();
+        var coordinator = new HonuaDeviceLocationCoordinator(
+            permissions,
+            new RecordingLocationProvider(),
+            backgroundProvider);
+
+        var session = await coordinator.StartBackgroundUpdatesAsync(new HonuaBackgroundLocationOptions
+        {
+            MinimumInterval = TimeSpan.FromMinutes(10),
+            MinimumDistanceMeters = 50,
+            Purpose = "crew route replay",
+        });
+
+        Assert.Equal("session-1", session.SessionId);
+        Assert.Equal([HonuaLocationAccess.Background], permissions.CheckedAccesses);
+        Assert.Equal([HonuaLocationAccess.Background], permissions.RequestedAccesses);
+        Assert.Equal(TimeSpan.FromMinutes(10), backgroundProvider.Options.Single().MinimumInterval);
+    }
+
+    [Fact]
+    public async Task StartGeofencingAsync_DelegatesValidatedRegionsToMonitor()
+    {
+        var permissions = new RecordingPermissionService
+        {
+            CheckStatus = HonuaLocationPermissionStatus.Background,
+        };
+        var monitor = new RecordingGeofenceMonitor();
+        var coordinator = new HonuaDeviceLocationCoordinator(
+            permissions,
+            new RecordingLocationProvider(),
+            geofenceMonitor: monitor);
+        var request = new HonuaGeofenceMonitoringRequest
+        {
+            Regions =
+            [
+                new HonuaGeofenceRegion
+                {
+                    Id = "job-site",
+                    Center = new HonuaMapCoordinate(21.3069, -157.8583),
+                    RadiusMeters = 100,
+                    NotifyOnDwell = true,
+                    DwellTime = TimeSpan.FromMinutes(2),
+                },
+            ],
+        };
+
+        await coordinator.StartGeofencingAsync(request);
+
+        Assert.Same(request, monitor.Requests.Single());
+        Assert.Equal([HonuaLocationAccess.Background], permissions.CheckedAccesses);
+        Assert.Empty(permissions.RequestedAccesses);
+    }
+
+    [Fact]
+    public void AddHonuaDeviceLocation_RegistersCoordinatorWithOptionalProviders()
+    {
+        using var provider = new ServiceCollection()
+            .AddSingleton<IHonuaDeviceLocationPermissionService, RecordingPermissionService>()
+            .AddSingleton<IHonuaDeviceLocationProvider, RecordingLocationProvider>()
+            .AddSingleton<IHonuaBackgroundLocationProvider, RecordingBackgroundLocationProvider>()
+            .AddSingleton<IHonuaGeofenceMonitor, RecordingGeofenceMonitor>()
+            .AddHonuaDeviceLocation()
+            .BuildServiceProvider();
+
+        Assert.NotNull(provider.GetRequiredService<HonuaDeviceLocationCoordinator>());
+    }
+
+    [Fact]
+    public async Task AcquireCurrentLocationAsync_WhenPermissionDenied_Throws()
+    {
+        var coordinator = new HonuaDeviceLocationCoordinator(
+            new RecordingPermissionService
+            {
+                CheckStatus = HonuaLocationPermissionStatus.Denied,
+                RequestStatus = HonuaLocationPermissionStatus.Denied,
+            },
+            new RecordingLocationProvider());
+
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(async () =>
+            await coordinator.AcquireCurrentLocationAsync());
+    }
+
+    private sealed class RecordingPermissionService : IHonuaDeviceLocationPermissionService
+    {
+        public HonuaLocationPermissionStatus CheckStatus { get; init; } = HonuaLocationPermissionStatus.Foreground;
+
+        public HonuaLocationPermissionStatus RequestStatus { get; init; } = HonuaLocationPermissionStatus.Foreground;
+
+        public List<HonuaLocationAccess> CheckedAccesses { get; } = [];
+
+        public List<HonuaLocationAccess> RequestedAccesses { get; } = [];
+
+        public ValueTask<HonuaLocationPermissionStatus> CheckPermissionAsync(
+            HonuaLocationAccess access,
+            CancellationToken ct = default)
+        {
+            CheckedAccesses.Add(access);
+            return ValueTask.FromResult(CheckStatus);
+        }
+
+        public ValueTask<HonuaLocationPermissionStatus> RequestPermissionAsync(
+            HonuaLocationAccess access,
+            CancellationToken ct = default)
+        {
+            RequestedAccesses.Add(access);
+            return ValueTask.FromResult(RequestStatus);
+        }
+    }
+
+    private sealed class RecordingLocationProvider : IHonuaDeviceLocationProvider
+    {
+        public HonuaDeviceLocation? Location { get; init; } = new()
+        {
+            Coordinate = new HonuaMapCoordinate(21.3069, -157.8583),
+        };
+
+        public List<HonuaDeviceLocationRequest> Requests { get; } = [];
+
+        public ValueTask<HonuaDeviceLocation?> GetCurrentLocationAsync(
+            HonuaDeviceLocationRequest request,
+            CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            return ValueTask.FromResult(Location);
+        }
+    }
+
+    private sealed class RecordingBackgroundLocationProvider : IHonuaBackgroundLocationProvider
+    {
+        public List<HonuaBackgroundLocationOptions> Options { get; } = [];
+
+        public ValueTask<IHonuaBackgroundLocationSession> StartUpdatesAsync(
+            HonuaBackgroundLocationOptions options,
+            CancellationToken ct = default)
+        {
+            Options.Add(options);
+            return ValueTask.FromResult<IHonuaBackgroundLocationSession>(new RecordingSession("session-1"));
+        }
+    }
+
+    private sealed class RecordingSession : IHonuaBackgroundLocationSession
+    {
+        public RecordingSession(string sessionId)
+        {
+            SessionId = sessionId;
+        }
+
+        public string SessionId { get; }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class RecordingGeofenceMonitor : IHonuaGeofenceMonitor
+    {
+        public event EventHandler<HonuaGeofenceTransition>? Transitioned
+        {
+            add { }
+            remove { }
+        }
+
+        public List<HonuaGeofenceMonitoringRequest> Requests { get; } = [];
+
+        public ValueTask StartMonitoringAsync(
+            HonuaGeofenceMonitoringRequest request,
+            CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask StopMonitoringAsync(
+            IReadOnlyList<string> regionIds,
+            CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+    }
+}

--- a/tests/Honua.Mobile.Maui.Tests/HonuaDeviceLocationTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaDeviceLocationTests.cs
@@ -99,6 +99,34 @@ public sealed class HonuaDeviceLocationTests
         Assert.Empty(permissions.RequestedAccesses);
     }
 
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public async Task StartGeofencingAsync_RejectsNonFiniteRadius(double radiusMeters)
+    {
+        var monitor = new RecordingGeofenceMonitor();
+        var coordinator = new HonuaDeviceLocationCoordinator(
+            new RecordingPermissionService(),
+            new RecordingLocationProvider(),
+            geofenceMonitor: monitor);
+        var request = new HonuaGeofenceMonitoringRequest
+        {
+            Regions =
+            [
+                new HonuaGeofenceRegion
+                {
+                    Id = "job-site",
+                    Center = new HonuaMapCoordinate(21.3069, -157.8583),
+                    RadiusMeters = radiusMeters,
+                },
+            ],
+        };
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            await coordinator.StartGeofencingAsync(request));
+        Assert.Empty(monitor.Requests);
+    }
+
     [Fact]
     public void AddHonuaDeviceLocation_RegistersCoordinatorWithOptionalProviders()
     {

--- a/tests/Honua.Mobile.Maui.Tests/HonuaNativeDisplayTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaNativeDisplayTests.cs
@@ -80,6 +80,44 @@ public sealed class HonuaNativeDisplayTests
         Assert.Contains("defined more than once", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData(double.NaN, 21, -157, 22)]
+    [InlineData(-158, double.PositiveInfinity, -157, 22)]
+    [InlineData(-158, 21, double.NegativeInfinity, 22)]
+    [InlineData(-158, 21, -157, double.NaN)]
+    public async Task RefreshAsync_RejectsNonFiniteViewExtent(
+        double minX,
+        double minY,
+        double maxX,
+        double maxY)
+    {
+        var adapter = new RecordingNativeMapAdapter();
+        var featureClient = new RecordingFeatureQueryClient();
+        var controller = new HonuaNativeMapDisplayController(adapter, featureClient);
+        var layer = new HonuaNativeMapLayer
+        {
+            Id = "parks",
+            Source = CreateSource("parks"),
+        };
+        var view = new HonuaNativeMapViewState
+        {
+            Extent = new FeatureBoundingBox
+            {
+                MinX = minX,
+                MinY = minY,
+                MaxX = maxX,
+                MaxY = maxY,
+                Crs = HonuaNativeMapProjection.Wgs84,
+            },
+        };
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            controller.RefreshAsync(new HonuaNativeMapScene { Layers = [layer] }, view));
+
+        Assert.Contains("finite", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(featureClient.Requests);
+    }
+
     [Fact]
     public void AddHonuaNativeDisplay_RegistersController()
     {

--- a/tests/Honua.Mobile.Maui.Tests/HonuaNativeDisplayTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaNativeDisplayTests.cs
@@ -1,0 +1,183 @@
+using System.Runtime.CompilerServices;
+using Honua.Mobile.Maui;
+using Honua.Mobile.Maui.Annotations;
+using Honua.Mobile.Maui.Display;
+using Honua.Sdk.Abstractions.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Mobile.Maui.Tests;
+
+public sealed class HonuaNativeDisplayTests
+{
+    [Fact]
+    public async Task RefreshAsync_QueriesVisibleFeatureLayersAndRendersAnnotations()
+    {
+        var adapter = new RecordingNativeMapAdapter();
+        var featureClient = new RecordingFeatureQueryClient();
+        var controller = new HonuaNativeMapDisplayController(adapter, featureClient);
+        var featureLayer = new HonuaNativeMapLayer
+        {
+            Id = "parks",
+            Source = CreateSource("parks"),
+            Filter = "status = 'open'",
+            FilterLanguage = FeatureFilterLanguage.SqlWhere,
+            OutFields = ["objectid", "name"],
+            ZIndex = 10,
+        };
+        var hiddenLayer = featureLayer with
+        {
+            Id = "hidden",
+            Source = CreateSource("hidden"),
+            IsVisible = false,
+        };
+        var tileLayer = featureLayer with
+        {
+            Id = "tiles",
+            Source = CreateSource("tiles"),
+            Kind = HonuaNativeMapLayerKind.VectorTile,
+        };
+        var annotation = new HonuaAnnotationLayer()
+            .DrawPoint(new HonuaMapCoordinate(21.3069, -157.8583), id: "device");
+        var scene = new HonuaNativeMapScene
+        {
+            Layers = [hiddenLayer, tileLayer, featureLayer],
+            Annotations = [annotation],
+        };
+        var view = CreateView();
+
+        await controller.RefreshAsync(scene, view);
+
+        var request = Assert.Single(featureClient.Requests);
+        Assert.Equal("parks", request.Source.CollectionId);
+        Assert.Equal("status = 'open'", request.Filter);
+        Assert.Equal(FeatureFilterLanguage.SqlWhere, request.FilterLanguage);
+        Assert.Equal(["objectid", "name"], request.OutFields);
+        Assert.True(request.ReturnGeometry);
+        Assert.Same(view.Extent, request.Bbox);
+        Assert.Equal(HonuaNativeMapProjection.WebMercator, request.OutputCrs);
+        Assert.Same(scene, adapter.Scene);
+        Assert.Same(view, adapter.View);
+        Assert.Equal("parks", Assert.Single(adapter.FeatureRenders).Layer.Id);
+        Assert.Equal("device", Assert.Single(adapter.Annotations).Id);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_RejectsDuplicateLayerIds()
+    {
+        var controller = new HonuaNativeMapDisplayController(
+            new RecordingNativeMapAdapter(),
+            new RecordingFeatureQueryClient());
+        var layer = new HonuaNativeMapLayer
+        {
+            Id = "duplicate",
+            Source = CreateSource("parks"),
+        };
+        var scene = new HonuaNativeMapScene { Layers = [layer, layer] };
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            controller.RefreshAsync(scene, CreateView()));
+
+        Assert.Contains("defined more than once", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AddHonuaNativeDisplay_RegistersController()
+    {
+        using var provider = new ServiceCollection()
+            .AddSingleton<IHonuaNativeMapAdapter, RecordingNativeMapAdapter>()
+            .AddSingleton<IHonuaFeatureQueryClient, RecordingFeatureQueryClient>()
+            .AddHonuaNativeDisplay()
+            .BuildServiceProvider();
+
+        Assert.NotNull(provider.GetRequiredService<HonuaNativeMapDisplayController>());
+    }
+
+    private static SourceDescriptor CreateSource(string id)
+        => new()
+        {
+            Id = id,
+            Protocol = FeatureProtocolIds.OgcFeatures,
+            Locator = new SourceLocator { CollectionId = id },
+        };
+
+    private static HonuaNativeMapViewState CreateView()
+        => new()
+        {
+            Extent = new FeatureBoundingBox
+            {
+                MinX = -158,
+                MinY = 21,
+                MaxX = -157,
+                MaxY = 22,
+                Crs = HonuaNativeMapProjection.Wgs84,
+            },
+            DisplayCrs = HonuaNativeMapProjection.WebMercator,
+        };
+
+    private sealed class RecordingNativeMapAdapter : IHonuaNativeMapAdapter
+    {
+        public HonuaNativeMapScene? Scene { get; private set; }
+
+        public HonuaNativeMapViewState? View { get; private set; }
+
+        public List<(HonuaNativeMapLayer Layer, FeatureQueryResult Features)> FeatureRenders { get; } = [];
+
+        public IReadOnlyList<HonuaAnnotation> Annotations { get; private set; } = [];
+
+        public Task ApplySceneAsync(HonuaNativeMapScene scene, CancellationToken ct = default)
+        {
+            Scene = scene;
+            return Task.CompletedTask;
+        }
+
+        public Task SetViewAsync(HonuaNativeMapViewState view, CancellationToken ct = default)
+        {
+            View = view;
+            return Task.CompletedTask;
+        }
+
+        public Task RenderFeaturesAsync(
+            HonuaNativeMapLayer layer,
+            FeatureQueryResult features,
+            CancellationToken ct = default)
+        {
+            FeatureRenders.Add((layer, features));
+            return Task.CompletedTask;
+        }
+
+        public Task RenderAnnotationsAsync(
+            IReadOnlyList<HonuaAnnotation> annotations,
+            CancellationToken ct = default)
+        {
+            Annotations = annotations;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingFeatureQueryClient : IHonuaFeatureQueryClient
+    {
+        public string ProviderName => "recording";
+
+        public List<FeatureQueryRequest> Requests { get; } = [];
+
+        public Task<FeatureQueryResult> QueryAsync(
+            FeatureQueryRequest request,
+            CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            return Task.FromResult(new FeatureQueryResult
+            {
+                ProviderName = ProviderName,
+                NumberReturned = 0,
+                Features = [],
+            });
+        }
+
+        public async IAsyncEnumerable<FeatureQueryResult> QueryPagesAsync(
+            FeatureQueryRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            yield return await QueryAsync(request, ct);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the mobile/native portions of the remaining non-Flutter backlog:

- #57: adds a dependency-free native display boundary that consumes SDK source descriptors and feature query results, plus a controller for visible feature layers.
- #51: adds mobile-owned foreground/background location and OS geofencing abstractions, plus coordinator permission flow for acquisition, background sessions, and geofence registration.
- Documents the Mapsui evaluation while keeping Mapsui out of core SDK/mobile package dependencies.

## Validation

- `dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj` (24 passed)
