### PR TITLE
ci: authenticate Dependabot NuGet updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,15 @@
 version: 2
+registries:
+  github-honua:
+    type: nuget-feed
+    url: https://nuget.pkg.github.com/honua-io/index.json
+    token: ${{secrets.HONUA_PACKAGES_TOKEN}}
+
 updates:
   - package-ecosystem: "nuget"
     directory: "/"
+    registries:
+      - github-honua
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
## Summary
- Add the GitHub Packages NuGet feed to Dependabot's private registry configuration.
- Attach that registry to the NuGet updater so Dependabot sends credentials during restore.

## Root Cause
The failed Dependabot update runs hit `private_source_authentication_failure` while restoring `Honua.Sdk.Field` from `https://nuget.pkg.github.com/honua-io/index.json`. CI configures GitHub Packages credentials at runtime, but Dependabot version updates use `dependabot.yml` registry credentials and Dependabot secrets.

## Required Setup
Add a Dependabot secret named `HONUA_PACKAGES_TOKEN` with a token that can read packages from `honua-io`. Without that secret, this config is correct but the updater will still fail at authentication time.

## Validation
- `git diff --check`
- Parsed `.github/dependabot.yml` with PyYAML
