### PR TITLE
mobile: add SDK-backed offline demo harness

### DIFF
--- a/apps/Honua.Mobile.App/MauiProgram.cs
+++ b/apps/Honua.Mobile.App/MauiProgram.cs
@@ -2,7 +2,10 @@
 using Honua.Mobile.Offline.GeoPackage;
 using Honua.Mobile.Offline.Sync;
 using Honua.Mobile.Sdk;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Offline.Abstractions;
 using Microsoft.Extensions.Logging;
+using SdkOfflineSyncEngineOptions = Honua.Sdk.Offline.OfflineSyncEngineOptions;
 
 namespace Honua.Mobile.App;
 
@@ -27,14 +30,18 @@ public static class MauiProgram
             {
                 BaseUri = new Uri("https://api.honua.io"),
             })
-            .AddHonuaApiOfflineUploader()
             .AddHonuaMobileFieldCollection()
-            .AddHonuaGeoPackageOfflineSync(
-                new GeoPackageSyncStoreOptions { DatabasePath = offlineDb },
-                new OfflineSyncEngineOptions
+            .AddHonuaSdkGeoPackageOfflineSync(
+                new GeoPackageSyncStoreOptions
+                {
+                    DatabasePath = offlineDb,
+                    DefaultFeatureCacheTtl = TimeSpan.FromDays(7),
+                },
+                CreateCloudDemoOfflineManifest(),
+                new SdkOfflineSyncEngineOptions
                 {
                     BatchSize = 50,
-                    ConflictStrategy = SyncConflictStrategy.ManualReview,
+                    ConflictStrategy = OfflineConflictStrategy.ManualReview,
                 })
             .AddHonuaMapAreaDownload()
             .AddHonuaBackgroundSync(new BackgroundSyncOrchestratorOptions
@@ -49,4 +56,62 @@ public static class MauiProgram
 
         return builder.Build();
     }
+
+    private static OfflinePackageManifest CreateCloudDemoOfflineManifest()
+        => new()
+        {
+            PackageId = "mobile-offline-field-ops-v1",
+            DisplayName = "Mobile Offline Field Operations",
+            Version = "2026.05",
+            Sources =
+            [
+                new OfflineSourceDescriptor
+                {
+                    SourceId = "mobile_offline_demo/FeatureServer/68910",
+                    Source = new SourceDescriptor
+                    {
+                        Id = "mobile-offline-field-sites",
+                        Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+                        Locator = new SourceLocator { ServiceId = "mobile_offline_demo", LayerId = 68910 },
+                    },
+                    Where = "1=1",
+                    OutFields =
+                    [
+                        "objectid",
+                        "globalid",
+                        "site_name",
+                        "status",
+                        "priority",
+                        "assigned_to",
+                        "inspection_date",
+                        "sync_version",
+                        "offline_action",
+                        "notes"
+                    ],
+                    ReturnGeometry = true,
+                    PageSize = 100,
+                },
+                new OfflineSourceDescriptor
+                {
+                    SourceId = "mobile_offline_demo/FeatureServer/68920",
+                    Source = new SourceDescriptor
+                    {
+                        Id = "mobile-offline-work-zones",
+                        Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+                        Locator = new SourceLocator { ServiceId = "mobile_offline_demo", LayerId = 68920 },
+                    },
+                    Where = "1=1",
+                    OutFields = ["objectid", "globalid", "zone_name", "zone_status", "sync_version", "notes"],
+                    ReturnGeometry = true,
+                    PageSize = 100,
+                },
+            ],
+            Metadata = new Dictionary<string, string>
+            {
+                ["fixture"] = "mobile-offline-field-ops-v1",
+                ["serviceId"] = "mobile_offline_demo",
+                ["editableLayerId"] = "68910",
+                ["contextLayerId"] = "68920",
+            },
+        };
 }

--- a/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/DiagnosticService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/DiagnosticService.cs
@@ -131,6 +131,26 @@ public class DiagnosticService
         return diagnostics;
     }
 
+    public async Task<OfflineCacheDiagnostics> GetOfflineCacheDiagnosticsAsync()
+    {
+        try
+        {
+            var storage = await _databaseService.GetStorageServiceAsync();
+            return await storage.GetOfflineCacheDiagnosticsAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to collect offline cache diagnostics");
+            return new OfflineCacheDiagnostics
+            {
+                PackageId = "unavailable",
+                MetadataCache = new MetadataCacheDiagnostics { Status = "Unavailable" },
+                FeatureCache = new FeatureCacheDiagnostics { Status = "Unavailable" },
+                Timestamp = DateTime.UtcNow
+            };
+        }
+    }
+
     #endregion
 
     #region Database Management
@@ -199,7 +219,8 @@ public class DiagnosticService
             System = await GetSystemDiagnosticsAsync(),
             Connectivity = await GetConnectivityDiagnosticsAsync(),
             Sync = await GetSyncDiagnosticsAsync(),
-            Database = await GetDatabaseDiagnosticsAsync()
+            Database = await GetDatabaseDiagnosticsAsync(),
+            OfflineCache = await GetOfflineCacheDiagnosticsAsync()
         };
 
         return report;
@@ -300,17 +321,11 @@ public class DiagnosticService
 
         if (report.System.DatabaseInfo != null)
         {
-            report.System.DatabaseInfo.DatabasePath = RedactPath(report.System.DatabaseInfo.DatabasePath);
+            report.System.DatabaseInfo.DatabasePath = DiagnosticRedactor.RedactPath(report.System.DatabaseInfo.DatabasePath);
         }
 
-        report.Database.DatabasePath = RedactPath(report.Database.DatabasePath);
-    }
-
-    private static string RedactPath(string path)
-    {
-        return string.IsNullOrWhiteSpace(path)
-            ? string.Empty
-            : Path.GetFileName(path);
+        report.Database.DatabasePath = DiagnosticRedactor.RedactPath(report.Database.DatabasePath);
+        report.OfflineCache.PackageFileName = DiagnosticRedactor.RedactPath(report.OfflineCache.PackageFileName);
     }
 
     #endregion
@@ -389,6 +404,7 @@ public class DiagnosticReport
     public ConnectivityDiagnostics Connectivity { get; set; } = new();
     public SyncDiagnostics Sync { get; set; } = new();
     public DatabaseDiagnostics Database { get; set; } = new();
+    public OfflineCacheDiagnostics OfflineCache { get; set; } = new();
 }
 
 #endregion

--- a/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/OfflineCacheDiagnostics.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/OfflineCacheDiagnostics.cs
@@ -1,0 +1,187 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Honua.Mobile.FieldCollection.Services.Diagnostics;
+
+public sealed class OfflineCacheDiagnostics
+{
+    public string PackageId { get; set; } = string.Empty;
+    public string PackageFileName { get; set; } = string.Empty;
+    public long PackageSizeBytes { get; set; }
+    public DateTime? LastSyncTime { get; set; }
+    public long? LocalGeneration { get; set; }
+    public long? ServerGeneration { get; set; }
+    public MetadataCacheDiagnostics MetadataCache { get; set; } = new();
+    public FeatureCacheDiagnostics FeatureCache { get; set; } = new();
+    public OfflineOperationDiagnostics Operations { get; set; } = new();
+    public IReadOnlyList<OfflineConflictReviewItem> ConflictReview { get; set; } = Array.Empty<OfflineConflictReviewItem>();
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+
+    public string PackageSizeDisplay => FormatBytes(PackageSizeBytes);
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes < 1024)
+        {
+            return $"{bytes} B";
+        }
+
+        if (bytes < 1024 * 1024)
+        {
+            return $"{bytes / 1024.0:F1} KB";
+        }
+
+        return $"{bytes / (1024.0 * 1024.0):F2} MB";
+    }
+}
+
+public sealed class MetadataCacheDiagnostics
+{
+    public string Status { get; set; } = "Missing";
+    public int SourceCount { get; set; }
+    public DateTime? LastUpdatedUtc { get; set; }
+    public IReadOnlyList<OfflineSourceDiagnostics> Sources { get; set; } = Array.Empty<OfflineSourceDiagnostics>();
+}
+
+public sealed class FeatureCacheDiagnostics
+{
+    public string Status { get; set; } = "Empty";
+    public int SourceCount { get; set; }
+    public int TotalFeatureCount { get; set; }
+    public long SizeBytes { get; set; }
+    public IReadOnlyList<OfflineSourceDiagnostics> Sources { get; set; } = Array.Empty<OfflineSourceDiagnostics>();
+}
+
+public sealed class OfflineSourceDiagnostics
+{
+    public string SourceId { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public int FeatureCount { get; set; }
+    public DateTime? LastSyncTime { get; set; }
+    public string? SourceUrl { get; set; }
+}
+
+public sealed class OfflineOperationDiagnostics
+{
+    public int PendingCount { get; set; }
+    public int ClaimedCount { get; set; }
+    public int SucceededCount { get; set; }
+    public int FailedCount { get; set; }
+    public int RetryCount { get; set; }
+    public int ConflictCount { get; set; }
+}
+
+public sealed class OfflineConflictReviewItem
+{
+    public string ConflictId { get; set; } = string.Empty;
+    public string OperationId { get; set; } = string.Empty;
+    public string SourceId { get; set; } = string.Empty;
+    public string FeatureId { get; set; } = string.Empty;
+    public string ConflictType { get; set; } = string.Empty;
+    public string Reason { get; set; } = string.Empty;
+    public string LocalState { get; set; } = string.Empty;
+    public string ServerState { get; set; } = string.Empty;
+    public DateTime DetectedAtUtc { get; set; }
+    public IReadOnlyList<string> ResolutionActions { get; set; } = Array.Empty<string>();
+}
+
+public static partial class DiagnosticRedactor
+{
+    private const string Redacted = "[redacted]";
+
+    public static string RedactPath(string path)
+    {
+        return string.IsNullOrWhiteSpace(path)
+            ? string.Empty
+            : Path.GetFileName(path);
+    }
+
+    public static string? RedactUrl(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return value;
+        }
+
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri))
+        {
+            return RedactSensitiveText(value);
+        }
+
+        return uri.GetLeftPart(UriPartial.Path);
+    }
+
+    public static string RedactSensitiveText(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var redacted = BearerTokenRegex().Replace(value, $"Bearer {Redacted}");
+        redacted = SecretPairRegex().Replace(redacted, match => $"{match.Groups[1].Value}{Redacted}");
+        return redacted;
+    }
+
+    public static string RedactJson(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            var redacted = RedactElement(document.RootElement);
+            return JsonSerializer.Serialize(redacted, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        }
+        catch (JsonException)
+        {
+            return RedactSensitiveText(json);
+        }
+    }
+
+    private static object? RedactElement(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Object => RedactObject(element),
+            JsonValueKind.Array => element.EnumerateArray().Select(RedactElement).ToArray(),
+            JsonValueKind.String => RedactSensitiveText(element.GetString()),
+            JsonValueKind.Number when element.TryGetInt64(out var longValue) => longValue,
+            JsonValueKind.Number => element.GetDouble(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => null
+        };
+    }
+
+    private static Dictionary<string, object?> RedactObject(JsonElement element)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var property in element.EnumerateObject())
+        {
+            values[property.Name] = IsSensitiveName(property.Name)
+                ? Redacted
+                : RedactElement(property.Value);
+        }
+
+        return values;
+    }
+
+    private static bool IsSensitiveName(string name)
+    {
+        return name.Contains("token", StringComparison.OrdinalIgnoreCase) ||
+            name.Contains("secret", StringComparison.OrdinalIgnoreCase) ||
+            name.Contains("password", StringComparison.OrdinalIgnoreCase) ||
+            name.Contains("apiKey", StringComparison.OrdinalIgnoreCase) ||
+            name.Contains("authorization", StringComparison.OrdinalIgnoreCase);
+    }
+
+    [GeneratedRegex("Bearer\\s+[A-Za-z0-9._~+/=-]+", RegexOptions.IgnoreCase)]
+    private static partial Regex BearerTokenRegex();
+
+    [GeneratedRegex("(?i)(api[_-]?key|token|password|secret|authorization)([\"'\\s:=]+)[^,\"'\\s}]+")]
+    private static partial Regex SecretPairRegex();
+}

--- a/apps/Honua.Mobile.FieldCollection/Services/ISyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/ISyncService.cs
@@ -56,12 +56,23 @@ public class SyncResult
 public class ConflictInfo
 {
     public string Id { get; set; } = string.Empty;
+    public string OperationId { get; set; } = string.Empty;
     public string FeatureId { get; set; } = string.Empty;
+    public string SourceId { get; set; } = string.Empty;
     public string LayerName { get; set; } = string.Empty;
     public ConflictType Type { get; set; }
     public DateTime DetectedAt { get; set; }
     public object? LocalVersion { get; set; }
     public object? ServerVersion { get; set; }
+    public string? FailureReason { get; set; }
+    public string? RedactedLocalVersion { get; set; }
+    public string? RedactedServerVersion { get; set; }
+    public IReadOnlyList<ConflictResolution> AvailableResolutions { get; set; } =
+    [
+        ConflictResolution.AcceptLocal,
+        ConflictResolution.AcceptServer,
+        ConflictResolution.Manual
+    ];
 
     public string ConflictDescription => Type switch
     {

--- a/apps/Honua.Mobile.FieldCollection/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Storage/GeoPackageStorageService.cs
@@ -1,7 +1,9 @@
 using SQLite;
+using System.Globalization;
 using System.Text.Json;
 using NetTopologySuite.IO;
 using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using Honua.Mobile.FieldCollection.Services.Storage.Models;
 using ChangeOperation = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeOperation;
 using CoreModels = Honua.Mobile.FieldCollection.Models;
@@ -767,6 +769,138 @@ public class GeoPackageStorageService : IDisposable
         }
     }
 
+    public async Task<OfflineCacheDiagnostics> GetOfflineCacheDiagnosticsAsync()
+    {
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            var fileInfo = new FileInfo(_databasePath);
+            var metadataRows = await _connection.Table<LayerMetadata>().ToListAsync();
+            var featureRows = await _connection.QueryAsync<LayerFeatureCount>(
+                "SELECT layer_id AS layer_id, COUNT(*) AS feature_count FROM local_features GROUP BY layer_id ORDER BY layer_id");
+            var operationCounts = await _connection.QueryAsync<OperationStatusCount>(
+                "SELECT sync_status AS sync_status, COUNT(*) AS item_count FROM change_records GROUP BY sync_status");
+            var unresolvedConflictCount = await _connection.ExecuteScalarAsync<int>(
+                "SELECT COUNT(*) FROM conflict_records WHERE resolved_at IS NULL");
+            var conflicts = await _connection.QueryAsync<ConflictRecord>(
+                "SELECT * FROM conflict_records WHERE resolved_at IS NULL ORDER BY created_at LIMIT 10");
+            var latestSession = await _connection.QueryAsync<SyncSession>(
+                "SELECT * FROM sync_sessions ORDER BY COALESCE(end_time, start_time) DESC LIMIT 1");
+
+            var featureCounts = featureRows.ToDictionary(row => row.LayerId, row => row.FeatureCount);
+            var metadataSources = metadataRows
+                .OrderBy(row => row.Id)
+                .Select(row => new OfflineSourceDiagnostics
+                {
+                    SourceId = row.Id.ToString(CultureInfo.InvariantCulture),
+                    DisplayName = string.IsNullOrWhiteSpace(row.Name) ? $"Layer {row.Id}" : row.Name,
+                    FeatureCount = featureCounts.GetValueOrDefault(row.Id),
+                    LastSyncTime = row.LastSync,
+                    SourceUrl = DiagnosticRedactor.RedactUrl(row.ServerUrl)
+                })
+                .ToList();
+
+            var featureSources = featureCounts
+                .OrderBy(row => row.Key)
+                .Select(row =>
+                {
+                    var metadata = metadataRows.FirstOrDefault(layer => layer.Id == row.Key);
+                    return new OfflineSourceDiagnostics
+                    {
+                        SourceId = row.Key.ToString(CultureInfo.InvariantCulture),
+                        DisplayName = metadata == null || string.IsNullOrWhiteSpace(metadata.Name)
+                            ? $"Layer {row.Key}"
+                            : metadata.Name,
+                        FeatureCount = row.Value,
+                        LastSyncTime = metadata?.LastSync,
+                        SourceUrl = DiagnosticRedactor.RedactUrl(metadata?.ServerUrl)
+                    };
+                })
+                .ToList();
+
+            var operations = MapOperationCounts(operationCounts, unresolvedConflictCount);
+            var session = latestSession.FirstOrDefault();
+            var lastSyncTimes = metadataRows
+                .Select(row => row.LastSync)
+                .Concat(latestSession.Select(row => (DateTime?)(row.EndTime ?? row.StartTime)))
+                .Where(value => value.HasValue)
+                .ToList();
+            var lastSyncTime = lastSyncTimes.Count == 0 ? null : lastSyncTimes.Max();
+            var metadataCreatedTimes = metadataRows.Select(row => row.CreatedAt).ToList();
+
+            return new OfflineCacheDiagnostics
+            {
+                PackageId = Path.GetFileNameWithoutExtension(_databasePath),
+                PackageFileName = DiagnosticRedactor.RedactPath(_databasePath),
+                PackageSizeBytes = fileInfo.Exists ? fileInfo.Length : 0,
+                LastSyncTime = lastSyncTime,
+                LocalGeneration = session?.LocalGeneration,
+                ServerGeneration = session?.ServerGeneration,
+                MetadataCache = new MetadataCacheDiagnostics
+                {
+                    Status = metadataRows.Count == 0 ? "Missing" : "Available",
+                    SourceCount = metadataRows.Count,
+                    LastUpdatedUtc = metadataCreatedTimes.Count == 0 ? null : metadataCreatedTimes.Max(),
+                    Sources = metadataSources
+                },
+                FeatureCache = new FeatureCacheDiagnostics
+                {
+                    Status = featureRows.Count == 0 ? "Empty" : "Available",
+                    SourceCount = featureRows.Count,
+                    TotalFeatureCount = featureRows.Sum(row => row.FeatureCount),
+                    SizeBytes = fileInfo.Exists ? fileInfo.Length : 0,
+                    Sources = featureSources
+                },
+                Operations = operations,
+                ConflictReview = conflicts.Select(MapConflictReviewItem).ToList()
+            };
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    private static OfflineOperationDiagnostics MapOperationCounts(
+        IEnumerable<OperationStatusCount> counts,
+        int unresolvedConflictCount)
+    {
+        var byStatus = counts.ToDictionary(row => row.SyncStatus, row => row.ItemCount);
+        return new OfflineOperationDiagnostics
+        {
+            PendingCount = byStatus.GetValueOrDefault(StorageSyncStatus.PendingUpload) +
+                byStatus.GetValueOrDefault(StorageSyncStatus.PendingDownload),
+            ClaimedCount = 0,
+            SucceededCount = byStatus.GetValueOrDefault(StorageSyncStatus.Synced),
+            FailedCount = byStatus.GetValueOrDefault(StorageSyncStatus.Error),
+            RetryCount = 0,
+            ConflictCount = unresolvedConflictCount + byStatus.GetValueOrDefault(StorageSyncStatus.Conflict)
+        };
+    }
+
+    private static OfflineConflictReviewItem MapConflictReviewItem(ConflictRecord conflict)
+    {
+        return new OfflineConflictReviewItem
+        {
+            ConflictId = conflict.Id,
+            OperationId = conflict.Id,
+            SourceId = conflict.LayerId.ToString(CultureInfo.InvariantCulture),
+            FeatureId = conflict.FeatureId,
+            ConflictType = conflict.ConflictType.ToString(),
+            Reason = $"Local v{conflict.LocalVersion} conflicts with server v{conflict.ServerVersion}.",
+            LocalState = DiagnosticRedactor.RedactJson(conflict.LocalData),
+            ServerState = DiagnosticRedactor.RedactJson(conflict.ServerData),
+            DetectedAtUtc = conflict.CreatedAt,
+            ResolutionActions =
+            [
+                "AcceptLocal",
+                "AcceptServer",
+                "Manual"
+            ]
+        };
+    }
+
     public async Task CompactAsync()
     {
         await EnsureInitializedAsync();
@@ -810,4 +944,22 @@ internal sealed class TableColumnInfo
 
     [Column("pk")]
     public int PrimaryKey { get; set; }
+}
+
+internal sealed class LayerFeatureCount
+{
+    [Column("layer_id")]
+    public int LayerId { get; set; }
+
+    [Column("feature_count")]
+    public int FeatureCount { get; set; }
+}
+
+internal sealed class OperationStatusCount
+{
+    [Column("sync_status")]
+    public StorageSyncStatus SyncStatus { get; set; }
+
+    [Column("item_count")]
+    public int ItemCount { get; set; }
 }

--- a/apps/Honua.Mobile.FieldCollection/Services/Sync/GeoPackageSyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Sync/GeoPackageSyncService.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using StorageChangeOperation = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeOperation;
@@ -449,12 +450,17 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         return conflicts.Select(conflict => new ConflictInfo
         {
             Id = conflict.Id,
+            OperationId = conflict.Id,
             FeatureId = conflict.FeatureId,
+            SourceId = conflict.LayerId.ToString(),
             LayerName = $"Layer {conflict.LayerId}",
             Type = MapConflictType(conflict.ConflictType),
             DetectedAt = conflict.CreatedAt,
             LocalVersion = conflict.LocalData,
-            ServerVersion = conflict.ServerData
+            ServerVersion = conflict.ServerData,
+            FailureReason = $"Local v{conflict.LocalVersion} conflicts with server v{conflict.ServerVersion}.",
+            RedactedLocalVersion = DiagnosticRedactor.RedactJson(conflict.LocalData),
+            RedactedServerVersion = DiagnosticRedactor.RedactJson(conflict.ServerData)
         });
     }
 

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/SyncCenterViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/SyncCenterViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using System.Collections.ObjectModel;
 
 namespace Honua.Mobile.FieldCollection.ViewModels;
@@ -11,6 +12,7 @@ public partial class SyncCenterViewModel : BaseViewModel
     private readonly ISyncService _syncService;
     private readonly IConnectivityService _connectivityService;
     private readonly IAuthenticationService _authService;
+    private readonly DiagnosticService _diagnosticService;
 
     [ObservableProperty]
     private bool isSyncing;
@@ -36,19 +38,26 @@ public partial class SyncCenterViewModel : BaseViewModel
     [ObservableProperty]
     private double syncProgress;
 
+    [ObservableProperty]
+    private OfflineCacheDiagnostics? offlineCacheDiagnostics;
+
     public ObservableCollection<ConflictInfo> ActiveConflicts { get; } = new();
+    public ObservableCollection<OfflineSourceDiagnostics> OfflineSources { get; } = new();
+    public ObservableCollection<OfflineConflictReviewItem> ConflictReviewItems { get; } = new();
     public ObservableCollection<SyncHistoryItem> SyncHistory { get; } = new();
 
     public SyncCenterViewModel(
         INavigationService navigationService,
         ISyncService syncService,
         IConnectivityService connectivityService,
-        IAuthenticationService authService)
+        IAuthenticationService authService,
+        DiagnosticService diagnosticService)
         : base(navigationService)
     {
         _syncService = syncService;
         _connectivityService = connectivityService;
         _authService = authService;
+        _diagnosticService = diagnosticService;
 
         Title = "Sync Center";
 
@@ -111,6 +120,7 @@ public partial class SyncCenterViewModel : BaseViewModel
 
     protected override async Task OnRefresh()
     {
+        await LoadOfflineDiagnostics();
         await LoadConflicts();
         await LoadSyncHistory();
     }
@@ -175,6 +185,8 @@ public partial class SyncCenterViewModel : BaseViewModel
                 {
                     await LoadConflicts();
                 }
+
+                await LoadOfflineDiagnostics();
             }
             else
             {
@@ -263,6 +275,31 @@ public partial class SyncCenterViewModel : BaseViewModel
     }
 
     [RelayCommand]
+    private async Task LoadOfflineDiagnostics()
+    {
+        await ExecuteAsync(async () =>
+        {
+            OfflineCacheDiagnostics = await _diagnosticService.GetOfflineCacheDiagnosticsAsync();
+
+            OfflineSources.Clear();
+            foreach (var source in OfflineCacheDiagnostics.MetadataCache.Sources
+                         .Concat(OfflineCacheDiagnostics.FeatureCache.Sources)
+                         .GroupBy(source => source.SourceId)
+                         .Select(group => group.First())
+                         .OrderBy(source => source.SourceId))
+            {
+                OfflineSources.Add(source);
+            }
+
+            ConflictReviewItems.Clear();
+            foreach (var conflict in OfflineCacheDiagnostics.ConflictReview)
+            {
+                ConflictReviewItems.Add(conflict);
+            }
+        });
+    }
+
+    [RelayCommand]
     private async Task LoadConflicts()
     {
         await ExecuteAsync(async () =>
@@ -313,6 +350,7 @@ public partial class SyncCenterViewModel : BaseViewModel
                 if (success)
                 {
                     ActiveConflicts.Remove(conflict);
+                    await LoadOfflineDiagnostics();
                     await ShowMessage("Conflict Resolved", "The conflict has been resolved successfully.");
                 }
                 else

--- a/apps/Honua.Mobile.FieldCollection/Views/SyncCenterPage.xaml
+++ b/apps/Honua.Mobile.FieldCollection/Views/SyncCenterPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:diagnostics="clr-namespace:Honua.Mobile.FieldCollection.Services.Diagnostics"
              xmlns:services="clr-namespace:Honua.Mobile.FieldCollection.Services"
              xmlns:vm="clr-namespace:Honua.Mobile.FieldCollection.ViewModels"
              x:Class="Honua.Mobile.FieldCollection.Views.SyncCenterPage"
@@ -133,6 +134,97 @@
                     </VerticalStackLayout>
                 </Frame>
 
+                <!-- Offline Diagnostics -->
+                <Frame Style="{StaticResource CardFrameStyle}"
+                       IsVisible="{Binding OfflineCacheDiagnostics, Converter={StaticResource IsNotNullConverter}}">
+                    <VerticalStackLayout Spacing="12">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <Label Grid.Column="0"
+                                   Text="Offline Diagnostics"
+                                   Style="{StaticResource SectionHeaderStyle}" />
+                            <Button Grid.Column="1"
+                                    Text="Refresh"
+                                    Style="{StaticResource SecondaryButtonStyle}"
+                                    Command="{Binding LoadOfflineDiagnosticsCommand}" />
+                        </Grid>
+
+                        <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
+                            <Label Grid.Row="0" Grid.Column="0"
+                                   Text="{Binding OfflineCacheDiagnostics.PackageId, StringFormat='Package: {0}'}"
+                                   FontSize="13" FontAttributes="Bold"
+                                   LineBreakMode="TailTruncation" />
+                            <Label Grid.Row="0" Grid.Column="1"
+                                   Text="{Binding OfflineCacheDiagnostics.PackageSizeDisplay, StringFormat='Size: {0}'}"
+                                   FontSize="13" />
+                            <Label Grid.Row="1" Grid.Column="0"
+                                   Text="{Binding OfflineCacheDiagnostics.MetadataCache.Status, StringFormat='Metadata: {0}'}"
+                                   FontSize="13" />
+                            <Label Grid.Row="1" Grid.Column="1"
+                                   Text="{Binding OfflineCacheDiagnostics.FeatureCache.TotalFeatureCount, StringFormat='Features: {0}'}"
+                                   FontSize="13" />
+                            <Label Grid.Row="2" Grid.Column="0"
+                                   Text="{Binding OfflineCacheDiagnostics.LocalGeneration, StringFormat='Local gen: {0}'}"
+                                   FontSize="13" />
+                            <Label Grid.Row="2" Grid.Column="1"
+                                   Text="{Binding OfflineCacheDiagnostics.ServerGeneration, StringFormat='Server gen: {0}'}"
+                                   FontSize="13" />
+                        </Grid>
+
+                        <Grid ColumnDefinitions="*,*,*" RowDefinitions="Auto,Auto" ColumnSpacing="8" RowSpacing="8">
+                            <StackLayout Grid.Row="0" Grid.Column="0">
+                                <Label Text="{Binding OfflineCacheDiagnostics.Operations.PendingCount}"
+                                       FontSize="16" FontAttributes="Bold" HorizontalOptions="Center" />
+                                <Label Text="Pending" FontSize="11" HorizontalOptions="Center" />
+                            </StackLayout>
+                            <StackLayout Grid.Row="0" Grid.Column="1">
+                                <Label Text="{Binding OfflineCacheDiagnostics.Operations.ClaimedCount}"
+                                       FontSize="16" FontAttributes="Bold" HorizontalOptions="Center" />
+                                <Label Text="Claimed" FontSize="11" HorizontalOptions="Center" />
+                            </StackLayout>
+                            <StackLayout Grid.Row="0" Grid.Column="2">
+                                <Label Text="{Binding OfflineCacheDiagnostics.Operations.SucceededCount}"
+                                       FontSize="16" FontAttributes="Bold" HorizontalOptions="Center" />
+                                <Label Text="Succeeded" FontSize="11" HorizontalOptions="Center" />
+                            </StackLayout>
+                            <StackLayout Grid.Row="1" Grid.Column="0">
+                                <Label Text="{Binding OfflineCacheDiagnostics.Operations.FailedCount}"
+                                       FontSize="16" FontAttributes="Bold" HorizontalOptions="Center" />
+                                <Label Text="Failed" FontSize="11" HorizontalOptions="Center" />
+                            </StackLayout>
+                            <StackLayout Grid.Row="1" Grid.Column="1">
+                                <Label Text="{Binding OfflineCacheDiagnostics.Operations.RetryCount}"
+                                       FontSize="16" FontAttributes="Bold" HorizontalOptions="Center" />
+                                <Label Text="Retry" FontSize="11" HorizontalOptions="Center" />
+                            </StackLayout>
+                            <StackLayout Grid.Row="1" Grid.Column="2">
+                                <Label Text="{Binding OfflineCacheDiagnostics.Operations.ConflictCount}"
+                                       FontSize="16" FontAttributes="Bold" HorizontalOptions="Center" />
+                                <Label Text="Conflict" FontSize="11" HorizontalOptions="Center" />
+                            </StackLayout>
+                        </Grid>
+
+                        <CollectionView ItemsSource="{Binding OfflineSources}"
+                                        IsVisible="{Binding OfflineSources.Count, Converter={StaticResource IntToBoolConverter}}"
+                                        MaximumHeightRequest="180">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="diagnostics:OfflineSourceDiagnostics">
+                                    <Grid ColumnDefinitions="*,Auto" Padding="4" ColumnSpacing="8">
+                                        <StackLayout Grid.Column="0">
+                                            <Label Text="{Binding DisplayName}" FontSize="13" FontAttributes="Bold" />
+                                            <Label Text="{Binding SourceId, StringFormat='Source {0}'}"
+                                                   FontSize="11" TextColor="{StaticResource Gray600}" />
+                                        </StackLayout>
+                                        <Label Grid.Column="1"
+                                               Text="{Binding FeatureCount, StringFormat='{0} features'}"
+                                               FontSize="12"
+                                               VerticalOptions="Center" />
+                                    </Grid>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Frame>
+
                 <!-- Active Conflicts -->
                 <Frame Style="{StaticResource CardFrameStyle}"
                        IsVisible="{Binding ActiveConflicts.Count, Converter={StaticResource IntToBoolConverter}}">
@@ -158,6 +250,42 @@
                                                 Command="{Binding Source={RelativeSource AncestorType={x:Type vm:SyncCenterViewModel}}, Path=ResolveConflictCommand}"
                                                 CommandParameter="{Binding .}" />
                                     </Grid>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Conflict Review Diagnostics -->
+                <Frame Style="{StaticResource CardFrameStyle}"
+                       IsVisible="{Binding ConflictReviewItems.Count, Converter={StaticResource IntToBoolConverter}}">
+                    <VerticalStackLayout Spacing="10">
+                        <Label Text="Conflict Review" Style="{StaticResource SectionHeaderStyle}"
+                               TextColor="{StaticResource Warning}" />
+
+                        <CollectionView ItemsSource="{Binding ConflictReviewItems}"
+                                        MaximumHeightRequest="260">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="diagnostics:OfflineConflictReviewItem">
+                                    <VerticalStackLayout Padding="6" Spacing="4">
+                                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                                            <Label Grid.Column="0"
+                                                   Text="{Binding FeatureId, StringFormat='Feature {0}'}"
+                                                   FontSize="13" FontAttributes="Bold" />
+                                            <Label Grid.Column="1"
+                                                   Text="{Binding SourceId, StringFormat='Source {0}'}"
+                                                   FontSize="12" />
+                                        </Grid>
+                                        <Label Text="{Binding Reason}"
+                                               FontSize="12"
+                                               TextColor="{StaticResource Gray600}" />
+                                        <Label Text="{Binding LocalState, StringFormat='Local: {0}'}"
+                                               FontSize="11"
+                                               LineBreakMode="TailTruncation" />
+                                        <Label Text="{Binding ServerState, StringFormat='Server: {0}'}"
+                                               FontSize="11"
+                                               LineBreakMode="TailTruncation" />
+                                    </VerticalStackLayout>
                                 </DataTemplate>
                             </CollectionView.ItemTemplate>
                         </CollectionView>

--- a/apps/Honua.Mobile.FieldCollection/Views/SyncCenterPage.xaml.cs
+++ b/apps/Honua.Mobile.FieldCollection/Views/SyncCenterPage.xaml.cs
@@ -18,6 +18,7 @@ public partial class SyncCenterPage : ContentPage
         base.OnAppearing();
 
         // Load current sync state and history
+        await _viewModel.LoadOfflineDiagnosticsCommand.ExecuteAsync(null);
         await _viewModel.LoadConflictsCommand.ExecuteAsync(null);
         await _viewModel.LoadSyncHistoryCommand.ExecuteAsync(null);
     }

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -105,39 +105,55 @@ Install-Package Honua.Mobile.Maui
 ### 1. Update MauiProgram.cs
 
 ```csharp
-using Honua.Mobile.Core;
-using Honua.Mobile.Storage;
-using Honua.Mobile.IoT;
 using Honua.Mobile.Maui;
+using Honua.Mobile.Offline.GeoPackage;
+using Honua.Mobile.Offline.Sync;
+using Honua.Mobile.Sdk;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Offline.Abstractions;
 
 public static class MauiProgram
 {
     public static MauiApp CreateMauiApp()
     {
         var builder = MauiApp.CreateBuilder();
+        var offlineDb = Path.Combine(FileSystem.Current.AppDataDirectory, "fielddata.gpkg");
 
-        builder
-            .UseMauiApp<App>()
-            .UseHonuaMobileSDK(config =>
+        builder.UseMauiApp<App>();
+
+        builder.Services
+            .AddHonuaMobileSdk(new HonuaMobileClientOptions
             {
-                // Required: Your Honua server endpoint
-                config.ServerEndpoint = "https://your-honua-server.com";
-
-                // Required: API key for authentication
-                config.ApiKey = "your-api-key-here";
-
-                // Optional: Enable offline storage (recommended)
-                config.EnableOfflineStorage = true;
-
-                // Optional: Enable IoT sensor support
-                config.EnableIoTSensors = true;
-
-                // Optional: Configure logging
-                config.LogLevel = LogLevel.Information;
-
-                // Optional: Sync settings
-                config.AutoSyncInterval = TimeSpan.FromMinutes(5);
-                config.MaxRetryAttempts = 3;
+                BaseUri = new Uri("https://your-honua-server.com"),
+                ApiKey = "your-api-key-here",
+            })
+            .AddHonuaMobileFieldCollection()
+            .AddHonuaSdkGeoPackageOfflineSync(
+                new GeoPackageSyncStoreOptions { DatabasePath = offlineDb },
+                new OfflinePackageManifest
+                {
+                    PackageId = "mobile-offline-field-ops-v1",
+                    Sources =
+                    [
+                        new OfflineSourceDescriptor
+                        {
+                            SourceId = "mobile_offline_demo/FeatureServer/68910",
+                            Source = new SourceDescriptor
+                            {
+                                Id = "mobile-offline-field-sites",
+                                Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+                                Locator = new SourceLocator { ServiceId = "mobile_offline_demo", LayerId = 68910 },
+                            },
+                            Where = "1=1",
+                            OutFields = ["objectid", "globalid", "site_name", "status", "priority", "assigned_to", "inspection_date", "sync_version", "offline_action", "notes"],
+                            ReturnGeometry = true,
+                            PageSize = 100,
+                        },
+                    ],
+                })
+            .AddHonuaBackgroundSync(new BackgroundSyncOrchestratorOptions
+            {
+                SyncInterval = TimeSpan.FromMinutes(5),
             });
 
         // Register additional services if needed

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -31,26 +31,54 @@ cd MyFieldApp
 Open `MauiProgram.cs` and configure your server connection:
 
 ```csharp
+using Honua.Mobile.Maui;
+using Honua.Mobile.Offline.GeoPackage;
+using Honua.Mobile.Sdk;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Offline.Abstractions;
+
 public static class MauiProgram
 {
     public static MauiApp CreateMauiApp()
     {
         var builder = MauiApp.CreateBuilder();
+        var offlineDb = Path.Combine(FileSystem.Current.AppDataDirectory, "honua-fieldcollector.gpkg");
 
         builder
             .UseMauiApp<App>()
-            .UseHonuaMobileSDK(config =>
+            .ConfigureFonts(fonts => fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular"));
+
+        builder.Services
+            .AddHonuaMobileSdk(new HonuaMobileClientOptions
             {
-                // 🔥 Replace with your Honua server
-                config.ServerEndpoint = "https://demo.honua.com";
-
-                // 🔑 Get your free API key at demo.honua.com
-                config.ApiKey = "your-api-key-here";
-
-                // ✅ Enable powerful features
-                config.EnableOfflineStorage = true;
-                config.EnableIoTSensors = false; // Start simple
-            });
+                BaseUri = new Uri("https://api.honua.io"),
+                ApiKey = "your-api-key-here",
+            })
+            .AddHonuaMobileFieldCollection()
+            .AddHonuaSdkGeoPackageOfflineSync(
+                new GeoPackageSyncStoreOptions { DatabasePath = offlineDb },
+                new OfflinePackageManifest
+                {
+                    PackageId = "mobile-offline-field-ops-v1",
+                    DisplayName = "Mobile Offline Field Operations",
+                    Sources =
+                    [
+                        new OfflineSourceDescriptor
+                        {
+                            SourceId = "mobile_offline_demo/FeatureServer/68910",
+                            Source = new SourceDescriptor
+                            {
+                                Id = "mobile-offline-field-sites",
+                                Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+                                Locator = new SourceLocator { ServiceId = "mobile_offline_demo", LayerId = 68910 },
+                            },
+                            Where = "1=1",
+                            OutFields = ["objectid", "globalid", "site_name", "status", "priority", "assigned_to", "inspection_date", "sync_version", "offline_action", "notes"],
+                            ReturnGeometry = true,
+                            PageSize = 100,
+                        },
+                    ],
+                });
 
         return builder.Build();
     }
@@ -58,9 +86,10 @@ public static class MauiProgram
 ```
 
 **💡 No Server Yet?** Use our demo server:
-- **Endpoint**: `https://demo.honua.com`
+- **Endpoint**: `https://api.honua.io`
 - **API Key**: `demo_key_field_collection_2026`
-- **Form ID**: `site_inspection` (pre-configured demo form)
+- **Service**: `mobile_offline_demo` (pre-configured offline field operations fixture)
+- **Editable layer**: `68910`
 
 ## Step 3: Build the Data Collection UI (90 seconds)
 
@@ -86,7 +115,7 @@ Replace `MainPage.xaml` content:
         <!-- 📝 Dynamic Data Collection Form -->
         <ScrollView Grid.Row="1">
             <honua:HonuaFeatureForm x:Name="DataForm"
-                                   FormId="site_inspection"
+                                   FormId="field-site-inspection"
                                    AllowDrafts="true"
                                    ShowProgress="true"
                                    FormSubmitted="OnDataCollected"
@@ -265,7 +294,7 @@ Add to MainPage.xaml above the form:
 
 # Or query via API:
 curl -H "X-API-Key: your-api-key" \
-     https://demo.honua.com/api/v1/features/site_inspection
+     "https://api.honua.io/rest/services/mobile_offline_demo/FeatureServer/68910/query?where=1%3D1&outFields=*&f=json"
 ```
 
 ## Compare to Competition

--- a/docs/guides/offline-sync.md
+++ b/docs/guides/offline-sync.md
@@ -36,39 +36,78 @@ For new offline workflows, register the SDK sync core with the mobile GeoPackage
 ```csharp
 using Honua.Mobile.Maui;
 using Honua.Mobile.Offline.GeoPackage;
+using Honua.Mobile.Offline.Sync;
 using Honua.Mobile.Sdk;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Offline.Abstractions;
+using SdkOfflineSyncEngineOptions = Honua.Sdk.Offline.OfflineSyncEngineOptions;
 
 var manifest = new OfflinePackageManifest
 {
-    PackageId = "inspection-area-1",
+    PackageId = "mobile-offline-field-ops-v1",
+    DisplayName = "Mobile Offline Field Operations",
+    Version = "2026.05",
     Sources =
     [
         new OfflineSourceDescriptor
         {
-            SourceId = "parks",
+            SourceId = "mobile_offline_demo/FeatureServer/68910",
             Source = new SourceDescriptor
             {
-                Id = "parks",
-                Protocol = FeatureProtocolIds.OgcFeatures,
-                Locator = new SourceLocator { CollectionId = "parks" },
+                Id = "mobile-offline-field-sites",
+                Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+                Locator = new SourceLocator { ServiceId = "mobile_offline_demo", LayerId = 68910 },
             },
-            OutFields = ["name", "status"],
-            PageSize = 500,
+            Where = "1=1",
+            OutFields = ["objectid", "globalid", "site_name", "status", "priority", "assigned_to", "inspection_date", "sync_version", "offline_action", "notes"],
+            ReturnGeometry = true,
+            PageSize = 100,
+        },
+        new OfflineSourceDescriptor
+        {
+            SourceId = "mobile_offline_demo/FeatureServer/68920",
+            Source = new SourceDescriptor
+            {
+                Id = "mobile-offline-work-zones",
+                Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+                Locator = new SourceLocator { ServiceId = "mobile_offline_demo", LayerId = 68920 },
+            },
+            Where = "1=1",
+            OutFields = ["objectid", "globalid", "zone_name", "zone_status", "sync_version", "notes"],
+            ReturnGeometry = true,
+            PageSize = 100,
         },
     ],
+    Metadata = new Dictionary<string, string>
+    {
+        ["fixture"] = "mobile-offline-field-ops-v1",
+        ["serviceId"] = "mobile_offline_demo",
+        ["editableLayerId"] = "68910",
+        ["contextLayerId"] = "68920",
+    },
 };
 
 builder.Services
     .AddHonuaMobileSdk(new HonuaMobileClientOptions
     {
-        BaseUri = new Uri("https://api.example.com"),
+        BaseUri = new Uri("https://api.honua.io"),
     })
     .AddHonuaSdkGeoPackageOfflineSync(
-        new GeoPackageSyncStoreOptions { DatabasePath = "fielddata.gpkg" },
-        manifest)
-    .AddHonuaBackgroundSync();
+        new GeoPackageSyncStoreOptions
+        {
+            DatabasePath = Path.Combine(FileSystem.Current.AppDataDirectory, "fielddata.gpkg"),
+            DefaultFeatureCacheTtl = TimeSpan.FromDays(7),
+        },
+        manifest,
+        new SdkOfflineSyncEngineOptions
+        {
+            BatchSize = 50,
+            ConflictStrategy = OfflineConflictStrategy.ManualReview,
+        })
+    .AddHonuaBackgroundSync(new BackgroundSyncOrchestratorOptions
+    {
+        SyncInterval = TimeSpan.FromMinutes(5),
+    });
 ```
 
 `AddHonuaSdkGeoPackageOfflineSync` wires `Honua.Sdk.Offline.OfflineSyncEngine` to:
@@ -78,6 +117,8 @@ builder.Services
 - `SdkOfflineSyncRunner` for the existing mobile `IOfflineSyncRunner` used by foreground and background sync scheduling.
 
 The adapter partitions cached features and queued edits by SDK package ID and source ID, so multiple offline packages can safely include the same source without overwriting feature rows or claiming each other's pending edits.
+
+`AddHonuaGeoPackageOfflineSync(...)` remains available as lower-level mobile runtime plumbing for existing apps that already use the mobile-owned sync engine and uploader. New apps should prefer `AddHonuaSdkGeoPackageOfflineSync(...)` so portable package manifests, feature query/edit clients, journal, checkpoint, sync state, and `Honua.Sdk.Offline.OfflineSyncEngine` stay aligned with `honua-sdk-dotnet`, while this repo continues to own GeoPackage/SQLite storage, native file placement, connectivity, background scheduling, and permissions.
 
 ## Cache Policy And Spatial Indexing
 
@@ -105,6 +146,69 @@ SpatiaLite is not bundled for the baseline mobile cache path. Current feature-ca
 `BackgroundPrefetchScheduler` runs optional cache-warming work with bounded concurrency. Call `CancelForLifecycleEventAsync(PrefetchLifecycleEvent.Suspend)` from app suspend handlers and `PrefetchLifecycleEvent.LowMemory` from platform memory-pressure hooks so downloads and cache fills observe cancellation before the OS reclaims resources.
 
 ## Configuration
+
+## Disconnected Field Workflow Acceptance Harness
+
+`tests/Honua.Mobile.ServerIntegration.Tests/DisconnectedFieldWorkflowAcceptanceTests.cs`
+defines the acceptance scaffold for the cloud Honua disconnected field workflow:
+
+1. `online-download`: create or reuse a replica and download server changes into the local GeoPackage cache.
+2. `offline-edit`: queue a deterministic offline feature edit while the harness is logically disconnected.
+3. `reconnect-sync`: run the mobile sync engine and upload queued edits.
+4. `verify`: assert local cache/cursor state, drained queue state, and cloud fixture evidence.
+
+The loopback test runs by default against the in-process integration server. The cloud/staging path is gated and only runs when explicitly enabled:
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `HONUA_MOBILE_CLOUD_ACCEPTANCE` | Yes | Set to `1` or `true` to run cloud acceptance. Otherwise the cloud test emits skipped evidence and returns. |
+| `HONUA_MOBILE_CLOUD_BASE_URL` | Yes when enabled | Cloud Honua base URL. |
+| `HONUA_MOBILE_CLOUD_SERVICE_ID` | Yes when enabled | FeatureServer service id supplied by the honua-server#895 fixture. |
+| `HONUA_MOBILE_CLOUD_LAYER_IDS` | No | Comma-separated FeatureServer layer IDs. Defaults to `0`. |
+| `HONUA_MOBILE_CLOUD_API_KEY` | No | API key sent as `X-API-Key`. |
+| `HONUA_MOBILE_CLOUD_BEARER_TOKEN` | No | Bearer token for authenticated staging fixtures. |
+| `HONUA_MOBILE_ACCEPTANCE_EVIDENCE_DIR` | No | Directory for evidence JSON artifacts. Defaults to a temp evidence directory for cloud runs. |
+| `HONUA_MOBILE_ACCEPTANCE_RUN_ID` | No | Stable run id used in artifact names and operation metadata. |
+| `HONUA_MOBILE_ACCEPTANCE_PACKAGE_ID` | No | Offline package id recorded in evidence. Defaults to `pkg_acceptance_field_workflow`. |
+| `HONUA_MOBILE_ACCEPTANCE_DATABASE_PATH` | No | GeoPackage path for the cloud acceptance run. |
+
+Evidence artifacts are written as `<run-id>.evidence.json` and use schema
+`honua.mobile.disconnected-field-workflow.evidence.v1`:
+
+```json
+{
+  "schemaVersion": "honua.mobile.disconnected-field-workflow.evidence.v1",
+  "workflowName": "disconnected-field-workflow",
+  "runId": "cloud-disconnected-field-workflow-20260504120000",
+  "status": "passed",
+  "packageId": "pkg_acceptance_field_workflow",
+  "serviceId": "assets",
+  "sourceIds": ["0"],
+  "operationIds": ["op-acceptance-add-001"],
+  "cursorState": {
+    "replica:assets": "replica-abc-123",
+    "servergen:assets": "100"
+  },
+  "phases": [
+    { "name": "online-download", "status": "passed" },
+    { "name": "offline-edit", "status": "passed" },
+    { "name": "reconnect-sync", "status": "passed" },
+    { "name": "verify", "status": "passed" }
+  ],
+  "finalState": {
+    "localFeatureCount": 1,
+    "pendingOperationCount": 0,
+    "localVerification": "downloaded features retained and sync queue drained",
+    "cloudVerification": "fixture-specific verification result"
+  }
+}
+```
+
+Until honua-server#895 is available, the cloud test intentionally does not
+assume server-side readback endpoints beyond the replica and `applyEdits`
+contract. The loopback harness verifies request-level behavior locally; the
+cloud harness records the fixture assumption in the queued operation metadata
+and evidence artifact.
 
 ### Basic Setup
 

--- a/templates/honua-fieldcollector/MainPage.xaml
+++ b/templates/honua-fieldcollector/MainPage.xaml
@@ -58,7 +58,7 @@
 
                             <!-- Dynamic Form -->
                             <honua:HonuaFeatureForm x:Name="DataForm"
-                                                   FormId="site_inspection"
+                                                   FormId="field-site-inspection"
                                                    AllowDrafts="true"
                                                    ShowProgress="true"
                                                    FormSubmitted="OnDataCollected"

--- a/templates/honua-fieldcollector/MainPage.xaml.cs
+++ b/templates/honua-fieldcollector/MainPage.xaml.cs
@@ -45,7 +45,7 @@ public partial class MainPage : ContentPage
             RecentActivityList.ItemsSource = _recentActivity;
 
             // Load initial form
-            await DataForm.LoadFormSchemaAsync("site_inspection");
+            await DataForm.LoadFormSchemaAsync("field-site-inspection");
 
             // Add welcome activity
             AddActivity("🚀", "App Started", "Ready for field data collection");

--- a/templates/honua-fieldcollector/MauiProgram.cs
+++ b/templates/honua-fieldcollector/MauiProgram.cs
@@ -1,8 +1,12 @@
 using Microsoft.Extensions.Logging;
 using CommunityToolkit.Maui;
-using Honua.Mobile.Core;
-using Honua.Mobile.Storage;
 using Honua.Mobile.Maui;
+using Honua.Mobile.Offline.GeoPackage;
+using Honua.Mobile.Offline.Sync;
+using Honua.Mobile.Sdk;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Offline.Abstractions;
+using SdkOfflineSyncEngineOptions = Honua.Sdk.Offline.OfflineSyncEngineOptions;
 <!--#if (enableIoT)-->
 using Honua.Mobile.IoT;
 <!--#endif-->
@@ -23,56 +27,97 @@ public static class MauiProgram
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
             });
 
-        // Configure Honua Mobile SDK
-        builder.Services.AddHonuaMobileSDK(config =>
-        {
-            // 🔗 Server Connection
-            config.ServerEndpoint = "serverEndpoint";
-            config.ApiKey = "apiKey";
+        var offlineDb = Path.Combine(FileSystem.Current.AppDataDirectory, "honua-fieldcollector.gpkg");
 
-            // 📱 Mobile Features
-            config.EnableOfflineStorage = true;
-            config.EnableLocationServices = true;
-            config.EnableCameraIntegration = true;
-<!--#if (enableIoT)-->
-            config.EnableIoTSensors = true;
-<!--#endif-->
-<!--#if (enableAR)-->
-            config.EnableAugmentedReality = true;
-<!--#endif-->
-
-            // 🔄 Sync Configuration
-            config.AutoSyncInterval = TimeSpan.FromMinutes(5);
-            config.MaxRetryAttempts = 3;
-            config.SyncConflictResolution = ConflictResolution.LastWriterWins;
-
-            // 📊 Logging
-            config.LogLevel = LogLevel.Information;
-        });
-
-        // Additional Services
-        builder.Services.AddSingleton<MainPage>();
+        builder.Services
+            .AddSingleton<MainPage>()
+            .AddHonuaMobileSdk(new HonuaMobileClientOptions
+            {
+                BaseUri = new Uri("HONUA_SERVER_ENDPOINT"),
+                ApiKey = "YOUR_API_KEY_HERE",
+            })
+            .AddHonuaMobileFieldCollection()
+            .AddHonuaSdkGeoPackageOfflineSync(
+                new GeoPackageSyncStoreOptions
+                {
+                    DatabasePath = offlineDb,
+                    DefaultFeatureCacheTtl = TimeSpan.FromDays(7),
+                },
+                CreateOfflinePackageManifest(),
+                new SdkOfflineSyncEngineOptions
+                {
+                    BatchSize = 50,
+                    MaxAttempts = 3,
+                    ConflictStrategy = OfflineConflictStrategy.ManualReview,
+                })
+            .AddHonuaBackgroundSync(new BackgroundSyncOrchestratorOptions
+            {
+                SyncInterval = TimeSpan.FromMinutes(5),
+                RunImmediately = false,
+            });
 
 #if DEBUG
         builder.Logging.AddDebug();
 #endif
 
-        var app = builder.Build();
-
-        // Initialize Honua services
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                var honuaClient = app.Services.GetRequiredService<IHonuaClient>();
-                await honuaClient.InitializeAsync();
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"Honua initialization error: {ex.Message}");
-            }
-        });
-
-        return app;
+        return builder.Build();
     }
+
+    private static OfflinePackageManifest CreateOfflinePackageManifest()
+        => new()
+        {
+            PackageId = "mobile-offline-field-ops-v1",
+            DisplayName = "Mobile Offline Field Operations",
+            Version = "2026.05",
+            Sources =
+            [
+                new OfflineSourceDescriptor
+                {
+                    SourceId = "mobile_offline_demo/FeatureServer/68910",
+                    Source = new SourceDescriptor
+                    {
+                        Id = "mobile-offline-field-sites",
+                        Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+                        Locator = new SourceLocator { ServiceId = "mobile_offline_demo", LayerId = 68910 },
+                    },
+                    Where = "1=1",
+                    OutFields =
+                    [
+                        "objectid",
+                        "globalid",
+                        "site_name",
+                        "status",
+                        "priority",
+                        "assigned_to",
+                        "inspection_date",
+                        "sync_version",
+                        "offline_action",
+                        "notes"
+                    ],
+                    ReturnGeometry = true,
+                    PageSize = 100,
+                },
+                new OfflineSourceDescriptor
+                {
+                    SourceId = "mobile_offline_demo/FeatureServer/68920",
+                    Source = new SourceDescriptor
+                    {
+                        Id = "mobile-offline-work-zones",
+                        Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+                        Locator = new SourceLocator { ServiceId = "mobile_offline_demo", LayerId = 68920 },
+                    },
+                    Where = "1=1",
+                    OutFields = ["objectid", "globalid", "zone_name", "zone_status", "sync_version", "notes"],
+                    ReturnGeometry = true,
+                    PageSize = 100,
+                },
+            ],
+            Metadata = new Dictionary<string, string>
+            {
+                ["fixture"] = "mobile-offline-field-ops-v1",
+                ["serviceId"] = "mobile_offline_demo",
+                ["editableLayerId"] = "68910",
+                ["contextLayerId"] = "68920",
+            },
+        };
 }

--- a/templates/honua-fieldcollector/README.md
+++ b/templates/honua-fieldcollector/README.md
@@ -62,16 +62,36 @@ This template creates a complete field data collection application with:
 
 ### 1. Configure Your Server
 
-Update the server connection in `MauiProgram.cs`:
+Update the server connection and offline package manifest in `MauiProgram.cs`:
 
 ```csharp
-config.ServerEndpoint = "https://your-honua-server.com";
-config.ApiKey = "your-api-key-here";
+builder.Services
+    .AddHonuaMobileSdk(new HonuaMobileClientOptions
+    {
+        BaseUri = new Uri("https://api.honua.io"),
+        ApiKey = "your-api-key-here",
+    })
+    .AddHonuaSdkGeoPackageOfflineSync(
+        new GeoPackageSyncStoreOptions
+        {
+            DatabasePath = Path.Combine(FileSystem.Current.AppDataDirectory, "honua-fieldcollector.gpkg"),
+            DefaultFeatureCacheTtl = TimeSpan.FromDays(7),
+        },
+        CreateOfflinePackageManifest());
 ```
+
+The template uses the SDK-backed offline path by default. `Honua.Sdk.Offline`
+owns the portable package manifest and sync engine; the mobile app still owns
+GeoPackage storage, native file placement, connectivity, permissions, and
+background scheduling.
+
+The checked-in manifest targets the cloud/staging fixture from
+`honua-server#895`: service `mobile_offline_demo`, editable layer `68910`, and
+readonly context layer `68920`.
 
 ### 2. Customize Your Form
 
-The app is configured to use form ID `"site_inspection"`. To use your own form:
+The app is configured to use form ID `"field-site-inspection"`. To use your own form:
 
 1. Create a form schema on your Honua server
 2. Update the `FormId` in `MainPage.xaml`:

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -1,9 +1,12 @@
 using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using Honua.Mobile.FieldCollection.Services.Sync;
 using Honua.Mobile.FieldCollection.Services.Storage;
 using StorageChangeRecord = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeRecord;
 using StorageChangeOperation = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeOperation;
+using StorageConflictRecord = Honua.Mobile.FieldCollection.Services.Storage.Models.ConflictRecord;
+using StorageConflictType = Honua.Mobile.FieldCollection.Services.Storage.Models.ConflictType;
 
 namespace Honua.Mobile.FieldCollection.Tests;
 
@@ -100,6 +103,51 @@ public sealed class GeoPackageSyncServiceTests
         var resolvedFeature = await storage.GetFeatureAsync("asset-1", 1);
         Assert.NotNull(resolvedFeature);
         Assert.Equal("server", resolvedFeature.Attributes["name"].ToString());
+    }
+
+    [Fact]
+    public async Task GetOfflineCacheDiagnosticsAsync_SeparatesMetadataFeatureAndOperationState()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.CreateLayerAsync(new LayerInfo
+        {
+            Id = 1,
+            Name = "Assets",
+            GeometryType = GeometryType.Point,
+            IsEditable = true
+        });
+        await storage.StoreFeatureAsync(CreateFeature("asset-1", version: 1));
+        var pendingChanges = await storage.GetPendingChangesAsync();
+        await storage.MarkChangesAsSynced([pendingChanges[0].Id]);
+        await storage.StoreConflictAsync(new StorageConflictRecord
+        {
+            Id = "conflict-1",
+            FeatureId = "asset-1",
+            LayerId = 1,
+            ConflictType = StorageConflictType.UpdateUpdate,
+            LocalVersion = 2,
+            ServerVersion = 3,
+            LocalData = """{"attributes":{"name":"local","apiKey":"secret-local"}}""",
+            ServerData = """{"attributes":{"name":"server","authorization":"Bearer secret-token"}}""",
+            CreatedAt = DateTime.UtcNow
+        });
+
+        var diagnostics = await storage.GetOfflineCacheDiagnosticsAsync();
+
+        Assert.Equal("honua-field-tests-", diagnostics.PackageId[..18]);
+        Assert.Equal("Available", diagnostics.MetadataCache.Status);
+        Assert.Equal("Available", diagnostics.FeatureCache.Status);
+        Assert.Equal(1, diagnostics.MetadataCache.SourceCount);
+        Assert.Equal(1, diagnostics.FeatureCache.TotalFeatureCount);
+        Assert.Equal(1, diagnostics.Operations.SucceededCount);
+        Assert.Equal(1, diagnostics.Operations.ConflictCount);
+        var conflict = Assert.Single(diagnostics.ConflictReview);
+        Assert.Equal("1", conflict.SourceId);
+        Assert.Contains("[redacted]", conflict.LocalState);
+        Assert.Contains("[redacted]", conflict.ServerState);
+        Assert.DoesNotContain("secret-token", conflict.ServerState);
     }
 
     private static GeoPackageSyncService CreateSyncService(

--- a/tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj
+++ b/tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj
@@ -30,6 +30,7 @@
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\CoreServices.cs" Link="App\Services\CoreServices.cs" />
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\IAuthenticationService.cs" Link="App\Services\IAuthenticationService.cs" />
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\ISyncService.cs" Link="App\Services\ISyncService.cs" />
+    <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\Diagnostics\OfflineCacheDiagnostics.cs" Link="App\Services\Diagnostics\OfflineCacheDiagnostics.cs" />
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\Diagnostics\MobileExceptionReporter.cs" Link="App\Services\Diagnostics\MobileExceptionReporter.cs" />
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\Storage\GeoPackageStorageService.cs" Link="App\Services\Storage\GeoPackageStorageService.cs" />
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\Storage\Models\StorageModels.cs" Link="App\Services\Storage\Models\StorageModels.cs" />

--- a/tests/Honua.Mobile.Maui.Tests/SdkOfflineRegistrationTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/SdkOfflineRegistrationTests.cs
@@ -11,7 +11,11 @@ using Microsoft.Extensions.DependencyInjection;
 using SdkFeatureClient = Honua.Mobile.Sdk.Features.HonuaMobileSdkFeatureClient;
 using SdkRoutingClient = Honua.Sdk.GeoServices.Routing.HonuaRoutingClient;
 using MobileOfflineSyncRunner = Honua.Mobile.Offline.Sync.IOfflineSyncRunner;
+using SdkOfflineChangeJournal = Honua.Sdk.Offline.Abstractions.IOfflineChangeJournal;
+using SdkOfflineCheckpointStore = Honua.Sdk.Offline.Abstractions.IOfflineSyncCheckpointStore;
 using SdkOfflineFeatureStore = Honua.Sdk.Offline.Abstractions.IOfflineFeatureStore;
+using SdkOfflineStateStore = Honua.Sdk.Offline.Abstractions.IOfflineSyncStateStore;
+using SdkOfflineSyncEngine = Honua.Sdk.Offline.OfflineSyncEngine;
 
 namespace Honua.Mobile.Maui.Tests;
 
@@ -52,13 +56,23 @@ public sealed class SdkOfflineRegistrationTests
                 .BuildServiceProvider();
 
             var runner = provider.GetRequiredService<MobileOfflineSyncRunner>();
+            var adapter = provider.GetRequiredService<GeoPackageSdkOfflineStoreAdapter>();
+            var manifest = provider.GetRequiredService<OfflinePackageManifest>();
 
             Assert.IsType<SdkOfflineSyncRunner>(runner);
-            Assert.IsType<GeoPackageSdkOfflineStoreAdapter>(provider.GetRequiredService<SdkOfflineFeatureStore>());
+            Assert.NotNull(provider.GetRequiredService<SdkOfflineSyncEngine>());
+            Assert.Same(adapter, provider.GetRequiredService<SdkOfflineFeatureStore>());
+            Assert.Same(adapter, provider.GetRequiredService<SdkOfflineChangeJournal>());
+            Assert.Same(adapter, provider.GetRequiredService<SdkOfflineCheckpointStore>());
+            Assert.Same(adapter, provider.GetRequiredService<SdkOfflineStateStore>());
             Assert.IsType<SdkFeatureClient>(provider.GetRequiredService<IHonuaFeatureQueryClient>());
             Assert.IsType<SdkFeatureClient>(provider.GetRequiredService<IHonuaFeatureEditClient>());
             Assert.IsType<SdkFeatureClient>(provider.GetRequiredService<IHonuaFeatureAttachmentClient>());
             Assert.IsType<HonuaMobileSdkFeatureClient>(provider.GetRequiredService<HonuaMobileSdkFeatureClient>());
+            Assert.Equal("mobile-offline-field-ops-v1", manifest.PackageId);
+            Assert.Equal(
+                ["mobile_offline_demo/FeatureServer/68910", "mobile_offline_demo/FeatureServer/68920"],
+                manifest.Sources.Select(source => source.SourceId).ToArray());
         }
         finally
         {
@@ -83,19 +97,46 @@ public sealed class SdkOfflineRegistrationTests
     private static OfflinePackageManifest CreateManifest()
         => new()
         {
-            PackageId = "area-1",
+            PackageId = "mobile-offline-field-ops-v1",
+            DisplayName = "Mobile Offline Field Operations",
+            Version = "2026.05",
             Sources =
             [
                 new OfflineSourceDescriptor
                 {
-                    SourceId = "parks",
+                    SourceId = "mobile_offline_demo/FeatureServer/68910",
                     Source = new SourceDescriptor
                     {
-                        Id = "parks",
-                        Protocol = FeatureProtocolIds.OgcFeatures,
-                        Locator = new SourceLocator { CollectionId = "parks" },
+                        Id = "mobile-offline-field-sites",
+                        Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+                        Locator = new SourceLocator { ServiceId = "mobile_offline_demo", LayerId = 68910 },
                     },
+                    Where = "1=1",
+                    OutFields = ["objectid", "globalid", "site_name", "status", "priority", "assigned_to", "inspection_date", "sync_version", "offline_action", "notes"],
+                    ReturnGeometry = true,
+                    PageSize = 100,
+                },
+                new OfflineSourceDescriptor
+                {
+                    SourceId = "mobile_offline_demo/FeatureServer/68920",
+                    Source = new SourceDescriptor
+                    {
+                        Id = "mobile-offline-work-zones",
+                        Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+                        Locator = new SourceLocator { ServiceId = "mobile_offline_demo", LayerId = 68920 },
+                    },
+                    Where = "1=1",
+                    OutFields = ["objectid", "globalid", "zone_name", "zone_status", "sync_version", "notes"],
+                    ReturnGeometry = true,
+                    PageSize = 100,
                 },
             ],
+            Metadata = new Dictionary<string, string>
+            {
+                ["fixture"] = "mobile-offline-field-ops-v1",
+                ["serviceId"] = "mobile_offline_demo",
+                ["editableLayerId"] = "68910",
+                ["contextLayerId"] = "68920",
+            },
         };
 }

--- a/tests/Honua.Mobile.ServerIntegration.Tests/DisconnectedFieldWorkflowAcceptanceTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/DisconnectedFieldWorkflowAcceptanceTests.cs
@@ -1,0 +1,512 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Honua.Mobile.Offline.GeoPackage;
+using Honua.Mobile.Offline.Sync;
+using Honua.Mobile.Sdk;
+
+namespace Honua.Mobile.ServerIntegration.Tests;
+
+public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
+{
+    private const string SchemaVersion = "honua.mobile.disconnected-field-workflow.evidence.v1";
+    private const string WorkflowName = "disconnected-field-workflow";
+    private const string DefaultPackageId = "pkg_acceptance_field_workflow";
+    private const string DefaultServiceId = "assets";
+    private static readonly DateTimeOffset FixedOperationTime = new(2026, 5, 4, 10, 0, 0, TimeSpan.Zero);
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+
+    private readonly string _rootDirectory;
+
+    public DisconnectedFieldWorkflowAcceptanceTests()
+    {
+        _rootDirectory = Path.Combine(Path.GetTempPath(), $"honua-disconnected-field-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_rootDirectory);
+    }
+
+    [Fact]
+    public async Task LoopbackHarness_RunsOnlineOfflineReconnectWorkflow_AndEmitsEvidence()
+    {
+        await using var server = await HonuaIntegrationServer.StartAsync();
+        var config = AcceptanceHarnessConfiguration.Loopback(
+            server.BaseUri,
+            Path.Combine(_rootDirectory, "evidence"));
+
+        var result = await RunHarnessAsync(
+            config,
+            createReplicaClient: () => CreateReplicaClient(config),
+            createUploader: () => CreateUploader(config),
+            verifyCloudStateAsync: async evidence =>
+            {
+                Assert.True(server.Received("POST", "/rest/services/assets/FeatureServer/createReplica"));
+                Assert.True(server.Received("POST", "/rest/services/assets/FeatureServer/extractChanges"));
+                Assert.True(server.Received("POST", "/rest/services/assets/FeatureServer/synchronizeReplica"));
+                Assert.True(server.Received("POST", "/rest/services/assets/FeatureServer/0/applyEdits"));
+
+                var applyEdits = server.SingleRequest("POST", "/rest/services/assets/FeatureServer/0/applyEdits");
+                Assert.Contains("Offline Pump Acceptance", WebUtility.UrlDecode(applyEdits.Body));
+                evidence.FinalState.CloudVerification = "loopback applyEdits observed";
+                await Task.CompletedTask;
+            });
+
+        Assert.Equal("passed", result.Evidence.Status);
+        Assert.True(File.Exists(result.EvidencePath));
+        Assert.Equal(0, result.Evidence.FinalState.PendingOperationCount);
+        Assert.True(result.Evidence.FinalState.LocalFeatureCount >= 1);
+        Assert.Equal("replica-abc-123", result.Evidence.CursorState["replica:assets"]);
+        Assert.Equal("100", result.Evidence.CursorState["servergen:assets"]);
+        Assert.Equal(["op-acceptance-add-001"], result.Evidence.OperationIds);
+
+        var evidenceJson = await File.ReadAllTextAsync(result.EvidencePath);
+        Assert.Contains(SchemaVersion, evidenceJson);
+        Assert.Contains("\"online-download\"", evidenceJson);
+        Assert.Contains("\"offline-edit\"", evidenceJson);
+        Assert.Contains("\"reconnect-sync\"", evidenceJson);
+        Assert.Contains("\"verify\"", evidenceJson);
+    }
+
+    [Fact]
+    [Trait("Category", "CloudAcceptance")]
+    public async Task CloudHarness_RunsOnlyWhenExplicitlyConfigured_AndOtherwiseEmitsSkippedEvidence()
+    {
+        var config = AcceptanceHarnessConfiguration.TryLoadCloudFromEnvironment();
+        if (config is null)
+        {
+            var skipped = DisconnectedFieldWorkflowEvidence.Skipped(
+                Path.Combine(_rootDirectory, "evidence"),
+                "Set HONUA_MOBILE_CLOUD_ACCEPTANCE=1 plus cloud fixture env vars to run.");
+            await WriteEvidenceAsync(skipped);
+            return;
+        }
+
+        var result = await RunHarnessAsync(
+            config,
+            createReplicaClient: () => CreateReplicaClient(config),
+            createUploader: () => CreateUploader(config),
+            verifyCloudStateAsync: evidence =>
+            {
+                evidence.FinalState.CloudVerification =
+                    "cloud fixture verification delegated to honua-server#895; request-level verification is not available from this process";
+                return Task.CompletedTask;
+            });
+
+        Assert.Equal("passed", result.Evidence.Status);
+        Assert.True(File.Exists(result.EvidencePath));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_rootDirectory))
+        {
+            Directory.Delete(_rootDirectory, recursive: true);
+        }
+    }
+
+    private static async Task<AcceptanceHarnessResult> RunHarnessAsync(
+        AcceptanceHarnessConfiguration config,
+        Func<IReplicaSyncClient> createReplicaClient,
+        Func<IOfflineOperationUploader> createUploader,
+        Func<DisconnectedFieldWorkflowEvidence, Task> verifyCloudStateAsync)
+    {
+        var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions
+        {
+            DatabasePath = config.DatabasePath,
+        });
+
+        var evidence = DisconnectedFieldWorkflowEvidence.Started(config);
+
+        try
+        {
+            await RunPhaseAsync(evidence, "online-download", async phase =>
+            {
+                var download = new DeltaDownloadEngine(
+                    store,
+                    createReplicaClient(),
+                    new DeltaDownloadOptions
+                    {
+                        ReplicaName = config.ReplicaName,
+                        LayerIds = config.LayerIds,
+                    });
+
+                var result = await download.DownloadAsync(config.ServiceId);
+                phase.Details["adds"] = result.Adds.ToString();
+                phase.Details["updates"] = result.Updates.ToString();
+                phase.Details["deletes"] = result.Deletes.ToString();
+                phase.Details["serverGen"] = result.ServerGen.ToString();
+            });
+
+            await RunPhaseAsync(evidence, "offline-edit", async phase =>
+            {
+                await store.InitializeAsync();
+                var operation = CreateAcceptanceOperation(config);
+                await store.EnqueueAsync(operation);
+                evidence.OperationIds.Add(operation.OperationId);
+                phase.Details["queuedOperationId"] = operation.OperationId;
+                phase.Details["queuedOperationType"] = operation.OperationType.ToString();
+                phase.Details["pendingAfterEdit"] = (await store.CountPendingAsync()).ToString();
+            });
+
+            await RunPhaseAsync(evidence, "reconnect-sync", async phase =>
+            {
+                var sync = new OfflineSyncEngine(
+                    store,
+                    createUploader(),
+                    new OfflineSyncEngineOptions
+                    {
+                        BatchSize = 10,
+                        ConflictStrategy = SyncConflictStrategy.ManualReview,
+                    });
+
+                var result = await sync.SyncAsync();
+                phase.Details["loaded"] = result.Loaded.ToString();
+                phase.Details["succeeded"] = result.Succeeded.ToString();
+                phase.Details["failed"] = result.Failed.ToString();
+                phase.Details["failures"] = string.Join(" | ", result.Failures.Select(failure => $"{failure.OperationId}: {failure.Reason}"));
+
+                Assert.Equal(1, result.Loaded);
+                Assert.True(result.Succeeded == 1, phase.Details["failures"]);
+                Assert.True(result.Failed == 0, phase.Details["failures"]);
+            });
+
+            await RunPhaseAsync(evidence, "verify", async phase =>
+            {
+                var layerKey = config.LayerIds[0].ToString();
+                var features = await store.GetFeaturesAsync(layerKey);
+                var pending = await store.CountPendingAsync();
+
+                evidence.CursorState[$"replica:{config.ServiceId}"] =
+                    await store.GetSyncCursorAsync($"replica:{config.ServiceId}") ?? string.Empty;
+                evidence.CursorState[$"servergen:{config.ServiceId}"] =
+                    await store.GetSyncCursorAsync($"servergen:{config.ServiceId}") ?? string.Empty;
+                evidence.FinalState.LocalFeatureCount = features.Count;
+                evidence.FinalState.PendingOperationCount = pending;
+                evidence.FinalState.LocalVerification = "downloaded features retained and sync queue drained";
+
+                phase.Details["localFeatureCount"] = features.Count.ToString();
+                phase.Details["pendingOperationCount"] = pending.ToString();
+
+                Assert.NotEmpty(features);
+                Assert.Equal(0, pending);
+                Assert.False(string.IsNullOrWhiteSpace(evidence.CursorState[$"replica:{config.ServiceId}"]));
+                Assert.False(string.IsNullOrWhiteSpace(evidence.CursorState[$"servergen:{config.ServiceId}"]));
+
+                await verifyCloudStateAsync(evidence);
+            });
+
+            evidence.Status = "passed";
+            evidence.CompletedAtUtc = DateTimeOffset.UtcNow;
+            var evidencePath = await WriteEvidenceAsync(evidence);
+            return new AcceptanceHarnessResult(evidence, evidencePath);
+        }
+        catch
+        {
+            evidence.Status = "failed";
+            evidence.CompletedAtUtc = DateTimeOffset.UtcNow;
+            await WriteEvidenceAsync(evidence);
+            throw;
+        }
+    }
+
+    private static async Task RunPhaseAsync(
+        DisconnectedFieldWorkflowEvidence evidence,
+        string phaseName,
+        Func<AcceptancePhaseEvidence, Task> action)
+    {
+        var phase = new AcceptancePhaseEvidence
+        {
+            Name = phaseName,
+            Status = "running",
+            StartedAtUtc = DateTimeOffset.UtcNow,
+        };
+        evidence.Phases.Add(phase);
+
+        try
+        {
+            await action(phase);
+            phase.Status = "passed";
+        }
+        catch (Exception ex)
+        {
+            phase.Status = "failed";
+            phase.Details["error"] = ex.Message;
+            throw;
+        }
+        finally
+        {
+            phase.CompletedAtUtc = DateTimeOffset.UtcNow;
+        }
+    }
+
+    private static OfflineEditOperation CreateAcceptanceOperation(AcceptanceHarnessConfiguration config)
+    {
+        var layerId = config.LayerIds[0];
+        var feature = JsonSerializer.SerializeToElement(new
+        {
+            attributes = new
+            {
+                objectid = 2,
+                name = "Offline Pump Acceptance",
+                status = "inspected-offline",
+                honua_acceptance_run = config.RunId,
+            },
+            geometry = new
+            {
+                x = -157.8,
+                y = 21.3,
+            },
+        }, JsonOptions);
+
+        return new OfflineEditOperation
+        {
+            OperationId = "op-acceptance-add-001",
+            LayerKey = $"{config.ServiceId}/{layerId}",
+            TargetCollection = config.ServiceId,
+            OperationType = OfflineOperationType.Add,
+            CreatedAtUtc = FixedOperationTime,
+            Priority = 1,
+            PayloadJson = JsonSerializer.Serialize(new OfflineOperationPayload
+            {
+                PackageId = config.PackageId,
+                SourceId = layerId.ToString(),
+                BaseSyncToken = $"servergen:{config.ServiceId}",
+                Protocol = "FeatureServer",
+                ServiceId = config.ServiceId,
+                LayerId = layerId,
+                Feature = feature,
+                Metadata = new Dictionary<string, string>
+                {
+                    ["workflow"] = WorkflowName,
+                    ["fixtureAssumption"] = "honua-server#895 provides FeatureServer replica and applyEdits endpoints",
+                },
+            }, JsonOptions),
+        };
+    }
+
+    private static IReplicaSyncClient CreateReplicaClient(AcceptanceHarnessConfiguration config)
+    {
+        var http = new HttpClient { BaseAddress = config.BaseUri };
+        ApplyAuthHeaders(http.DefaultRequestHeaders, config);
+        return new ReplicaSyncClient(http);
+    }
+
+    private static IOfflineOperationUploader CreateUploader(AcceptanceHarnessConfiguration config)
+    {
+        var options = new HonuaMobileClientOptions
+        {
+            BaseUri = config.BaseUri,
+            ApiKey = config.ApiKey,
+            BearerToken = config.BearerToken,
+            AllowInsecureTransportForDevelopment = config.BaseUri.Scheme == Uri.UriSchemeHttp,
+            PreferGrpcForFeatureQueries = false,
+            PreferGrpcForFeatureEdits = false,
+        };
+
+        return new HonuaApiOfflineOperationUploader(new HonuaMobileClient(new HttpClient(), options));
+    }
+
+    private static void ApplyAuthHeaders(HttpRequestHeaders headers, AcceptanceHarnessConfiguration config)
+    {
+        if (!string.IsNullOrWhiteSpace(config.ApiKey))
+        {
+            headers.TryAddWithoutValidation("X-API-Key", config.ApiKey);
+        }
+
+        if (!string.IsNullOrWhiteSpace(config.BearerToken))
+        {
+            headers.Authorization = new AuthenticationHeaderValue("Bearer", config.BearerToken);
+        }
+    }
+
+    private static async Task<string> WriteEvidenceAsync(DisconnectedFieldWorkflowEvidence evidence)
+    {
+        Directory.CreateDirectory(evidence.ArtifactDirectory);
+        var path = Path.Combine(evidence.ArtifactDirectory, $"{evidence.RunId}.evidence.json");
+        await File.WriteAllTextAsync(path, JsonSerializer.Serialize(evidence, JsonOptions));
+        return path;
+    }
+
+    private sealed record AcceptanceHarnessResult(
+        DisconnectedFieldWorkflowEvidence Evidence,
+        string EvidencePath);
+
+    private sealed class AcceptanceHarnessConfiguration
+    {
+        public required Uri BaseUri { get; init; }
+
+        public required string ServiceId { get; init; }
+
+        public required int[] LayerIds { get; init; }
+
+        public required string PackageId { get; init; }
+
+        public required string RunId { get; init; }
+
+        public required string DatabasePath { get; init; }
+
+        public required string ArtifactDirectory { get; init; }
+
+        public string ReplicaName => $"honua-mobile-acceptance-{RunId}";
+
+        public string[] SourceIds => LayerIds.Select(layerId => layerId.ToString()).ToArray();
+
+        public string? ApiKey { get; init; }
+
+        public string? BearerToken { get; init; }
+
+        public static AcceptanceHarnessConfiguration Loopback(Uri baseUri, string artifactDirectory)
+            => new()
+            {
+                BaseUri = baseUri,
+                ServiceId = DefaultServiceId,
+                LayerIds = [0],
+                PackageId = DefaultPackageId,
+                RunId = "loopback-disconnected-field-workflow",
+                DatabasePath = Path.Combine(artifactDirectory, "loopback-field-workflow.gpkg"),
+                ArtifactDirectory = artifactDirectory,
+            };
+
+        public static AcceptanceHarnessConfiguration? TryLoadCloudFromEnvironment()
+        {
+            var enabled = Environment.GetEnvironmentVariable("HONUA_MOBILE_CLOUD_ACCEPTANCE");
+            if (!string.Equals(enabled, "1", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(enabled, "true", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            var baseUrl = RequireEnvironment("HONUA_MOBILE_CLOUD_BASE_URL");
+            var serviceId = RequireEnvironment("HONUA_MOBILE_CLOUD_SERVICE_ID");
+            var layerIds = ParseLayerIds(Environment.GetEnvironmentVariable("HONUA_MOBILE_CLOUD_LAYER_IDS") ?? "0");
+            var artifactDirectory = Environment.GetEnvironmentVariable("HONUA_MOBILE_ACCEPTANCE_EVIDENCE_DIR")
+                ?? Path.Combine(Path.GetTempPath(), "honua-mobile-acceptance-evidence");
+            var runId = Environment.GetEnvironmentVariable("HONUA_MOBILE_ACCEPTANCE_RUN_ID")
+                ?? $"cloud-disconnected-field-workflow-{DateTimeOffset.UtcNow:yyyyMMddHHmmss}";
+
+            return new AcceptanceHarnessConfiguration
+            {
+                BaseUri = new Uri(baseUrl),
+                ServiceId = serviceId,
+                LayerIds = layerIds,
+                PackageId = Environment.GetEnvironmentVariable("HONUA_MOBILE_ACCEPTANCE_PACKAGE_ID") ?? DefaultPackageId,
+                RunId = runId,
+                DatabasePath = Environment.GetEnvironmentVariable("HONUA_MOBILE_ACCEPTANCE_DATABASE_PATH")
+                    ?? Path.Combine(artifactDirectory, $"{runId}.gpkg"),
+                ArtifactDirectory = artifactDirectory,
+                ApiKey = Environment.GetEnvironmentVariable("HONUA_MOBILE_CLOUD_API_KEY"),
+                BearerToken = Environment.GetEnvironmentVariable("HONUA_MOBILE_CLOUD_BEARER_TOKEN"),
+            };
+        }
+
+        private static string RequireEnvironment(string name)
+            => Environment.GetEnvironmentVariable(name)
+               ?? throw new InvalidOperationException($"{name} is required when HONUA_MOBILE_CLOUD_ACCEPTANCE is enabled.");
+
+        private static int[] ParseLayerIds(string value)
+        {
+            var layerIds = value.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                .Select(int.Parse)
+                .ToArray();
+
+            if (layerIds.Length == 0)
+            {
+                throw new InvalidOperationException("HONUA_MOBILE_CLOUD_LAYER_IDS must include at least one layer id.");
+            }
+
+            return layerIds;
+        }
+    }
+
+    private sealed class DisconnectedFieldWorkflowEvidence
+    {
+        public string SchemaVersion { get; init; } = DisconnectedFieldWorkflowAcceptanceTests.SchemaVersion;
+
+        public string WorkflowName { get; init; } = DisconnectedFieldWorkflowAcceptanceTests.WorkflowName;
+
+        public required string RunId { get; init; }
+
+        public required string ArtifactDirectory { get; init; }
+
+        public required string Status { get; set; }
+
+        public required DateTimeOffset StartedAtUtc { get; init; }
+
+        public DateTimeOffset? CompletedAtUtc { get; set; }
+
+        public required string PackageId { get; init; }
+
+        public required string ServiceId { get; init; }
+
+        public required List<string> SourceIds { get; init; }
+
+        public List<string> OperationIds { get; } = [];
+
+        public Dictionary<string, string> CursorState { get; } = new(StringComparer.Ordinal);
+
+        public List<AcceptancePhaseEvidence> Phases { get; } = [];
+
+        public AcceptanceFinalStateEvidence FinalState { get; } = new();
+
+        public static DisconnectedFieldWorkflowEvidence Started(AcceptanceHarnessConfiguration config)
+            => new()
+            {
+                RunId = config.RunId,
+                ArtifactDirectory = config.ArtifactDirectory,
+                Status = "running",
+                StartedAtUtc = DateTimeOffset.UtcNow,
+                PackageId = config.PackageId,
+                ServiceId = config.ServiceId,
+                SourceIds = config.SourceIds.ToList(),
+            };
+
+        public static DisconnectedFieldWorkflowEvidence Skipped(string artifactDirectory, string reason)
+        {
+            var evidence = new DisconnectedFieldWorkflowEvidence
+            {
+                RunId = "cloud-disconnected-field-workflow-skipped",
+                ArtifactDirectory = artifactDirectory,
+                Status = "skipped",
+                StartedAtUtc = DateTimeOffset.UtcNow,
+                CompletedAtUtc = DateTimeOffset.UtcNow,
+                PackageId = DefaultPackageId,
+                ServiceId = DefaultServiceId,
+                SourceIds = ["0"],
+            };
+            evidence.Phases.Add(new AcceptancePhaseEvidence
+            {
+                Name = "cloud-fixture-gate",
+                Status = "skipped",
+                StartedAtUtc = evidence.StartedAtUtc,
+                CompletedAtUtc = evidence.CompletedAtUtc,
+                Details = { ["reason"] = reason },
+            });
+            return evidence;
+        }
+    }
+
+    private sealed class AcceptancePhaseEvidence
+    {
+        public required string Name { get; init; }
+
+        public required string Status { get; set; }
+
+        public required DateTimeOffset StartedAtUtc { get; init; }
+
+        public DateTimeOffset? CompletedAtUtc { get; set; }
+
+        public Dictionary<string, string> Details { get; init; } = new(StringComparer.Ordinal);
+    }
+
+    private sealed class AcceptanceFinalStateEvidence
+    {
+        public int LocalFeatureCount { get; set; }
+
+        public int PendingOperationCount { get; set; }
+
+        public string? LocalVerification { get; set; }
+
+        public string? CloudVerification { get; set; }
+    }
+}

--- a/tests/Honua.Mobile.ServerIntegration.Tests/HonuaIntegrationServer.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/HonuaIntegrationServer.cs
@@ -279,10 +279,10 @@ internal sealed class HonuaIntegrationServer : IAsyncDisposable
             }
             """));
 
-        app.MapPost("/rest/services/offline/FeatureServer/createReplica", () => Json("""
+        app.MapPost("/rest/services/{serviceId}/FeatureServer/createReplica", () => Json("""
             { "replicaID": "replica-abc-123", "serverGen": 42 }
             """));
-        app.MapPost("/rest/services/offline/FeatureServer/extractChanges", () => Json("""
+        app.MapPost("/rest/services/{serviceId}/FeatureServer/extractChanges", () => Json("""
             {
               "serverGen": 55,
               "layerChanges": [
@@ -295,10 +295,10 @@ internal sealed class HonuaIntegrationServer : IAsyncDisposable
               ]
             }
             """));
-        app.MapPost("/rest/services/offline/FeatureServer/synchronizeReplica", () => Json("""
+        app.MapPost("/rest/services/{serviceId}/FeatureServer/synchronizeReplica", () => Json("""
             { "serverGen": 100 }
             """));
-        app.MapPost("/rest/services/offline/FeatureServer/unRegisterReplica", () => Json("""
+        app.MapPost("/rest/services/{serviceId}/FeatureServer/unRegisterReplica", () => Json("""
             { "success": true }
             """));
 


### PR DESCRIPTION
## Summary

- converges the flagship app and fieldcollector template on `AddHonuaSdkGeoPackageOfflineSync(...)`
- aligns the mobile offline manifest examples with the `mobile_offline_demo` FeatureServer fixture
- adds Sync Center offline diagnostics, conflict review state, redaction, and focused tests
- adds a disconnected field workflow acceptance harness with evidence JSON and cloud/staging gates

## User Impact

Mobile developers get a copyable SDK-backed offline path while `honua-mobile` continues to own GeoPackage/native runtime, background sync, connectivity, permissions, and UX.

Related to #92
Related to #94
Related to #95
Related to #97
Related to honua-io/honua-server#895

## Platform Impact

- MAUI app and fieldcollector template wiring now exercise the same SDK-backed offline sync path.
- Android/iOS/Windows CI builds remain the platform verification gate for the PR.

## Offline Impact

- Demonstrates manifest-driven package download, disconnected edits, reconnect sync, conflict review, and redacted diagnostics.
- Uses the `mobile_offline_demo` server fixture and keeps cloud acceptance disabled unless fixture env vars are supplied.

## Testing

- `dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --no-restore`
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore`
- `dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --no-restore`
- `git diff --check`

## Breaking Changes

None.

## Notes

Android app build still needs an environment with Android SDK installed. The cloud acceptance path is gated behind `HONUA_MOBILE_CLOUD_ACCEPTANCE=1` and fixture env vars.
