### PR TITLE
feat: JS/embed: Cesium scene controls for Honua construction world-model demo (#98)

### DIFF
--- a/docs/guides/3d-scene-embed.md
+++ b/docs/guides/3d-scene-embed.md
@@ -58,7 +58,9 @@ scene.addEventListener('honua-scene-load-error', (event) => {
 });
 
 scene.addEventListener('honua-scene-identify', (event) => {
-  console.log(event.detail.x, event.detail.y, event.detail.picked);
+  // detail.position is { latitude, longitude, height } when the scene
+  // could sample a surface at (x, y); otherwise null.
+  console.log(event.detail.x, event.detail.y, event.detail.picked, event.detail.position);
 });
 ```
 

--- a/docs/guides/3d-scene-embed.md
+++ b/docs/guides/3d-scene-embed.md
@@ -118,6 +118,14 @@ ensure nested 3D Tiles references are also rewritten or served through a stable
 package-local URL prefix. Call `resolver.dispose?.()` when a host tears down a
 Cache Storage resolver that created object URLs.
 
+## Scene Controls
+
+For multi-layer demos with bookmarks, timeline phases, compare modes, feature
+inspection, and measurement, see [Scene Controls](scene-controls.md). Those
+controls compose with `<honua-scene>`, accept a typed
+`HonuaSceneMetadata` document, and emit stable `honua-scene-*` events that
+app shells (and the JS SDK) can subscribe to without importing CesiumJS.
+
 ## Current Scope
 
 This first slice proves client-side 3D Tiles loading, scene events, and typed SDK scene discovery. Honua-hosted scene registry, terrain tiles, elevation APIs, 3D Tiles generation, and I3S compatibility are tracked in the linked server backlog.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -19,5 +19,6 @@ In-depth guides for building with the Honua Mobile SDK.
 | [Performance](performance.md) | Optimizing startup time, memory usage, and sync throughput |
 | [Plugin and Host Extension Boundary](plugin-extension-api.md) | Web embed extension APIs and the SDK/mobile ownership split for plugin work |
 | [Protected 3D Scene Auth](protected-3d-scene-auth.md) | Signed URL, proxy, header, CORS, cache, and revocation policy for protected scene assets |
+| [Scene Controls](scene-controls.md) | `<honua-scene-*>` control surfaces, `HonuaSceneMetadata` schema, and typed scene events |
 | [Security](security.md) | Authentication, transport security, and secure storage best practices |
 | [Troubleshooting](troubleshooting.md) | Common issues and solutions for development and production |

--- a/docs/guides/scene-controls.md
+++ b/docs/guides/scene-controls.md
@@ -1,0 +1,181 @@
+# Scene Controls
+
+`@honua-io/embed` ships a set of reusable control surfaces that compose with
+`<honua-scene>` to give Honua its operational 3D-workspace feel. Each control
+is a framework-agnostic web component that consumes a shared
+`HonuaSceneMetadata` document and emits typed `honua-scene-*` events the JS
+SDK and app shells can synchronize against without importing CesiumJS.
+
+## What you get
+
+| Element | Purpose |
+| --- | --- |
+| `<honua-scene-layers>` | Layer switcher with visibility + opacity. |
+| `<honua-scene-bookmarks>` | Saved camera framings. |
+| `<honua-scene-timeline>` | Phase-based playback that toggles layers. |
+| `<honua-scene-compare>` | Side picker between left/right layer sets. |
+| `<honua-scene-inspector>` | Feature attribute panel populated from picks. |
+| `<honua-scene-measure>` | Point/distance/area measurement tools. |
+
+The components register automatically when you `import '@honua-io/embed'`. They
+can also be defined individually with `defineHonuaSceneLayersElement`, etc., or
+all at once with `defineHonuaSceneControls()`.
+
+## Composition
+
+Controls bind to a `<honua-scene>` via the `for` attribute (any CSS selector
+works) or, when omitted, by walking back through previous siblings. App shells
+are free to lay out controls outside the scene viewport — sidebars, panels,
+floating cards.
+
+```html
+<honua-scene id="scene" metadata-url="/scenes/site-42.json"></honua-scene>
+<aside>
+  <honua-scene-layers for="#scene"></honua-scene-layers>
+  <honua-scene-bookmarks for="#scene"></honua-scene-bookmarks>
+  <honua-scene-timeline for="#scene"></honua-scene-timeline>
+  <honua-scene-compare for="#scene"></honua-scene-compare>
+  <honua-scene-inspector for="#scene"></honua-scene-inspector>
+  <honua-scene-measure for="#scene"></honua-scene-measure>
+</aside>
+```
+
+The local `examples/scene-construction/` demo wires all six controls with a
+construction-themed metadata fixture and runs without AWS, Azure, or a Cesium
+ion token.
+
+## Scene metadata
+
+`<honua-scene>` accepts metadata via either the `metadata-url` attribute (the
+component fetches and parses the document) or the `metadata` property
+(programmatic). Both paths surface a typed `HonuaSceneMetadata` value to every
+bound control.
+
+The metadata shape is `honua-scene-metadata/v1`. It is a forward-compatible
+superset of the SDK fixture at
+`tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/scene-metadata.json` — the
+familiar `id`, `name`, `description`, `center`, `bounds`, `tileset`, `terrain`,
+`capabilities`, and `links` fields stay where they are. The new optional
+fields drive the controls:
+
+```jsonc
+{
+  "schema": "honua-scene-metadata/v1",
+  "id": "site-42",
+  "name": "Site 42",
+  "layers": [
+    { "id": "as-built", "title": "As-built capture", "kind": "3d-tiles", "url": "https://…/asbuilt.json" },
+    { "id": "design-overlay", "title": "Design overlay", "kind": "3d-tiles", "url": "https://…/design.json", "opacity": 0.85 }
+  ],
+  "bookmarks": [
+    {
+      "id": "site-overview",
+      "title": "Site overview",
+      "view": {
+        "center": { "latitude": 39.95, "longitude": -75.16 },
+        "height": 2400,
+        "orientation": { "heading": 0, "pitch": -45, "roll": 0 }
+      }
+    }
+  ],
+  "timeline": {
+    "phases": [
+      {
+        "id": "phase-1",
+        "title": "Foundation",
+        "startUtc": "2026-01-06T00:00:00Z",
+        "endUtc": "2026-03-30T00:00:00Z",
+        "visibleLayerIds": ["as-built"]
+      }
+    ]
+  },
+  "compare": {
+    "modes": [
+      {
+        "id": "design-vs-asbuilt",
+        "title": "Design vs As-built",
+        "leftLayerIds": ["design-overlay"],
+        "rightLayerIds": ["as-built"]
+      }
+    ]
+  },
+  "inspector": {
+    "fields": [
+      { "key": "id", "title": "Asset ID" },
+      { "key": "phase", "title": "Phase" },
+      { "key": "elevation", "title": "Elevation", "format": "number", "unit": "m" }
+    ]
+  }
+}
+```
+
+Validation surfaces a `metadata-invalid` code with a JSONPath-style `path` for
+the offending field on a `honua-scene-metadata-error` event:
+
+```ts
+scene.addEventListener('honua-scene-metadata-error', (event) => {
+  console.warn(event.detail.code, event.detail.path, event.detail.message);
+});
+```
+
+A `metadata-fetch-failed` code is emitted when the network request fails or
+returns a non-2xx status.
+
+## Imperative scene API
+
+`HonuaSceneElement` exposes a small layer API the controls (and host code) can
+call directly:
+
+| Method | Description |
+| --- | --- |
+| `applyView(view)` | Wraps `setView` for a `HonuaSceneViewSpec`. |
+| `addLayer(metadata)` | Registers a metadata-shaped layer; loads the tileset when the scene is live. |
+| `removeLayer(id)` | Removes a registered layer and any backing tileset. |
+| `setLayerVisibility(id, visible)` | Toggles visibility; emits `honua-scene-layer-change`. |
+| `setLayerOpacity(id, opacity)` | Sets the layer opacity (0–1); emits `honua-scene-layer-change`. |
+| `getLayer(id)` | Returns the live layer handle (metadata + visibility/opacity + tileset). |
+
+Layers declared in `metadata.layers` are tracked under their declared `id`.
+The implicit `tileset-url` becomes the `id: "primary"` layer when no metadata
+overrides it, so timelines and compare modes can refer to it by name.
+
+## Typed events
+
+All control events bubble and compose. None of them leak Cesium types, so the
+JS SDK can model them without importing Cesium.
+
+| Event | Detail |
+| --- | --- |
+| `honua-scene-metadata-change` | `{ metadata, source: 'attribute'\|'property'\|'fetch'\|'cleared' }` |
+| `honua-scene-metadata-error` | `{ url, code, message, path?, error? }` |
+| `honua-scene-layer-change` | `{ layerId, reason, layer, visible, opacity }` |
+| `honua-scene-layer-toggle` | `{ layerId, visible, controlId: 'layers' }` |
+| `honua-scene-layer-opacity` | `{ layerId, opacity, controlId: 'layers' }` |
+| `honua-scene-bookmark-apply` | `{ bookmarkId, view, controlId: 'bookmarks' }` |
+| `honua-scene-timeline-change` | `{ phaseId, startUtc, endUtc, visibleLayerIds, controlId: 'timeline' }` |
+| `honua-scene-compare-set` | `{ modeId, side, leftLayerIds, rightLayerIds, controlId: 'compare' }` |
+| `honua-scene-feature-select` | `{ featureId, attributes, controlId: 'inspector' }` |
+| `honua-scene-measurement-add` | `{ measurementId, kind, points, distance?, area?, controlId: 'measure' }` |
+| `honua-scene-measurement-clear` | `{ measurementId, controlId: 'measure' }` |
+| `honua-scene-control-error` | `{ controlId, kind, message, error? }` |
+
+Existing scene events (`honua-scene-ready`, `honua-scene-config-change`,
+`honua-scene-load-error`, `honua-scene-camera-change`,
+`honua-scene-identify`) keep their current contract.
+
+## Running the demo
+
+From the repository root:
+
+```bash
+npm ci --prefix src/Honua.Embed
+npm run build --prefix src/Honua.Embed
+python3 -m http.server 8080
+```
+
+Then open `http://localhost:8080/examples/scene-construction/`. The default
+fixture references public CesiumGS 3D Tiles samples, so no Honua, AWS, Azure,
+or Cesium ion credentials are required for the local demo. App shells that
+need a fully offline tileset can pair the controls with the existing
+[`packageAssetResolver`](3d-scene-embed.md#offline-package-resolver) flow —
+the metadata document is independent of asset fetch policy.

--- a/docs/guides/scene-controls.md
+++ b/docs/guides/scene-controls.md
@@ -55,8 +55,11 @@ The metadata shape is `honua-scene-metadata/v1`. It is a forward-compatible
 superset of the SDK fixture at
 `tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/scene-metadata.json` — the
 familiar `id`, `name`, `description`, `center`, `bounds`, `tileset`, `terrain`,
-`capabilities`, and `links` fields stay where they are. The new optional
-fields drive the controls:
+`capabilities`, and `links` fields stay where they are, so an existing SDK
+scene metadata document parses without modification. The `schema` field is
+optional and defaults to `honua-scene-metadata/v1`; supplying a different
+schema string still emits `metadata-invalid`. The new optional fields drive
+the controls:
 
 ```jsonc
 {

--- a/docs/guides/scene-controls.md
+++ b/docs/guides/scene-controls.md
@@ -132,11 +132,12 @@ call directly:
 | Method | Description |
 | --- | --- |
 | `applyView(view)` | Wraps `setView` for a `HonuaSceneViewSpec`. |
-| `addLayer(metadata)` | Registers a metadata-shaped layer; loads the tileset when the scene is live. |
+| `addLayer(metadata)` | Registers a metadata-shaped layer; loads the tileset when the scene is live. Re-calling with the same `id` but a new `kind`/`url` detaches the previous tileset and reloads from the new source. |
 | `removeLayer(id)` | Removes a registered layer and any backing tileset. |
 | `setLayerVisibility(id, visible)` | Toggles visibility; emits `honua-scene-layer-change`. |
 | `setLayerOpacity(id, opacity)` | Sets the layer opacity (0–1); emits `honua-scene-layer-change`. |
 | `getLayer(id)` | Returns the live layer handle (metadata + visibility/opacity + tileset). |
+| `samplePoint(x, y)` | Converts canvas-space pick coordinates into `{ latitude, longitude, height } \| null` using the active scene; returns `null` when the scene has not loaded or no surface was sampled. Used by `<honua-scene-measure>` and exposed for hosts that need to derive cartographic coordinates from custom pointer events. |
 
 Layers declared in `metadata.layers` are tracked under their declared `id`.
 The implicit `tileset-url` becomes the `id: "primary"` layer when no metadata
@@ -158,13 +159,17 @@ JS SDK can model them without importing Cesium.
 | `honua-scene-timeline-change` | `{ phaseId, startUtc, endUtc, visibleLayerIds, controlId: 'timeline' }` |
 | `honua-scene-compare-set` | `{ modeId, side, leftLayerIds, rightLayerIds, controlId: 'compare' }` |
 | `honua-scene-feature-select` | `{ featureId, attributes, controlId: 'inspector' }` |
-| `honua-scene-measurement-add` | `{ measurementId, kind, points, distance?, area?, controlId: 'measure' }` |
+| `honua-scene-measurement-add` | `{ measurementId, kind, points, distance?, area?, controlId: 'measure' }` — emitted only when the measurement meets the per-kind minimum: `point` ≥ 1, `line` ≥ 2, `polygon` ≥ 3 points. Earlier finalize attempts emit `honua-scene-control-error` with `kind: 'insufficient-points'`. |
 | `honua-scene-measurement-clear` | `{ measurementId, controlId: 'measure' }` |
 | `honua-scene-control-error` | `{ controlId, kind, message, error? }` |
 
 Existing scene events (`honua-scene-ready`, `honua-scene-config-change`,
 `honua-scene-load-error`, `honua-scene-camera-change`,
-`honua-scene-identify`) keep their current contract.
+`honua-scene-identify`) keep their previous contract; the only change is
+additive — `honua-scene-identify` now also carries
+`position: { latitude, longitude, height } | null`, computed via
+`samplePoint(x, y)`. Hosts that previously read only `x`, `y`, `picked`, and
+`config` continue to work unchanged.
 
 ## Running the demo
 

--- a/docs/guides/scene-controls.md
+++ b/docs/guides/scene-controls.md
@@ -147,7 +147,11 @@ call directly:
 
 Layers declared in `metadata.layers` are tracked under their declared `id`.
 The implicit `tileset-url` becomes the `id: "primary"` layer when no metadata
-overrides it, so timelines and compare modes can refer to it by name.
+overrides it, so timelines and compare modes can refer to it by name. When
+`metadata.layers` declares its own `id: "primary"` entry, the metadata layer
+wins: its `url`, `title`, `description`, `visible`, and `opacity` are
+authoritative, and the `tileset-url` attribute is ignored for the primary
+slot.
 
 Layer-id references inside `timeline.phases[*].visibleLayerIds`,
 `compare.modes[*].leftLayerIds`, and `compare.modes[*].rightLayerIds` must

--- a/docs/guides/scene-controls.md
+++ b/docs/guides/scene-controls.md
@@ -29,7 +29,11 @@ are free to lay out controls outside the scene viewport — sidebars, panels,
 floating cards.
 
 ```html
-<honua-scene id="scene" metadata-url="/scenes/site-42.json"></honua-scene>
+<honua-scene
+  id="scene"
+  metadata-url="/scenes/site-42.json"
+  tileset-url="https://example.test/site-42/primary/tileset.json">
+</honua-scene>
 <aside>
   <honua-scene-layers for="#scene"></honua-scene-layers>
   <honua-scene-bookmarks for="#scene"></honua-scene-bookmarks>
@@ -39,6 +43,16 @@ floating cards.
   <honua-scene-measure for="#scene"></honua-scene-measure>
 </aside>
 ```
+
+`metadata-url` (or the `metadata` property) provides the layer/bookmark/
+timeline/compare/inspector content. `<honua-scene>` still loads the primary
+3D Tiles dataset from `tileset-url`, `terrain-url`, or a configured offline
+package — at least one of those must be set for the scene to load (the same
+`hasSceneData` rule that drives autoload). The
+`examples/scene-construction/` demo declares the primary URL inline in
+`metadata.tileset.url` and mirrors it onto the `tileset-url` attribute when
+`honua-scene-metadata-change` fires; either pattern works as long as
+`tileset-url` is set by the time the scene loads.
 
 The local `examples/scene-construction/` demo wires all six controls with a
 construction-themed metadata fixture and runs without AWS, Azure, or a Cesium

--- a/docs/guides/scene-controls.md
+++ b/docs/guides/scene-controls.md
@@ -124,6 +124,12 @@ scene.addEventListener('honua-scene-metadata-error', (event) => {
 A `metadata-fetch-failed` code is emitted when the network request fails or
 returns a non-2xx status.
 
+When `inspector.fields` is omitted, `<honua-scene-inspector>` derives the
+attribute list from the picked feature itself: it prefers Cesium feature
+accessors (`getPropertyIds()` + `getProperty(key)`), then falls back to
+`picked.properties`, and finally renders no attributes. The
+`honua-scene-feature-select` event surface is identical in both cases.
+
 ## Imperative scene API
 
 `HonuaSceneElement` exposes a small layer API the controls (and host code) can
@@ -142,6 +148,16 @@ call directly:
 Layers declared in `metadata.layers` are tracked under their declared `id`.
 The implicit `tileset-url` becomes the `id: "primary"` layer when no metadata
 overrides it, so timelines and compare modes can refer to it by name.
+
+Layer-id references inside `timeline.phases[*].visibleLayerIds`,
+`compare.modes[*].leftLayerIds`, and `compare.modes[*].rightLayerIds` must
+resolve to either `"primary"` or a layer declared in `metadata.layers`;
+fetched metadata that references any other id is rejected with
+`metadata-invalid` on `honua-scene-metadata-error`. Hosts can override or
+substitute a declared layer's tileset at runtime by calling
+`scene.addLayer({ id, kind, url })` with a matching id — phase/mode
+visibility then drives the host-supplied tileset the same way it drives the
+metadata-declared one.
 
 ## Typed events
 

--- a/examples/scene-construction/README.md
+++ b/examples/scene-construction/README.md
@@ -35,3 +35,8 @@ To swap in your own scene, point `metadata-url` at any document that conforms
 to `honua-scene-metadata/v1`. See
 [`docs/guides/scene-controls.md`](../../docs/guides/scene-controls.md) for the
 full schema and event reference.
+
+The demo's inline script mirrors `metadata.tileset.url` onto the `tileset-url`
+attribute after `honua-scene-metadata-change` fires. This is a small wiring
+workaround until `<honua-scene>` consumes the metadata document's `tileset.url`
+directly; remove the mirror once that lands.

--- a/examples/scene-construction/README.md
+++ b/examples/scene-construction/README.md
@@ -1,0 +1,37 @@
+# Construction World Model Demo
+
+A side-by-side scene + controls demo that loads a Honua scene metadata document
+(`metadata.json`) and exercises the demo-critical controls: layers, bookmarks,
+timeline phases, compare, feature inspector, and measurement.
+
+The default fixture references public CesiumGS 3D Tiles samples, so it runs
+without AWS, Azure, or a Cesium ion token.
+
+## Run locally
+
+From the repository root:
+
+```bash
+npm ci --prefix src/Honua.Embed
+npm run build --prefix src/Honua.Embed
+python3 -m http.server 8080
+```
+
+Then open `http://localhost:8080/examples/scene-construction/`.
+
+The right-hand event log shows the typed `honua-scene-*` events as you
+interact with the controls. Use the layer toggles, click a bookmark, switch
+timeline phases, flip compare modes, click into the scene to inspect a
+feature, and use the measure tool to drop point/line/polygon measurements.
+
+## Wiring the controls
+
+The demo binds controls to the scene with `for="#scene"`. You can also place a
+control immediately after `<honua-scene>` to use the default sibling lookup.
+The metadata document is loaded via `metadata-url` and parsed into a
+`HonuaSceneMetadata` value that drives every control's UI.
+
+To swap in your own scene, point `metadata-url` at any document that conforms
+to `honua-scene-metadata/v1`. See
+[`docs/guides/scene-controls.md`](../../docs/guides/scene-controls.md) for the
+full schema and event reference.

--- a/examples/scene-construction/index.html
+++ b/examples/scene-construction/index.html
@@ -162,7 +162,7 @@
         'honua-scene-control-error',
       ];
       for (const type of recorded) {
-        scene.addEventListener(type, (event) => {
+        document.body.addEventListener(type, (event) => {
           const entry = document.createElement('li');
           const detail = event.detail ?? null;
           entry.textContent = `${type}: ${JSON.stringify(detail)}`;

--- a/examples/scene-construction/index.html
+++ b/examples/scene-construction/index.html
@@ -1,0 +1,183 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Honua Construction World Model Demo</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0a121a;
+        --panel: #101820;
+        --border: rgba(238, 245, 247, 0.18);
+        --foreground: #eef5f7;
+        --muted: #a9b8bf;
+        --accent: #4fb4c8;
+      }
+
+      * { box-sizing: border-box; }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        color: var(--foreground);
+        background: var(--bg);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      header.page {
+        padding: 18px 24px;
+        border-bottom: 1px solid var(--border);
+      }
+
+      header.page h1 {
+        margin: 0;
+        font-size: 18px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+
+      header.page p {
+        margin: 4px 0 0;
+        color: var(--muted);
+        font-size: 13px;
+      }
+
+      .layout {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) 320px;
+        gap: 16px;
+        padding: 16px;
+      }
+
+      .scene-host {
+        position: relative;
+        min-height: 540px;
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        overflow: hidden;
+      }
+
+      honua-scene {
+        --honua-scene-accent: var(--accent);
+        --honua-scene-background: var(--bg);
+        --honua-scene-foreground: var(--foreground);
+        --honua-scene-border: var(--border);
+        --honua-scene-muted: var(--muted);
+        height: 100%;
+        min-height: 540px;
+        display: block;
+      }
+
+      aside.controls {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      aside.controls > * {
+        --honua-scene-background: var(--panel);
+        --honua-scene-border: var(--border);
+        --honua-scene-foreground: var(--foreground);
+        --honua-scene-muted: var(--muted);
+        --honua-scene-accent: var(--accent);
+      }
+
+      .event-log {
+        padding: 12px;
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        background: var(--panel);
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        font-size: 12px;
+        color: var(--muted);
+        max-height: 220px;
+        overflow: auto;
+      }
+
+      .event-log h2 {
+        margin: 0 0 6px;
+        font-size: 11px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--foreground);
+      }
+
+      .event-log ul {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .event-log li {
+        padding: 2px 0;
+        border-bottom: 1px dashed var(--border);
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <h1>Honua Construction Demo</h1>
+      <p>Scene controls bound to a typed metadata document. Open the browser console to see typed honua-scene-* events as they flow.</p>
+    </header>
+    <main class="layout">
+      <section class="scene-host">
+        <honua-scene
+          id="scene"
+          metadata-url="./metadata.json"
+          autoload="false"
+          height="2400"
+          heading="0"
+          pitch="-45">
+        </honua-scene>
+      </section>
+      <aside class="controls">
+        <honua-scene-layers for="#scene"></honua-scene-layers>
+        <honua-scene-bookmarks for="#scene"></honua-scene-bookmarks>
+        <honua-scene-timeline for="#scene"></honua-scene-timeline>
+        <honua-scene-compare for="#scene"></honua-scene-compare>
+        <honua-scene-inspector for="#scene"></honua-scene-inspector>
+        <honua-scene-measure for="#scene"></honua-scene-measure>
+        <section class="event-log" id="event-log">
+          <h2>Event log</h2>
+          <ul></ul>
+        </section>
+      </aside>
+    </main>
+    <script type="module" src="../../src/Honua.Embed/dist/index.js"></script>
+    <script>
+      const scene = document.getElementById('scene');
+      const log = document.querySelector('#event-log ul');
+      const recorded = [
+        'honua-scene-ready',
+        'honua-scene-metadata-change',
+        'honua-scene-layer-change',
+        'honua-scene-layer-toggle',
+        'honua-scene-layer-opacity',
+        'honua-scene-bookmark-apply',
+        'honua-scene-timeline-change',
+        'honua-scene-compare-set',
+        'honua-scene-feature-select',
+        'honua-scene-measurement-add',
+        'honua-scene-control-error',
+      ];
+      for (const type of recorded) {
+        scene.addEventListener(type, (event) => {
+          const entry = document.createElement('li');
+          const detail = event.detail ?? null;
+          entry.textContent = `${type}: ${JSON.stringify(detail)}`;
+          log.prepend(entry);
+        });
+      }
+
+      scene.addEventListener('honua-scene-metadata-change', () => {
+        scene.removeAttribute('autoload');
+        scene.setAttribute('autoload', 'true');
+        const tileset = scene.metadata?.tileset?.url;
+        if (tileset) {
+          scene.setAttribute('tileset-url', tileset);
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/examples/scene-construction/metadata.json
+++ b/examples/scene-construction/metadata.json
@@ -1,0 +1,125 @@
+{
+  "schema": "honua-scene-metadata/v1",
+  "id": "construction-demo",
+  "name": "Construction World Model Demo",
+  "description": "Sample scene that exercises Honua scene controls against public CesiumGS 3D Tiles.",
+  "center": {
+    "latitude": 39.95215,
+    "longitude": -75.16356,
+    "height": 1500
+  },
+  "bounds": {
+    "west": -75.18,
+    "south": 39.93,
+    "east": -75.14,
+    "north": 39.97
+  },
+  "tileset": {
+    "url": "https://raw.githubusercontent.com/CesiumGS/3d-tiles-samples/main/1.0/TilesetWithDiscreteLOD/tileset.json",
+    "format": "3d-tiles"
+  },
+  "capabilities": {
+    "3d-tiles": true,
+    "terrain": false
+  },
+  "layers": [
+    {
+      "id": "as-built",
+      "title": "As-built capture",
+      "kind": "3d-tiles",
+      "url": "https://raw.githubusercontent.com/CesiumGS/3d-tiles-samples/main/1.0/TilesetWithDiscreteLOD/tileset.json",
+      "description": "Latest reality capture for the active phase.",
+      "visible": true,
+      "opacity": 1
+    },
+    {
+      "id": "design-overlay",
+      "title": "Design overlay",
+      "kind": "3d-tiles",
+      "url": "https://raw.githubusercontent.com/CesiumGS/3d-tiles-samples/main/1.0/TilesetWithRequestVolume/tileset.json",
+      "description": "BIM-derived design tileset overlaid on the site.",
+      "visible": false,
+      "opacity": 0.85
+    }
+  ],
+  "bookmarks": [
+    {
+      "id": "site-overview",
+      "title": "Site overview",
+      "description": "Wide camera that frames the entire site.",
+      "view": {
+        "center": { "latitude": 39.952, "longitude": -75.163 },
+        "height": 2400,
+        "orientation": { "heading": 0, "pitch": -45, "roll": 0 }
+      }
+    },
+    {
+      "id": "north-elevation",
+      "title": "North elevation",
+      "description": "North-facing facade inspection vantage.",
+      "view": {
+        "center": { "latitude": 39.954, "longitude": -75.163 },
+        "height": 600,
+        "orientation": { "heading": 180, "pitch": -20, "roll": 0 }
+      }
+    },
+    {
+      "id": "entrance",
+      "title": "Entrance approach",
+      "description": "Pedestrian entrance walk-up.",
+      "view": {
+        "center": { "latitude": 39.9515, "longitude": -75.1632 },
+        "height": 80,
+        "orientation": { "heading": 90, "pitch": -10, "roll": 0 }
+      }
+    }
+  ],
+  "timeline": {
+    "phases": [
+      {
+        "id": "phase-1-foundation",
+        "title": "Phase 1 – Foundation",
+        "startUtc": "2026-01-06T00:00:00Z",
+        "endUtc": "2026-03-30T00:00:00Z",
+        "visibleLayerIds": ["as-built"],
+        "description": "Foundation pour and underground utilities."
+      },
+      {
+        "id": "phase-2-superstructure",
+        "title": "Phase 2 – Superstructure",
+        "startUtc": "2026-04-01T00:00:00Z",
+        "endUtc": "2026-08-30T00:00:00Z",
+        "visibleLayerIds": ["as-built", "design-overlay"],
+        "description": "Superstructure framing and curtain wall installation."
+      },
+      {
+        "id": "phase-3-fitout",
+        "title": "Phase 3 – Fit-out",
+        "startUtc": "2026-09-01T00:00:00Z",
+        "endUtc": "2026-12-15T00:00:00Z",
+        "visibleLayerIds": ["as-built", "design-overlay"],
+        "description": "Interior fit-out and commissioning."
+      }
+    ]
+  },
+  "compare": {
+    "modes": [
+      {
+        "id": "design-vs-asbuilt",
+        "title": "Design vs. as-built",
+        "description": "Toggle between the design intent and the latest capture.",
+        "leftLayerIds": ["design-overlay"],
+        "rightLayerIds": ["as-built"]
+      }
+    ]
+  },
+  "inspector": {
+    "fields": [
+      { "key": "id", "title": "Asset ID", "format": "string" },
+      { "key": "elementCategory", "title": "Element category", "format": "string" },
+      { "key": "phase", "title": "Phase", "format": "string" },
+      { "key": "elevation", "title": "Elevation", "format": "number", "unit": "m" },
+      { "key": "lastSurveyUtc", "title": "Last survey", "format": "date" }
+    ]
+  }
+}

--- a/examples/scene-construction/metadata.json
+++ b/examples/scene-construction/metadata.json
@@ -24,7 +24,7 @@
   },
   "layers": [
     {
-      "id": "as-built",
+      "id": "primary",
       "title": "As-built capture",
       "kind": "3d-tiles",
       "url": "https://raw.githubusercontent.com/CesiumGS/3d-tiles-samples/main/1.0/TilesetWithDiscreteLOD/tileset.json",
@@ -81,7 +81,7 @@
         "title": "Phase 1 – Foundation",
         "startUtc": "2026-01-06T00:00:00Z",
         "endUtc": "2026-03-30T00:00:00Z",
-        "visibleLayerIds": ["as-built"],
+        "visibleLayerIds": ["primary"],
         "description": "Foundation pour and underground utilities."
       },
       {
@@ -89,7 +89,7 @@
         "title": "Phase 2 – Superstructure",
         "startUtc": "2026-04-01T00:00:00Z",
         "endUtc": "2026-08-30T00:00:00Z",
-        "visibleLayerIds": ["as-built", "design-overlay"],
+        "visibleLayerIds": ["primary", "design-overlay"],
         "description": "Superstructure framing and curtain wall installation."
       },
       {
@@ -97,7 +97,7 @@
         "title": "Phase 3 – Fit-out",
         "startUtc": "2026-09-01T00:00:00Z",
         "endUtc": "2026-12-15T00:00:00Z",
-        "visibleLayerIds": ["as-built", "design-overlay"],
+        "visibleLayerIds": ["primary", "design-overlay"],
         "description": "Interior fit-out and commissioning."
       }
     ]
@@ -109,7 +109,7 @@
         "title": "Design vs. as-built",
         "description": "Toggle between the design intent and the latest capture.",
         "leftLayerIds": ["design-overlay"],
-        "rightLayerIds": ["as-built"]
+        "rightLayerIds": ["primary"]
       }
     ]
   },

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -120,8 +120,12 @@ scene.setAttribute('package-expires-at', manifest.offlineUseExpiresAtUtc);
 
 `HonuaSceneElement` also exposes an imperative API: `metadata` (property),
 `applyView(view)`, `addLayer(metadata)`, `removeLayer(id)`,
-`setLayerVisibility(id, visible)`, `setLayerOpacity(id, opacity)`, and
-`getLayer(id)`. See the [Scene Controls guide](../../docs/guides/scene-controls.md)
+`setLayerVisibility(id, visible)`, `setLayerOpacity(id, opacity)`,
+`getLayer(id)`, and `samplePoint(x, y)` (returns
+`{ latitude, longitude, height } | null` for the surface picked at canvas-space
+`x`/`y`). `addLayer` is also re-entrant — calling it again with the same `id`
+but a different `kind` or `url` detaches the previous tileset and reloads from
+the new source. See the [Scene Controls guide](../../docs/guides/scene-controls.md)
 for the metadata shape and the full event reference.
 
 ## Events
@@ -136,7 +140,7 @@ for the metadata shape and the full event reference.
 | `honua-scene-config-change` | Current `HonuaSceneConfig`. |
 | `honua-scene-load-error` | `{ source, code, message, config, error }`. |
 | `honua-scene-camera-change` | `{ center, height, orientation, config }`. |
-| `honua-scene-identify` | `{ x, y, picked, config }`. |
+| `honua-scene-identify` | `{ x, y, picked, position, config }` where `position` is `{ latitude, longitude, height } \| null`. |
 | `honua-scene-metadata-change` | `{ metadata, source }`. |
 | `honua-scene-metadata-error` | `{ url, code, message, path?, error? }`. |
 | `honua-scene-layer-change` | `{ layerId, reason, layer, visible, opacity }`. |

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -165,7 +165,11 @@ scene with `for="<css-selector>"` (or place it as a sibling and let it resolve
 the nearest preceding `<honua-scene>`).
 
 ```html
-<honua-scene id="scene" metadata-url="/scenes/site.json"></honua-scene>
+<honua-scene
+  id="scene"
+  metadata-url="/scenes/site.json"
+  tileset-url="https://example.test/site/primary/tileset.json">
+</honua-scene>
 <honua-scene-layers for="#scene"></honua-scene-layers>
 <honua-scene-bookmarks for="#scene"></honua-scene-bookmarks>
 <honua-scene-timeline for="#scene"></honua-scene-timeline>
@@ -173,6 +177,10 @@ the nearest preceding `<honua-scene>`).
 <honua-scene-inspector for="#scene"></honua-scene-inspector>
 <honua-scene-measure for="#scene"></honua-scene-measure>
 ```
+
+`metadata-url` carries the control content (layers/bookmarks/timeline/
+compare/inspector); `tileset-url`, `terrain-url`, or a configured offline
+package still has to be set for the primary 3D Tiles dataset to load.
 
 See the [Scene Controls guide](../../docs/guides/scene-controls.md) for the
 metadata schema, control composition recipes, and the full typed event

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -109,6 +109,7 @@ scene.setAttribute('package-expires-at', manifest.offlineUseExpiresAtUtc);
 | `package-expires-at` | Offline-use expiry timestamp. Expired packages emit `expired-package`. |
 | `ion-token` | Optional Cesium ion token. It is not rendered. |
 | `cesium-base-url` | Optional URL for hosted Cesium `Assets`, `Workers`, `ThirdParty`, and `Widgets`. |
+| `metadata-url` | URL of a `honua-scene-metadata/v1` document. The scene fetches and parses it, then emits `honua-scene-metadata-change`. |
 | `center` | Initial latitude/longitude pair, for example `21.3069,-157.8583`. |
 | `height` | Initial camera height in meters. |
 | `heading` | Initial camera heading in degrees. |
@@ -116,6 +117,12 @@ scene.setAttribute('package-expires-at', manifest.offlineUseExpiresAtUtc);
 | `roll` | Initial camera roll in degrees. |
 | `autoload` | Set to `false`, `0`, or `no` to disable automatic loading. |
 | `theme` | `light` or `dark`. |
+
+`HonuaSceneElement` also exposes an imperative API: `metadata` (property),
+`applyView(view)`, `addLayer(metadata)`, `removeLayer(id)`,
+`setLayerVisibility(id, visible)`, `setLayerOpacity(id, opacity)`, and
+`getLayer(id)`. See the [Scene Controls guide](../../docs/guides/scene-controls.md)
+for the metadata shape and the full event reference.
 
 ## Events
 
@@ -130,7 +137,43 @@ scene.setAttribute('package-expires-at', manifest.offlineUseExpiresAtUtc);
 | `honua-scene-load-error` | `{ source, code, message, config, error }`. |
 | `honua-scene-camera-change` | `{ center, height, orientation, config }`. |
 | `honua-scene-identify` | `{ x, y, picked, config }`. |
+| `honua-scene-metadata-change` | `{ metadata, source }`. |
+| `honua-scene-metadata-error` | `{ url, code, message, path?, error? }`. |
+| `honua-scene-layer-change` | `{ layerId, reason, layer, visible, opacity }`. |
+| `honua-scene-layer-toggle` | `{ layerId, visible, controlId }` (from `<honua-scene-layers>`). |
+| `honua-scene-layer-opacity` | `{ layerId, opacity, controlId }`. |
+| `honua-scene-bookmark-apply` | `{ bookmarkId, view, controlId }`. |
+| `honua-scene-timeline-change` | `{ phaseId, startUtc, endUtc, visibleLayerIds, controlId }`. |
+| `honua-scene-compare-set` | `{ modeId, side, leftLayerIds, rightLayerIds, controlId }`. |
+| `honua-scene-feature-select` | `{ featureId, attributes, controlId }`. |
+| `honua-scene-measurement-add` | `{ measurementId, kind, points, distance?, area?, controlId }`. |
+| `honua-scene-measurement-clear` | `{ measurementId, controlId }`. |
+| `honua-scene-control-error` | `{ controlId, kind, message, error? }`. |
 | `honua-embed-extension-error` | `{ extensionId, target, lifecycle, error }`. |
+
+## Scene Controls
+
+`<honua-scene-layers>`, `<honua-scene-bookmarks>`, `<honua-scene-timeline>`,
+`<honua-scene-compare>`, `<honua-scene-inspector>`, and
+`<honua-scene-measure>` compose with `<honua-scene>` and consume a typed
+`HonuaSceneMetadata` document instead of hard-coded URLs. Bind a control to a
+scene with `for="<css-selector>"` (or place it as a sibling and let it resolve
+the nearest preceding `<honua-scene>`).
+
+```html
+<honua-scene id="scene" metadata-url="/scenes/site.json"></honua-scene>
+<honua-scene-layers for="#scene"></honua-scene-layers>
+<honua-scene-bookmarks for="#scene"></honua-scene-bookmarks>
+<honua-scene-timeline for="#scene"></honua-scene-timeline>
+<honua-scene-compare for="#scene"></honua-scene-compare>
+<honua-scene-inspector for="#scene"></honua-scene-inspector>
+<honua-scene-measure for="#scene"></honua-scene-measure>
+```
+
+See the [Scene Controls guide](../../docs/guides/scene-controls.md) for the
+metadata schema, control composition recipes, and the full typed event
+surface. The local `examples/scene-construction/` demo wires all six controls
+together against a public CesiumGS sample tileset.
 
 ## Generated Map Snippets
 

--- a/src/Honua.Embed/src/controls/bookmarks.ts
+++ b/src/Honua.Embed/src/controls/bookmarks.ts
@@ -1,0 +1,189 @@
+import type { HonuaSceneElement } from '../scene';
+import type {
+  HonuaSceneBookmarkMetadata,
+  HonuaSceneViewSpec,
+} from '../scene-metadata';
+import { HonuaSceneLink } from './scene-link';
+import {
+  CONTROL_BASE_STYLES,
+  controlTemplate,
+  upgradeProperty,
+} from './shared';
+
+export interface HonuaSceneBookmarkApplyDetail {
+  bookmarkId: string;
+  view: HonuaSceneViewSpec;
+  controlId: string;
+}
+
+const ELEMENT_NAME = 'honua-scene-bookmarks';
+const CONTROL_ID = 'bookmarks';
+
+const template = controlTemplate(`
+  ${CONTROL_BASE_STYLES}
+  <style>
+    .bookmark {
+      width: 100%;
+      text-align: left;
+    }
+
+    .bookmark-title {
+      font-weight: 500;
+    }
+
+    .bookmark-description {
+      color: var(--honua-control-muted);
+      font-size: 12px;
+    }
+
+    .empty {
+      color: var(--honua-control-muted);
+      font-style: italic;
+    }
+  </style>
+  <section class="control" part="control">
+    <header part="header">
+      <h2 class="title" part="title">Bookmarks</h2>
+    </header>
+    <div class="body" part="body">
+      <p class="empty" data-empty>No bookmarks for this scene yet.</p>
+      <ul class="list" part="list" hidden></ul>
+    </div>
+  </section>
+`);
+
+export class HonuaSceneBookmarksElement extends HTMLElement {
+  static get observedAttributes(): string[] {
+    return ['for', 'heading'];
+  }
+
+  readonly #root: ShadowRoot;
+  readonly #link: HonuaSceneLink;
+
+  constructor() {
+    super();
+    this.#root = this.attachShadow({ mode: 'open' });
+    this.#root.append(template.content.cloneNode(true));
+    this.#link = new HonuaSceneLink({
+      host: this,
+      controlId: CONTROL_ID,
+      onSceneChange: () => this.#render(),
+    });
+  }
+
+  connectedCallback(): void {
+    upgradeProperty(this, 'sceneSelector');
+    this.#applyHeading();
+    this.#link.connect();
+    this.#render();
+  }
+
+  disconnectedCallback(): void {
+    this.#link.disconnect();
+  }
+
+  attributeChangedCallback(name: string): void {
+    if (name === 'for') {
+      this.#link.refresh('attribute');
+      return;
+    }
+
+    if (name === 'heading') {
+      this.#applyHeading();
+    }
+  }
+
+  get scene(): HonuaSceneElement | null {
+    return this.#link.scene;
+  }
+
+  apply(bookmarkId: string): boolean {
+    const scene = this.#link.scene;
+    const bookmark = scene?.metadata?.bookmarks?.find((entry) => entry.id === bookmarkId);
+    if (!scene || !bookmark) {
+      this.#link.emitError('bookmark-not-found', `Unknown bookmark "${bookmarkId}".`);
+      return false;
+    }
+
+    scene.applyView(bookmark.view);
+    this.dispatchEvent(new CustomEvent<HonuaSceneBookmarkApplyDetail>('honua-scene-bookmark-apply', {
+      bubbles: true,
+      composed: true,
+      detail: { bookmarkId, view: bookmark.view, controlId: CONTROL_ID },
+    }));
+    return true;
+  }
+
+  refresh(): void {
+    this.#render();
+  }
+
+  #applyHeading(): void {
+    const heading = this.getAttribute('heading');
+    const node = this.#root.querySelector<HTMLElement>('.title');
+    if (node) {
+      node.textContent = heading ?? 'Bookmarks';
+    }
+  }
+
+  #render(): void {
+    const list = this.#root.querySelector<HTMLUListElement>('.list')!;
+    const empty = this.#root.querySelector<HTMLElement>('.empty')!;
+    list.replaceChildren();
+
+    const bookmarks = this.#link.scene?.metadata?.bookmarks ?? [];
+    if (bookmarks.length === 0) {
+      list.hidden = true;
+      empty.hidden = false;
+      return;
+    }
+
+    list.hidden = false;
+    empty.hidden = true;
+
+    for (const bookmark of bookmarks) {
+      list.append(this.#renderBookmark(bookmark));
+    }
+  }
+
+  #renderBookmark(bookmark: HonuaSceneBookmarkMetadata): HTMLLIElement {
+    const item = document.createElement('li');
+    item.dataset.bookmarkId = bookmark.id;
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'bookmark';
+    button.dataset.bookmarkId = bookmark.id;
+
+    const title = document.createElement('div');
+    title.className = 'bookmark-title';
+    title.textContent = bookmark.title;
+    button.append(title);
+
+    if (bookmark.description) {
+      const description = document.createElement('div');
+      description.className = 'bookmark-description';
+      description.textContent = bookmark.description;
+      button.append(description);
+    }
+
+    button.addEventListener('click', () => this.apply(bookmark.id));
+    item.append(button);
+    return item;
+  }
+}
+
+export function defineHonuaSceneBookmarksElement(name = ELEMENT_NAME): CustomElementConstructor {
+  const existing = customElements.get(name);
+  if (existing) {
+    return existing;
+  }
+  customElements.define(name, HonuaSceneBookmarksElement);
+  return HonuaSceneBookmarksElement;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'honua-scene-bookmarks': HonuaSceneBookmarksElement;
+  }
+}

--- a/src/Honua.Embed/src/controls/compare.ts
+++ b/src/Honua.Embed/src/controls/compare.ts
@@ -1,0 +1,276 @@
+import type { HonuaSceneElement } from '../scene';
+import type { HonuaSceneCompareMode } from '../scene-metadata';
+import { HonuaSceneLink } from './scene-link';
+import {
+  CONTROL_BASE_STYLES,
+  controlTemplate,
+  upgradeProperty,
+} from './shared';
+
+export interface HonuaSceneCompareSetDetail {
+  modeId: string;
+  side: 'left' | 'right' | 'both';
+  leftLayerIds: string[];
+  rightLayerIds: string[];
+  controlId: string;
+}
+
+const ELEMENT_NAME = 'honua-scene-compare';
+const CONTROL_ID = 'compare';
+
+const template = controlTemplate(`
+  ${CONTROL_BASE_STYLES}
+  <style>
+    .modes {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .mode {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      padding: 8px 10px;
+      border: 1px solid var(--honua-control-border);
+      border-radius: 6px;
+      background: var(--honua-control-surface);
+    }
+
+    .mode-title {
+      font-weight: 500;
+    }
+
+    .mode-buttons {
+      display: flex;
+      gap: 6px;
+    }
+
+    .mode-buttons button {
+      flex: 1;
+    }
+
+    .empty {
+      color: var(--honua-control-muted);
+      font-style: italic;
+    }
+  </style>
+  <section class="control" part="control">
+    <header part="header">
+      <h2 class="title" part="title">Compare</h2>
+    </header>
+    <div class="body" part="body">
+      <p class="empty" data-empty>No compare modes for this scene.</p>
+      <div class="modes" part="modes" hidden></div>
+    </div>
+  </section>
+`);
+
+export class HonuaSceneCompareElement extends HTMLElement {
+  static get observedAttributes(): string[] {
+    return ['for', 'heading', 'mode', 'side'];
+  }
+
+  readonly #root: ShadowRoot;
+  readonly #link: HonuaSceneLink;
+  #activeMode: string | null = null;
+  #activeSide: 'left' | 'right' | 'both' = 'both';
+
+  constructor() {
+    super();
+    this.#root = this.attachShadow({ mode: 'open' });
+    this.#root.append(template.content.cloneNode(true));
+    this.#link = new HonuaSceneLink({
+      host: this,
+      controlId: CONTROL_ID,
+      onSceneChange: () => this.#render(),
+    });
+  }
+
+  connectedCallback(): void {
+    upgradeProperty(this, 'sceneSelector');
+    this.#applyHeading();
+    this.#link.connect();
+    this.#render();
+  }
+
+  disconnectedCallback(): void {
+    this.#link.disconnect();
+  }
+
+  attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null): void {
+    if (name === 'for') {
+      this.#link.refresh('attribute');
+      return;
+    }
+
+    if (name === 'heading') {
+      this.#applyHeading();
+      return;
+    }
+
+    if (name === 'mode' && newValue && newValue !== this.#activeMode) {
+      this.activate(newValue, this.#activeSide);
+      return;
+    }
+
+    if (name === 'side' && newValue) {
+      const side = (['left', 'right', 'both'] as const).includes(newValue as 'left' | 'right' | 'both')
+        ? (newValue as 'left' | 'right' | 'both')
+        : 'both';
+      if (side !== this.#activeSide && this.#activeMode) {
+        this.activate(this.#activeMode, side);
+      }
+    }
+  }
+
+  get scene(): HonuaSceneElement | null {
+    return this.#link.scene;
+  }
+
+  get activeModeId(): string | null {
+    return this.#activeMode;
+  }
+
+  get activeSide(): 'left' | 'right' | 'both' {
+    return this.#activeSide;
+  }
+
+  activate(modeId: string, side: 'left' | 'right' | 'both' = 'both'): boolean {
+    const scene = this.#link.scene;
+    const modes = scene?.metadata?.compare?.modes ?? [];
+    const mode = modes.find((entry) => entry.id === modeId);
+    if (!scene || !mode) {
+      this.#link.emitError('mode-not-found', `Unknown compare mode "${modeId}".`);
+      return false;
+    }
+
+    this.#activeMode = modeId;
+    this.#activeSide = side;
+    this.#applyVisibility(scene, mode, side);
+    this.#renderActiveState();
+
+    this.dispatchEvent(new CustomEvent<HonuaSceneCompareSetDetail>('honua-scene-compare-set', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        modeId,
+        side,
+        leftLayerIds: [...mode.leftLayerIds],
+        rightLayerIds: [...mode.rightLayerIds],
+        controlId: CONTROL_ID,
+      },
+    }));
+    return true;
+  }
+
+  refresh(): void {
+    this.#render();
+  }
+
+  #applyHeading(): void {
+    const heading = this.getAttribute('heading');
+    const node = this.#root.querySelector<HTMLElement>('.title');
+    if (node) {
+      node.textContent = heading ?? 'Compare';
+    }
+  }
+
+  #render(): void {
+    const modesEl = this.#root.querySelector<HTMLElement>('.modes')!;
+    const empty = this.#root.querySelector<HTMLElement>('.empty')!;
+    modesEl.replaceChildren();
+
+    const modes = this.#link.scene?.metadata?.compare?.modes ?? [];
+    if (modes.length === 0) {
+      modesEl.hidden = true;
+      empty.hidden = false;
+      return;
+    }
+
+    modesEl.hidden = false;
+    empty.hidden = true;
+
+    for (const mode of modes) {
+      modesEl.append(this.#renderMode(mode));
+    }
+    this.#renderActiveState();
+  }
+
+  #renderMode(mode: HonuaSceneCompareMode): HTMLDivElement {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'mode';
+    wrapper.dataset.modeId = mode.id;
+
+    const title = document.createElement('div');
+    title.className = 'mode-title';
+    title.textContent = mode.title;
+    wrapper.append(title);
+
+    if (mode.description) {
+      const description = document.createElement('div');
+      description.className = 'mode-description';
+      description.textContent = mode.description;
+      wrapper.append(description);
+    }
+
+    const buttons = document.createElement('div');
+    buttons.className = 'mode-buttons';
+
+    for (const side of ['left', 'right', 'both'] as const) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.dataset.modeId = mode.id;
+      button.dataset.side = side;
+      button.textContent = side === 'both' ? 'Both' : side === 'left' ? 'Design' : 'As-built';
+      button.addEventListener('click', () => this.activate(mode.id, side));
+      buttons.append(button);
+    }
+
+    wrapper.append(buttons);
+    return wrapper;
+  }
+
+  #renderActiveState(): void {
+    const buttons = this.#root.querySelectorAll<HTMLButtonElement>('.mode-buttons button');
+    for (const button of buttons) {
+      const matches =
+        button.dataset.modeId === this.#activeMode && button.dataset.side === this.#activeSide;
+      button.setAttribute('aria-pressed', String(matches));
+    }
+  }
+
+  #applyVisibility(
+    scene: HonuaSceneElement,
+    mode: HonuaSceneCompareMode,
+    side: 'left' | 'right' | 'both',
+  ): void {
+    const visible = new Set<string>();
+    if (side === 'left' || side === 'both') {
+      mode.leftLayerIds.forEach((id) => visible.add(id));
+    }
+    if (side === 'right' || side === 'both') {
+      mode.rightLayerIds.forEach((id) => visible.add(id));
+    }
+
+    const layers = scene.metadata?.layers ?? [];
+    for (const layer of layers) {
+      scene.setLayerVisibility(layer.id, visible.has(layer.id));
+    }
+  }
+}
+
+export function defineHonuaSceneCompareElement(name = ELEMENT_NAME): CustomElementConstructor {
+  const existing = customElements.get(name);
+  if (existing) {
+    return existing;
+  }
+  customElements.define(name, HonuaSceneCompareElement);
+  return HonuaSceneCompareElement;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'honua-scene-compare': HonuaSceneCompareElement;
+  }
+}

--- a/src/Honua.Embed/src/controls/compare.ts
+++ b/src/Honua.Embed/src/controls/compare.ts
@@ -4,6 +4,7 @@ import { HonuaSceneLink } from './scene-link';
 import {
   CONTROL_BASE_STYLES,
   controlTemplate,
+  resolveControlLayerIds,
   upgradeProperty,
 } from './shared';
 
@@ -253,9 +254,8 @@ export class HonuaSceneCompareElement extends HTMLElement {
       mode.rightLayerIds.forEach((id) => visible.add(id));
     }
 
-    const layers = scene.metadata?.layers ?? [];
-    for (const layer of layers) {
-      scene.setLayerVisibility(layer.id, visible.has(layer.id));
+    for (const id of resolveControlLayerIds(scene)) {
+      scene.setLayerVisibility(id, visible.has(id));
     }
   }
 }

--- a/src/Honua.Embed/src/controls/index.ts
+++ b/src/Honua.Embed/src/controls/index.ts
@@ -1,0 +1,56 @@
+export {
+  HonuaSceneLayersElement,
+  defineHonuaSceneLayersElement,
+  type HonuaSceneLayerOpacityDetail,
+  type HonuaSceneLayerToggleDetail,
+} from './layers';
+export {
+  HonuaSceneBookmarksElement,
+  defineHonuaSceneBookmarksElement,
+  type HonuaSceneBookmarkApplyDetail,
+} from './bookmarks';
+export {
+  HonuaSceneTimelineElement,
+  defineHonuaSceneTimelineElement,
+  type HonuaSceneTimelineChangeDetail,
+} from './timeline';
+export {
+  HonuaSceneCompareElement,
+  defineHonuaSceneCompareElement,
+  type HonuaSceneCompareSetDetail,
+} from './compare';
+export {
+  HonuaSceneInspectorElement,
+  defineHonuaSceneInspectorElement,
+  type HonuaSceneFeatureSelectDetail,
+} from './inspector';
+export {
+  HonuaSceneMeasureElement,
+  defineHonuaSceneMeasureElement,
+  type HonuaSceneMeasurementAddDetail,
+  type HonuaSceneMeasurementClearDetail,
+  type HonuaSceneMeasurementKind,
+  type HonuaSceneMeasurementPoint,
+} from './measure';
+export {
+  HonuaSceneLink,
+  type HonuaSceneControlErrorDetail,
+  type HonuaSceneLinkChangeReason,
+  type HonuaSceneLinkOptions,
+} from './scene-link';
+
+import { defineHonuaSceneBookmarksElement } from './bookmarks';
+import { defineHonuaSceneCompareElement } from './compare';
+import { defineHonuaSceneInspectorElement } from './inspector';
+import { defineHonuaSceneLayersElement } from './layers';
+import { defineHonuaSceneMeasureElement } from './measure';
+import { defineHonuaSceneTimelineElement } from './timeline';
+
+export function defineHonuaSceneControls(): void {
+  defineHonuaSceneLayersElement();
+  defineHonuaSceneBookmarksElement();
+  defineHonuaSceneTimelineElement();
+  defineHonuaSceneCompareElement();
+  defineHonuaSceneInspectorElement();
+  defineHonuaSceneMeasureElement();
+}

--- a/src/Honua.Embed/src/controls/inspector.ts
+++ b/src/Honua.Embed/src/controls/inspector.ts
@@ -198,10 +198,38 @@ function readPickedAttributes(
   }
 
   const accessor = (picked as { getProperty?: (key: string) => unknown }).getProperty;
+  const idsAccessor = (picked as { getPropertyIds?: () => string[] }).getPropertyIds;
   const properties = (picked as { properties?: Record<string, unknown> }).properties;
   const direct = picked as Record<string, unknown>;
 
   if (fields.length === 0) {
+    if (typeof accessor === 'function' && typeof idsAccessor === 'function') {
+      let ids: string[] | undefined;
+      try {
+        ids = idsAccessor.call(picked);
+      } catch {
+        ids = undefined;
+      }
+      if (Array.isArray(ids)) {
+        for (const key of ids) {
+          if (typeof key !== 'string') {
+            continue;
+          }
+          try {
+            const value = accessor.call(picked, key);
+            if (value !== undefined) {
+              result[key] = value;
+            }
+          } catch {
+            /* getProperty may throw for missing keys on some renderers */
+          }
+        }
+        if (Object.keys(result).length > 0) {
+          return result;
+        }
+      }
+    }
+
     if (properties && typeof properties === 'object') {
       for (const [key, value] of Object.entries(properties)) {
         result[key] = value;

--- a/src/Honua.Embed/src/controls/inspector.ts
+++ b/src/Honua.Embed/src/controls/inspector.ts
@@ -1,0 +1,291 @@
+import type {
+  HonuaSceneElement,
+  HonuaSceneIdentifyDetail,
+} from '../scene';
+import type { HonuaSceneInspectorField } from '../scene-metadata';
+import { HonuaSceneLink } from './scene-link';
+import {
+  CONTROL_BASE_STYLES,
+  controlTemplate,
+  upgradeProperty,
+} from './shared';
+
+export interface HonuaSceneFeatureSelectDetail {
+  featureId: string | null;
+  attributes: Record<string, unknown>;
+  controlId: string;
+}
+
+const ELEMENT_NAME = 'honua-scene-inspector';
+const CONTROL_ID = 'inspector';
+
+const template = controlTemplate(`
+  ${CONTROL_BASE_STYLES}
+  <style>
+    dl {
+      margin: 0;
+      display: grid;
+      grid-template-columns: max-content 1fr;
+      gap: 4px 12px;
+    }
+
+    dt {
+      color: var(--honua-control-muted);
+      font-size: 12px;
+      font-weight: 500;
+    }
+
+    dd {
+      margin: 0;
+      color: var(--honua-control-foreground);
+      font-size: 13px;
+      word-break: break-word;
+    }
+
+    .empty {
+      color: var(--honua-control-muted);
+      font-style: italic;
+    }
+  </style>
+  <section class="control" part="control">
+    <header part="header">
+      <h2 class="title" part="title">Inspector</h2>
+    </header>
+    <div class="body" part="body">
+      <p class="empty" data-empty>Click a feature to inspect attributes.</p>
+      <dl class="fields" part="fields" hidden></dl>
+    </div>
+  </section>
+`);
+
+export class HonuaSceneInspectorElement extends HTMLElement {
+  static get observedAttributes(): string[] {
+    return ['for', 'heading'];
+  }
+
+  readonly #root: ShadowRoot;
+  readonly #link: HonuaSceneLink;
+  readonly #handleIdentify = (event: Event) => this.#onIdentify(event as CustomEvent<HonuaSceneIdentifyDetail>);
+  #attributes: Record<string, unknown> | null = null;
+  #featureId: string | null = null;
+
+  constructor() {
+    super();
+    this.#root = this.attachShadow({ mode: 'open' });
+    this.#root.append(template.content.cloneNode(true));
+    this.#link = new HonuaSceneLink({
+      host: this,
+      controlId: CONTROL_ID,
+      onSceneChange: () => this.#render(),
+      forwardEvents: ['honua-scene-identify'],
+      onForwardedEvent: this.#handleIdentify,
+    });
+  }
+
+  connectedCallback(): void {
+    upgradeProperty(this, 'sceneSelector');
+    this.#applyHeading();
+    this.#link.connect();
+    this.#render();
+  }
+
+  disconnectedCallback(): void {
+    this.#link.disconnect();
+  }
+
+  attributeChangedCallback(name: string): void {
+    if (name === 'for') {
+      this.#link.refresh('attribute');
+      return;
+    }
+
+    if (name === 'heading') {
+      this.#applyHeading();
+    }
+  }
+
+  get scene(): HonuaSceneElement | null {
+    return this.#link.scene;
+  }
+
+  get featureId(): string | null {
+    return this.#featureId;
+  }
+
+  get featureAttributes(): Record<string, unknown> | null {
+    return this.#attributes ? { ...this.#attributes } : null;
+  }
+
+  setFeature(featureId: string | null, attributes: Record<string, unknown>): void {
+    this.#featureId = featureId;
+    this.#attributes = { ...attributes };
+    this.#render();
+    this.dispatchEvent(new CustomEvent<HonuaSceneFeatureSelectDetail>('honua-scene-feature-select', {
+      bubbles: true,
+      composed: true,
+      detail: { featureId, attributes: { ...attributes }, controlId: CONTROL_ID },
+    }));
+  }
+
+  clearFeature(): void {
+    this.#featureId = null;
+    this.#attributes = null;
+    this.#render();
+  }
+
+  refresh(): void {
+    this.#render();
+  }
+
+  #applyHeading(): void {
+    const heading = this.getAttribute('heading');
+    const node = this.#root.querySelector<HTMLElement>('.title');
+    if (node) {
+      node.textContent = heading ?? 'Inspector';
+    }
+  }
+
+  #onIdentify(event: CustomEvent<HonuaSceneIdentifyDetail>): void {
+    const fields = this.#link.scene?.metadata?.inspector?.fields ?? [];
+    const picked = event.detail.picked;
+    if (!picked) {
+      this.clearFeature();
+      return;
+    }
+
+    const attributes = readPickedAttributes(picked, fields);
+    const id = readPickedId(picked) ?? null;
+    this.setFeature(id, attributes);
+  }
+
+  #render(): void {
+    const fieldsEl = this.#root.querySelector<HTMLDListElement>('.fields')!;
+    const empty = this.#root.querySelector<HTMLElement>('.empty')!;
+    fieldsEl.replaceChildren();
+
+    if (!this.#attributes) {
+      fieldsEl.hidden = true;
+      empty.hidden = false;
+      return;
+    }
+
+    const fields = this.#link.scene?.metadata?.inspector?.fields ?? defaultFields(this.#attributes);
+    fieldsEl.hidden = false;
+    empty.hidden = true;
+
+    for (const field of fields) {
+      const value = this.#attributes[field.key];
+      if (value === undefined || value === null) {
+        continue;
+      }
+      const term = document.createElement('dt');
+      term.textContent = field.title;
+      const def = document.createElement('dd');
+      def.textContent = formatValue(value, field);
+      fieldsEl.append(term, def);
+    }
+  }
+}
+
+function readPickedAttributes(
+  picked: unknown,
+  fields: HonuaSceneInspectorField[],
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  if (typeof picked !== 'object' || picked === null) {
+    return result;
+  }
+
+  const accessor = (picked as { getProperty?: (key: string) => unknown }).getProperty;
+  const properties = (picked as { properties?: Record<string, unknown> }).properties;
+  const direct = picked as Record<string, unknown>;
+
+  if (fields.length === 0) {
+    if (properties && typeof properties === 'object') {
+      for (const [key, value] of Object.entries(properties)) {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+
+  for (const field of fields) {
+    let value: unknown;
+    if (typeof accessor === 'function') {
+      try {
+        value = accessor.call(picked, field.key);
+      } catch {
+        value = undefined;
+      }
+    } else if (properties && Object.prototype.hasOwnProperty.call(properties, field.key)) {
+      value = properties[field.key];
+    } else if (Object.prototype.hasOwnProperty.call(direct, field.key)) {
+      value = direct[field.key];
+    }
+
+    if (value !== undefined) {
+      result[field.key] = value;
+    }
+  }
+
+  return result;
+}
+
+function readPickedId(picked: unknown): string | undefined {
+  if (typeof picked !== 'object' || picked === null) {
+    return undefined;
+  }
+
+  const candidate =
+    (picked as { id?: unknown }).id ??
+    (picked as { featureId?: unknown }).featureId;
+
+  if (typeof candidate === 'string') {
+    return candidate;
+  }
+  if (typeof candidate === 'number') {
+    return String(candidate);
+  }
+  return undefined;
+}
+
+function formatValue(value: unknown, field: HonuaSceneInspectorField): string {
+  if (field.format === 'date' && typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) {
+      return new Date(parsed).toISOString();
+    }
+  }
+
+  if (field.format === 'number' && typeof value === 'number') {
+    return field.unit ? `${value} ${field.unit}` : String(value);
+  }
+
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+
+  return field.unit && typeof value === 'number'
+    ? `${value} ${field.unit}`
+    : String(value);
+}
+
+function defaultFields(attributes: Record<string, unknown>): HonuaSceneInspectorField[] {
+  return Object.keys(attributes).map((key) => ({ key, title: key }));
+}
+
+export function defineHonuaSceneInspectorElement(name = ELEMENT_NAME): CustomElementConstructor {
+  const existing = customElements.get(name);
+  if (existing) {
+    return existing;
+  }
+  customElements.define(name, HonuaSceneInspectorElement);
+  return HonuaSceneInspectorElement;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'honua-scene-inspector': HonuaSceneInspectorElement;
+  }
+}

--- a/src/Honua.Embed/src/controls/layers.ts
+++ b/src/Honua.Embed/src/controls/layers.ts
@@ -1,0 +1,272 @@
+import type {
+  HonuaSceneElement,
+  HonuaSceneLayerChangeDetail,
+} from '../scene';
+import type { HonuaSceneLayerMetadata } from '../scene-metadata';
+import { HonuaSceneLink, type HonuaSceneControlErrorDetail } from './scene-link';
+import {
+  CONTROL_BASE_STYLES,
+  controlTemplate,
+  upgradeProperty,
+} from './shared';
+
+export interface HonuaSceneLayerToggleDetail {
+  layerId: string;
+  visible: boolean;
+  controlId: string;
+}
+
+export interface HonuaSceneLayerOpacityDetail {
+  layerId: string;
+  opacity: number;
+  controlId: string;
+}
+
+const ELEMENT_NAME = 'honua-scene-layers';
+const CONTROL_ID = 'layers';
+
+const template = controlTemplate(`
+  ${CONTROL_BASE_STYLES}
+  <style>
+    .layer {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      padding: 8px 10px;
+      border: 1px solid var(--honua-control-border);
+      border-radius: 6px;
+      background: var(--honua-control-surface);
+    }
+
+    .layer-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .layer-title {
+      flex: 1;
+      font-weight: 500;
+      color: var(--honua-control-foreground);
+    }
+
+    .layer-description {
+      color: var(--honua-control-muted);
+      font-size: 12px;
+    }
+
+    input[type="range"] {
+      width: 100%;
+    }
+
+    .empty {
+      color: var(--honua-control-muted);
+      font-style: italic;
+    }
+  </style>
+  <section class="control" part="control">
+    <header part="header">
+      <h2 class="title" part="title">Layers</h2>
+    </header>
+    <div class="body" part="body" data-empty="true">
+      <p class="empty" data-empty>No layers in this scene yet.</p>
+      <ul class="list" part="list" hidden></ul>
+    </div>
+  </section>
+`);
+
+export class HonuaSceneLayersElement extends HTMLElement {
+  static get observedAttributes(): string[] {
+    return ['for', 'heading'];
+  }
+
+  readonly #root: ShadowRoot;
+  readonly #link: HonuaSceneLink;
+  readonly #handleLayerChange = (event: Event) => {
+    void event;
+    this.#render();
+  };
+
+  constructor() {
+    super();
+    this.#root = this.attachShadow({ mode: 'open' });
+    this.#root.append(template.content.cloneNode(true));
+    this.#link = new HonuaSceneLink({
+      host: this,
+      controlId: CONTROL_ID,
+      onSceneChange: () => this.#render(),
+      forwardEvents: ['honua-scene-layer-change'],
+      onForwardedEvent: this.#handleLayerChange,
+    });
+  }
+
+  connectedCallback(): void {
+    upgradeProperty(this, 'sceneSelector');
+    this.#applyHeading();
+    this.#link.connect();
+    this.#render();
+  }
+
+  disconnectedCallback(): void {
+    this.#link.disconnect();
+  }
+
+  attributeChangedCallback(name: string): void {
+    if (name === 'for') {
+      this.#link.refresh('attribute');
+      return;
+    }
+
+    if (name === 'heading') {
+      this.#applyHeading();
+    }
+  }
+
+  get scene(): HonuaSceneElement | null {
+    return this.#link.scene;
+  }
+
+  refresh(): void {
+    this.#render();
+  }
+
+  #applyHeading(): void {
+    const heading = this.getAttribute('heading');
+    const node = this.#root.querySelector<HTMLElement>('.title');
+    if (node) {
+      node.textContent = heading ?? 'Layers';
+    }
+  }
+
+  #render(): void {
+    const scene = this.#link.scene;
+    const list = this.#root.querySelector<HTMLUListElement>('.list')!;
+    const empty = this.#root.querySelector<HTMLElement>('.empty')!;
+    const body = this.#root.querySelector<HTMLElement>('.body')!;
+    list.replaceChildren();
+
+    const layers = listLayers(scene);
+    if (!scene || layers.length === 0) {
+      list.hidden = true;
+      empty.hidden = false;
+      body.dataset.empty = 'true';
+      return;
+    }
+
+    list.hidden = false;
+    empty.hidden = true;
+    body.dataset.empty = 'false';
+
+    for (const layer of layers) {
+      list.append(this.#renderLayer(layer));
+    }
+  }
+
+  #renderLayer(layer: HonuaSceneLayerMetadata): HTMLLIElement {
+    const item = document.createElement('li');
+    item.className = 'layer';
+    item.dataset.layerId = layer.id;
+
+    const row = document.createElement('div');
+    row.className = 'layer-row';
+
+    const visibleInput = document.createElement('input');
+    visibleInput.type = 'checkbox';
+    visibleInput.id = `honua-scene-layer-${layer.id}`;
+    visibleInput.checked = this.scene?.getLayer(layer.id)?.visible ?? layer.visible ?? true;
+    visibleInput.addEventListener('change', () => {
+      this.#emitToggle(layer.id, visibleInput.checked);
+    });
+
+    const labelEl = document.createElement('label');
+    labelEl.htmlFor = visibleInput.id;
+    labelEl.className = 'layer-title';
+    labelEl.textContent = layer.title;
+
+    row.append(visibleInput, labelEl);
+    item.append(row);
+
+    if (layer.description) {
+      const description = document.createElement('p');
+      description.className = 'layer-description';
+      description.textContent = layer.description;
+      item.append(description);
+    }
+
+    const opacityInput = document.createElement('input');
+    opacityInput.type = 'range';
+    opacityInput.min = '0';
+    opacityInput.max = '1';
+    opacityInput.step = '0.05';
+    opacityInput.value = String(this.scene?.getLayer(layer.id)?.opacity ?? layer.opacity ?? 1);
+    opacityInput.setAttribute('aria-label', `Opacity for ${layer.title}`);
+    opacityInput.addEventListener('input', () => {
+      this.#emitOpacity(layer.id, Number(opacityInput.value));
+    });
+    item.append(opacityInput);
+
+    return item;
+  }
+
+  #emitToggle(layerId: string, visible: boolean): void {
+    const scene = this.#link.scene;
+    if (!scene) {
+      this.#link.emitError('no-scene', 'Layers control is not bound to a <honua-scene>.');
+      return;
+    }
+
+    if (!scene.setLayerVisibility(layerId, visible)) {
+      this.#link.emitError('layer-not-found', `Unknown layer "${layerId}".`);
+      return;
+    }
+
+    this.dispatchEvent(new CustomEvent<HonuaSceneLayerToggleDetail>('honua-scene-layer-toggle', {
+      bubbles: true,
+      composed: true,
+      detail: { layerId, visible, controlId: CONTROL_ID },
+    }));
+  }
+
+  #emitOpacity(layerId: string, opacity: number): void {
+    const scene = this.#link.scene;
+    if (!scene) {
+      this.#link.emitError('no-scene', 'Layers control is not bound to a <honua-scene>.');
+      return;
+    }
+
+    if (!scene.setLayerOpacity(layerId, opacity)) {
+      this.#link.emitError('layer-not-found', `Unknown layer "${layerId}".`);
+      return;
+    }
+
+    this.dispatchEvent(new CustomEvent<HonuaSceneLayerOpacityDetail>('honua-scene-layer-opacity', {
+      bubbles: true,
+      composed: true,
+      detail: { layerId, opacity, controlId: CONTROL_ID },
+    }));
+  }
+}
+
+function listLayers(scene: HonuaSceneElement | null): HonuaSceneLayerMetadata[] {
+  if (!scene) {
+    return [];
+  }
+  return scene.metadata?.layers ?? [];
+}
+
+export function defineHonuaSceneLayersElement(name = ELEMENT_NAME): CustomElementConstructor {
+  const existing = customElements.get(name);
+  if (existing) {
+    return existing;
+  }
+  customElements.define(name, HonuaSceneLayersElement);
+  return HonuaSceneLayersElement;
+}
+
+export type { HonuaSceneControlErrorDetail, HonuaSceneLayerChangeDetail };
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'honua-scene-layers': HonuaSceneLayersElement;
+  }
+}

--- a/src/Honua.Embed/src/controls/measure.ts
+++ b/src/Honua.Embed/src/controls/measure.ts
@@ -31,6 +31,12 @@ export interface HonuaSceneMeasurementClearDetail {
 const ELEMENT_NAME = 'honua-scene-measure';
 const CONTROL_ID = 'measure';
 
+const MINIMUM_POINTS: Record<HonuaSceneMeasurementKind, number> = {
+  point: 1,
+  line: 2,
+  polygon: 3,
+};
+
 const template = controlTemplate(`
   ${CONTROL_BASE_STYLES}
   <style>
@@ -143,7 +149,16 @@ export class HonuaSceneMeasureElement extends HTMLElement {
   }
 
   finalize(): boolean {
-    if (!this.#activeKind || this.#points.length === 0) {
+    if (!this.#activeKind) {
+      return false;
+    }
+
+    const required = MINIMUM_POINTS[this.#activeKind];
+    if (this.#points.length < required) {
+      this.#link.emitError(
+        'insufficient-points',
+        `${this.#activeKind} measurement requires at least ${required} point${required === 1 ? '' : 's'}.`,
+      );
       return false;
     }
 
@@ -154,11 +169,11 @@ export class HonuaSceneMeasureElement extends HTMLElement {
       controlId: CONTROL_ID,
     };
 
-    if (this.#activeKind === 'line' && this.#points.length >= 2) {
+    if (this.#activeKind === 'line') {
       detail.distance = computeDistance(this.#points);
     }
 
-    if (this.#activeKind === 'polygon' && this.#points.length >= 3) {
+    if (this.#activeKind === 'polygon') {
       detail.area = computeArea(this.#points);
     }
 

--- a/src/Honua.Embed/src/controls/measure.ts
+++ b/src/Honua.Embed/src/controls/measure.ts
@@ -276,79 +276,57 @@ function readMeasurementPoint(
   scene: HonuaSceneElement | null,
   event: CustomEvent,
 ): HonuaSceneMeasurementPoint | null {
-  const detail = event.detail as { picked?: unknown; x?: number; y?: number } | undefined;
+  const detail = event.detail as
+    | {
+        picked?: unknown;
+        x?: number;
+        y?: number;
+        position?: { latitude?: number; longitude?: number; height?: number } | null;
+      }
+    | undefined;
   if (!detail) {
     return null;
   }
 
-  const widget = scene?.cesiumWidget as
-    | {
-        scene: {
-          pickPosition?: (position: { x: number; y: number }) => unknown;
-        };
-      }
-    | null
-    | undefined;
-
-  const cesium = (globalThis as { Cesium?: unknown }).Cesium;
-
-  if (widget?.scene?.pickPosition && detail.x !== undefined && detail.y !== undefined) {
-    try {
-      const cartesian = widget.scene.pickPosition({ x: detail.x, y: detail.y });
-      const cartographic = cartesianToCartographic(cartesian, cesium);
-      if (cartographic) {
-        return cartographic;
-      }
-    } catch {
-      /* fall through */
-    }
+  const fromDetail = readPointFromCandidate(detail.position);
+  if (fromDetail) {
+    return fromDetail;
   }
 
-  if (detail.picked && typeof detail.picked === 'object') {
-    const position = (detail.picked as { position?: { latitude?: number; longitude?: number; height?: number } }).position;
-    if (
-      position &&
-      typeof position.latitude === 'number' &&
-      typeof position.longitude === 'number'
-    ) {
-      return {
-        latitude: position.latitude,
-        longitude: position.longitude,
-        height: position.height ?? 0,
-      };
+  const fromPicked =
+    detail.picked && typeof detail.picked === 'object'
+      ? readPointFromCandidate(
+          (detail.picked as { position?: unknown }).position,
+        )
+      : null;
+  if (fromPicked) {
+    return fromPicked;
+  }
+
+  if (scene && typeof detail.x === 'number' && typeof detail.y === 'number') {
+    const sampled = scene.samplePoint(detail.x, detail.y);
+    if (sampled) {
+      return sampled;
     }
   }
 
   return null;
 }
 
-function cartesianToCartographic(
-  cartesian: unknown,
-  cesium: unknown,
-): HonuaSceneMeasurementPoint | null {
-  if (!cartesian || !cesium || typeof cesium !== 'object') {
+function readPointFromCandidate(value: unknown): HonuaSceneMeasurementPoint | null {
+  if (!value || typeof value !== 'object') {
     return null;
   }
 
-  const cartographicFactory = (cesium as {
-    Cartographic?: { fromCartesian?: (value: unknown) => { latitude: number; longitude: number; height: number } };
-    Math?: { toDegrees?: (value: number) => number };
-  });
-
-  const cartographic = cartographicFactory.Cartographic?.fromCartesian?.(cartesian);
-  if (!cartographic) {
-    return null;
-  }
-
-  const toDegrees = cartographicFactory.Math?.toDegrees;
-  if (!toDegrees) {
+  const candidate = value as { latitude?: unknown; longitude?: unknown; height?: unknown };
+  if (typeof candidate.latitude !== 'number' || typeof candidate.longitude !== 'number') {
     return null;
   }
 
   return {
-    latitude: toDegrees(cartographic.latitude),
-    longitude: toDegrees(cartographic.longitude),
-    height: cartographic.height,
+    latitude: candidate.latitude,
+    longitude: candidate.longitude,
+    height: typeof candidate.height === 'number' ? candidate.height : 0,
   };
 }
 

--- a/src/Honua.Embed/src/controls/measure.ts
+++ b/src/Honua.Embed/src/controls/measure.ts
@@ -101,6 +101,7 @@ export class HonuaSceneMeasureElement extends HTMLElement {
     super();
     this.#root = this.attachShadow({ mode: 'open' });
     this.#root.append(template.content.cloneNode(true));
+    this.#wireControls();
     this.#link = new HonuaSceneLink({
       host: this,
       controlId: CONTROL_ID,
@@ -113,7 +114,6 @@ export class HonuaSceneMeasureElement extends HTMLElement {
   connectedCallback(): void {
     upgradeProperty(this, 'sceneSelector');
     this.#applyHeading();
-    this.#wireControls();
     this.#link.connect();
     this.#renderActiveState();
   }

--- a/src/Honua.Embed/src/controls/measure.ts
+++ b/src/Honua.Embed/src/controls/measure.ts
@@ -1,0 +1,416 @@
+import type { HonuaSceneElement } from '../scene';
+import { HonuaSceneLink } from './scene-link';
+import {
+  CONTROL_BASE_STYLES,
+  controlTemplate,
+  upgradeProperty,
+} from './shared';
+
+export type HonuaSceneMeasurementKind = 'point' | 'line' | 'polygon';
+
+export interface HonuaSceneMeasurementPoint {
+  latitude: number;
+  longitude: number;
+  height: number;
+}
+
+export interface HonuaSceneMeasurementAddDetail {
+  measurementId: string;
+  kind: HonuaSceneMeasurementKind;
+  points: HonuaSceneMeasurementPoint[];
+  distance?: number;
+  area?: number;
+  controlId: string;
+}
+
+export interface HonuaSceneMeasurementClearDetail {
+  measurementId: string | 'all';
+  controlId: string;
+}
+
+const ELEMENT_NAME = 'honua-scene-measure';
+const CONTROL_ID = 'measure';
+
+const template = controlTemplate(`
+  ${CONTROL_BASE_STYLES}
+  <style>
+    .modes {
+      display: flex;
+      gap: 6px;
+    }
+
+    .modes button {
+      flex: 1;
+    }
+
+    .summary {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      color: var(--honua-control-foreground);
+      font-size: 13px;
+    }
+
+    .summary span {
+      color: var(--honua-control-muted);
+      font-size: 12px;
+    }
+
+    .empty {
+      color: var(--honua-control-muted);
+      font-style: italic;
+    }
+  </style>
+  <section class="control" part="control">
+    <header part="header">
+      <h2 class="title" part="title">Measure</h2>
+      <button type="button" class="clear" part="clear">Clear</button>
+    </header>
+    <div class="body" part="body">
+      <div class="modes" part="modes">
+        <button type="button" data-kind="point" aria-pressed="false">Point</button>
+        <button type="button" data-kind="line" aria-pressed="false">Distance</button>
+        <button type="button" data-kind="polygon" aria-pressed="false">Area</button>
+      </div>
+      <div class="summary" part="summary">
+        <p class="empty" data-empty>Choose a tool, then click in the scene to measure.</p>
+      </div>
+    </div>
+  </section>
+`);
+
+export class HonuaSceneMeasureElement extends HTMLElement {
+  static get observedAttributes(): string[] {
+    return ['for', 'heading'];
+  }
+
+  readonly #root: ShadowRoot;
+  readonly #link: HonuaSceneLink;
+  readonly #handleIdentify = (event: Event) => this.#onIdentify(event as CustomEvent);
+  #activeKind: HonuaSceneMeasurementKind | null = null;
+  #points: HonuaSceneMeasurementPoint[] = [];
+  #counter = 0;
+
+  constructor() {
+    super();
+    this.#root = this.attachShadow({ mode: 'open' });
+    this.#root.append(template.content.cloneNode(true));
+    this.#link = new HonuaSceneLink({
+      host: this,
+      controlId: CONTROL_ID,
+      onSceneChange: () => this.#renderActiveState(),
+      forwardEvents: ['honua-scene-identify'],
+      onForwardedEvent: this.#handleIdentify,
+    });
+  }
+
+  connectedCallback(): void {
+    upgradeProperty(this, 'sceneSelector');
+    this.#applyHeading();
+    this.#wireControls();
+    this.#link.connect();
+    this.#renderActiveState();
+  }
+
+  disconnectedCallback(): void {
+    this.#link.disconnect();
+  }
+
+  attributeChangedCallback(name: string): void {
+    if (name === 'for') {
+      this.#link.refresh('attribute');
+      return;
+    }
+
+    if (name === 'heading') {
+      this.#applyHeading();
+    }
+  }
+
+  get scene(): HonuaSceneElement | null {
+    return this.#link.scene;
+  }
+
+  get activeKind(): HonuaSceneMeasurementKind | null {
+    return this.#activeKind;
+  }
+
+  selectKind(kind: HonuaSceneMeasurementKind | null): void {
+    this.#activeKind = kind;
+    this.#points = [];
+    this.#renderActiveState();
+    this.#renderSummary();
+  }
+
+  finalize(): boolean {
+    if (!this.#activeKind || this.#points.length === 0) {
+      return false;
+    }
+
+    const detail: HonuaSceneMeasurementAddDetail = {
+      measurementId: `m-${++this.#counter}`,
+      kind: this.#activeKind,
+      points: [...this.#points],
+      controlId: CONTROL_ID,
+    };
+
+    if (this.#activeKind === 'line' && this.#points.length >= 2) {
+      detail.distance = computeDistance(this.#points);
+    }
+
+    if (this.#activeKind === 'polygon' && this.#points.length >= 3) {
+      detail.area = computeArea(this.#points);
+    }
+
+    this.dispatchEvent(new CustomEvent<HonuaSceneMeasurementAddDetail>('honua-scene-measurement-add', {
+      bubbles: true,
+      composed: true,
+      detail,
+    }));
+
+    this.#points = [];
+    this.#renderSummary();
+    return true;
+  }
+
+  clear(): void {
+    this.#points = [];
+    this.#activeKind = null;
+    this.#renderActiveState();
+    this.#renderSummary();
+    this.dispatchEvent(new CustomEvent<HonuaSceneMeasurementClearDetail>('honua-scene-measurement-clear', {
+      bubbles: true,
+      composed: true,
+      detail: { measurementId: 'all', controlId: CONTROL_ID },
+    }));
+  }
+
+  #onIdentify(event: CustomEvent): void {
+    if (!this.#activeKind) {
+      return;
+    }
+
+    const point = readMeasurementPoint(this.#link.scene, event);
+    if (!point) {
+      this.#link.emitError('pick-failed', 'Unable to sample a point at the click location.');
+      return;
+    }
+
+    this.#points.push(point);
+    this.#renderSummary();
+
+    if (this.#activeKind === 'point') {
+      this.finalize();
+    }
+  }
+
+  #wireControls(): void {
+    const buttons = this.#root.querySelectorAll<HTMLButtonElement>('.modes button');
+    for (const button of buttons) {
+      button.addEventListener('click', () => {
+        const kind = button.dataset.kind as HonuaSceneMeasurementKind | undefined;
+        if (!kind) {
+          return;
+        }
+        if (this.#activeKind === kind && (kind === 'line' || kind === 'polygon')) {
+          this.finalize();
+          return;
+        }
+        this.selectKind(kind);
+      });
+    }
+
+    const clearButton = this.#root.querySelector<HTMLButtonElement>('.clear')!;
+    clearButton.addEventListener('click', () => this.clear());
+  }
+
+  #applyHeading(): void {
+    const heading = this.getAttribute('heading');
+    const node = this.#root.querySelector<HTMLElement>('.title');
+    if (node) {
+      node.textContent = heading ?? 'Measure';
+    }
+  }
+
+  #renderActiveState(): void {
+    const buttons = this.#root.querySelectorAll<HTMLButtonElement>('.modes button');
+    for (const button of buttons) {
+      const matches = button.dataset.kind === this.#activeKind;
+      button.setAttribute('aria-pressed', String(matches));
+    }
+  }
+
+  #renderSummary(): void {
+    const summary = this.#root.querySelector<HTMLElement>('.summary')!;
+    summary.replaceChildren();
+
+    if (!this.#activeKind) {
+      const empty = document.createElement('p');
+      empty.className = 'empty';
+      empty.textContent = 'Choose a tool, then click in the scene to measure.';
+      summary.append(empty);
+      return;
+    }
+
+    const heading = document.createElement('p');
+    heading.textContent = `Measuring (${this.#activeKind}) – ${this.#points.length} point${this.#points.length === 1 ? '' : 's'}`;
+    summary.append(heading);
+
+    if (this.#activeKind === 'line' && this.#points.length >= 2) {
+      const distance = computeDistance(this.#points);
+      const span = document.createElement('span');
+      span.textContent = `Running distance: ${distance.toFixed(2)} m`;
+      summary.append(span);
+    }
+
+    if (this.#activeKind === 'polygon' && this.#points.length >= 3) {
+      const area = computeArea(this.#points);
+      const span = document.createElement('span');
+      span.textContent = `Approximate area: ${area.toFixed(2)} m²`;
+      summary.append(span);
+    }
+  }
+}
+
+function readMeasurementPoint(
+  scene: HonuaSceneElement | null,
+  event: CustomEvent,
+): HonuaSceneMeasurementPoint | null {
+  const detail = event.detail as { picked?: unknown; x?: number; y?: number } | undefined;
+  if (!detail) {
+    return null;
+  }
+
+  const widget = scene?.cesiumWidget as
+    | {
+        scene: {
+          pickPosition?: (position: { x: number; y: number }) => unknown;
+        };
+      }
+    | null
+    | undefined;
+
+  const cesium = (globalThis as { Cesium?: unknown }).Cesium;
+
+  if (widget?.scene?.pickPosition && detail.x !== undefined && detail.y !== undefined) {
+    try {
+      const cartesian = widget.scene.pickPosition({ x: detail.x, y: detail.y });
+      const cartographic = cartesianToCartographic(cartesian, cesium);
+      if (cartographic) {
+        return cartographic;
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+
+  if (detail.picked && typeof detail.picked === 'object') {
+    const position = (detail.picked as { position?: { latitude?: number; longitude?: number; height?: number } }).position;
+    if (
+      position &&
+      typeof position.latitude === 'number' &&
+      typeof position.longitude === 'number'
+    ) {
+      return {
+        latitude: position.latitude,
+        longitude: position.longitude,
+        height: position.height ?? 0,
+      };
+    }
+  }
+
+  return null;
+}
+
+function cartesianToCartographic(
+  cartesian: unknown,
+  cesium: unknown,
+): HonuaSceneMeasurementPoint | null {
+  if (!cartesian || !cesium || typeof cesium !== 'object') {
+    return null;
+  }
+
+  const cartographicFactory = (cesium as {
+    Cartographic?: { fromCartesian?: (value: unknown) => { latitude: number; longitude: number; height: number } };
+    Math?: { toDegrees?: (value: number) => number };
+  });
+
+  const cartographic = cartographicFactory.Cartographic?.fromCartesian?.(cartesian);
+  if (!cartographic) {
+    return null;
+  }
+
+  const toDegrees = cartographicFactory.Math?.toDegrees;
+  if (!toDegrees) {
+    return null;
+  }
+
+  return {
+    latitude: toDegrees(cartographic.latitude),
+    longitude: toDegrees(cartographic.longitude),
+    height: cartographic.height,
+  };
+}
+
+function computeDistance(points: HonuaSceneMeasurementPoint[]): number {
+  let total = 0;
+  for (let i = 1; i < points.length; i += 1) {
+    total += haversineMeters(points[i - 1], points[i]);
+  }
+  return total;
+}
+
+function computeArea(points: HonuaSceneMeasurementPoint[]): number {
+  if (points.length < 3) {
+    return 0;
+  }
+
+  const radius = 6371000;
+  let area = 0;
+  for (let i = 0; i < points.length; i += 1) {
+    const a = points[i];
+    const b = points[(i + 1) % points.length];
+    area +=
+      toRadians(b.longitude - a.longitude) *
+      (2 + Math.sin(toRadians(a.latitude)) + Math.sin(toRadians(b.latitude)));
+  }
+
+  return Math.abs((area * radius * radius) / 2);
+}
+
+function haversineMeters(
+  a: HonuaSceneMeasurementPoint,
+  b: HonuaSceneMeasurementPoint,
+): number {
+  const radius = 6371000;
+  const lat1 = toRadians(a.latitude);
+  const lat2 = toRadians(b.latitude);
+  const dLat = toRadians(b.latitude - a.latitude);
+  const dLon = toRadians(b.longitude - a.longitude);
+
+  const sinLat = Math.sin(dLat / 2);
+  const sinLon = Math.sin(dLon / 2);
+  const h = sinLat * sinLat + Math.cos(lat1) * Math.cos(lat2) * sinLon * sinLon;
+  const surface = 2 * radius * Math.asin(Math.min(1, Math.sqrt(h)));
+  const dHeight = b.height - a.height;
+  return Math.sqrt(surface * surface + dHeight * dHeight);
+}
+
+function toRadians(value: number): number {
+  return (value * Math.PI) / 180;
+}
+
+export function defineHonuaSceneMeasureElement(name = ELEMENT_NAME): CustomElementConstructor {
+  const existing = customElements.get(name);
+  if (existing) {
+    return existing;
+  }
+  customElements.define(name, HonuaSceneMeasureElement);
+  return HonuaSceneMeasureElement;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'honua-scene-measure': HonuaSceneMeasureElement;
+  }
+}

--- a/src/Honua.Embed/src/controls/scene-link.ts
+++ b/src/Honua.Embed/src/controls/scene-link.ts
@@ -1,0 +1,205 @@
+import type { HonuaSceneElement } from '../scene';
+
+export interface HonuaSceneControlErrorDetail {
+  controlId: string;
+  kind: string;
+  message: string;
+  error?: unknown;
+}
+
+export type HonuaSceneLinkChangeReason =
+  | 'attribute'
+  | 'connected'
+  | 'disconnected'
+  | 'metadata-change'
+  | 'config-change'
+  | 'ready';
+
+export interface HonuaSceneLinkContext {
+  readonly scene: HonuaSceneElement | null;
+}
+
+export interface HonuaSceneLinkOptions {
+  host: HTMLElement;
+  controlId: string;
+  onSceneChange?(scene: HonuaSceneElement | null, reason: HonuaSceneLinkChangeReason): void;
+  forwardEvents?: readonly string[];
+  onForwardedEvent?(event: Event): void;
+}
+
+const SCENE_EVENT_TYPES_FOR_REWIRE = [
+  'honua-scene-ready',
+  'honua-scene-config-change',
+  'honua-scene-metadata-change',
+] as const;
+
+export class HonuaSceneLink {
+  readonly #host: HTMLElement;
+  readonly #controlId: string;
+  readonly #onSceneChange?: (
+    scene: HonuaSceneElement | null,
+    reason: HonuaSceneLinkChangeReason,
+  ) => void;
+  readonly #forwardEvents: readonly string[];
+  readonly #onForwardedEvent?: (event: Event) => void;
+  readonly #boundForwardListener: (event: Event) => void;
+  readonly #boundRewireListener: (event: Event) => void;
+  #scene: HonuaSceneElement | null = null;
+  #connected = false;
+  #observer: MutationObserver | null = null;
+
+  constructor(options: HonuaSceneLinkOptions) {
+    this.#host = options.host;
+    this.#controlId = options.controlId;
+    this.#onSceneChange = options.onSceneChange;
+    this.#forwardEvents = options.forwardEvents ?? [];
+    this.#onForwardedEvent = options.onForwardedEvent;
+    this.#boundForwardListener = (event: Event) => this.#handleForward(event);
+    this.#boundRewireListener = () => this.#handleSceneRewire();
+  }
+
+  get scene(): HonuaSceneElement | null {
+    return this.#scene;
+  }
+
+  get controlId(): string {
+    return this.#controlId;
+  }
+
+  connect(): void {
+    if (this.#connected) {
+      return;
+    }
+    this.#connected = true;
+    this.#installObserver();
+    this.#updateScene('connected');
+  }
+
+  disconnect(): void {
+    if (!this.#connected) {
+      return;
+    }
+    this.#connected = false;
+    this.#observer?.disconnect();
+    this.#observer = null;
+    this.#detachScene();
+    this.#scene = null;
+    this.#onSceneChange?.(null, 'disconnected');
+  }
+
+  refresh(reason: HonuaSceneLinkChangeReason = 'attribute'): void {
+    if (!this.#connected) {
+      return;
+    }
+    this.#updateScene(reason);
+  }
+
+  emitError(kind: string, message: string, error?: unknown): void {
+    this.#host.dispatchEvent(new CustomEvent<HonuaSceneControlErrorDetail>('honua-scene-control-error', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        controlId: this.#controlId,
+        kind,
+        message,
+        error,
+      },
+    }));
+  }
+
+  #installObserver(): void {
+    if (typeof MutationObserver === 'undefined') {
+      return;
+    }
+
+    this.#observer = new MutationObserver(() => this.#updateScene('attribute'));
+    const root = this.#host.getRootNode();
+    if (root instanceof Document || root instanceof ShadowRoot) {
+      this.#observer.observe(root, {
+        childList: true,
+        subtree: true,
+      });
+    }
+  }
+
+  #updateScene(reason: HonuaSceneLinkChangeReason): void {
+    const next = resolveSceneTarget(this.#host);
+    if (next === this.#scene) {
+      return;
+    }
+
+    this.#detachScene();
+    this.#scene = next;
+    this.#attachScene();
+    this.#onSceneChange?.(next, reason);
+  }
+
+  #attachScene(): void {
+    if (!this.#scene) {
+      return;
+    }
+
+    for (const type of SCENE_EVENT_TYPES_FOR_REWIRE) {
+      this.#scene.addEventListener(type, this.#boundRewireListener);
+    }
+
+    for (const type of this.#forwardEvents) {
+      this.#scene.addEventListener(type, this.#boundForwardListener);
+    }
+  }
+
+  #detachScene(): void {
+    if (!this.#scene) {
+      return;
+    }
+
+    for (const type of SCENE_EVENT_TYPES_FOR_REWIRE) {
+      this.#scene.removeEventListener(type, this.#boundRewireListener);
+    }
+
+    for (const type of this.#forwardEvents) {
+      this.#scene.removeEventListener(type, this.#boundForwardListener);
+    }
+  }
+
+  #handleSceneRewire(): void {
+    if (!this.#scene) {
+      return;
+    }
+
+    this.#onSceneChange?.(this.#scene, 'metadata-change');
+  }
+
+  #handleForward(event: Event): void {
+    this.#onForwardedEvent?.(event);
+  }
+}
+
+function resolveSceneTarget(host: HTMLElement): HonuaSceneElement | null {
+  const selector = host.getAttribute('for');
+  const root = host.getRootNode();
+  const search = (root instanceof Document || root instanceof ShadowRoot) ? root : document;
+
+  if (selector) {
+    const match = (search.querySelector?.(selector) ?? null) as HTMLElement | null;
+    return isSceneElement(match) ? match : null;
+  }
+
+  let sibling = host.previousElementSibling;
+  while (sibling) {
+    if (isSceneElement(sibling)) {
+      return sibling;
+    }
+    sibling = sibling.previousElementSibling;
+  }
+
+  const fallback = (search.querySelector?.('honua-scene') ?? null) as HTMLElement | null;
+  return isSceneElement(fallback) ? fallback : null;
+}
+
+function isSceneElement(node: Element | null): node is HonuaSceneElement {
+  if (!node) {
+    return false;
+  }
+  return node.tagName.toLowerCase() === 'honua-scene';
+}

--- a/src/Honua.Embed/src/controls/shared.ts
+++ b/src/Honua.Embed/src/controls/shared.ts
@@ -94,3 +94,19 @@ export function upgradeProperty(element: HTMLElement, propertyName: string): voi
   delete (element as unknown as Record<string, unknown>)[propertyName];
   (element as unknown as Record<string, unknown>)[propertyName] = value;
 }
+
+interface SceneLayerSurface {
+  metadata?: { layers?: { id: string }[] | null } | null;
+  layers?: ReadonlyArray<{ metadata: { id: string } }>;
+}
+
+export function resolveControlLayerIds(scene: SceneLayerSurface): string[] {
+  const ids = new Set<string>();
+  for (const layer of scene.metadata?.layers ?? []) {
+    ids.add(layer.id);
+  }
+  for (const handle of scene.layers ?? []) {
+    ids.add(handle.metadata.id);
+  }
+  return [...ids];
+}

--- a/src/Honua.Embed/src/controls/shared.ts
+++ b/src/Honua.Embed/src/controls/shared.ts
@@ -1,0 +1,96 @@
+export const CONTROL_BASE_STYLES = `
+  <style>
+    :host {
+      --honua-control-background: var(--honua-scene-background, #101820);
+      --honua-control-foreground: var(--honua-scene-foreground, #eef5f7);
+      --honua-control-muted: var(--honua-scene-muted, #a9b8bf);
+      --honua-control-accent: var(--honua-scene-accent, #4fb4c8);
+      --honua-control-border: var(--honua-scene-border, rgba(238, 245, 247, 0.18));
+      --honua-control-surface: color-mix(in srgb, var(--honua-control-background) 80%, transparent);
+      --honua-control-font-family: var(--honua-scene-font-family, Inter, ui-sans-serif, system-ui, sans-serif);
+      display: block;
+      box-sizing: border-box;
+      color: var(--honua-control-foreground);
+      font-family: var(--honua-control-font-family);
+      font-size: 13px;
+    }
+
+    .control {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      padding: 12px;
+      border: 1px solid var(--honua-control-border);
+      border-radius: 8px;
+      background: var(--honua-control-background);
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+    }
+
+    .title {
+      margin: 0;
+      font-size: 13px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--honua-control-foreground);
+    }
+
+    .body {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    button {
+      padding: 6px 10px;
+      color: var(--honua-control-foreground);
+      background: var(--honua-control-surface);
+      border: 1px solid var(--honua-control-border);
+      border-radius: 6px;
+      font: inherit;
+      cursor: pointer;
+    }
+
+    button:hover,
+    button:focus-visible {
+      border-color: var(--honua-control-accent);
+      outline: none;
+    }
+
+    button[aria-pressed="true"] {
+      border-color: var(--honua-control-accent);
+      color: var(--honua-control-accent);
+    }
+
+    ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+  </style>
+`;
+
+export function controlTemplate(html: string): HTMLTemplateElement {
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  return template;
+}
+
+export function upgradeProperty(element: HTMLElement, propertyName: string): void {
+  if (!Object.prototype.hasOwnProperty.call(element, propertyName)) {
+    return;
+  }
+
+  const value = (element as unknown as Record<string, unknown>)[propertyName];
+  delete (element as unknown as Record<string, unknown>)[propertyName];
+  (element as unknown as Record<string, unknown>)[propertyName] = value;
+}

--- a/src/Honua.Embed/src/controls/timeline.ts
+++ b/src/Honua.Embed/src/controls/timeline.ts
@@ -4,6 +4,7 @@ import { HonuaSceneLink } from './scene-link';
 import {
   CONTROL_BASE_STYLES,
   controlTemplate,
+  resolveControlLayerIds,
   upgradeProperty,
 } from './shared';
 
@@ -206,9 +207,8 @@ export class HonuaSceneTimelineElement extends HTMLElement {
 
   #syncLayerVisibility(scene: HonuaSceneElement, phase: HonuaSceneTimelinePhase): void {
     const visible = new Set(phase.visibleLayerIds);
-    const layers = scene.metadata?.layers ?? [];
-    for (const layer of layers) {
-      scene.setLayerVisibility(layer.id, visible.has(layer.id));
+    for (const id of resolveControlLayerIds(scene)) {
+      scene.setLayerVisibility(id, visible.has(id));
     }
   }
 }

--- a/src/Honua.Embed/src/controls/timeline.ts
+++ b/src/Honua.Embed/src/controls/timeline.ts
@@ -1,0 +1,238 @@
+import type { HonuaSceneElement } from '../scene';
+import type { HonuaSceneTimelinePhase } from '../scene-metadata';
+import { HonuaSceneLink } from './scene-link';
+import {
+  CONTROL_BASE_STYLES,
+  controlTemplate,
+  upgradeProperty,
+} from './shared';
+
+export interface HonuaSceneTimelineChangeDetail {
+  phaseId: string;
+  startUtc: string;
+  endUtc: string;
+  visibleLayerIds: string[];
+  controlId: string;
+}
+
+const ELEMENT_NAME = 'honua-scene-timeline';
+const CONTROL_ID = 'timeline';
+
+const template = controlTemplate(`
+  ${CONTROL_BASE_STYLES}
+  <style>
+    .phases {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .phase {
+      flex: 1 1 auto;
+      min-width: 120px;
+      text-align: left;
+    }
+
+    .phase-title {
+      font-weight: 500;
+    }
+
+    .phase-range {
+      color: var(--honua-control-muted);
+      font-size: 12px;
+    }
+
+    .empty {
+      color: var(--honua-control-muted);
+      font-style: italic;
+    }
+  </style>
+  <section class="control" part="control">
+    <header part="header">
+      <h2 class="title" part="title">Timeline</h2>
+    </header>
+    <div class="body" part="body">
+      <p class="empty" data-empty>No timeline phases for this scene.</p>
+      <div class="phases" part="phases" role="tablist" hidden></div>
+    </div>
+  </section>
+`);
+
+export class HonuaSceneTimelineElement extends HTMLElement {
+  static get observedAttributes(): string[] {
+    return ['for', 'heading', 'phase'];
+  }
+
+  readonly #root: ShadowRoot;
+  readonly #link: HonuaSceneLink;
+  #activePhase: string | null = null;
+
+  constructor() {
+    super();
+    this.#root = this.attachShadow({ mode: 'open' });
+    this.#root.append(template.content.cloneNode(true));
+    this.#link = new HonuaSceneLink({
+      host: this,
+      controlId: CONTROL_ID,
+      onSceneChange: () => this.#render(),
+    });
+  }
+
+  connectedCallback(): void {
+    upgradeProperty(this, 'sceneSelector');
+    this.#applyHeading();
+    this.#link.connect();
+    this.#render();
+  }
+
+  disconnectedCallback(): void {
+    this.#link.disconnect();
+  }
+
+  attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null): void {
+    if (name === 'for') {
+      this.#link.refresh('attribute');
+      return;
+    }
+
+    if (name === 'heading') {
+      this.#applyHeading();
+      return;
+    }
+
+    if (name === 'phase' && newValue && newValue !== this.#activePhase) {
+      this.activate(newValue);
+    }
+  }
+
+  get scene(): HonuaSceneElement | null {
+    return this.#link.scene;
+  }
+
+  get activePhaseId(): string | null {
+    return this.#activePhase;
+  }
+
+  activate(phaseId: string): boolean {
+    const scene = this.#link.scene;
+    const phases = scene?.metadata?.timeline?.phases ?? [];
+    const phase = phases.find((entry) => entry.id === phaseId);
+    if (!scene || !phase) {
+      this.#link.emitError('phase-not-found', `Unknown timeline phase "${phaseId}".`);
+      return false;
+    }
+
+    this.#activePhase = phaseId;
+    this.#syncLayerVisibility(scene, phase);
+    this.#renderActiveState();
+
+    this.dispatchEvent(new CustomEvent<HonuaSceneTimelineChangeDetail>('honua-scene-timeline-change', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        phaseId: phase.id,
+        startUtc: phase.startUtc,
+        endUtc: phase.endUtc,
+        visibleLayerIds: [...phase.visibleLayerIds],
+        controlId: CONTROL_ID,
+      },
+    }));
+    return true;
+  }
+
+  refresh(): void {
+    this.#render();
+  }
+
+  #applyHeading(): void {
+    const heading = this.getAttribute('heading');
+    const node = this.#root.querySelector<HTMLElement>('.title');
+    if (node) {
+      node.textContent = heading ?? 'Timeline';
+    }
+  }
+
+  #render(): void {
+    const phasesEl = this.#root.querySelector<HTMLElement>('.phases')!;
+    const empty = this.#root.querySelector<HTMLElement>('.empty')!;
+    phasesEl.replaceChildren();
+
+    const phases = this.#link.scene?.metadata?.timeline?.phases ?? [];
+    if (phases.length === 0) {
+      phasesEl.hidden = true;
+      empty.hidden = false;
+      return;
+    }
+
+    phasesEl.hidden = false;
+    empty.hidden = true;
+
+    for (const phase of phases) {
+      phasesEl.append(this.#renderPhase(phase));
+    }
+
+    this.#renderActiveState();
+  }
+
+  #renderPhase(phase: HonuaSceneTimelinePhase): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'phase';
+    button.dataset.phaseId = phase.id;
+    button.role = 'tab';
+
+    const title = document.createElement('div');
+    title.className = 'phase-title';
+    title.textContent = phase.title;
+    button.append(title);
+
+    const range = document.createElement('div');
+    range.className = 'phase-range';
+    range.textContent = `${formatRange(phase.startUtc)} – ${formatRange(phase.endUtc)}`;
+    button.append(range);
+
+    button.addEventListener('click', () => this.activate(phase.id));
+    return button;
+  }
+
+  #renderActiveState(): void {
+    const buttons = this.#root.querySelectorAll<HTMLButtonElement>('.phase');
+    for (const button of buttons) {
+      const isActive = button.dataset.phaseId === this.#activePhase;
+      button.setAttribute('aria-pressed', String(isActive));
+      button.setAttribute('aria-selected', String(isActive));
+    }
+  }
+
+  #syncLayerVisibility(scene: HonuaSceneElement, phase: HonuaSceneTimelinePhase): void {
+    const visible = new Set(phase.visibleLayerIds);
+    const layers = scene.metadata?.layers ?? [];
+    for (const layer of layers) {
+      scene.setLayerVisibility(layer.id, visible.has(layer.id));
+    }
+  }
+}
+
+function formatRange(value: string): string {
+  const time = Date.parse(value);
+  if (!Number.isFinite(time)) {
+    return value;
+  }
+  const date = new Date(time);
+  return date.toISOString().slice(0, 10);
+}
+
+export function defineHonuaSceneTimelineElement(name = ELEMENT_NAME): CustomElementConstructor {
+  const existing = customElements.get(name);
+  if (existing) {
+    return existing;
+  }
+  customElements.define(name, HonuaSceneTimelineElement);
+  return HonuaSceneTimelineElement;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'honua-scene-timeline': HonuaSceneTimelineElement;
+  }
+}

--- a/src/Honua.Embed/src/index.ts
+++ b/src/Honua.Embed/src/index.ts
@@ -1,5 +1,6 @@
 export * from './map';
 export * from './scene';
+export * from './scene-metadata';
 export * from './scene-package-cache';
 export * from './display-adapter';
 export type {
@@ -19,11 +20,14 @@ export {
   registerHonuaEmbedExtension,
 } from './extensions';
 export * from './snippets';
+export * from './controls';
 
 import { defineHonuaMapElement } from './map';
 import { defineHonuaSceneElement } from './scene';
+import { defineHonuaSceneControls } from './controls';
 
 if (typeof customElements !== 'undefined') {
   defineHonuaMapElement();
   defineHonuaSceneElement();
+  defineHonuaSceneControls();
 }

--- a/src/Honua.Embed/src/scene-metadata.ts
+++ b/src/Honua.Embed/src/scene-metadata.ts
@@ -126,8 +126,8 @@ export function parseHonuaSceneMetadata(input: unknown): HonuaSceneMetadata {
     );
   }
 
-  const schema = readString(input, 'schema', '$.schema', { required: true });
-  if (schema !== HONUA_SCENE_METADATA_SCHEMA) {
+  const schema = readString(input, 'schema', '$.schema');
+  if (schema !== undefined && schema !== HONUA_SCENE_METADATA_SCHEMA) {
     throw new HonuaSceneMetadataError(
       `Unsupported scene metadata schema: ${schema}. Expected ${HONUA_SCENE_METADATA_SCHEMA}.`,
       '$.schema',

--- a/src/Honua.Embed/src/scene-metadata.ts
+++ b/src/Honua.Embed/src/scene-metadata.ts
@@ -1,0 +1,768 @@
+import type {
+  HonuaSceneCoordinate,
+  HonuaSceneOrientation,
+} from './scene';
+
+export const HONUA_SCENE_METADATA_SCHEMA = 'honua-scene-metadata/v1';
+
+export type HonuaSceneLayerKind = '3d-tiles' | 'terrain' | 'imagery';
+
+export type HonuaSceneInspectorFieldFormat =
+  | 'string'
+  | 'number'
+  | 'date'
+  | 'enum';
+
+export interface HonuaSceneLayerMetadata {
+  id: string;
+  title: string;
+  kind: HonuaSceneLayerKind;
+  url: string;
+  description?: string;
+  visible?: boolean;
+  opacity?: number;
+}
+
+export interface HonuaSceneViewSpec {
+  center: HonuaSceneCoordinate;
+  height: number;
+  orientation: HonuaSceneOrientation;
+}
+
+export interface HonuaSceneBookmarkMetadata {
+  id: string;
+  title: string;
+  description?: string;
+  view: HonuaSceneViewSpec;
+}
+
+export interface HonuaSceneTimelinePhase {
+  id: string;
+  title: string;
+  startUtc: string;
+  endUtc: string;
+  visibleLayerIds: string[];
+  description?: string;
+}
+
+export interface HonuaSceneCompareMode {
+  id: string;
+  title: string;
+  leftLayerIds: string[];
+  rightLayerIds: string[];
+  description?: string;
+}
+
+export interface HonuaSceneInspectorField {
+  key: string;
+  title: string;
+  format?: HonuaSceneInspectorFieldFormat;
+  unit?: string;
+}
+
+export interface HonuaSceneBoundsMetadata {
+  west: number;
+  south: number;
+  east: number;
+  north: number;
+}
+
+export interface HonuaSceneTilesetMetadata {
+  url: string;
+  format?: string;
+  mediaType?: string;
+  requiresAuthentication?: boolean;
+}
+
+export interface HonuaSceneTerrainMetadata {
+  url: string;
+  format?: string;
+  requiresAuthentication?: boolean;
+}
+
+export interface HonuaSceneLinkMetadata {
+  rel: string;
+  href: string;
+  type?: string;
+  title?: string;
+}
+
+export interface HonuaSceneMetadata {
+  schema: typeof HONUA_SCENE_METADATA_SCHEMA;
+  id: string;
+  name: string;
+  description?: string;
+  center?: (HonuaSceneCoordinate & { height?: number }) | null;
+  bounds?: HonuaSceneBoundsMetadata | null;
+  tileset?: HonuaSceneTilesetMetadata | null;
+  terrain?: HonuaSceneTerrainMetadata | null;
+  capabilities?: Record<string, boolean>;
+  links?: HonuaSceneLinkMetadata[];
+  layers?: HonuaSceneLayerMetadata[];
+  bookmarks?: HonuaSceneBookmarkMetadata[];
+  timeline?: { phases: HonuaSceneTimelinePhase[] } | null;
+  compare?: { modes: HonuaSceneCompareMode[] } | null;
+  inspector?: { fields: HonuaSceneInspectorField[] } | null;
+}
+
+export type HonuaSceneMetadataErrorCode = 'metadata-invalid';
+
+export class HonuaSceneMetadataError extends Error {
+  readonly code: HonuaSceneMetadataErrorCode = 'metadata-invalid';
+  readonly path: string;
+
+  constructor(message: string, path: string) {
+    super(message);
+    this.name = 'HonuaSceneMetadataError';
+    this.path = path;
+  }
+}
+
+export function parseHonuaSceneMetadata(input: unknown): HonuaSceneMetadata {
+  if (!isObject(input)) {
+    throw new HonuaSceneMetadataError(
+      'Scene metadata must be a JSON object.',
+      '$',
+    );
+  }
+
+  const schema = readString(input, 'schema', '$.schema', { required: true });
+  if (schema !== HONUA_SCENE_METADATA_SCHEMA) {
+    throw new HonuaSceneMetadataError(
+      `Unsupported scene metadata schema: ${schema}. Expected ${HONUA_SCENE_METADATA_SCHEMA}.`,
+      '$.schema',
+    );
+  }
+
+  const id = readString(input, 'id', '$.id', { required: true });
+  const name = readString(input, 'name', '$.name', { required: true });
+  const description = readString(input, 'description', '$.description');
+  const center = parseCenter(input.center, '$.center');
+  const bounds = parseBounds(input.bounds, '$.bounds');
+  const tileset = parseTileset(input.tileset, '$.tileset');
+  const terrain = parseTerrain(input.terrain, '$.terrain');
+  const capabilities = parseCapabilities(input.capabilities, '$.capabilities');
+  const links = parseLinks(input.links, '$.links');
+  const layers = parseLayers(input.layers, '$.layers');
+  const bookmarks = parseBookmarks(input.bookmarks, '$.bookmarks');
+  const timeline = parseTimeline(input.timeline, '$.timeline');
+  const compare = parseCompare(input.compare, '$.compare');
+  const inspector = parseInspector(input.inspector, '$.inspector');
+
+  validateLayerReferences({ layers, timeline, compare });
+
+  return {
+    schema: HONUA_SCENE_METADATA_SCHEMA,
+    id,
+    name,
+    ...(description !== undefined && { description }),
+    ...(center !== undefined && { center }),
+    ...(bounds !== undefined && { bounds }),
+    ...(tileset !== undefined && { tileset }),
+    ...(terrain !== undefined && { terrain }),
+    ...(capabilities !== undefined && { capabilities }),
+    ...(links !== undefined && { links }),
+    ...(layers !== undefined && { layers }),
+    ...(bookmarks !== undefined && { bookmarks }),
+    ...(timeline !== undefined && { timeline }),
+    ...(compare !== undefined && { compare }),
+    ...(inspector !== undefined && { inspector }),
+  };
+}
+
+function parseCenter(
+  value: unknown,
+  path: string,
+): (HonuaSceneCoordinate & { height?: number }) | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (!isObject(value)) {
+    throw new HonuaSceneMetadataError('Center must be an object.', path);
+  }
+
+  const latitude = readNumber(value, 'latitude', `${path}.latitude`, { required: true });
+  const longitude = readNumber(value, 'longitude', `${path}.longitude`, { required: true });
+  const height = readNumber(value, 'height', `${path}.height`);
+
+  return {
+    latitude,
+    longitude,
+    ...(height !== undefined && { height }),
+  };
+}
+
+function parseBounds(
+  value: unknown,
+  path: string,
+): HonuaSceneBoundsMetadata | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (!isObject(value)) {
+    throw new HonuaSceneMetadataError('Bounds must be an object.', path);
+  }
+
+  return {
+    west: readNumber(value, 'west', `${path}.west`, { required: true }),
+    south: readNumber(value, 'south', `${path}.south`, { required: true }),
+    east: readNumber(value, 'east', `${path}.east`, { required: true }),
+    north: readNumber(value, 'north', `${path}.north`, { required: true }),
+  };
+}
+
+function parseTileset(
+  value: unknown,
+  path: string,
+): HonuaSceneTilesetMetadata | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (!isObject(value)) {
+    throw new HonuaSceneMetadataError('Tileset must be an object.', path);
+  }
+
+  return {
+    url: readString(value, 'url', `${path}.url`, { required: true }),
+    ...maybeAdd('format', readString(value, 'format', `${path}.format`)),
+    ...maybeAdd('mediaType', readString(value, 'mediaType', `${path}.mediaType`)),
+    ...maybeAdd('requiresAuthentication', readBoolean(value, 'requiresAuthentication', `${path}.requiresAuthentication`)),
+  };
+}
+
+function parseTerrain(
+  value: unknown,
+  path: string,
+): HonuaSceneTerrainMetadata | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (!isObject(value)) {
+    throw new HonuaSceneMetadataError('Terrain must be an object.', path);
+  }
+
+  return {
+    url: readString(value, 'url', `${path}.url`, { required: true }),
+    ...maybeAdd('format', readString(value, 'format', `${path}.format`)),
+    ...maybeAdd('requiresAuthentication', readBoolean(value, 'requiresAuthentication', `${path}.requiresAuthentication`)),
+  };
+}
+
+function parseCapabilities(
+  value: unknown,
+  path: string,
+): Record<string, boolean> | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (!isObject(value)) {
+    throw new HonuaSceneMetadataError('Capabilities must be an object.', path);
+  }
+
+  const result: Record<string, boolean> = {};
+  for (const [key, capability] of Object.entries(value)) {
+    if (typeof capability !== 'boolean') {
+      throw new HonuaSceneMetadataError(
+        `Capability values must be booleans.`,
+        `${path}.${key}`,
+      );
+    }
+    result[key] = capability;
+  }
+
+  return result;
+}
+
+function parseLinks(value: unknown, path: string): HonuaSceneLinkMetadata[] | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value)) {
+    throw new HonuaSceneMetadataError('Links must be an array.', path);
+  }
+
+  return value.map((entry, index) => {
+    const itemPath = `${path}[${index}]`;
+    if (!isObject(entry)) {
+      throw new HonuaSceneMetadataError('Link entries must be objects.', itemPath);
+    }
+
+    return {
+      rel: readString(entry, 'rel', `${itemPath}.rel`, { required: true }),
+      href: readString(entry, 'href', `${itemPath}.href`, { required: true }),
+      ...maybeAdd('type', readString(entry, 'type', `${itemPath}.type`)),
+      ...maybeAdd('title', readString(entry, 'title', `${itemPath}.title`)),
+    };
+  });
+}
+
+function parseLayers(
+  value: unknown,
+  path: string,
+): HonuaSceneLayerMetadata[] | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value)) {
+    throw new HonuaSceneMetadataError('Layers must be an array.', path);
+  }
+
+  const seenIds = new Set<string>();
+  return value.map((entry, index) => {
+    const itemPath = `${path}[${index}]`;
+    if (!isObject(entry)) {
+      throw new HonuaSceneMetadataError('Layer entries must be objects.', itemPath);
+    }
+
+    const id = readString(entry, 'id', `${itemPath}.id`, { required: true });
+    if (seenIds.has(id)) {
+      throw new HonuaSceneMetadataError(
+        `Duplicate layer id "${id}".`,
+        `${itemPath}.id`,
+      );
+    }
+    seenIds.add(id);
+
+    const kind = readString(entry, 'kind', `${itemPath}.kind`, { required: true });
+    if (kind !== '3d-tiles' && kind !== 'terrain' && kind !== 'imagery') {
+      throw new HonuaSceneMetadataError(
+        `Unsupported layer kind "${kind}". Expected "3d-tiles", "terrain", or "imagery".`,
+        `${itemPath}.kind`,
+      );
+    }
+
+    const opacity = readNumber(entry, 'opacity', `${itemPath}.opacity`);
+    if (opacity !== undefined && (opacity < 0 || opacity > 1)) {
+      throw new HonuaSceneMetadataError(
+        `Layer opacity must be between 0 and 1.`,
+        `${itemPath}.opacity`,
+      );
+    }
+
+    return {
+      id,
+      title: readString(entry, 'title', `${itemPath}.title`, { required: true }),
+      kind: kind as HonuaSceneLayerKind,
+      url: readString(entry, 'url', `${itemPath}.url`, { required: true }),
+      ...maybeAdd('description', readString(entry, 'description', `${itemPath}.description`)),
+      ...maybeAdd('visible', readBoolean(entry, 'visible', `${itemPath}.visible`)),
+      ...maybeAdd('opacity', opacity),
+    };
+  });
+}
+
+function parseBookmarks(
+  value: unknown,
+  path: string,
+): HonuaSceneBookmarkMetadata[] | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value)) {
+    throw new HonuaSceneMetadataError('Bookmarks must be an array.', path);
+  }
+
+  const seenIds = new Set<string>();
+  return value.map((entry, index) => {
+    const itemPath = `${path}[${index}]`;
+    if (!isObject(entry)) {
+      throw new HonuaSceneMetadataError('Bookmark entries must be objects.', itemPath);
+    }
+
+    const id = readString(entry, 'id', `${itemPath}.id`, { required: true });
+    if (seenIds.has(id)) {
+      throw new HonuaSceneMetadataError(
+        `Duplicate bookmark id "${id}".`,
+        `${itemPath}.id`,
+      );
+    }
+    seenIds.add(id);
+
+    return {
+      id,
+      title: readString(entry, 'title', `${itemPath}.title`, { required: true }),
+      ...maybeAdd('description', readString(entry, 'description', `${itemPath}.description`)),
+      view: parseView(entry.view, `${itemPath}.view`),
+    };
+  });
+}
+
+function parseView(value: unknown, path: string): HonuaSceneViewSpec {
+  if (!isObject(value)) {
+    throw new HonuaSceneMetadataError('View must be an object.', path);
+  }
+
+  if (!isObject(value.center)) {
+    throw new HonuaSceneMetadataError('View center must be an object.', `${path}.center`);
+  }
+
+  return {
+    center: {
+      latitude: readNumber(value.center, 'latitude', `${path}.center.latitude`, { required: true }),
+      longitude: readNumber(value.center, 'longitude', `${path}.center.longitude`, { required: true }),
+    },
+    height: readNumber(value, 'height', `${path}.height`, { required: true }),
+    orientation: parseOrientation(value.orientation, `${path}.orientation`),
+  };
+}
+
+function parseOrientation(value: unknown, path: string): HonuaSceneOrientation {
+  if (!isObject(value)) {
+    throw new HonuaSceneMetadataError('Orientation must be an object.', path);
+  }
+
+  return {
+    heading: readNumber(value, 'heading', `${path}.heading`, { required: true }),
+    pitch: readNumber(value, 'pitch', `${path}.pitch`, { required: true }),
+    roll: readNumber(value, 'roll', `${path}.roll`, { required: true }),
+  };
+}
+
+function parseTimeline(
+  value: unknown,
+  path: string,
+): { phases: HonuaSceneTimelinePhase[] } | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (!isObject(value)) {
+    throw new HonuaSceneMetadataError('Timeline must be an object.', path);
+  }
+
+  if (!Array.isArray(value.phases)) {
+    throw new HonuaSceneMetadataError('Timeline phases must be an array.', `${path}.phases`);
+  }
+
+  const seenIds = new Set<string>();
+  const phases = value.phases.map((entry: unknown, index: number) => {
+    const itemPath = `${path}.phases[${index}]`;
+    if (!isObject(entry)) {
+      throw new HonuaSceneMetadataError('Timeline phase entries must be objects.', itemPath);
+    }
+
+    const id = readString(entry, 'id', `${itemPath}.id`, { required: true });
+    if (seenIds.has(id)) {
+      throw new HonuaSceneMetadataError(
+        `Duplicate timeline phase id "${id}".`,
+        `${itemPath}.id`,
+      );
+    }
+    seenIds.add(id);
+
+    const startUtc = readString(entry, 'startUtc', `${itemPath}.startUtc`, { required: true });
+    const endUtc = readString(entry, 'endUtc', `${itemPath}.endUtc`, { required: true });
+    requireFiniteIso(startUtc, `${itemPath}.startUtc`);
+    requireFiniteIso(endUtc, `${itemPath}.endUtc`);
+
+    return {
+      id,
+      title: readString(entry, 'title', `${itemPath}.title`, { required: true }),
+      startUtc,
+      endUtc,
+      visibleLayerIds: readStringArray(entry, 'visibleLayerIds', `${itemPath}.visibleLayerIds`),
+      ...maybeAdd('description', readString(entry, 'description', `${itemPath}.description`)),
+    };
+  });
+
+  return { phases };
+}
+
+function parseCompare(
+  value: unknown,
+  path: string,
+): { modes: HonuaSceneCompareMode[] } | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (!isObject(value)) {
+    throw new HonuaSceneMetadataError('Compare must be an object.', path);
+  }
+
+  if (!Array.isArray(value.modes)) {
+    throw new HonuaSceneMetadataError('Compare modes must be an array.', `${path}.modes`);
+  }
+
+  const seenIds = new Set<string>();
+  const modes = value.modes.map((entry: unknown, index: number) => {
+    const itemPath = `${path}.modes[${index}]`;
+    if (!isObject(entry)) {
+      throw new HonuaSceneMetadataError('Compare mode entries must be objects.', itemPath);
+    }
+
+    const id = readString(entry, 'id', `${itemPath}.id`, { required: true });
+    if (seenIds.has(id)) {
+      throw new HonuaSceneMetadataError(
+        `Duplicate compare mode id "${id}".`,
+        `${itemPath}.id`,
+      );
+    }
+    seenIds.add(id);
+
+    return {
+      id,
+      title: readString(entry, 'title', `${itemPath}.title`, { required: true }),
+      leftLayerIds: readStringArray(entry, 'leftLayerIds', `${itemPath}.leftLayerIds`),
+      rightLayerIds: readStringArray(entry, 'rightLayerIds', `${itemPath}.rightLayerIds`),
+      ...maybeAdd('description', readString(entry, 'description', `${itemPath}.description`)),
+    };
+  });
+
+  return { modes };
+}
+
+function parseInspector(
+  value: unknown,
+  path: string,
+): { fields: HonuaSceneInspectorField[] } | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (!isObject(value)) {
+    throw new HonuaSceneMetadataError('Inspector must be an object.', path);
+  }
+
+  if (!Array.isArray(value.fields)) {
+    throw new HonuaSceneMetadataError('Inspector fields must be an array.', `${path}.fields`);
+  }
+
+  const fields = value.fields.map((entry: unknown, index: number) => {
+    const itemPath = `${path}.fields[${index}]`;
+    if (!isObject(entry)) {
+      throw new HonuaSceneMetadataError('Inspector field entries must be objects.', itemPath);
+    }
+
+    const format = readString(entry, 'format', `${itemPath}.format`);
+    if (
+      format !== undefined &&
+      format !== 'string' &&
+      format !== 'number' &&
+      format !== 'date' &&
+      format !== 'enum'
+    ) {
+      throw new HonuaSceneMetadataError(
+        `Unsupported inspector field format "${format}".`,
+        `${itemPath}.format`,
+      );
+    }
+
+    return {
+      key: readString(entry, 'key', `${itemPath}.key`, { required: true }),
+      title: readString(entry, 'title', `${itemPath}.title`, { required: true }),
+      ...maybeAdd('format', format as HonuaSceneInspectorFieldFormat | undefined),
+      ...maybeAdd('unit', readString(entry, 'unit', `${itemPath}.unit`)),
+    };
+  });
+
+  return { fields };
+}
+
+function validateLayerReferences(args: {
+  layers: HonuaSceneLayerMetadata[] | undefined;
+  timeline: { phases: HonuaSceneTimelinePhase[] } | null | undefined;
+  compare: { modes: HonuaSceneCompareMode[] } | null | undefined;
+}): void {
+  const known = new Set<string>(['primary', ...(args.layers?.map((layer) => layer.id) ?? [])]);
+  if (args.timeline) {
+    args.timeline.phases.forEach((phase, index) => {
+      phase.visibleLayerIds.forEach((layerId, layerIndex) => {
+        if (!known.has(layerId)) {
+          throw new HonuaSceneMetadataError(
+            `Timeline phase references unknown layer "${layerId}".`,
+            `$.timeline.phases[${index}].visibleLayerIds[${layerIndex}]`,
+          );
+        }
+      });
+    });
+  }
+
+  if (args.compare) {
+    args.compare.modes.forEach((mode, index) => {
+      mode.leftLayerIds.forEach((layerId, layerIndex) => {
+        if (!known.has(layerId)) {
+          throw new HonuaSceneMetadataError(
+            `Compare mode references unknown left layer "${layerId}".`,
+            `$.compare.modes[${index}].leftLayerIds[${layerIndex}]`,
+          );
+        }
+      });
+      mode.rightLayerIds.forEach((layerId, layerIndex) => {
+        if (!known.has(layerId)) {
+          throw new HonuaSceneMetadataError(
+            `Compare mode references unknown right layer "${layerId}".`,
+            `$.compare.modes[${index}].rightLayerIds[${layerIndex}]`,
+          );
+        }
+      });
+    });
+  }
+}
+
+interface ReadOptions {
+  required?: boolean;
+}
+
+interface RequiredReadOptions extends ReadOptions {
+  required: true;
+}
+
+function readString(
+  source: Record<string, unknown>,
+  key: string,
+  path: string,
+  options: RequiredReadOptions,
+): string;
+function readString(
+  source: Record<string, unknown>,
+  key: string,
+  path: string,
+  options?: ReadOptions,
+): string | undefined;
+function readString(
+  source: Record<string, unknown>,
+  key: string,
+  path: string,
+  options: ReadOptions = {},
+): string | undefined {
+  const value = source[key];
+  if (value === undefined || value === null) {
+    if (options.required) {
+      throw new HonuaSceneMetadataError(`Missing required string at ${path}.`, path);
+    }
+    return undefined;
+  }
+
+  if (typeof value !== 'string') {
+    throw new HonuaSceneMetadataError(`Expected string at ${path}.`, path);
+  }
+
+  return value;
+}
+
+function readNumber(
+  source: Record<string, unknown>,
+  key: string,
+  path: string,
+  options: RequiredReadOptions,
+): number;
+function readNumber(
+  source: Record<string, unknown>,
+  key: string,
+  path: string,
+  options?: ReadOptions,
+): number | undefined;
+function readNumber(
+  source: Record<string, unknown>,
+  key: string,
+  path: string,
+  options: ReadOptions = {},
+): number | undefined {
+  const value = source[key];
+  if (value === undefined || value === null) {
+    if (options.required) {
+      throw new HonuaSceneMetadataError(`Missing required number at ${path}.`, path);
+    }
+    return undefined;
+  }
+
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new HonuaSceneMetadataError(`Expected finite number at ${path}.`, path);
+  }
+
+  return value;
+}
+
+function readBoolean(
+  source: Record<string, unknown>,
+  key: string,
+  path: string,
+): boolean | undefined {
+  const value = source[key];
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value !== 'boolean') {
+    throw new HonuaSceneMetadataError(`Expected boolean at ${path}.`, path);
+  }
+
+  return value;
+}
+
+function readStringArray(
+  source: Record<string, unknown>,
+  key: string,
+  path: string,
+): string[] {
+  const value = source[key];
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new HonuaSceneMetadataError(`Expected an array at ${path}.`, path);
+  }
+
+  return value.map((entry, index) => {
+    if (typeof entry !== 'string') {
+      throw new HonuaSceneMetadataError(`Expected string at ${path}[${index}].`, `${path}[${index}]`);
+    }
+    return entry;
+  });
+}
+
+function requireFiniteIso(value: string, path: string): void {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    throw new HonuaSceneMetadataError(
+      `Expected an ISO-8601 timestamp at ${path}.`,
+      path,
+    );
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function maybeAdd<K extends string, V>(key: K, value: V | undefined): { [P in K]?: V } {
+  return value === undefined ? ({} as { [P in K]?: V }) : ({ [key]: value } as { [P in K]?: V });
+}

--- a/src/Honua.Embed/src/scene.ts
+++ b/src/Honua.Embed/src/scene.ts
@@ -604,27 +604,40 @@ export class HonuaSceneElement extends HTMLElement {
         showRenderLoopErrors: false,
       });
     } catch (error) {
-      this.#emitLoadError('terrain', 'Unable to initialize the terrain provider or scene widget.', error);
+      if (version === this.#loadVersion) {
+        this.#emitLoadError('terrain', 'Unable to initialize the terrain provider or scene widget.', error);
+      }
       return;
     }
 
     try {
       if (dataUrls.tilesetUrl) {
-        this.#tileset = await cesium.Cesium3DTileset.fromUrl(dataUrls.tilesetUrl);
+        const loaded = await cesium.Cesium3DTileset.fromUrl(dataUrls.tilesetUrl);
 
         if (version !== this.#loadVersion || !this.#widget) {
+          destroyTilesetSafely(loaded);
           return;
         }
 
-        this.#widget.scene.primitives.add(this.#tileset);
-        this.#registerPrimaryLayer(dataUrls.tilesetUrl, this.#tileset);
+        this.#tileset = loaded;
+        this.#widget.scene.primitives.add(loaded);
+        this.#registerPrimaryLayer(dataUrls.tilesetUrl, loaded);
         if (!config.center) {
-          await this.#widget.zoomTo(this.#tileset);
+          await this.#widget.zoomTo(loaded);
+        }
+
+        if (version !== this.#loadVersion) {
+          return;
         }
       }
 
       this.#bindCesiumEvents(cesium);
       await this.#hydrateLayersFromMetadata();
+
+      if (version !== this.#loadVersion || !this.#widget) {
+        return;
+      }
+
       this.#applyCamera();
       this.#widget.scene.requestRender();
       this.#setStatus('', true);
@@ -638,7 +651,9 @@ export class HonuaSceneElement extends HTMLElement {
         },
       }));
     } catch (error) {
-      this.#emitLoadError('tileset', 'Unable to load the 3D Tiles dataset.', error);
+      if (version === this.#loadVersion) {
+        this.#emitLoadError('tileset', 'Unable to load the 3D Tiles dataset.', error);
+      }
     }
   }
 
@@ -711,6 +726,7 @@ export class HonuaSceneElement extends HTMLElement {
       handle.metadata.url !== targetUrl ||
       !this.#widget
     ) {
+      destroyTilesetSafely(tileset);
       return;
     }
 
@@ -1018,12 +1034,14 @@ export class HonuaSceneElement extends HTMLElement {
     try {
       payload = await response.json();
     } catch (error) {
-      this.#emitMetadataError({
-        url,
-        code: 'metadata-fetch-failed',
-        message: 'Scene metadata response was not valid JSON.',
-        error,
-      });
+      if (version === this.#metadataFetchVersion) {
+        this.#emitMetadataError({
+          url,
+          code: 'metadata-fetch-failed',
+          message: 'Scene metadata response was not valid JSON.',
+          error,
+        });
+      }
       return;
     }
 
@@ -1033,8 +1051,14 @@ export class HonuaSceneElement extends HTMLElement {
 
     try {
       const metadata = parseHonuaSceneMetadata(payload);
+      if (version !== this.#metadataFetchVersion) {
+        return;
+      }
       this.#applyMetadata(metadata, 'fetch');
     } catch (error) {
+      if (version !== this.#metadataFetchVersion) {
+        return;
+      }
       if (error instanceof HonuaSceneMetadataError) {
         this.#emitMetadataError({
           url,
@@ -1302,6 +1326,20 @@ function clampOpacity(value: number): number {
   }
 
   return Math.max(0, Math.min(1, value));
+}
+
+function destroyTilesetSafely(tileset: Cesium3DTileset | null): void {
+  if (!tileset) {
+    return;
+  }
+  const candidate = tileset as { isDestroyed?: () => boolean; destroy?: () => void };
+  try {
+    if (candidate.isDestroyed?.() === false) {
+      candidate.destroy?.();
+    }
+  } catch {
+    /* tilesets may already be torn down by Cesium */
+  }
 }
 
 function canUseWebGl(): boolean {

--- a/src/Honua.Embed/src/scene.ts
+++ b/src/Honua.Embed/src/scene.ts
@@ -705,12 +705,15 @@ export class HonuaSceneElement extends HTMLElement {
     const targetUrl = handle.metadata.url;
     const targetKind = handle.metadata.kind;
     const captured = this.#layerLoadVersions.get(layerId) ?? 0;
+    const capturedSceneVersion = this.#loadVersion;
+    const capturedWidget = this.#widget;
 
     let tileset: Cesium3DTileset;
     try {
       tileset = await cesium.Cesium3DTileset.fromUrl(targetUrl);
     } catch (error) {
       if (
+        capturedSceneVersion === this.#loadVersion &&
         this.#layers.get(layerId) === handle &&
         (this.#layerLoadVersions.get(layerId) ?? 0) === captured
       ) {
@@ -720,11 +723,13 @@ export class HonuaSceneElement extends HTMLElement {
     }
 
     if (
+      capturedSceneVersion !== this.#loadVersion ||
       this.#layers.get(layerId) !== handle ||
       (this.#layerLoadVersions.get(layerId) ?? 0) !== captured ||
       handle.metadata.kind !== targetKind ||
       handle.metadata.url !== targetUrl ||
-      !this.#widget
+      !this.#widget ||
+      this.#widget !== capturedWidget
     ) {
       destroyTilesetSafely(tileset);
       return;

--- a/src/Honua.Embed/src/scene.ts
+++ b/src/Honua.Embed/src/scene.ts
@@ -612,7 +612,7 @@ export class HonuaSceneElement extends HTMLElement {
       return;
     }
 
-    const metadataDeclaresPrimary =
+    let metadataDeclaresPrimary =
       this.#metadata?.layers?.some((layer) => layer.id === 'primary') ?? false;
 
     try {
@@ -624,15 +624,22 @@ export class HonuaSceneElement extends HTMLElement {
           return;
         }
 
-        this.#tileset = loaded;
-        this.#widget.scene.primitives.add(loaded);
-        this.#registerPrimaryLayer(dataUrls.tilesetUrl, loaded);
-        if (!config.center) {
-          await this.#widget.zoomTo(loaded);
-        }
+        metadataDeclaresPrimary =
+          this.#metadata?.layers?.some((layer) => layer.id === 'primary') ?? false;
 
-        if (version !== this.#loadVersion) {
-          return;
+        if (metadataDeclaresPrimary) {
+          destroyTilesetSafely(loaded);
+        } else {
+          this.#tileset = loaded;
+          this.#widget.scene.primitives.add(loaded);
+          this.#registerPrimaryLayer(dataUrls.tilesetUrl, loaded);
+          if (!config.center) {
+            await this.#widget.zoomTo(loaded);
+          }
+
+          if (version !== this.#loadVersion) {
+            return;
+          }
         }
       }
 

--- a/src/Honua.Embed/src/scene.ts
+++ b/src/Honua.Embed/src/scene.ts
@@ -124,6 +124,7 @@ type CesiumModule = typeof import('cesium');
 type BuildModuleUrl = ((relativeUrl: string) => string) & {
   setBaseUrl?: (baseUrl: string) => void;
 };
+type LayerTilesetLoadResult = 'loaded' | 'failed' | 'stale' | 'skipped';
 
 const DEFAULT_HEIGHT = 1200;
 const DEFAULT_PITCH = -45;
@@ -677,15 +678,20 @@ export class HonuaSceneElement extends HTMLElement {
         return;
       }
 
+      metadataDeclaresPrimary =
+        this.#metadata?.layers?.some((layer) => layer.id === 'primary') ?? false;
+
       if (metadataDeclaresPrimary) {
         const primaryHandle = this.#layers.get('primary');
-        if (primaryHandle?.tileset) {
-          this.#tileset = primaryHandle.tileset;
-          if (!config.center) {
-            await this.#widget.zoomTo(primaryHandle.tileset);
-            if (version !== this.#loadVersion || !this.#widget) {
-              return;
-            }
+        if (!primaryHandle?.tileset) {
+          return;
+        }
+
+        this.#tileset = primaryHandle.tileset;
+        if (!config.center) {
+          await this.#widget.zoomTo(primaryHandle.tileset);
+          if (version !== this.#loadVersion || !this.#widget) {
+            return;
           }
         }
       }
@@ -768,10 +774,10 @@ export class HonuaSceneElement extends HTMLElement {
     );
   }
 
-  async #loadLayerTileset(handle: HonuaSceneLayerHandle): Promise<void> {
+  async #loadLayerTileset(handle: HonuaSceneLayerHandle): Promise<LayerTilesetLoadResult> {
     const cesium = this.#cesium;
     if (!this.#canLoadLayerTileset(handle) || !cesium) {
-      return;
+      return 'skipped';
     }
 
     const layerId = handle.metadata.id;
@@ -786,37 +792,68 @@ export class HonuaSceneElement extends HTMLElement {
       tileset = await cesium.Cesium3DTileset.fromUrl(targetUrl);
     } catch (error) {
       if (
-        capturedSceneVersion === this.#loadVersion &&
-        this.#layers.get(layerId) === handle &&
-        (this.#layerLoadVersions.get(layerId) ?? 0) === captured
+        this.#isCurrentLayerTilesetLoad(
+          layerId,
+          handle,
+          captured,
+          capturedSceneVersion,
+          capturedWidget,
+        )
       ) {
         this.#emitLoadError('tileset', `Unable to load layer "${layerId}".`, error);
+        return 'failed';
       }
-      return;
+      return 'stale';
     }
 
     if (
-      capturedSceneVersion !== this.#loadVersion ||
-      this.#layers.get(layerId) !== handle ||
-      (this.#layerLoadVersions.get(layerId) ?? 0) !== captured ||
+      !this.#isCurrentLayerTilesetLoad(
+        layerId,
+        handle,
+        captured,
+        capturedSceneVersion,
+        capturedWidget,
+      ) ||
       handle.metadata.kind !== targetKind ||
-      handle.metadata.url !== targetUrl ||
-      !this.#widget ||
-      this.#widget !== capturedWidget
+      handle.metadata.url !== targetUrl
     ) {
       destroyTilesetSafely(tileset);
-      return;
+      return 'stale';
+    }
+
+    const widget = this.#widget;
+    if (!widget) {
+      destroyTilesetSafely(tileset);
+      return 'stale';
     }
 
     this.#detachLayerTileset(handle);
     handle.tileset = tileset;
-    this.#widget.scene.primitives.add(tileset);
+    widget.scene.primitives.add(tileset);
     this.#applyLayerVisibility(handle, handle.visible);
     this.#applyLayerOpacity(handle, handle.opacity);
     if (handle.metadata.id === 'primary') {
       this.#tileset = tileset;
     }
-    this.#widget.scene.requestRender();
+    widget.scene.requestRender();
+    return 'loaded';
+  }
+
+  #isCurrentLayerTilesetLoad(
+    layerId: string,
+    handle: HonuaSceneLayerHandle,
+    captured: number,
+    capturedSceneVersion: number,
+    capturedWidget: CesiumWidget | null,
+  ): boolean {
+    return (
+      capturedSceneVersion === this.#loadVersion &&
+      this.#layers.get(layerId) === handle &&
+      (this.#layerLoadVersions.get(layerId) ?? 0) === captured &&
+      capturedWidget !== null &&
+      this.#widget === capturedWidget &&
+      !capturedWidget.isDestroyed()
+    );
   }
 
   #detachLayerTileset(handle: HonuaSceneLayerHandle): void {

--- a/src/Honua.Embed/src/scene.ts
+++ b/src/Honua.Embed/src/scene.ts
@@ -71,11 +71,18 @@ export interface HonuaSceneCameraChangeDetail {
   orientation: HonuaSceneOrientation;
 }
 
+export interface HonuaSceneSampledPoint {
+  latitude: number;
+  longitude: number;
+  height: number;
+}
+
 export interface HonuaSceneIdentifyDetail {
   config: HonuaSceneConfig;
   x: number;
   y: number;
   picked: unknown;
+  position: HonuaSceneSampledPoint | null;
 }
 
 export interface HonuaSceneMetadataChangeDetail {
@@ -266,6 +273,7 @@ export class HonuaSceneElement extends HTMLElement {
   #metadataUrl: string | null = null;
   #metadataFetchVersion = 0;
   readonly #layers = new Map<string, HonuaSceneLayerHandle>();
+  readonly #layerLoadVersions = new Map<string, number>();
 
   constructor() {
     super();
@@ -421,9 +429,27 @@ export class HonuaSceneElement extends HTMLElement {
   async addLayer(metadata: HonuaSceneLayerMetadata): Promise<HonuaSceneLayerHandle> {
     const existing = this.#layers.get(metadata.id);
     if (existing) {
+      const sourceChanged =
+        existing.metadata.kind !== metadata.kind ||
+        existing.metadata.url !== metadata.url;
+
       existing.metadata = metadata;
+
+      if (sourceChanged) {
+        this.#detachLayerTileset(existing);
+        this.#layerLoadVersions.set(
+          metadata.id,
+          (this.#layerLoadVersions.get(metadata.id) ?? 0) + 1,
+        );
+      }
+
       this.#applyLayerVisibility(existing, metadata.visible ?? existing.visible);
       this.#applyLayerOpacity(existing, metadata.opacity ?? existing.opacity);
+
+      if (sourceChanged && this.#canLoadLayerTileset(existing)) {
+        await this.#loadLayerTileset(existing);
+      }
+
       this.#emitLayerChange(existing, 'metadata');
       return existing;
     }
@@ -435,20 +461,10 @@ export class HonuaSceneElement extends HTMLElement {
       tileset: null,
     };
     this.#layers.set(metadata.id, handle);
+    this.#layerLoadVersions.set(metadata.id, (this.#layerLoadVersions.get(metadata.id) ?? 0) + 1);
 
-    if (metadata.kind === '3d-tiles' && this.#widget && this.#cesium) {
-      try {
-        handle.tileset = await this.#cesium.Cesium3DTileset.fromUrl(metadata.url);
-        if (!this.#layers.has(metadata.id) || !this.#widget) {
-          return handle;
-        }
-        this.#widget.scene.primitives.add(handle.tileset);
-        this.#applyLayerVisibility(handle, handle.visible);
-        this.#applyLayerOpacity(handle, handle.opacity);
-        this.#widget.scene.requestRender();
-      } catch (error) {
-        this.#emitLoadError('tileset', `Unable to load layer "${metadata.id}".`, error);
-      }
+    if (this.#canLoadLayerTileset(handle)) {
+      await this.#loadLayerTileset(handle);
     }
 
     this.#emitLayerChange(handle, 'added');
@@ -462,15 +478,8 @@ export class HonuaSceneElement extends HTMLElement {
     }
 
     this.#layers.delete(layerId);
-
-    if (handle.tileset && this.#widget) {
-      try {
-        this.#widget.scene.primitives.remove(handle.tileset);
-      } catch {
-        /* primitives may already be torn down */
-      }
-      this.#widget.scene.requestRender();
-    }
+    this.#layerLoadVersions.delete(layerId);
+    this.#detachLayerTileset(handle);
 
     this.dispatchEvent(new CustomEvent<HonuaSceneLayerChangeDetail>('honua-scene-layer-change', {
       bubbles: true,
@@ -651,31 +660,81 @@ export class HonuaSceneElement extends HTMLElement {
   }
 
   async #hydrateLayersFromMetadata(): Promise<void> {
-    const metadata = this.#metadata;
-    if (!metadata?.layers || !this.#widget || !this.#cesium) {
+    if (!this.#widget || !this.#cesium) {
       return;
     }
 
-    for (const layer of metadata.layers) {
-      if (layer.kind !== '3d-tiles') {
+    for (const handle of [...this.#layers.values()]) {
+      if (handle.tileset) {
         continue;
       }
-      const handle = this.#layers.get(layer.id);
-      if (!handle || handle.tileset) {
-        continue;
-      }
-      try {
-        handle.tileset = await this.#cesium.Cesium3DTileset.fromUrl(layer.url);
-        if (!this.#widget) {
-          return;
-        }
-        this.#widget.scene.primitives.add(handle.tileset);
-        this.#applyLayerVisibility(handle, handle.visible);
-        this.#applyLayerOpacity(handle, handle.opacity);
-      } catch (error) {
-        this.#emitLoadError('tileset', `Unable to load layer "${layer.id}".`, error);
-      }
+      await this.#loadLayerTileset(handle);
     }
+  }
+
+  #canLoadLayerTileset(handle: HonuaSceneLayerHandle): boolean {
+    return (
+      handle.metadata.kind === '3d-tiles' &&
+      this.#widget !== null &&
+      this.#cesium !== null
+    );
+  }
+
+  async #loadLayerTileset(handle: HonuaSceneLayerHandle): Promise<void> {
+    const cesium = this.#cesium;
+    if (!this.#canLoadLayerTileset(handle) || !cesium) {
+      return;
+    }
+
+    const layerId = handle.metadata.id;
+    const targetUrl = handle.metadata.url;
+    const targetKind = handle.metadata.kind;
+    const captured = this.#layerLoadVersions.get(layerId) ?? 0;
+
+    let tileset: Cesium3DTileset;
+    try {
+      tileset = await cesium.Cesium3DTileset.fromUrl(targetUrl);
+    } catch (error) {
+      if (
+        this.#layers.get(layerId) === handle &&
+        (this.#layerLoadVersions.get(layerId) ?? 0) === captured
+      ) {
+        this.#emitLoadError('tileset', `Unable to load layer "${layerId}".`, error);
+      }
+      return;
+    }
+
+    if (
+      this.#layers.get(layerId) !== handle ||
+      (this.#layerLoadVersions.get(layerId) ?? 0) !== captured ||
+      handle.metadata.kind !== targetKind ||
+      handle.metadata.url !== targetUrl ||
+      !this.#widget
+    ) {
+      return;
+    }
+
+    this.#detachLayerTileset(handle);
+    handle.tileset = tileset;
+    this.#widget.scene.primitives.add(tileset);
+    this.#applyLayerVisibility(handle, handle.visible);
+    this.#applyLayerOpacity(handle, handle.opacity);
+    this.#widget.scene.requestRender();
+  }
+
+  #detachLayerTileset(handle: HonuaSceneLayerHandle): void {
+    if (!handle.tileset) {
+      return;
+    }
+    if (this.#widget) {
+      try {
+        this.#widget.scene.primitives.remove(handle.tileset);
+      } catch {
+        /* primitives may already be torn down */
+      }
+      this.#widget.scene.requestRender();
+    }
+    handle.tileset = null;
   }
 
   async #resolveSceneDataUrls(config: HonuaSceneConfig): Promise<{
@@ -754,6 +813,7 @@ export class HonuaSceneElement extends HTMLElement {
       }
 
       const picked = this.#widget.scene.pick(event.position);
+      const position = this.samplePoint(event.position.x, event.position.y);
       this.dispatchEvent(new CustomEvent<HonuaSceneIdentifyDetail>('honua-scene-identify', {
         bubbles: true,
         composed: true,
@@ -762,9 +822,54 @@ export class HonuaSceneElement extends HTMLElement {
           x: event.position.x,
           y: event.position.y,
           picked,
+          position,
         },
       }));
     }, cesium.ScreenSpaceEventType.LEFT_CLICK);
+  }
+
+  samplePoint(x: number, y: number): HonuaSceneSampledPoint | null {
+    if (!this.#widget || !this.#cesium) {
+      return null;
+    }
+
+    const scene = this.#widget.scene as unknown as {
+      pickPosition?: (position: { x: number; y: number }) => unknown;
+    };
+    if (typeof scene.pickPosition !== 'function') {
+      return null;
+    }
+
+    let cartesian: unknown;
+    try {
+      cartesian = scene.pickPosition({ x, y });
+    } catch {
+      return null;
+    }
+
+    if (!cartesian) {
+      return null;
+    }
+
+    const { Cartographic, Math: CesiumMath } = this.#cesium;
+    let cartographic: { latitude: number; longitude: number; height: number } | null;
+    try {
+      cartographic = Cartographic.fromCartesian(
+        cartesian as Parameters<typeof Cartographic.fromCartesian>[0],
+      );
+    } catch {
+      return null;
+    }
+
+    if (!cartographic) {
+      return null;
+    }
+
+    return {
+      latitude: CesiumMath.toDegrees(cartographic.latitude),
+      longitude: CesiumMath.toDegrees(cartographic.longitude),
+      height: cartographic.height,
+    };
   }
 
   #applyCamera(): void {

--- a/src/Honua.Embed/src/scene.ts
+++ b/src/Honua.Embed/src/scene.ts
@@ -547,6 +547,8 @@ export class HonuaSceneElement extends HTMLElement {
       return;
     }
 
+    this.#dropStaleImplicitPrimary(dataUrls?.tilesetUrl ?? null);
+
     if (dataUrls === null) {
       this.#destroyCesium();
       return;
@@ -672,6 +674,25 @@ export class HonuaSceneElement extends HTMLElement {
       tileset,
     };
     this.#layers.set('primary', handle);
+  }
+
+  #dropStaleImplicitPrimary(targetTilesetUrl: string | null): void {
+    const primary = this.#layers.get('primary');
+    if (!primary) {
+      return;
+    }
+
+    if (this.#metadata?.layers?.some((layer) => layer.id === 'primary')) {
+      return;
+    }
+
+    if (primary.metadata.url === targetTilesetUrl) {
+      return;
+    }
+
+    this.#detachLayerTileset(primary);
+    this.#layers.delete('primary');
+    this.#layerLoadVersions.delete('primary');
   }
 
   async #hydrateLayersFromMetadata(): Promise<void> {

--- a/src/Honua.Embed/src/scene.ts
+++ b/src/Honua.Embed/src/scene.ts
@@ -612,8 +612,11 @@ export class HonuaSceneElement extends HTMLElement {
       return;
     }
 
+    const metadataDeclaresPrimary =
+      this.#metadata?.layers?.some((layer) => layer.id === 'primary') ?? false;
+
     try {
-      if (dataUrls.tilesetUrl) {
+      if (dataUrls.tilesetUrl && !metadataDeclaresPrimary) {
         const loaded = await cesium.Cesium3DTileset.fromUrl(dataUrls.tilesetUrl);
 
         if (version !== this.#loadVersion || !this.#widget) {
@@ -638,6 +641,19 @@ export class HonuaSceneElement extends HTMLElement {
 
       if (version !== this.#loadVersion || !this.#widget) {
         return;
+      }
+
+      if (metadataDeclaresPrimary) {
+        const primaryHandle = this.#layers.get('primary');
+        if (primaryHandle?.tileset) {
+          this.#tileset = primaryHandle.tileset;
+          if (!config.center) {
+            await this.#widget.zoomTo(primaryHandle.tileset);
+            if (version !== this.#loadVersion || !this.#widget) {
+              return;
+            }
+          }
+        }
       }
 
       this.#applyCamera();

--- a/src/Honua.Embed/src/scene.ts
+++ b/src/Honua.Embed/src/scene.ts
@@ -272,6 +272,8 @@ export class HonuaSceneElement extends HTMLElement {
   #metadata: HonuaSceneMetadata | null = null;
   #metadataUrl: string | null = null;
   #metadataFetchVersion = 0;
+  #pendingMetadataFetch: Promise<void> | null = null;
+  #primaryOwner: 'implicit' | 'metadata' | null = null;
   readonly #layers = new Map<string, HonuaSceneLayerHandle>();
   readonly #layerLoadVersions = new Map<string, number>();
 
@@ -313,6 +315,7 @@ export class HonuaSceneElement extends HTMLElement {
   set metadata(value: HonuaSceneMetadata | null) {
     this.#metadataUrl = null;
     this.#metadataFetchVersion += 1;
+    this.#pendingMetadataFetch = null;
     this.#applyMetadata(value, 'property');
   }
 
@@ -330,7 +333,7 @@ export class HonuaSceneElement extends HTMLElement {
     const metadataUrl = this.getAttribute('metadata-url');
     if (metadataUrl && metadataUrl !== this.#metadataUrl) {
       this.#metadataUrl = metadataUrl;
-      void this.#fetchMetadata(metadataUrl);
+      this.#pendingMetadataFetch = this.#fetchMetadata(metadataUrl);
     }
 
     const config = this.config;
@@ -372,8 +375,9 @@ export class HonuaSceneElement extends HTMLElement {
       this.#metadataUrl = next;
       this.#metadataFetchVersion += 1;
       if (next) {
-        void this.#fetchMetadata(next);
+        this.#pendingMetadataFetch = this.#fetchMetadata(next);
       } else {
+        this.#pendingMetadataFetch = null;
         this.#applyMetadata(null, 'cleared');
       }
       return;
@@ -446,6 +450,10 @@ export class HonuaSceneElement extends HTMLElement {
       this.#applyLayerVisibility(existing, metadata.visible ?? existing.visible);
       this.#applyLayerOpacity(existing, metadata.opacity ?? existing.opacity);
 
+      if (metadata.id === 'primary') {
+        this.#primaryOwner = 'implicit';
+      }
+
       if (sourceChanged && this.#canLoadLayerTileset(existing)) {
         await this.#loadLayerTileset(existing);
       }
@@ -463,6 +471,10 @@ export class HonuaSceneElement extends HTMLElement {
     this.#layers.set(metadata.id, handle);
     this.#layerLoadVersions.set(metadata.id, (this.#layerLoadVersions.get(metadata.id) ?? 0) + 1);
 
+    if (metadata.id === 'primary') {
+      this.#primaryOwner = 'implicit';
+    }
+
     if (this.#canLoadLayerTileset(handle)) {
       await this.#loadLayerTileset(handle);
     }
@@ -479,6 +491,9 @@ export class HonuaSceneElement extends HTMLElement {
 
     this.#layers.delete(layerId);
     this.#layerLoadVersions.delete(layerId);
+    if (layerId === 'primary') {
+      this.#primaryOwner = null;
+    }
     this.#detachLayerTileset(handle);
 
     this.dispatchEvent(new CustomEvent<HonuaSceneLayerChangeDetail>('honua-scene-layer-change', {
@@ -578,6 +593,18 @@ export class HonuaSceneElement extends HTMLElement {
 
     if (version !== this.#loadVersion) {
       return;
+    }
+
+    const pendingMetadataFetch = this.#pendingMetadataFetch;
+    if (pendingMetadataFetch) {
+      try {
+        await pendingMetadataFetch;
+      } catch {
+        /* #fetchMetadata surfaces errors via honua-scene-metadata-error */
+      }
+      if (version !== this.#loadVersion) {
+        return;
+      }
     }
 
     this.#configureCesiumAssets(cesium, config);
@@ -697,6 +724,7 @@ export class HonuaSceneElement extends HTMLElement {
       tileset,
     };
     this.#layers.set('primary', handle);
+    this.#primaryOwner = 'implicit';
   }
 
   #dropStaleImplicitPrimary(targetTilesetUrl: string | null): void {
@@ -716,6 +744,7 @@ export class HonuaSceneElement extends HTMLElement {
     this.#detachLayerTileset(primary);
     this.#layers.delete('primary');
     this.#layerLoadVersions.delete('primary');
+    this.#primaryOwner = null;
   }
 
   async #hydrateLayersFromMetadata(): Promise<void> {
@@ -1156,7 +1185,22 @@ export class HonuaSceneElement extends HTMLElement {
       for (const layer of metadata.layers) {
         declaredIds.add(layer.id);
         void this.addLayer(layer);
+        if (layer.id === 'primary') {
+          this.#primaryOwner = 'metadata';
+        }
       }
+    }
+
+    let metadataPrimaryDropped = false;
+    if (!declaredIds.has('primary') && this.#primaryOwner === 'metadata') {
+      const primary = this.#layers.get('primary');
+      if (primary) {
+        this.#detachLayerTileset(primary);
+        this.#layers.delete('primary');
+        this.#layerLoadVersions.delete('primary');
+      }
+      this.#primaryOwner = null;
+      metadataPrimaryDropped = true;
     }
 
     for (const id of [...this.#layers.keys()]) {
@@ -1167,6 +1211,13 @@ export class HonuaSceneElement extends HTMLElement {
         continue;
       }
       this.removeLayer(id);
+    }
+
+    if (metadataPrimaryDropped) {
+      const config = this.config;
+      if (this.isConnected && config.autoload && hasSceneData(config)) {
+        void this.load();
+      }
     }
   }
 

--- a/src/Honua.Embed/src/scene.ts
+++ b/src/Honua.Embed/src/scene.ts
@@ -777,12 +777,18 @@ export class HonuaSceneElement extends HTMLElement {
     this.#widget.scene.primitives.add(tileset);
     this.#applyLayerVisibility(handle, handle.visible);
     this.#applyLayerOpacity(handle, handle.opacity);
+    if (handle.metadata.id === 'primary') {
+      this.#tileset = tileset;
+    }
     this.#widget.scene.requestRender();
   }
 
   #detachLayerTileset(handle: HonuaSceneLayerHandle): void {
     if (!handle.tileset) {
       return;
+    }
+    if (this.#tileset === handle.tileset) {
+      this.#tileset = null;
     }
     if (this.#widget) {
       try {

--- a/src/Honua.Embed/src/scene.ts
+++ b/src/Honua.Embed/src/scene.ts
@@ -15,6 +15,13 @@ import {
   type HonuaScenePackageCacheErrorCode,
   resolveScenePackageAsset,
 } from './scene-package-cache';
+import {
+  HonuaSceneMetadataError,
+  parseHonuaSceneMetadata,
+  type HonuaSceneLayerMetadata,
+  type HonuaSceneMetadata,
+  type HonuaSceneViewSpec,
+} from './scene-metadata';
 
 export interface HonuaSceneCoordinate {
   latitude: number;
@@ -69,6 +76,41 @@ export interface HonuaSceneIdentifyDetail {
   x: number;
   y: number;
   picked: unknown;
+}
+
+export interface HonuaSceneMetadataChangeDetail {
+  metadata: HonuaSceneMetadata | null;
+  source: 'attribute' | 'property' | 'fetch' | 'cleared';
+}
+
+export interface HonuaSceneMetadataErrorDetail {
+  url: string | null;
+  code: 'metadata-invalid' | 'metadata-fetch-failed';
+  message: string;
+  path?: string;
+  error?: unknown;
+}
+
+export type HonuaSceneLayerChangeReason =
+  | 'added'
+  | 'removed'
+  | 'visibility'
+  | 'opacity'
+  | 'metadata';
+
+export interface HonuaSceneLayerChangeDetail {
+  layerId: string;
+  reason: HonuaSceneLayerChangeReason;
+  layer: HonuaSceneLayerMetadata | null;
+  visible: boolean;
+  opacity: number;
+}
+
+export interface HonuaSceneLayerHandle {
+  metadata: HonuaSceneLayerMetadata;
+  visible: boolean;
+  opacity: number;
+  tileset: Cesium3DTileset | null;
 }
 
 type CesiumModule = typeof import('cesium');
@@ -207,6 +249,7 @@ export class HonuaSceneElement extends HTMLElement {
       'roll',
       'theme',
       'autoload',
+      'metadata-url',
     ];
   }
 
@@ -219,6 +262,10 @@ export class HonuaSceneElement extends HTMLElement {
   #assetResolver: HonuaScenePackageAssetResolverInput | null = null;
   readonly #extensionHost: HonuaEmbedExtensionHost<'scene'>;
   #loadVersion = 0;
+  #metadata: HonuaSceneMetadata | null = null;
+  #metadataUrl: string | null = null;
+  #metadataFetchVersion = 0;
+  readonly #layers = new Map<string, HonuaSceneLayerHandle>();
 
   constructor() {
     super();
@@ -251,11 +298,32 @@ export class HonuaSceneElement extends HTMLElement {
     this.setPackageAssetResolver(resolver);
   }
 
+  get metadata(): HonuaSceneMetadata | null {
+    return this.#metadata;
+  }
+
+  set metadata(value: HonuaSceneMetadata | null) {
+    this.#metadataUrl = null;
+    this.#metadataFetchVersion += 1;
+    this.#applyMetadata(value, 'property');
+  }
+
+  get layers(): readonly HonuaSceneLayerHandle[] {
+    return [...this.#layers.values()];
+  }
+
   connectedCallback(): void {
     this.#upgradeProperty('center');
     this.#upgradeProperty('packageAssetResolver');
+    this.#upgradeProperty('metadata');
     this.#render();
     this.#extensionHost.connect();
+
+    const metadataUrl = this.getAttribute('metadata-url');
+    if (metadataUrl && metadataUrl !== this.#metadataUrl) {
+      this.#metadataUrl = metadataUrl;
+      void this.#fetchMetadata(metadataUrl);
+    }
 
     const config = this.config;
     if (config.autoload && hasSceneData(config)) {
@@ -288,6 +356,18 @@ export class HonuaSceneElement extends HTMLElement {
 
     if (['center', 'height', 'heading', 'pitch', 'roll'].includes(name)) {
       this.#applyCamera();
+      return;
+    }
+
+    if (name === 'metadata-url') {
+      const next = emptyToNull(newValue);
+      this.#metadataUrl = next;
+      this.#metadataFetchVersion += 1;
+      if (next) {
+        void this.#fetchMetadata(next);
+      } else {
+        this.#applyMetadata(null, 'cleared');
+      }
       return;
     }
 
@@ -328,6 +408,113 @@ export class HonuaSceneElement extends HTMLElement {
     if (orientation.roll !== undefined) {
       this.setAttribute('roll', String(orientation.roll));
     }
+  }
+
+  applyView(view: HonuaSceneViewSpec): void {
+    this.setView(view.center, view.height, view.orientation);
+  }
+
+  getLayer(layerId: string): HonuaSceneLayerHandle | null {
+    return this.#layers.get(layerId) ?? null;
+  }
+
+  async addLayer(metadata: HonuaSceneLayerMetadata): Promise<HonuaSceneLayerHandle> {
+    const existing = this.#layers.get(metadata.id);
+    if (existing) {
+      existing.metadata = metadata;
+      this.#applyLayerVisibility(existing, metadata.visible ?? existing.visible);
+      this.#applyLayerOpacity(existing, metadata.opacity ?? existing.opacity);
+      this.#emitLayerChange(existing, 'metadata');
+      return existing;
+    }
+
+    const handle: HonuaSceneLayerHandle = {
+      metadata,
+      visible: metadata.visible ?? true,
+      opacity: metadata.opacity ?? 1,
+      tileset: null,
+    };
+    this.#layers.set(metadata.id, handle);
+
+    if (metadata.kind === '3d-tiles' && this.#widget && this.#cesium) {
+      try {
+        handle.tileset = await this.#cesium.Cesium3DTileset.fromUrl(metadata.url);
+        if (!this.#layers.has(metadata.id) || !this.#widget) {
+          return handle;
+        }
+        this.#widget.scene.primitives.add(handle.tileset);
+        this.#applyLayerVisibility(handle, handle.visible);
+        this.#applyLayerOpacity(handle, handle.opacity);
+        this.#widget.scene.requestRender();
+      } catch (error) {
+        this.#emitLoadError('tileset', `Unable to load layer "${metadata.id}".`, error);
+      }
+    }
+
+    this.#emitLayerChange(handle, 'added');
+    return handle;
+  }
+
+  removeLayer(layerId: string): boolean {
+    const handle = this.#layers.get(layerId);
+    if (!handle) {
+      return false;
+    }
+
+    this.#layers.delete(layerId);
+
+    if (handle.tileset && this.#widget) {
+      try {
+        this.#widget.scene.primitives.remove(handle.tileset);
+      } catch {
+        /* primitives may already be torn down */
+      }
+      this.#widget.scene.requestRender();
+    }
+
+    this.dispatchEvent(new CustomEvent<HonuaSceneLayerChangeDetail>('honua-scene-layer-change', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        layerId,
+        reason: 'removed',
+        layer: null,
+        visible: false,
+        opacity: handle.opacity,
+      },
+    }));
+    return true;
+  }
+
+  setLayerVisibility(layerId: string, visible: boolean): boolean {
+    const handle = this.#layers.get(layerId);
+    if (!handle) {
+      return false;
+    }
+
+    if (handle.visible === visible) {
+      return true;
+    }
+
+    this.#applyLayerVisibility(handle, visible);
+    this.#emitLayerChange(handle, 'visibility');
+    return true;
+  }
+
+  setLayerOpacity(layerId: string, opacity: number): boolean {
+    const handle = this.#layers.get(layerId);
+    if (!handle) {
+      return false;
+    }
+
+    const clamped = clampOpacity(opacity);
+    if (handle.opacity === clamped) {
+      return true;
+    }
+
+    this.#applyLayerOpacity(handle, clamped);
+    this.#emitLayerChange(handle, 'opacity');
+    return true;
   }
 
   async refresh(): Promise<void> {
@@ -421,12 +608,14 @@ export class HonuaSceneElement extends HTMLElement {
         }
 
         this.#widget.scene.primitives.add(this.#tileset);
+        this.#registerPrimaryLayer(dataUrls.tilesetUrl, this.#tileset);
         if (!config.center) {
           await this.#widget.zoomTo(this.#tileset);
         }
       }
 
       this.#bindCesiumEvents(cesium);
+      await this.#hydrateLayersFromMetadata();
       this.#applyCamera();
       this.#widget.scene.requestRender();
       this.#setStatus('', true);
@@ -441,6 +630,51 @@ export class HonuaSceneElement extends HTMLElement {
       }));
     } catch (error) {
       this.#emitLoadError('tileset', 'Unable to load the 3D Tiles dataset.', error);
+    }
+  }
+
+  #registerPrimaryLayer(url: string, tileset: Cesium3DTileset): void {
+    const handle: HonuaSceneLayerHandle = {
+      metadata: {
+        id: 'primary',
+        title: 'Primary tileset',
+        kind: '3d-tiles',
+        url,
+        visible: true,
+        opacity: 1,
+      },
+      visible: true,
+      opacity: 1,
+      tileset,
+    };
+    this.#layers.set('primary', handle);
+  }
+
+  async #hydrateLayersFromMetadata(): Promise<void> {
+    const metadata = this.#metadata;
+    if (!metadata?.layers || !this.#widget || !this.#cesium) {
+      return;
+    }
+
+    for (const layer of metadata.layers) {
+      if (layer.kind !== '3d-tiles') {
+        continue;
+      }
+      const handle = this.#layers.get(layer.id);
+      if (!handle || handle.tileset) {
+        continue;
+      }
+      try {
+        handle.tileset = await this.#cesium.Cesium3DTileset.fromUrl(layer.url);
+        if (!this.#widget) {
+          return;
+        }
+        this.#widget.scene.primitives.add(handle.tileset);
+        this.#applyLayerVisibility(handle, handle.visible);
+        this.#applyLayerOpacity(handle, handle.opacity);
+      } catch (error) {
+        this.#emitLoadError('tileset', `Unable to load layer "${layer.id}".`, error);
+      }
     }
   }
 
@@ -634,11 +868,169 @@ export class HonuaSceneElement extends HTMLElement {
     this.#handler = null;
     this.#tileset = null;
 
+    for (const handle of this.#layers.values()) {
+      handle.tileset = null;
+    }
+
     if (this.#widget && !this.#widget.isDestroyed()) {
       this.#widget.destroy();
     }
 
     this.#widget = null;
+  }
+
+  async #fetchMetadata(url: string): Promise<void> {
+    const version = ++this.#metadataFetchVersion;
+    let response: Response;
+    try {
+      response = await fetch(url, { credentials: 'same-origin' });
+    } catch (error) {
+      if (version === this.#metadataFetchVersion) {
+        this.#emitMetadataError({
+          url,
+          code: 'metadata-fetch-failed',
+          message: 'Unable to fetch scene metadata.',
+          error,
+        });
+      }
+      return;
+    }
+
+    if (version !== this.#metadataFetchVersion) {
+      return;
+    }
+
+    if (!response.ok) {
+      this.#emitMetadataError({
+        url,
+        code: 'metadata-fetch-failed',
+        message: `Scene metadata request failed (${response.status}).`,
+      });
+      return;
+    }
+
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch (error) {
+      this.#emitMetadataError({
+        url,
+        code: 'metadata-fetch-failed',
+        message: 'Scene metadata response was not valid JSON.',
+        error,
+      });
+      return;
+    }
+
+    if (version !== this.#metadataFetchVersion) {
+      return;
+    }
+
+    try {
+      const metadata = parseHonuaSceneMetadata(payload);
+      this.#applyMetadata(metadata, 'fetch');
+    } catch (error) {
+      if (error instanceof HonuaSceneMetadataError) {
+        this.#emitMetadataError({
+          url,
+          code: error.code,
+          message: error.message,
+          path: error.path,
+          error,
+        });
+        return;
+      }
+      this.#emitMetadataError({
+        url,
+        code: 'metadata-invalid',
+        message: 'Scene metadata could not be parsed.',
+        error,
+      });
+    }
+  }
+
+  #applyMetadata(
+    metadata: HonuaSceneMetadata | null,
+    source: HonuaSceneMetadataChangeDetail['source'],
+  ): void {
+    this.#metadata = metadata;
+    this.#syncLayersFromMetadata(metadata);
+
+    this.dispatchEvent(new CustomEvent<HonuaSceneMetadataChangeDetail>('honua-scene-metadata-change', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        metadata,
+        source,
+      },
+    }));
+  }
+
+  #syncLayersFromMetadata(metadata: HonuaSceneMetadata | null): void {
+    const declaredIds = new Set<string>();
+    if (metadata?.layers) {
+      for (const layer of metadata.layers) {
+        declaredIds.add(layer.id);
+        void this.addLayer(layer);
+      }
+    }
+
+    for (const id of [...this.#layers.keys()]) {
+      if (declaredIds.has(id)) {
+        continue;
+      }
+      if (id === 'primary') {
+        continue;
+      }
+      this.removeLayer(id);
+    }
+  }
+
+  #emitMetadataError(detail: HonuaSceneMetadataErrorDetail): void {
+    this.dispatchEvent(new CustomEvent<HonuaSceneMetadataErrorDetail>('honua-scene-metadata-error', {
+      bubbles: true,
+      composed: true,
+      detail,
+    }));
+  }
+
+  #applyLayerVisibility(handle: HonuaSceneLayerHandle, visible: boolean): void {
+    handle.visible = visible;
+    if (handle.tileset) {
+      handle.tileset.show = visible;
+    }
+    this.#widget?.scene.requestRender();
+  }
+
+  #applyLayerOpacity(handle: HonuaSceneLayerHandle, opacity: number): void {
+    handle.opacity = opacity;
+    if (handle.tileset && this.#cesium) {
+      try {
+        handle.tileset.style = new this.#cesium.Cesium3DTileStyle({
+          color: `color('white', ${opacity})`,
+        });
+      } catch {
+        /* style construction is best-effort and may fail in mocks */
+      }
+    }
+    this.#widget?.scene.requestRender();
+  }
+
+  #emitLayerChange(
+    handle: HonuaSceneLayerHandle,
+    reason: HonuaSceneLayerChangeReason,
+  ): void {
+    this.dispatchEvent(new CustomEvent<HonuaSceneLayerChangeDetail>('honua-scene-layer-change', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        layerId: handle.metadata.id,
+        reason,
+        layer: handle.metadata,
+        visible: handle.visible,
+        opacity: handle.opacity,
+      },
+    }));
   }
 
   #emitPackageCacheError(error: unknown): void {
@@ -797,6 +1189,14 @@ function parseBooleanAttribute(element: HTMLElement, name: string, defaultValue 
 
   const value = element.getAttribute(name);
   return value === '' || value === null || !['false', '0', 'no'].includes(value.toLowerCase());
+}
+
+function clampOpacity(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 1;
+  }
+
+  return Math.max(0, Math.min(1, value));
 }
 
 function canUseWebGl(): boolean {

--- a/src/Honua.Embed/tests/controls/bookmarks.test.ts
+++ b/src/Honua.Embed/tests/controls/bookmarks.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupScene, type SceneSetup } from './test-utils';
+
+describe('honua-scene-bookmarks', () => {
+  let setup: SceneSetup;
+
+  beforeEach(async () => {
+    document.body.replaceChildren();
+    setup = await setupScene();
+  });
+
+  afterEach(() => {
+    setup.cleanup();
+  });
+
+  it('renders one entry per metadata bookmark', () => {
+    const control = createBookmarksControl(setup);
+    expect(control.shadowRoot!.querySelectorAll('button.bookmark')).toHaveLength(2);
+  });
+
+  it('emits honua-scene-bookmark-apply and applies the view', () => {
+    const control = createBookmarksControl(setup);
+    const listener = vi.fn();
+    control.addEventListener('honua-scene-bookmark-apply', listener);
+
+    const button = control.shadowRoot!.querySelector<HTMLButtonElement>('button.bookmark[data-bookmark-id="entrance"]')!;
+    button.click();
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail).toMatchObject({
+      bookmarkId: 'entrance',
+      controlId: 'bookmarks',
+    });
+    expect(setup.scene.getAttribute('center')).toBe('39.95,-75.16');
+    expect(setup.scene.getAttribute('height')).toBe('80');
+  });
+
+  it('emits honua-scene-control-error when calling apply with an unknown id', () => {
+    const control = createBookmarksControl(setup);
+    const listener = vi.fn();
+    control.addEventListener('honua-scene-control-error', listener);
+
+    const result = (control as unknown as { apply(id: string): boolean }).apply('does-not-exist');
+    expect(result).toBe(false);
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail).toMatchObject({
+      controlId: 'bookmarks',
+      kind: 'bookmark-not-found',
+    });
+  });
+});
+
+function createBookmarksControl(setup: SceneSetup): HTMLElement {
+  setup.scene.id = 'scene-under-test';
+  const control = document.createElement('honua-scene-bookmarks');
+  control.setAttribute('for', '#scene-under-test');
+  document.body.append(control);
+  return control;
+}

--- a/src/Honua.Embed/tests/controls/compare.test.ts
+++ b/src/Honua.Embed/tests/controls/compare.test.ts
@@ -51,6 +51,58 @@ describe('honua-scene-compare', () => {
     expect(setup.scene.getLayer('design-overlay')?.visible).toBe(true);
     expect(setup.scene.getLayer('as-built')?.visible).toBe(true);
   });
+
+  it('toggles the implicit primary layer when modes reference it', async () => {
+    setup.cleanup();
+    setup = await setupScene({
+      schema: 'honua-scene-metadata/v1',
+      id: 'with-primary',
+      name: 'Scene with implicit primary',
+      layers: [
+        {
+          id: 'as-built',
+          title: 'As-built',
+          kind: '3d-tiles',
+          url: 'https://example.test/as-built/tileset.json',
+          visible: true,
+          opacity: 1,
+        },
+      ],
+      compare: {
+        modes: [
+          {
+            id: 'primary-vs-asbuilt',
+            title: 'Primary vs As-built',
+            leftLayerIds: ['primary'],
+            rightLayerIds: ['as-built'],
+          },
+        ],
+      },
+    });
+    await setup.scene.addLayer({
+      id: 'primary',
+      title: 'Primary',
+      kind: '3d-tiles',
+      url: 'https://example.test/primary/tileset.json',
+      visible: true,
+      opacity: 1,
+    });
+
+    const control = createCompareControl(setup);
+    const leftButton = control.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button[data-mode-id="primary-vs-asbuilt"][data-side="left"]',
+    )!;
+    leftButton.click();
+    expect(setup.scene.getLayer('primary')?.visible).toBe(true);
+    expect(setup.scene.getLayer('as-built')?.visible).toBe(false);
+
+    const rightButton = control.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button[data-mode-id="primary-vs-asbuilt"][data-side="right"]',
+    )!;
+    rightButton.click();
+    expect(setup.scene.getLayer('primary')?.visible).toBe(false);
+    expect(setup.scene.getLayer('as-built')?.visible).toBe(true);
+  });
 });
 
 function createCompareControl(setup: SceneSetup): HTMLElement {

--- a/src/Honua.Embed/tests/controls/compare.test.ts
+++ b/src/Honua.Embed/tests/controls/compare.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupScene, type SceneSetup } from './test-utils';
+
+describe('honua-scene-compare', () => {
+  let setup: SceneSetup;
+
+  beforeEach(async () => {
+    document.body.replaceChildren();
+    setup = await setupScene();
+  });
+
+  afterEach(() => {
+    setup.cleanup();
+  });
+
+  it('renders compare modes and side buttons', () => {
+    const control = createCompareControl(setup);
+    expect(control.shadowRoot!.querySelectorAll('.mode')).toHaveLength(1);
+    expect(control.shadowRoot!.querySelectorAll('.mode-buttons button')).toHaveLength(3);
+  });
+
+  it('toggles layer visibility when activating a side', () => {
+    const control = createCompareControl(setup);
+    const listener = vi.fn();
+    control.addEventListener('honua-scene-compare-set', listener);
+
+    const button = control.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button[data-mode-id="design-vs-asbuilt"][data-side="left"]',
+    )!;
+    button.click();
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail).toMatchObject({
+      modeId: 'design-vs-asbuilt',
+      side: 'left',
+      leftLayerIds: ['design-overlay'],
+      rightLayerIds: ['as-built'],
+      controlId: 'compare',
+    });
+    expect(setup.scene.getLayer('design-overlay')?.visible).toBe(true);
+    expect(setup.scene.getLayer('as-built')?.visible).toBe(false);
+  });
+
+  it('shows both sides when "both" is selected', () => {
+    const control = createCompareControl(setup);
+    const button = control.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button[data-mode-id="design-vs-asbuilt"][data-side="both"]',
+    )!;
+    button.click();
+
+    expect(setup.scene.getLayer('design-overlay')?.visible).toBe(true);
+    expect(setup.scene.getLayer('as-built')?.visible).toBe(true);
+  });
+});
+
+function createCompareControl(setup: SceneSetup): HTMLElement {
+  setup.scene.id = 'scene-under-test';
+  const control = document.createElement('honua-scene-compare');
+  control.setAttribute('for', '#scene-under-test');
+  document.body.append(control);
+  return control;
+}

--- a/src/Honua.Embed/tests/controls/inspector.test.ts
+++ b/src/Honua.Embed/tests/controls/inspector.test.ts
@@ -81,6 +81,57 @@ describe('honua-scene-inspector', () => {
     const titles = [...fields].map((node) => node.textContent);
     expect(titles).toEqual(['Asset ID', 'Phase', 'Elevation']);
   });
+
+  it('falls back to Cesium getPropertyIds/getProperty when metadata has no inspector fields', async () => {
+    setup.cleanup();
+    setup = await setupScene({
+      schema: 'honua-scene-metadata/v1',
+      id: 'sample-no-inspector',
+      name: 'Sample Scene Without Inspector',
+    });
+
+    const control = createInspectorControl(setup);
+    const listener = vi.fn();
+    control.addEventListener('honua-scene-feature-select', listener);
+
+    const properties: Record<string, unknown> = {
+      id: 'cesium-feature-7',
+      phase: 'phase-3',
+      elevation: 42,
+    };
+    const cesiumLikeFeature = {
+      featureId: 7,
+      getPropertyIds: () => Object.keys(properties),
+      getProperty: (key: string) => properties[key],
+    };
+
+    setup.scene.dispatchEvent(
+      new CustomEvent('honua-scene-identify', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          x: 0,
+          y: 0,
+          picked: cesiumLikeFeature,
+        },
+      }),
+    );
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail).toMatchObject({
+      featureId: '7',
+      attributes: {
+        id: 'cesium-feature-7',
+        phase: 'phase-3',
+        elevation: 42,
+      },
+      controlId: 'inspector',
+    });
+
+    const fields = control.shadowRoot!.querySelectorAll('dt');
+    const titles = [...fields].map((node) => node.textContent);
+    expect(titles).toEqual(['id', 'phase', 'elevation']);
+  });
 });
 
 function createInspectorControl(setup: SceneSetup): HTMLElement {

--- a/src/Honua.Embed/tests/controls/inspector.test.ts
+++ b/src/Honua.Embed/tests/controls/inspector.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupScene, type SceneSetup } from './test-utils';
+
+describe('honua-scene-inspector', () => {
+  let setup: SceneSetup;
+
+  beforeEach(async () => {
+    document.body.replaceChildren();
+    setup = await setupScene();
+  });
+
+  afterEach(() => {
+    setup.cleanup();
+  });
+
+  it('shows the empty state until a feature is selected', () => {
+    const control = createInspectorControl(setup);
+    expect(control.shadowRoot!.querySelector<HTMLElement>('[data-empty]')!.hidden).toBe(false);
+    expect(control.shadowRoot!.querySelector<HTMLElement>('.fields')!.hidden).toBe(true);
+  });
+
+  it('emits honua-scene-feature-select on a scene identify event', () => {
+    const control = createInspectorControl(setup);
+    const listener = vi.fn();
+    control.addEventListener('honua-scene-feature-select', listener);
+
+    setup.scene.dispatchEvent(
+      new CustomEvent('honua-scene-identify', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          x: 10,
+          y: 20,
+          picked: {
+            id: 'asset-42',
+            properties: {
+              id: 'asset-42',
+              phase: 'phase-2',
+              elevation: 12,
+            },
+          },
+        },
+      }),
+    );
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail).toMatchObject({
+      featureId: 'asset-42',
+      attributes: {
+        id: 'asset-42',
+        phase: 'phase-2',
+        elevation: 12,
+      },
+      controlId: 'inspector',
+    });
+  });
+
+  it('renders inspector field titles from metadata', () => {
+    const control = createInspectorControl(setup);
+    setup.scene.dispatchEvent(
+      new CustomEvent('honua-scene-identify', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          x: 0,
+          y: 0,
+          picked: {
+            id: 'asset-1',
+            getProperty: (key: string) => {
+              if (key === 'id') return 'asset-1';
+              if (key === 'phase') return 'phase-1';
+              if (key === 'elevation') return 5;
+              return undefined;
+            },
+          },
+        },
+      }),
+    );
+
+    const fields = control.shadowRoot!.querySelectorAll('dt');
+    const titles = [...fields].map((node) => node.textContent);
+    expect(titles).toEqual(['Asset ID', 'Phase', 'Elevation']);
+  });
+});
+
+function createInspectorControl(setup: SceneSetup): HTMLElement {
+  setup.scene.id = 'scene-under-test';
+  const control = document.createElement('honua-scene-inspector');
+  control.setAttribute('for', '#scene-under-test');
+  document.body.append(control);
+  return control;
+}

--- a/src/Honua.Embed/tests/controls/layers.test.ts
+++ b/src/Honua.Embed/tests/controls/layers.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupScene, SAMPLE_METADATA, type SceneSetup } from './test-utils';
+
+describe('honua-scene-layers', () => {
+  let setup: SceneSetup;
+
+  beforeEach(async () => {
+    document.body.replaceChildren();
+    setup = await setupScene();
+  });
+
+  afterEach(() => {
+    setup.cleanup();
+  });
+
+  it('renders one toggle per metadata layer', () => {
+    const control = createLayersControl(setup);
+    const items = control.shadowRoot!.querySelectorAll('[data-layer-id]');
+    expect(items).toHaveLength(SAMPLE_METADATA.layers!.length);
+  });
+
+  it('emits honua-scene-layer-toggle and updates the scene', () => {
+    const control = createLayersControl(setup);
+    const listener = vi.fn();
+    control.addEventListener('honua-scene-layer-toggle', listener);
+    setup.scene.setLayerVisibility('as-built', true);
+
+    const checkbox = control.shadowRoot!.querySelector<HTMLInputElement>(
+      'input[type="checkbox"]',
+    )!;
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail).toMatchObject({
+      layerId: 'as-built',
+      visible: false,
+      controlId: 'layers',
+    });
+    expect(setup.scene.getLayer('as-built')?.visible).toBe(false);
+  });
+
+  it('emits honua-scene-layer-opacity when the slider moves', () => {
+    const control = createLayersControl(setup);
+    const listener = vi.fn();
+    control.addEventListener('honua-scene-layer-opacity', listener);
+
+    const range = control.shadowRoot!.querySelector<HTMLInputElement>(
+      'input[type="range"]',
+    )!;
+    range.value = '0.5';
+    range.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail).toMatchObject({
+      layerId: 'as-built',
+      opacity: 0.5,
+      controlId: 'layers',
+    });
+    expect(setup.scene.getLayer('as-built')?.opacity).toBe(0.5);
+  });
+
+  it('rerenders when the scene metadata changes', () => {
+    const control = createLayersControl(setup);
+    expect(control.shadowRoot!.querySelectorAll('[data-layer-id]')).toHaveLength(2);
+
+    setup.scene.metadata = {
+      ...SAMPLE_METADATA,
+      layers: [SAMPLE_METADATA.layers![0]],
+    };
+
+    expect(control.shadowRoot!.querySelectorAll('[data-layer-id]')).toHaveLength(1);
+  });
+
+  it('renders the empty state when no scene is bound', () => {
+    const control = document.createElement('honua-scene-layers');
+    control.setAttribute('for', '#missing');
+    document.body.append(control);
+
+    const empty = control.shadowRoot!.querySelector<HTMLElement>('.empty')!;
+    expect(empty.hidden).toBe(false);
+    expect(control.shadowRoot!.querySelectorAll('[data-layer-id]')).toHaveLength(0);
+  });
+});
+
+function createLayersControl(setup: SceneSetup): HTMLElement {
+  setup.scene.id = 'scene-under-test';
+  const control = document.createElement('honua-scene-layers');
+  control.setAttribute('for', '#scene-under-test');
+  document.body.append(control);
+  return control;
+}

--- a/src/Honua.Embed/tests/controls/measure.test.ts
+++ b/src/Honua.Embed/tests/controls/measure.test.ts
@@ -97,6 +97,66 @@ describe('honua-scene-measure', () => {
     expect(detail.distance).toBeGreaterThan(0);
   });
 
+  it('reads cartographic position from honua-scene-identify detail', () => {
+    const control = createMeasureControl(setup);
+    const listener = vi.fn();
+    control.addEventListener('honua-scene-measurement-add', listener);
+
+    const pointButton = control.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button[data-kind="point"]',
+    )!;
+    pointButton.click();
+
+    setup.scene.dispatchEvent(
+      new CustomEvent('honua-scene-identify', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          x: 1,
+          y: 2,
+          picked: { id: 'feature-1' },
+          position: { latitude: 21.31, longitude: -157.86, height: 12 },
+        },
+      }),
+    );
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail.points).toEqual([
+      { latitude: 21.31, longitude: -157.86, height: 12 },
+    ]);
+  });
+
+  it('falls back to scene.samplePoint when identify detail lacks a position', () => {
+    const control = createMeasureControl(setup);
+    const listener = vi.fn();
+    control.addEventListener('honua-scene-measurement-add', listener);
+
+    const sampleSpy = vi
+      .spyOn(setup.scene, 'samplePoint')
+      .mockReturnValue({ latitude: 39.95, longitude: -75.16, height: 0 });
+
+    const pointButton = control.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button[data-kind="point"]',
+    )!;
+    pointButton.click();
+
+    setup.scene.dispatchEvent(
+      new CustomEvent('honua-scene-identify', {
+        bubbles: true,
+        composed: true,
+        detail: { x: 4, y: 8, picked: null, position: null },
+      }),
+    );
+
+    expect(sampleSpy).toHaveBeenCalledWith(4, 8);
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail.points).toEqual([
+      { latitude: 39.95, longitude: -75.16, height: 0 },
+    ]);
+
+    sampleSpy.mockRestore();
+  });
+
   it('emits honua-scene-measurement-clear on Clear', () => {
     const control = createMeasureControl(setup);
     const listener = vi.fn();

--- a/src/Honua.Embed/tests/controls/measure.test.ts
+++ b/src/Honua.Embed/tests/controls/measure.test.ts
@@ -157,6 +157,72 @@ describe('honua-scene-measure', () => {
     sampleSpy.mockRestore();
   });
 
+  it('refuses to finalize a line measurement before two points are picked', () => {
+    const control = createMeasureControl(setup);
+    const addListener = vi.fn();
+    const errorListener = vi.fn();
+    control.addEventListener('honua-scene-measurement-add', addListener);
+    control.addEventListener('honua-scene-control-error', errorListener);
+
+    const lineButton = control.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button[data-kind="line"]',
+    )!;
+    lineButton.click();
+    lineButton.click();
+
+    expect(addListener).not.toHaveBeenCalled();
+    expect(errorListener).toHaveBeenCalledOnce();
+    expect(errorListener.mock.calls[0][0].detail).toMatchObject({
+      controlId: 'measure',
+      kind: 'insufficient-points',
+    });
+  });
+
+  it('refuses to finalize a polygon measurement before three points are picked', () => {
+    const control = createMeasureControl(setup);
+    const addListener = vi.fn();
+    const errorListener = vi.fn();
+    control.addEventListener('honua-scene-measurement-add', addListener);
+    control.addEventListener('honua-scene-control-error', errorListener);
+
+    const polygonButton = control.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button[data-kind="polygon"]',
+    )!;
+    polygonButton.click();
+
+    setup.scene.dispatchEvent(
+      new CustomEvent('honua-scene-identify', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          x: 1,
+          y: 1,
+          picked: { position: { latitude: 39.95, longitude: -75.16, height: 0 } },
+        },
+      }),
+    );
+    setup.scene.dispatchEvent(
+      new CustomEvent('honua-scene-identify', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          x: 2,
+          y: 2,
+          picked: { position: { latitude: 39.951, longitude: -75.161, height: 0 } },
+        },
+      }),
+    );
+
+    polygonButton.click();
+
+    expect(addListener).not.toHaveBeenCalled();
+    expect(errorListener).toHaveBeenCalledOnce();
+    expect(errorListener.mock.calls[0][0].detail).toMatchObject({
+      controlId: 'measure',
+      kind: 'insufficient-points',
+    });
+  });
+
   it('emits honua-scene-measurement-clear on Clear', () => {
     const control = createMeasureControl(setup);
     const listener = vi.fn();

--- a/src/Honua.Embed/tests/controls/measure.test.ts
+++ b/src/Honua.Embed/tests/controls/measure.test.ts
@@ -237,6 +237,37 @@ describe('honua-scene-measure', () => {
       measurementId: 'all',
     });
   });
+
+  it('does not duplicate mode-button click handlers across reconnects', () => {
+    const control = createMeasureControl(setup);
+
+    control.remove();
+    document.body.append(control);
+    control.remove();
+    document.body.append(control);
+
+    const listener = vi.fn();
+    control.addEventListener('honua-scene-measurement-add', listener);
+
+    const pointButton = control.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button[data-kind="point"]',
+    )!;
+    pointButton.click();
+
+    setup.scene.dispatchEvent(
+      new CustomEvent('honua-scene-identify', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          x: 1,
+          y: 1,
+          picked: { position: { latitude: 39.95, longitude: -75.16, height: 0 } },
+        },
+      }),
+    );
+
+    expect(listener).toHaveBeenCalledOnce();
+  });
 });
 
 function createMeasureControl(setup: SceneSetup): HTMLElement {

--- a/src/Honua.Embed/tests/controls/measure.test.ts
+++ b/src/Honua.Embed/tests/controls/measure.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupScene, type SceneSetup } from './test-utils';
+
+describe('honua-scene-measure', () => {
+  let setup: SceneSetup;
+
+  beforeEach(async () => {
+    document.body.replaceChildren();
+    setup = await setupScene();
+  });
+
+  afterEach(() => {
+    setup.cleanup();
+  });
+
+  it('renders point/line/polygon mode buttons', () => {
+    const control = createMeasureControl(setup);
+    const buttons = control.shadowRoot!.querySelectorAll('.modes button');
+    expect([...buttons].map((node) => node.getAttribute('data-kind'))).toEqual([
+      'point',
+      'line',
+      'polygon',
+    ]);
+  });
+
+  it('emits honua-scene-measurement-add on a single point pick', () => {
+    const control = createMeasureControl(setup);
+    const listener = vi.fn();
+    control.addEventListener('honua-scene-measurement-add', listener);
+
+    const pointButton = control.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button[data-kind="point"]',
+    )!;
+    pointButton.click();
+
+    setup.scene.dispatchEvent(
+      new CustomEvent('honua-scene-identify', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          x: 10,
+          y: 12,
+          picked: {
+            position: { latitude: 39.95, longitude: -75.16, height: 1500 },
+          },
+        },
+      }),
+    );
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail).toMatchObject({
+      kind: 'point',
+      controlId: 'measure',
+      points: [{ latitude: 39.95, longitude: -75.16, height: 1500 }],
+    });
+  });
+
+  it('finalizes a distance measurement when "line" is clicked twice', () => {
+    const control = createMeasureControl(setup);
+    const listener = vi.fn();
+    control.addEventListener('honua-scene-measurement-add', listener);
+
+    const lineButton = control.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button[data-kind="line"]',
+    )!;
+    lineButton.click();
+
+    setup.scene.dispatchEvent(
+      new CustomEvent('honua-scene-identify', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          x: 10,
+          y: 12,
+          picked: { position: { latitude: 39.95, longitude: -75.16, height: 0 } },
+        },
+      }),
+    );
+    setup.scene.dispatchEvent(
+      new CustomEvent('honua-scene-identify', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          x: 11,
+          y: 13,
+          picked: { position: { latitude: 39.951, longitude: -75.161, height: 0 } },
+        },
+      }),
+    );
+
+    lineButton.click();
+
+    expect(listener).toHaveBeenCalledOnce();
+    const detail = listener.mock.calls[0][0].detail;
+    expect(detail.kind).toBe('line');
+    expect(detail.points).toHaveLength(2);
+    expect(detail.distance).toBeGreaterThan(0);
+  });
+
+  it('emits honua-scene-measurement-clear on Clear', () => {
+    const control = createMeasureControl(setup);
+    const listener = vi.fn();
+    control.addEventListener('honua-scene-measurement-clear', listener);
+
+    const clearButton = control.shadowRoot!.querySelector<HTMLButtonElement>('.clear')!;
+    clearButton.click();
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail).toMatchObject({
+      controlId: 'measure',
+      measurementId: 'all',
+    });
+  });
+});
+
+function createMeasureControl(setup: SceneSetup): HTMLElement {
+  setup.scene.id = 'scene-under-test';
+  const control = document.createElement('honua-scene-measure');
+  control.setAttribute('for', '#scene-under-test');
+  document.body.append(control);
+  return control;
+}

--- a/src/Honua.Embed/tests/controls/test-utils.ts
+++ b/src/Honua.Embed/tests/controls/test-utils.ts
@@ -1,0 +1,171 @@
+import { vi } from 'vitest';
+import type { HonuaSceneElement } from '../../src/scene';
+import type { HonuaSceneMetadata } from '../../src/scene-metadata';
+
+vi.mock('cesium', () => {
+  class MockCesiumWidget {
+    readonly canvas = document.createElement('canvas');
+    readonly camera = {
+      changed: { addEventListener: vi.fn(() => vi.fn()) },
+      heading: 0,
+      pitch: 0,
+      roll: 0,
+      positionCartographic: { latitude: 0, longitude: 0, height: 0 },
+      setView: vi.fn(),
+    };
+    readonly scene = {
+      primitives: { add: vi.fn(), remove: vi.fn() },
+      pick: vi.fn(),
+      pickPosition: vi.fn(),
+      requestRender: vi.fn(),
+    };
+    readonly destroy = vi.fn();
+
+    constructor(container: HTMLElement) {
+      const widget = document.createElement('div');
+      widget.className = 'cesium-widget';
+      container.append(widget);
+    }
+
+    isDestroyed(): boolean {
+      return false;
+    }
+
+    async zoomTo(): Promise<void> {
+      return Promise.resolve();
+    }
+  }
+
+  return {
+    buildModuleUrl: Object.assign(vi.fn(), { setBaseUrl: vi.fn() }),
+    Cartesian3: { fromDegrees: vi.fn() },
+    Cartographic: {
+      fromCartesian: vi.fn(() => ({ latitude: 0, longitude: 0, height: 0 })),
+    },
+    Cesium3DTileset: {
+      fromUrl: vi.fn(async (url: string) => ({ url, show: true, style: undefined })),
+    },
+    Cesium3DTileStyle: vi.fn(function MockTileStyle(this: { color?: string }, opts: { color?: string }) {
+      this.color = opts?.color;
+    }),
+    CesiumTerrainProvider: { fromUrl: vi.fn(async (url: string) => ({ url })) },
+    CesiumWidget: MockCesiumWidget,
+    Ion: { defaultAccessToken: '' },
+    Math: {
+      toDegrees: vi.fn((value: number) => value * (180 / globalThis.Math.PI)),
+      toRadians: vi.fn((value: number) => value * (globalThis.Math.PI / 180)),
+    },
+    ScreenSpaceEventHandler: class {
+      readonly setInputAction = vi.fn();
+      destroy(): void {}
+      isDestroyed(): boolean {
+        return false;
+      }
+    },
+    ScreenSpaceEventType: { LEFT_CLICK: 0 },
+  };
+});
+
+export const SAMPLE_METADATA: HonuaSceneMetadata = {
+  schema: 'honua-scene-metadata/v1',
+  id: 'sample',
+  name: 'Sample Scene',
+  description: 'Fixture metadata',
+  layers: [
+    {
+      id: 'as-built',
+      title: 'As-built',
+      kind: '3d-tiles',
+      url: 'https://example.test/as-built/tileset.json',
+      visible: true,
+      opacity: 1,
+    },
+    {
+      id: 'design-overlay',
+      title: 'Design overlay',
+      kind: '3d-tiles',
+      url: 'https://example.test/design/tileset.json',
+      visible: false,
+      opacity: 0.85,
+    },
+  ],
+  bookmarks: [
+    {
+      id: 'site-overview',
+      title: 'Site overview',
+      view: {
+        center: { latitude: 39.95, longitude: -75.16 },
+        height: 2400,
+        orientation: { heading: 0, pitch: -45, roll: 0 },
+      },
+    },
+    {
+      id: 'entrance',
+      title: 'Entrance',
+      view: {
+        center: { latitude: 39.95, longitude: -75.16 },
+        height: 80,
+        orientation: { heading: 90, pitch: -10, roll: 0 },
+      },
+    },
+  ],
+  timeline: {
+    phases: [
+      {
+        id: 'phase-1',
+        title: 'Phase 1',
+        startUtc: '2026-01-01T00:00:00Z',
+        endUtc: '2026-03-31T00:00:00Z',
+        visibleLayerIds: ['as-built'],
+      },
+      {
+        id: 'phase-2',
+        title: 'Phase 2',
+        startUtc: '2026-04-01T00:00:00Z',
+        endUtc: '2026-06-30T00:00:00Z',
+        visibleLayerIds: ['as-built', 'design-overlay'],
+      },
+    ],
+  },
+  compare: {
+    modes: [
+      {
+        id: 'design-vs-asbuilt',
+        title: 'Design vs As-built',
+        leftLayerIds: ['design-overlay'],
+        rightLayerIds: ['as-built'],
+      },
+    ],
+  },
+  inspector: {
+    fields: [
+      { key: 'id', title: 'Asset ID' },
+      { key: 'phase', title: 'Phase' },
+      { key: 'elevation', title: 'Elevation', format: 'number', unit: 'm' },
+    ],
+  },
+};
+
+export interface SceneSetup {
+  scene: HonuaSceneElement;
+  cleanup(): void;
+}
+
+export async function setupScene(metadata: HonuaSceneMetadata = SAMPLE_METADATA): Promise<SceneSetup> {
+  const { defineHonuaSceneElement } = await import('../../src/scene');
+  const { defineHonuaSceneControls } = await import('../../src/controls');
+  defineHonuaSceneElement();
+  defineHonuaSceneControls();
+
+  const scene = document.createElement('honua-scene');
+  scene.setAttribute('autoload', 'false');
+  document.body.append(scene);
+  scene.metadata = metadata;
+
+  return {
+    scene,
+    cleanup() {
+      scene.remove();
+    },
+  };
+}

--- a/src/Honua.Embed/tests/controls/timeline.test.ts
+++ b/src/Honua.Embed/tests/controls/timeline.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupScene, type SceneSetup } from './test-utils';
+
+describe('honua-scene-timeline', () => {
+  let setup: SceneSetup;
+
+  beforeEach(async () => {
+    document.body.replaceChildren();
+    setup = await setupScene();
+  });
+
+  afterEach(() => {
+    setup.cleanup();
+  });
+
+  it('renders one tab per timeline phase', () => {
+    const control = createTimelineControl(setup);
+    expect(control.shadowRoot!.querySelectorAll('button.phase')).toHaveLength(2);
+  });
+
+  it('emits honua-scene-timeline-change and toggles layer visibility', () => {
+    const control = createTimelineControl(setup);
+    const listener = vi.fn();
+    control.addEventListener('honua-scene-timeline-change', listener);
+
+    const phase = control.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button[data-phase-id="phase-2"]',
+    )!;
+    phase.click();
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail).toMatchObject({
+      phaseId: 'phase-2',
+      visibleLayerIds: ['as-built', 'design-overlay'],
+      controlId: 'timeline',
+    });
+    expect(setup.scene.getLayer('as-built')?.visible).toBe(true);
+    expect(setup.scene.getLayer('design-overlay')?.visible).toBe(true);
+  });
+
+  it('hides layers that are not part of the active phase', () => {
+    const control = createTimelineControl(setup);
+    const phase = control.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button[data-phase-id="phase-1"]',
+    )!;
+    phase.click();
+    expect(setup.scene.getLayer('design-overlay')?.visible).toBe(false);
+    expect(setup.scene.getLayer('as-built')?.visible).toBe(true);
+  });
+});
+
+function createTimelineControl(setup: SceneSetup): HTMLElement {
+  setup.scene.id = 'scene-under-test';
+  const control = document.createElement('honua-scene-timeline');
+  control.setAttribute('for', '#scene-under-test');
+  document.body.append(control);
+  return control;
+}

--- a/src/Honua.Embed/tests/controls/timeline.test.ts
+++ b/src/Honua.Embed/tests/controls/timeline.test.ts
@@ -47,6 +47,66 @@ describe('honua-scene-timeline', () => {
     expect(setup.scene.getLayer('design-overlay')?.visible).toBe(false);
     expect(setup.scene.getLayer('as-built')?.visible).toBe(true);
   });
+
+  it('toggles the implicit primary layer when phases reference it', async () => {
+    setup.cleanup();
+    setup = await setupScene({
+      schema: 'honua-scene-metadata/v1',
+      id: 'with-primary',
+      name: 'Scene with implicit primary',
+      layers: [
+        {
+          id: 'as-built',
+          title: 'As-built',
+          kind: '3d-tiles',
+          url: 'https://example.test/as-built/tileset.json',
+          visible: true,
+          opacity: 1,
+        },
+      ],
+      timeline: {
+        phases: [
+          {
+            id: 'primary-only',
+            title: 'Primary only',
+            startUtc: '2026-01-01T00:00:00Z',
+            endUtc: '2026-01-31T00:00:00Z',
+            visibleLayerIds: ['primary'],
+          },
+          {
+            id: 'as-built-only',
+            title: 'As-built only',
+            startUtc: '2026-02-01T00:00:00Z',
+            endUtc: '2026-02-28T00:00:00Z',
+            visibleLayerIds: ['as-built'],
+          },
+        ],
+      },
+    });
+    await setup.scene.addLayer({
+      id: 'primary',
+      title: 'Primary',
+      kind: '3d-tiles',
+      url: 'https://example.test/primary/tileset.json',
+      visible: true,
+      opacity: 1,
+    });
+
+    const control = createTimelineControl(setup);
+    const primaryOnly = control.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button[data-phase-id="primary-only"]',
+    )!;
+    primaryOnly.click();
+    expect(setup.scene.getLayer('primary')?.visible).toBe(true);
+    expect(setup.scene.getLayer('as-built')?.visible).toBe(false);
+
+    const asBuiltOnly = control.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button[data-phase-id="as-built-only"]',
+    )!;
+    asBuiltOnly.click();
+    expect(setup.scene.getLayer('primary')?.visible).toBe(false);
+    expect(setup.scene.getLayer('as-built')?.visible).toBe(true);
+  });
 });
 
 function createTimelineControl(setup: SceneSetup): HTMLElement {

--- a/src/Honua.Embed/tests/honua-scene.test.ts
+++ b/src/Honua.Embed/tests/honua-scene.test.ts
@@ -638,18 +638,8 @@ describe('honua-scene', () => {
     webgl.mockRestore();
   });
 
-  it('lets metadata-declared primary win when metadata arrives during the implicit tileset load', async () => {
+  it('defers honua-scene-ready until a slow metadata fetch settles so the metadata-declared primary wins', async () => {
     const webgl = mockWebGl();
-
-    let resolveImplicit!: (value: { url: string; show: boolean; style: undefined }) => void;
-    const implicitStarted = new Promise<void>((resolve) => {
-      cesium.Cesium3DTileset.fromUrl.mockImplementationOnce(async (url: string) => {
-        resolve();
-        return await new Promise((tilesetResolve) => {
-          resolveImplicit = tilesetResolve as typeof resolveImplicit;
-        }).then(() => ({ url, show: true, style: undefined }));
-      });
-    });
 
     let resolveFetch!: (value: Response) => void;
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementationOnce(
@@ -670,8 +660,11 @@ describe('honua-scene', () => {
     element.addEventListener('honua-scene-ready', ready);
 
     const loading = element.load();
-    await implicitStarted;
 
+    for (let i = 0; i < 8; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    expect(ready).not.toHaveBeenCalled();
     expect(element.metadata).toBeNull();
 
     resolveFetch(
@@ -693,20 +686,11 @@ describe('honua-scene', () => {
       ),
     );
 
-    for (let i = 0; i < 8; i += 1) {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
-    expect(element.metadata?.layers?.[0]?.id).toBe('primary');
-
-    resolveImplicit({
-      url: 'https://data.example.test/attribute-primary.json',
-      show: true,
-      style: undefined,
-    });
     await loading;
 
     const fromUrlCalls = cesium.Cesium3DTileset.fromUrl.mock.calls.map((call) => call[0]);
     expect(fromUrlCalls).toContain('https://data.example.test/metadata-primary.json');
+    expect(fromUrlCalls).not.toContain('https://data.example.test/attribute-primary.json');
 
     const handle = element.getLayer('primary');
     expect(handle?.metadata.url).toBe('https://data.example.test/metadata-primary.json');
@@ -720,6 +704,89 @@ describe('honua-scene', () => {
     expect(ready.mock.calls[0][0].detail.tileset).toBe(handle?.tileset);
 
     fetchSpy.mockRestore();
+    webgl.mockRestore();
+  });
+
+  it('drops a metadata-owned primary when metadata is cleared and rebuilds it from tileset-url', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('tileset-url', 'https://data.example.test/attribute-primary.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    element.metadata = {
+      schema: 'honua-scene-metadata/v1',
+      id: 'demo',
+      name: 'Demo',
+      layers: [
+        {
+          id: 'primary',
+          title: 'Metadata primary',
+          description: 'From metadata document.',
+          kind: '3d-tiles',
+          url: 'https://data.example.test/metadata-primary.json',
+          opacity: 0.5,
+          visible: false,
+        },
+      ],
+    };
+
+    await element.load();
+    expect(element.getLayer('primary')?.metadata.url).toBe(
+      'https://data.example.test/metadata-primary.json',
+    );
+    expect(element.getLayer('primary')?.metadata.title).toBe('Metadata primary');
+    expect(element.getLayer('primary')?.metadata.opacity).toBe(0.5);
+    expect(element.getLayer('primary')?.metadata.visible).toBe(false);
+
+    element.metadata = null;
+    expect(element.getLayer('primary')).toBeNull();
+
+    await element.load();
+
+    const handle = element.getLayer('primary');
+    expect(handle).not.toBeNull();
+    expect(handle?.metadata.url).toBe('https://data.example.test/attribute-primary.json');
+    expect(handle?.metadata.title).toBe('Primary tileset');
+    expect(handle?.metadata.opacity).toBe(1);
+    expect(handle?.metadata.visible).toBe(true);
+
+    webgl.mockRestore();
+  });
+
+  it('removes a metadata-owned primary when metadata is cleared and tileset-url is unset', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('terrain-url', 'https://data.example.test/terrain');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    element.metadata = {
+      schema: 'honua-scene-metadata/v1',
+      id: 'demo',
+      name: 'Demo',
+      layers: [
+        {
+          id: 'primary',
+          title: 'Metadata primary',
+          kind: '3d-tiles',
+          url: 'https://data.example.test/metadata-primary.json',
+        },
+      ],
+    };
+
+    await element.load();
+    expect(element.getLayer('primary')?.metadata.url).toBe(
+      'https://data.example.test/metadata-primary.json',
+    );
+
+    element.metadata = null;
+
+    expect(element.getLayer('primary')).toBeNull();
+    expect(element.tileset).toBeNull();
+
     webgl.mockRestore();
   });
 

--- a/src/Honua.Embed/tests/honua-scene.test.ts
+++ b/src/Honua.Embed/tests/honua-scene.test.ts
@@ -519,6 +519,50 @@ describe('honua-scene', () => {
     webgl.mockRestore();
   });
 
+  it('does not emit honua-scene-ready when the metadata-declared primary fails to load', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    element.setAttribute('terrain-url', 'https://data.example.test/terrain');
+    document.body.append(element);
+
+    element.metadata = {
+      schema: 'honua-scene-metadata/v1',
+      id: 'demo',
+      name: 'Demo',
+      layers: [
+        {
+          id: 'primary',
+          title: 'Primary from metadata',
+          kind: '3d-tiles',
+          url: 'https://data.example.test/metadata-primary.json',
+        },
+      ],
+    };
+
+    cesium.Cesium3DTileset.fromUrl.mockRejectedValueOnce(new Error('metadata primary failed'));
+    const ready = vi.fn();
+    const errorListener = vi.fn();
+    element.addEventListener('honua-scene-ready', ready);
+    element.addEventListener('honua-scene-load-error', errorListener);
+
+    await element.load();
+
+    const status = element.shadowRoot!.querySelector('.status') as HTMLOutputElement;
+    expect(errorListener).toHaveBeenCalledOnce();
+    expect(errorListener.mock.calls[0][0].detail).toMatchObject({
+      source: 'tileset',
+      message: 'Unable to load layer "primary".',
+    });
+    expect(ready).not.toHaveBeenCalled();
+    expect(element.tileset).toBeNull();
+    expect(status.textContent).toBe('Unable to load layer "primary".');
+    expect(status.dataset.hidden).toBe('false');
+
+    webgl.mockRestore();
+  });
+
   it('hydrates the metadata-declared primary URL on a terrain-only reload after tileset-url is removed', async () => {
     const webgl = mockWebGl();
     const element = document.createElement('honua-scene');
@@ -702,6 +746,78 @@ describe('honua-scene', () => {
 
     expect(ready).toHaveBeenCalledOnce();
     expect(ready.mock.calls[0][0].detail.tileset).toBe(handle?.tileset);
+
+    fetchSpy.mockRestore();
+    webgl.mockRestore();
+  });
+
+  it('does not emit a stale metadata-primary load-error after reload hydration wins', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('tileset-url', 'https://data.example.test/attribute-primary.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    await element.load();
+
+    let resolveFetch!: (value: Response) => void;
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    let rejectStale!: (reason: unknown) => void;
+    cesium.Cesium3DTileset.fromUrl.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectStale = reject;
+        }),
+    );
+
+    const ready = vi.fn();
+    const errorListener = vi.fn();
+    element.addEventListener('honua-scene-ready', ready);
+    element.addEventListener('honua-scene-load-error', errorListener);
+    element.setAttribute('metadata-url', 'https://example.test/metadata.json');
+
+    const loading = element.load();
+    resolveFetch(
+      new Response(
+        JSON.stringify({
+          schema: 'honua-scene-metadata/v1',
+          id: 'demo',
+          name: 'Demo',
+          layers: [
+            {
+              id: 'primary',
+              title: 'Metadata primary',
+              kind: '3d-tiles',
+              url: 'https://data.example.test/metadata-primary.json',
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    await loading;
+
+    expect(ready).toHaveBeenCalledOnce();
+    expect(errorListener).not.toHaveBeenCalled();
+    expect((element.tileset as unknown as { url: string } | null)?.url).toBe(
+      'https://data.example.test/metadata-primary.json',
+    );
+
+    rejectStale(new Error('stale metadata primary failed'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(errorListener).not.toHaveBeenCalled();
+    expect((element.tileset as unknown as { url: string } | null)?.url).toBe(
+      'https://data.example.test/metadata-primary.json',
+    );
 
     fetchSpy.mockRestore();
     webgl.mockRestore();

--- a/src/Honua.Embed/tests/honua-scene.test.ts
+++ b/src/Honua.Embed/tests/honua-scene.test.ts
@@ -5,7 +5,22 @@ import {
   HonuaScenePackageCacheError,
 } from '../src/index';
 
+interface MockCesiumWidgetSnapshot {
+  destroy: ReturnType<typeof vi.fn>;
+  scene: {
+    primitives: {
+      add: ReturnType<typeof vi.fn>;
+      remove: ReturnType<typeof vi.fn>;
+    };
+    pickPosition: ReturnType<typeof vi.fn>;
+    requestRender: ReturnType<typeof vi.fn>;
+  };
+}
+
 interface MockCesiumModule {
+  Cesium3DTileset: {
+    fromUrl: ReturnType<typeof vi.fn>;
+  };
   CesiumTerrainProvider: {
     fromUrl: ReturnType<typeof vi.fn>;
   };
@@ -13,9 +28,7 @@ interface MockCesiumModule {
     defaultAccessToken: string;
   };
   __mock: {
-    widgets: Array<{
-      destroy: ReturnType<typeof vi.fn>;
-    }>;
+    widgets: MockCesiumWidgetSnapshot[];
   };
 }
 
@@ -78,6 +91,13 @@ vi.mock('cesium', () => {
         longitude,
         latitude,
         height,
+      })),
+    },
+    Cartographic: {
+      fromCartesian: vi.fn((cartesian: { x?: number; y?: number; z?: number }) => ({
+        latitude: (cartesian?.y ?? 0) / 100,
+        longitude: (cartesian?.x ?? 0) / 100,
+        height: cartesian?.z ?? 0,
       })),
     },
     Cesium3DTileset: {
@@ -503,6 +523,114 @@ describe('honua-scene', () => {
     expect(element.getAttribute('center')).toBe('21.31,-157.86');
     expect(element.getAttribute('height')).toBe('800');
     expect(element.getAttribute('heading')).toBe('45');
+  });
+
+  it('detaches an existing layer tileset when re-added with a different URL', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('tileset-url', 'https://data.example.test/primary.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    await element.load();
+    const widget = cesium.__mock.widgets[0];
+
+    await element.addLayer({
+      id: 'design-overlay',
+      title: 'Design overlay',
+      kind: '3d-tiles',
+      url: 'https://data.example.test/first.json',
+    });
+    const original = element.getLayer('design-overlay')?.tileset;
+    expect(original).toBeDefined();
+
+    await element.addLayer({
+      id: 'design-overlay',
+      title: 'Design overlay',
+      kind: '3d-tiles',
+      url: 'https://data.example.test/second.json',
+    });
+
+    expect(widget.scene.primitives.remove).toHaveBeenCalledWith(original);
+    expect((element.getLayer('design-overlay')?.tileset as { url?: string } | null)?.url).toBe(
+      'https://data.example.test/second.json',
+    );
+
+    webgl.mockRestore();
+  });
+
+  it('drops stale layer-tileset loads after a URL change', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('tileset-url', 'https://data.example.test/primary.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    await element.load();
+    const widget = cesium.__mock.widgets[0];
+
+    type StaleTileset = { url: string; show: boolean; style: undefined };
+    let resolveStale: (value: StaleTileset) => void = () => {};
+    cesium.Cesium3DTileset.fromUrl.mockImplementationOnce(
+      () =>
+        new Promise<StaleTileset>((resolve) => {
+          resolveStale = resolve;
+        }),
+    );
+
+    const stalePromise = element.addLayer({
+      id: 'design-overlay',
+      title: 'Design overlay',
+      kind: '3d-tiles',
+      url: 'https://data.example.test/v1.json',
+    });
+
+    await element.addLayer({
+      id: 'design-overlay',
+      title: 'Design overlay',
+      kind: '3d-tiles',
+      url: 'https://data.example.test/v2.json',
+    });
+
+    resolveStale({ url: 'https://data.example.test/v1.json', show: true, style: undefined });
+    await stalePromise;
+
+    const tileset = element.getLayer('design-overlay')?.tileset as { url?: string } | null;
+    expect(tileset?.url).toBe('https://data.example.test/v2.json');
+    expect(
+      widget.scene.primitives.add.mock.calls.some(
+        (call) => (call[0] as { url?: string } | undefined)?.url === 'https://data.example.test/v1.json',
+      ),
+    ).toBe(false);
+
+    webgl.mockRestore();
+  });
+
+  it('samplePoint returns null without a widget and a cartographic point when the widget is loaded', async () => {
+    const element = document.createElement('honua-scene');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+    expect(element.samplePoint(10, 20)).toBeNull();
+
+    const webgl = mockWebGl();
+    element.setAttribute('tileset-url', 'https://data.example.test/primary.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    await element.load();
+    const widget = cesium.__mock.widgets[0];
+    widget.scene.pickPosition.mockReturnValueOnce({ x: 100, y: 200, z: 300 });
+
+    const sampled = element.samplePoint(50, 60);
+    expect(widget.scene.pickPosition).toHaveBeenCalledWith({ x: 50, y: 60 });
+    expect(sampled).not.toBeNull();
+    expect(sampled?.height).toBe(300);
+    expect(typeof sampled?.latitude).toBe('number');
+    expect(typeof sampled?.longitude).toBe('number');
+    expect(Number.isFinite(sampled?.latitude)).toBe(true);
+    expect(Number.isFinite(sampled?.longitude)).toBe(true);
+
+    webgl.mockRestore();
   });
 
   it('clears the Cesium Ion token when the attribute is removed', async () => {

--- a/src/Honua.Embed/tests/honua-scene.test.ts
+++ b/src/Honua.Embed/tests/honua-scene.test.ts
@@ -638,6 +638,91 @@ describe('honua-scene', () => {
     webgl.mockRestore();
   });
 
+  it('lets metadata-declared primary win when metadata arrives during the implicit tileset load', async () => {
+    const webgl = mockWebGl();
+
+    let resolveImplicit!: (value: { url: string; show: boolean; style: undefined }) => void;
+    const implicitStarted = new Promise<void>((resolve) => {
+      cesium.Cesium3DTileset.fromUrl.mockImplementationOnce(async (url: string) => {
+        resolve();
+        return await new Promise((tilesetResolve) => {
+          resolveImplicit = tilesetResolve as typeof resolveImplicit;
+        }).then(() => ({ url, show: true, style: undefined }));
+      });
+    });
+
+    let resolveFetch!: (value: Response) => void;
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementationOnce(
+      () =>
+        new Promise<Response>((fetchResolve) => {
+          resolveFetch = fetchResolve;
+        }),
+    );
+
+    const element = document.createElement('honua-scene');
+    element.setAttribute('tileset-url', 'https://data.example.test/attribute-primary.json');
+    element.setAttribute('metadata-url', 'https://example.test/metadata.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    const ready = vi.fn();
+    element.addEventListener('honua-scene-ready', ready);
+
+    const loading = element.load();
+    await implicitStarted;
+
+    expect(element.metadata).toBeNull();
+
+    resolveFetch(
+      new Response(
+        JSON.stringify({
+          schema: 'honua-scene-metadata/v1',
+          id: 'demo',
+          name: 'Demo',
+          layers: [
+            {
+              id: 'primary',
+              title: 'Metadata primary',
+              kind: '3d-tiles',
+              url: 'https://data.example.test/metadata-primary.json',
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    for (let i = 0; i < 8; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    expect(element.metadata?.layers?.[0]?.id).toBe('primary');
+
+    resolveImplicit({
+      url: 'https://data.example.test/attribute-primary.json',
+      show: true,
+      style: undefined,
+    });
+    await loading;
+
+    const fromUrlCalls = cesium.Cesium3DTileset.fromUrl.mock.calls.map((call) => call[0]);
+    expect(fromUrlCalls).toContain('https://data.example.test/metadata-primary.json');
+
+    const handle = element.getLayer('primary');
+    expect(handle?.metadata.url).toBe('https://data.example.test/metadata-primary.json');
+    expect(handle?.metadata.title).toBe('Metadata primary');
+    expect(element.tileset).toBe(handle?.tileset);
+    expect((element.tileset as unknown as { url: string } | null)?.url).toBe(
+      'https://data.example.test/metadata-primary.json',
+    );
+
+    expect(ready).toHaveBeenCalledOnce();
+    expect(ready.mock.calls[0][0].detail.tileset).toBe(handle?.tileset);
+
+    fetchSpy.mockRestore();
+    webgl.mockRestore();
+  });
+
   it('cancels in-flight loads when disconnected', async () => {
     const webgl = mockWebGl();
     let resolveTerrain!: (value: unknown) => void;

--- a/src/Honua.Embed/tests/honua-scene.test.ts
+++ b/src/Honua.Embed/tests/honua-scene.test.ts
@@ -41,8 +41,10 @@ vi.mock('cesium', () => {
     readonly scene = {
       primitives: {
         add: vi.fn(),
+        remove: vi.fn(),
       },
       pick: vi.fn(),
+      pickPosition: vi.fn(),
       requestRender: vi.fn(),
     };
     readonly destroy = vi.fn(() => {
@@ -79,8 +81,11 @@ vi.mock('cesium', () => {
       })),
     },
     Cesium3DTileset: {
-      fromUrl: vi.fn(async (url: string) => ({ url })),
+      fromUrl: vi.fn(async (url: string) => ({ url, show: true, style: undefined })),
     },
+    Cesium3DTileStyle: vi.fn(function MockTileStyle(this: { color?: string }, opts: { color?: string }) {
+      this.color = opts?.color;
+    }),
     CesiumTerrainProvider: {
       fromUrl: vi.fn(async (url: string) => ({ url })),
     },
@@ -385,6 +390,119 @@ describe('honua-scene', () => {
 
     expect(cesium.__mock.widgets).toHaveLength(0);
     webgl.mockRestore();
+  });
+
+  it('parses metadata-url and emits honua-scene-metadata-change', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(JSON.stringify({
+      schema: 'honua-scene-metadata/v1',
+      id: 'demo',
+      name: 'Demo',
+      layers: [{ id: 'as-built', title: 'As-built', kind: '3d-tiles', url: 'https://example.test/a.json' }],
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+
+    const element = document.createElement('honua-scene');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+    const listener = vi.fn();
+    element.addEventListener('honua-scene-metadata-change', listener);
+    element.setAttribute('metadata-url', 'https://example.test/metadata.json');
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fetchSpy).toHaveBeenCalledWith('https://example.test/metadata.json', expect.objectContaining({ credentials: 'same-origin' }));
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail).toMatchObject({
+      source: 'fetch',
+      metadata: expect.objectContaining({
+        id: 'demo',
+        layers: [expect.objectContaining({ id: 'as-built' })],
+      }),
+    });
+
+    fetchSpy.mockRestore();
+  });
+
+  it('emits honua-scene-metadata-error when the document is invalid', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(JSON.stringify({
+      schema: 'unsupported',
+      id: 'demo',
+      name: 'Demo',
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+
+    const element = document.createElement('honua-scene');
+    element.setAttribute('autoload', 'false');
+    element.setAttribute('metadata-url', 'https://example.test/bad-metadata.json');
+    document.body.append(element);
+    const errorListener = vi.fn();
+    element.addEventListener('honua-scene-metadata-error', errorListener);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(errorListener).toHaveBeenCalledOnce();
+    expect(errorListener.mock.calls[0][0].detail).toMatchObject({
+      code: 'metadata-invalid',
+      url: 'https://example.test/bad-metadata.json',
+    });
+
+    fetchSpy.mockRestore();
+  });
+
+  it('exposes metadata via a property setter without fetching', () => {
+    const element = document.createElement('honua-scene');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+    const listener = vi.fn();
+    element.addEventListener('honua-scene-metadata-change', listener);
+
+    element.metadata = {
+      schema: 'honua-scene-metadata/v1',
+      id: 'demo',
+      name: 'Demo',
+      layers: [
+        { id: 'a', title: 'A', kind: '3d-tiles', url: 'https://example.test/a.json' },
+        { id: 'b', title: 'B', kind: '3d-tiles', url: 'https://example.test/b.json' },
+      ],
+    };
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail.source).toBe('property');
+    expect(element.metadata?.layers).toHaveLength(2);
+  });
+
+  it('addLayer / setLayerVisibility / removeLayer emit honua-scene-layer-change', () => {
+    const element = document.createElement('honua-scene');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+    const listener = vi.fn();
+    element.addEventListener('honua-scene-layer-change', listener);
+
+    void element.addLayer({
+      id: 'drone-orthomosaic',
+      title: 'Drone orthomosaic',
+      kind: '3d-tiles',
+      url: 'https://example.test/ortho.json',
+    });
+    element.setLayerVisibility('drone-orthomosaic', false);
+    element.removeLayer('drone-orthomosaic');
+
+    const reasons = listener.mock.calls.map((call) => call[0].detail.reason);
+    expect(reasons).toEqual(['added', 'visibility', 'removed']);
+  });
+
+  it('applyView writes camera attributes from a typed view spec', () => {
+    const element = document.createElement('honua-scene');
+    document.body.append(element);
+    element.applyView({
+      center: { latitude: 21.31, longitude: -157.86 },
+      height: 800,
+      orientation: { heading: 45, pitch: -30, roll: 0 },
+    });
+
+    expect(element.getAttribute('center')).toBe('21.31,-157.86');
+    expect(element.getAttribute('height')).toBe('800');
+    expect(element.getAttribute('heading')).toBe('45');
   });
 
   it('clears the Cesium Ion token when the attribute is removed', async () => {

--- a/src/Honua.Embed/tests/honua-scene.test.ts
+++ b/src/Honua.Embed/tests/honua-scene.test.ts
@@ -664,6 +664,71 @@ describe('honua-scene', () => {
     webgl.mockRestore();
   });
 
+  it('discards a metadata-layer tileset that resolves after the scene reconnects', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('tileset-url', 'https://data.example.test/primary.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    await element.load();
+
+    type StaleTileset = {
+      url: string;
+      show: boolean;
+      style: undefined;
+      destroy: ReturnType<typeof vi.fn>;
+      isDestroyed: () => boolean;
+    };
+    let staleDestroyed = false;
+    let resolveStale: (value: StaleTileset) => void = () => {};
+    cesium.Cesium3DTileset.fromUrl.mockImplementationOnce(
+      () =>
+        new Promise<StaleTileset>((resolve) => {
+          resolveStale = resolve;
+        }),
+    );
+
+    const errorListener = vi.fn();
+    element.addEventListener('honua-scene-load-error', errorListener);
+
+    const stalePromise = element.addLayer({
+      id: 'overlay',
+      title: 'Overlay',
+      kind: '3d-tiles',
+      url: 'https://data.example.test/overlay.json',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    element.remove();
+    document.body.append(element);
+    await element.load();
+    const widgetV2 = cesium.__mock.widgets[cesium.__mock.widgets.length - 1];
+
+    resolveStale({
+      url: 'https://data.example.test/overlay.json',
+      show: true,
+      style: undefined,
+      destroy: vi.fn(() => {
+        staleDestroyed = true;
+      }),
+      isDestroyed: () => staleDestroyed,
+    });
+    await stalePromise;
+
+    expect(staleDestroyed).toBe(true);
+    expect(
+      widgetV2.scene.primitives.add.mock.calls.some(
+        (call) => typeof (call[0] as { destroy?: unknown } | undefined)?.destroy === 'function',
+      ),
+    ).toBe(false);
+    expect(element.getLayer('overlay')?.tileset).not.toBeNull();
+    expect(errorListener).not.toHaveBeenCalled();
+
+    webgl.mockRestore();
+  });
+
   it('does not emit a load-error when a primary tileset load fails after disconnect', async () => {
     const webgl = mockWebGl();
     const element = document.createElement('honua-scene');

--- a/src/Honua.Embed/tests/honua-scene.test.ts
+++ b/src/Honua.Embed/tests/honua-scene.test.ts
@@ -519,6 +519,51 @@ describe('honua-scene', () => {
     webgl.mockRestore();
   });
 
+  it('hydrates the metadata-declared primary URL on a terrain-only reload after tileset-url is removed', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('tileset-url', 'https://data.example.test/attribute-primary.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    element.metadata = {
+      schema: 'honua-scene-metadata/v1',
+      id: 'demo',
+      name: 'Demo',
+      layers: [
+        {
+          id: 'primary',
+          title: 'Primary from metadata',
+          kind: '3d-tiles',
+          url: 'https://data.example.test/metadata-primary.json',
+        },
+      ],
+    };
+
+    await element.load();
+    expect(element.getLayer('primary')?.metadata.url).toBe(
+      'https://data.example.test/metadata-primary.json',
+    );
+
+    element.removeAttribute('tileset-url');
+    await element.load();
+
+    expect(element.getLayer('primary')?.metadata.url).toBe(
+      'https://data.example.test/metadata-primary.json',
+    );
+
+    cesium.Cesium3DTileset.fromUrl.mockClear();
+    element.setAttribute('terrain-url', 'https://data.example.test/terrain');
+    await element.load();
+
+    const fromUrlCalls = cesium.Cesium3DTileset.fromUrl.mock.calls.map((call) => call[0]);
+    expect(fromUrlCalls).toContain('https://data.example.test/metadata-primary.json');
+    expect(fromUrlCalls).not.toContain('https://data.example.test/attribute-primary.json');
+
+    webgl.mockRestore();
+  });
+
   it('tears down the existing scene when package resolution fails', async () => {
     const webgl = mockWebGl();
     const element = document.createElement('honua-scene');

--- a/src/Honua.Embed/tests/honua-scene.test.ts
+++ b/src/Honua.Embed/tests/honua-scene.test.ts
@@ -608,6 +608,134 @@ describe('honua-scene', () => {
     webgl.mockRestore();
   });
 
+  it('destroys a primary tileset that resolves after the element disconnects', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('tileset-url', 'https://data.example.test/v1.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    type StaleTileset = {
+      url: string;
+      show: boolean;
+      style: undefined;
+      destroy: ReturnType<typeof vi.fn>;
+      isDestroyed: () => boolean;
+    };
+    let staleDestroyed = false;
+    let resolveStale: (value: StaleTileset) => void = () => {};
+    cesium.Cesium3DTileset.fromUrl.mockImplementationOnce(
+      () =>
+        new Promise<StaleTileset>((resolve) => {
+          resolveStale = resolve;
+        }),
+    );
+
+    const errorListener = vi.fn();
+    element.addEventListener('honua-scene-load-error', errorListener);
+
+    const stalePromise = element.load();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const widget = cesium.__mock.widgets[cesium.__mock.widgets.length - 1];
+
+    element.remove();
+
+    resolveStale({
+      url: 'https://data.example.test/v1.json',
+      show: true,
+      style: undefined,
+      destroy: vi.fn(() => {
+        staleDestroyed = true;
+      }),
+      isDestroyed: () => staleDestroyed,
+    });
+    await stalePromise;
+
+    expect(staleDestroyed).toBe(true);
+    expect(element.tileset).toBeNull();
+    expect(
+      widget.scene.primitives.add.mock.calls.some(
+        (call) => (call[0] as { url?: string } | undefined)?.url === 'https://data.example.test/v1.json',
+      ),
+    ).toBe(false);
+    expect(errorListener).not.toHaveBeenCalled();
+
+    webgl.mockRestore();
+  });
+
+  it('does not emit a load-error when a primary tileset load fails after disconnect', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('tileset-url', 'https://data.example.test/v1.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    let rejectStale: (reason: unknown) => void = () => {};
+    cesium.Cesium3DTileset.fromUrl.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectStale = reject;
+        }),
+    );
+
+    const errorListener = vi.fn();
+    element.addEventListener('honua-scene-load-error', errorListener);
+
+    const stalePromise = element.load();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    element.remove();
+
+    rejectStale(new Error('stale tileset failed'));
+    await stalePromise;
+
+    expect(errorListener).not.toHaveBeenCalled();
+
+    webgl.mockRestore();
+  });
+
+  it('does not emit metadata-fetch-failed when a stale JSON parse rejects after a newer source wins', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    let rejectStaleJson: (reason: unknown) => void = () => {};
+    const stalePending = new Promise((_, reject) => {
+      rejectStaleJson = reject;
+    });
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => stalePending,
+    } as unknown as Response);
+
+    const element = document.createElement('honua-scene');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+    const errorListener = vi.fn();
+    const changeListener = vi.fn();
+    element.addEventListener('honua-scene-metadata-error', errorListener);
+    element.addEventListener('honua-scene-metadata-change', changeListener);
+
+    element.setAttribute('metadata-url', 'https://example.test/stale.json');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    element.metadata = {
+      schema: 'honua-scene-metadata/v1',
+      id: 'fresh',
+      name: 'Fresh',
+    };
+
+    rejectStaleJson(new SyntaxError('Unexpected token'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(errorListener).not.toHaveBeenCalled();
+    expect(changeListener).toHaveBeenCalled();
+    expect(element.metadata?.id).toBe('fresh');
+
+    fetchSpy.mockRestore();
+  });
+
   it('samplePoint returns null without a widget and a cartographic point when the widget is loaded', async () => {
     const element = document.createElement('honua-scene');
     element.setAttribute('autoload', 'false');

--- a/src/Honua.Embed/tests/honua-scene.test.ts
+++ b/src/Honua.Embed/tests/honua-scene.test.ts
@@ -442,6 +442,83 @@ describe('honua-scene', () => {
     webgl.mockRestore();
   });
 
+  it('lets metadata-declared primary win over tileset-url for both URL and fields', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('tileset-url', 'https://data.example.test/attribute-primary.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    element.metadata = {
+      schema: 'honua-scene-metadata/v1',
+      id: 'demo',
+      name: 'Demo',
+      layers: [
+        {
+          id: 'primary',
+          title: 'Site capture (metadata)',
+          description: 'As-built primary tileset from the scene document.',
+          kind: '3d-tiles',
+          url: 'https://data.example.test/metadata-primary.json',
+          opacity: 0.6,
+          visible: false,
+        },
+      ],
+    };
+
+    await element.load();
+
+    const fromUrlCalls = cesium.Cesium3DTileset.fromUrl.mock.calls.map((call) => call[0]);
+    expect(fromUrlCalls).toContain('https://data.example.test/metadata-primary.json');
+    expect(fromUrlCalls).not.toContain('https://data.example.test/attribute-primary.json');
+
+    const handle = element.getLayer('primary');
+    expect(handle?.metadata.url).toBe('https://data.example.test/metadata-primary.json');
+    expect(handle?.metadata.title).toBe('Site capture (metadata)');
+    expect(handle?.metadata.description).toBe('As-built primary tileset from the scene document.');
+    expect(handle?.metadata.opacity).toBe(0.6);
+    expect(handle?.metadata.visible).toBe(false);
+
+    webgl.mockRestore();
+  });
+
+  it('uses the metadata-declared primary tileset for the public tileset getter and ready event', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    element.setAttribute('terrain-url', 'https://data.example.test/terrain');
+    document.body.append(element);
+
+    element.metadata = {
+      schema: 'honua-scene-metadata/v1',
+      id: 'demo',
+      name: 'Demo',
+      layers: [
+        {
+          id: 'primary',
+          title: 'Primary from metadata',
+          kind: '3d-tiles',
+          url: 'https://data.example.test/metadata-primary.json',
+        },
+      ],
+    };
+
+    const ready = vi.fn();
+    element.addEventListener('honua-scene-ready', ready);
+
+    await element.load();
+
+    const handle = element.getLayer('primary');
+    expect(handle?.tileset).not.toBeNull();
+    expect(element.tileset).toBe(handle?.tileset);
+    expect(ready).toHaveBeenCalledOnce();
+    expect(ready.mock.calls[0][0].detail.tileset).toBe(handle?.tileset);
+
+    webgl.mockRestore();
+  });
+
   it('tears down the existing scene when package resolution fails', async () => {
     const webgl = mockWebGl();
     const element = document.createElement('honua-scene');

--- a/src/Honua.Embed/tests/honua-scene.test.ts
+++ b/src/Honua.Embed/tests/honua-scene.test.ts
@@ -591,6 +591,53 @@ describe('honua-scene', () => {
     webgl.mockRestore();
   });
 
+  it('keeps scene.tileset in sync when addLayer replaces the primary tileset source', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('tileset-url', 'https://data.example.test/attribute-primary.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    await element.load();
+    const initialPrimary = element.tileset;
+    expect(initialPrimary).not.toBeNull();
+    expect(element.getLayer('primary')?.tileset).toBe(initialPrimary);
+
+    await element.addLayer({
+      id: 'primary',
+      title: 'Replacement primary',
+      kind: '3d-tiles',
+      url: 'https://data.example.test/replacement-primary.json',
+    });
+
+    const replacement = element.getLayer('primary')?.tileset;
+    expect(replacement).not.toBeNull();
+    expect(replacement).not.toBe(initialPrimary);
+    expect(element.tileset).toBe(replacement);
+
+    webgl.mockRestore();
+  });
+
+  it('clears scene.tileset when removeLayer detaches the primary handle', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('tileset-url', 'https://data.example.test/primary.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    await element.load();
+    expect(element.tileset).not.toBeNull();
+
+    element.removeLayer('primary');
+
+    expect(element.getLayer('primary')).toBeNull();
+    expect(element.tileset).toBeNull();
+
+    webgl.mockRestore();
+  });
+
   it('cancels in-flight loads when disconnected', async () => {
     const webgl = mockWebGl();
     let resolveTerrain!: (value: unknown) => void;

--- a/src/Honua.Embed/tests/honua-scene.test.ts
+++ b/src/Honua.Embed/tests/honua-scene.test.ts
@@ -358,6 +358,90 @@ describe('honua-scene', () => {
     webgl.mockRestore();
   });
 
+  it('does not reload the implicit primary layer after tileset-url is removed', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('tileset-url', 'https://data.example.test/primary.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    await element.load();
+    expect(element.getLayer('primary')?.metadata.url).toBe(
+      'https://data.example.test/primary.json',
+    );
+
+    element.removeAttribute('tileset-url');
+    await element.load();
+    expect(element.getLayer('primary')).toBeNull();
+
+    cesium.Cesium3DTileset.fromUrl.mockClear();
+    element.setAttribute('terrain-url', 'https://data.example.test/terrain');
+    await element.load();
+
+    const reloadedFromStale = cesium.Cesium3DTileset.fromUrl.mock.calls.some(
+      (call) => call[0] === 'https://data.example.test/primary.json',
+    );
+    expect(reloadedFromStale).toBe(false);
+    expect(element.getLayer('primary')).toBeNull();
+
+    webgl.mockRestore();
+  });
+
+  it('replaces the implicit primary handle when tileset-url is repointed', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('tileset-url', 'https://data.example.test/v1.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    await element.load();
+    expect(element.getLayer('primary')?.metadata.url).toBe(
+      'https://data.example.test/v1.json',
+    );
+
+    element.setAttribute('tileset-url', 'https://data.example.test/v2.json');
+    await element.load();
+
+    expect(element.getLayer('primary')?.metadata.url).toBe(
+      'https://data.example.test/v2.json',
+    );
+
+    webgl.mockRestore();
+  });
+
+  it('preserves a metadata-declared primary layer when tileset-url is removed', async () => {
+    const webgl = mockWebGl();
+    const element = document.createElement('honua-scene');
+    element.setAttribute('tileset-url', 'https://data.example.test/override.json');
+    element.setAttribute('cesium-base-url', 'data:text/css,');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    element.metadata = {
+      schema: 'honua-scene-metadata/v1',
+      id: 'demo',
+      name: 'Demo',
+      layers: [
+        {
+          id: 'primary',
+          title: 'Primary from metadata',
+          kind: '3d-tiles',
+          url: 'https://data.example.test/metadata-primary.json',
+        },
+      ],
+    };
+
+    await element.load();
+
+    element.removeAttribute('tileset-url');
+    await element.load();
+
+    expect(element.getLayer('primary')).not.toBeNull();
+    webgl.mockRestore();
+  });
+
   it('tears down the existing scene when package resolution fails', async () => {
     const webgl = mockWebGl();
     const element = document.createElement('honua-scene');

--- a/src/Honua.Embed/tests/scene-metadata.test.ts
+++ b/src/Honua.Embed/tests/scene-metadata.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest';
+import {
+  HonuaSceneMetadataError,
+  parseHonuaSceneMetadata,
+} from '../src/scene-metadata';
+
+const VALID_DOCUMENT = {
+  schema: 'honua-scene-metadata/v1',
+  id: 'demo',
+  name: 'Demo',
+  description: 'Demo scene',
+  center: { latitude: 39.95, longitude: -75.16, height: 1500 },
+  bounds: { west: -75.18, south: 39.93, east: -75.14, north: 39.97 },
+  tileset: { url: 'https://example.test/tileset.json', format: '3d-tiles' },
+  capabilities: { '3d-tiles': true },
+  layers: [
+    {
+      id: 'as-built',
+      title: 'As-built capture',
+      kind: '3d-tiles',
+      url: 'https://example.test/as-built/tileset.json',
+      visible: true,
+      opacity: 1,
+    },
+    {
+      id: 'design-overlay',
+      title: 'Design overlay',
+      kind: '3d-tiles',
+      url: 'https://example.test/design/tileset.json',
+      visible: false,
+      opacity: 0.85,
+    },
+  ],
+  bookmarks: [
+    {
+      id: 'site-overview',
+      title: 'Site overview',
+      view: {
+        center: { latitude: 39.95, longitude: -75.16 },
+        height: 2400,
+        orientation: { heading: 0, pitch: -45, roll: 0 },
+      },
+    },
+  ],
+  timeline: {
+    phases: [
+      {
+        id: 'phase-1',
+        title: 'Phase 1',
+        startUtc: '2026-01-01T00:00:00Z',
+        endUtc: '2026-03-31T00:00:00Z',
+        visibleLayerIds: ['as-built'],
+      },
+    ],
+  },
+  compare: {
+    modes: [
+      {
+        id: 'design-vs-asbuilt',
+        title: 'Design vs As-built',
+        leftLayerIds: ['design-overlay'],
+        rightLayerIds: ['as-built'],
+      },
+    ],
+  },
+  inspector: {
+    fields: [
+      { key: 'id', title: 'Asset ID' },
+      { key: 'phase', title: 'Phase', format: 'string' },
+      { key: 'lastSurveyUtc', title: 'Last survey', format: 'date' },
+    ],
+  },
+};
+
+function expectMetadataError(
+  fn: () => void,
+  expectations: { path?: string; messagePattern?: RegExp },
+): void {
+  let caught: unknown;
+  try {
+    fn();
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(HonuaSceneMetadataError);
+  const error = caught as HonuaSceneMetadataError;
+  expect(error.code).toBe('metadata-invalid');
+  if (expectations.path !== undefined) {
+    expect(error.path).toBe(expectations.path);
+  }
+  if (expectations.messagePattern) {
+    expect(error.message).toMatch(expectations.messagePattern);
+  }
+}
+
+describe('parseHonuaSceneMetadata', () => {
+  it('parses a valid construction-themed metadata document', () => {
+    const metadata = parseHonuaSceneMetadata(VALID_DOCUMENT);
+
+    expect(metadata.schema).toBe('honua-scene-metadata/v1');
+    expect(metadata.id).toBe('demo');
+    expect(metadata.layers).toHaveLength(2);
+    expect(metadata.bookmarks).toHaveLength(1);
+    expect(metadata.timeline?.phases[0].visibleLayerIds).toEqual(['as-built']);
+    expect(metadata.compare?.modes[0].leftLayerIds).toEqual(['design-overlay']);
+    expect(metadata.inspector?.fields[0].key).toBe('id');
+  });
+
+  it('rejects unknown schema with a stable code and path', () => {
+    expectMetadataError(
+      () => parseHonuaSceneMetadata({ ...VALID_DOCUMENT, schema: 'honua-scene-metadata/v999' }),
+      { path: '$.schema' },
+    );
+  });
+
+  it('points to the offending path on a validation failure', () => {
+    expectMetadataError(
+      () =>
+        parseHonuaSceneMetadata({
+          ...VALID_DOCUMENT,
+          layers: [
+            {
+              id: 'as-built',
+              title: 'As-built',
+              kind: '3d-tiles',
+              url: 'https://example.test/tileset.json',
+              opacity: 5,
+            },
+          ],
+        }),
+      { path: '$.layers[0].opacity', messagePattern: /opacity/i },
+    );
+  });
+
+  it('flags duplicate layer ids', () => {
+    const document = {
+      ...VALID_DOCUMENT,
+      layers: [
+        ...VALID_DOCUMENT.layers,
+        { ...VALID_DOCUMENT.layers[0] },
+      ],
+    };
+
+    expectMetadataError(() => parseHonuaSceneMetadata(document), { path: '$.layers[2].id' });
+  });
+
+  it('rejects timeline phases that reference unknown layers', () => {
+    const document = {
+      ...VALID_DOCUMENT,
+      timeline: {
+        phases: [
+          {
+            id: 'phase-1',
+            title: 'Phase 1',
+            startUtc: '2026-01-01T00:00:00Z',
+            endUtc: '2026-03-31T00:00:00Z',
+            visibleLayerIds: ['ghost-layer'],
+          },
+        ],
+      },
+    };
+
+    expectMetadataError(() => parseHonuaSceneMetadata(document), {
+      path: '$.timeline.phases[0].visibleLayerIds[0]',
+    });
+  });
+
+  it('rejects compare modes that reference unknown layers', () => {
+    const document = {
+      ...VALID_DOCUMENT,
+      compare: {
+        modes: [
+          {
+            id: 'invalid',
+            title: 'Invalid',
+            leftLayerIds: ['ghost-layer'],
+            rightLayerIds: [],
+          },
+        ],
+      },
+    };
+
+    expectMetadataError(() => parseHonuaSceneMetadata(document), {
+      path: '$.compare.modes[0].leftLayerIds[0]',
+    });
+  });
+
+  it('accepts the implicit "primary" layer reference', () => {
+    const document = {
+      ...VALID_DOCUMENT,
+      timeline: {
+        phases: [
+          {
+            id: 'p',
+            title: 'Phase',
+            startUtc: '2026-01-01T00:00:00Z',
+            endUtc: '2026-03-31T00:00:00Z',
+            visibleLayerIds: ['primary'],
+          },
+        ],
+      },
+    };
+
+    expect(() => parseHonuaSceneMetadata(document)).not.toThrow();
+  });
+
+  it('requires required string fields', () => {
+    expectMetadataError(
+      () => parseHonuaSceneMetadata({ schema: 'honua-scene-metadata/v1' }),
+      { path: '$.id' },
+    );
+  });
+
+  it('rejects non-finite numbers', () => {
+    expectMetadataError(
+      () =>
+        parseHonuaSceneMetadata({
+          ...VALID_DOCUMENT,
+          center: { latitude: NaN, longitude: 10 },
+        }),
+      { path: '$.center.latitude' },
+    );
+  });
+
+  it('rejects malformed timeline timestamps', () => {
+    expectMetadataError(
+      () =>
+        parseHonuaSceneMetadata({
+          ...VALID_DOCUMENT,
+          timeline: {
+            phases: [
+              {
+                id: 'phase-1',
+                title: 'Phase 1',
+                startUtc: 'not-a-date',
+                endUtc: '2026-03-31T00:00:00Z',
+                visibleLayerIds: ['as-built'],
+              },
+            ],
+          },
+        }),
+      { path: '$.timeline.phases[0].startUtc' },
+    );
+  });
+});

--- a/src/Honua.Embed/tests/scene-metadata.test.ts
+++ b/src/Honua.Embed/tests/scene-metadata.test.ts
@@ -1,8 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   HonuaSceneMetadataError,
   parseHonuaSceneMetadata,
 } from '../src/scene-metadata';
+
+const SDK_FIXTURE_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../..',
+  'tests/Honua.Mobile.Sdk.Tests/Fixtures/Scenes/scene-metadata.json',
+);
 
 const VALID_DOCUMENT = {
   schema: 'honua-scene-metadata/v1',
@@ -219,6 +228,24 @@ describe('parseHonuaSceneMetadata', () => {
           center: { latitude: NaN, longitude: 10 },
         }),
       { path: '$.center.latitude' },
+    );
+  });
+
+  it('parses the SDK scene-metadata fixture without a schema field', () => {
+    const raw = readFileSync(SDK_FIXTURE_PATH, 'utf-8');
+    const document = JSON.parse(raw) as Record<string, unknown>;
+
+    expect(document.schema).toBeUndefined();
+
+    const metadata = parseHonuaSceneMetadata(document);
+
+    expect(metadata.schema).toBe('honua-scene-metadata/v1');
+    expect(metadata.id).toBe('downtown-honolulu');
+    expect(metadata.tileset?.url).toBe(
+      'https://api.honua.test/api/scenes/downtown-honolulu/tileset.json',
+    );
+    expect(metadata.terrain?.url).toBe(
+      'https://api.honua.test/api/scenes/downtown-honolulu/terrain',
     );
   });
 


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #98
## Summary

JS/embed: Cesium scene controls for Honua construction world-model demo
## Changes Made

- JS/embed: Cesium scene controls for Honua construction world-model demo
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Additional Context

Decisions:
- **No reopen of the deferred finding.** `scene-link.ts:170` ("every scene event reported as `metadata-change`") was *explicitly deferred* by `codex_local` to the cleanup backlog (severity: low, category: `docs_contract`). The deferral is a review decision, not a missed finding; reopening it would violate "Do not reopen solved areas without a concrete reason tied to a finding, failing check, or acceptance-criteria gap" and would expand scope past the current pass.
- **Confirmed `f50bcb8` is correctly merged.** The user-authored commit refactors `#loadLayerTileset`'s staleness/identity gate into a single `#isCurrentLayerTilesetLoad` predicate (DRY + adds `widget.isDestroyed()`), promotes the post-hydrate `metadataDeclaresPrimary` re-check to defense-in-depth, and adds two regression tests. All 97 tests pass; type-check is clean. No follow-up edits needed.
- **No cross-repo work.** The remaining items are local to `src/Honua.Embed`; no `honua-server` contract or deployment changes apply.

Follow-ons:
Carried forward unchanged:
- Inline `metadata.tileset.url` → `tileset-url` mirror in `examples/scene-construction/index.html` is still queued for the future scene-element change that consumes `metadata.tileset.url` directly.
- Mobile SDK roadmap and 3D/AR dependency matrix one-line refresh.
- JS SDK adapter cross-link from `scene-controls.md` once the SDK side lands.
- **New (deferred from this review)**: `src/Honua.Embed/src/controls/scene-link.ts:170` — `#handleSceneRewire` should map `event.type` to the corresponding `HonuaSceneLinkChangeReason` (`'ready'` / `'config-change'` / `'metadata-change'`) instead of always reporting `'metadata-change'`. Recorded in `review-findings.json` and the cleanup backlog.

Code kaizen:
Deferred 1 low-priority finding(s) to cleanup backlog. No Claude findings to disposition; confirmed the one low scene-link docs_contract follow-up and found no blocking issue in the scoped pass.
