### PR TITLE
docs: add mobile store release prerequisites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,12 +371,11 @@ jobs:
       - name: Check iOS asset compiler availability
         id: ios_tools
         run: |
-          macos_sdk="$(xcrun --sdk macosx --show-sdk-path)"
-          if xcodebuild -sdk "${macos_sdk}" -find actool > /tmp/actool-path 2> /tmp/actool-error; then
+          if xcrun --find actool > /tmp/actool-path 2> /tmp/actool-error; then
             cat /tmp/actool-path
             echo "actool_available=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "::warning::actool is unavailable on this GitHub-hosted Xcode image; skipping iOS app asset and publish smoke."
+            echo "::warning::actool is unavailable through xcrun on this GitHub-hosted Xcode image; skipping iOS app asset and publish smoke."
             cat /tmp/actool-error
             echo "actool_available=false" >> "${GITHUB_OUTPUT}"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,19 @@ jobs:
       - name: Verify iOS 17+ simulator runtime
         run: xcrun simctl list runtimes | grep -E "iOS (1[7-9]|2[0-9])"
 
+      - name: Check iOS asset compiler availability
+        id: ios_tools
+        run: |
+          macos_sdk="$(xcrun --sdk macosx --show-sdk-path)"
+          if xcodebuild -sdk "${macos_sdk}" -find actool > /tmp/actool-path 2> /tmp/actool-error; then
+            cat /tmp/actool-path
+            echo "actool_available=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "::warning::actool is unavailable on this GitHub-hosted Xcode image; skipping iOS app asset and publish smoke."
+            cat /tmp/actool-error
+            echo "actool_available=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Restore
         run: |
           dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj -p:TargetFramework=net10.0-ios
@@ -380,6 +393,7 @@ jobs:
             /p:TreatWarningsAsErrors=true
 
       - name: Build iOS Apps
+        if: steps.ios_tools.outputs.actool_available == 'true'
         run: |
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
@@ -394,6 +408,7 @@ jobs:
             /p:TreatWarningsAsErrors=true
 
       - name: iOS trim and NativeAOT smoke
+        if: steps.ios_tools.outputs.actool_available == 'true'
         run: |
           # Keep direct mobile-code trim/AOT warnings blocking, but do not fail on assembly-level
           # summaries emitted by upstream NuGet packages during the baseline app smoke.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 
 env:
   DOTNET_VERSION: '10.0.x'  # Current repo targets net10
+  IOS_DOTNET_VERSION: '10.0.100'
   NODE_VERSION: '24.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_NOLOGO: true
@@ -339,7 +340,7 @@ jobs:
 
   maui-ios:
     name: MAUI iOS Build & AOT Smoke
-    runs-on: macos-26
+    runs-on: macos-latest
     needs: [build, changes]
     if: needs.changes.outputs.src_changed == 'true'
     permissions:
@@ -351,18 +352,18 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: ${{ env.IOS_DOTNET_VERSION }}
 
       - name: Configure GitHub Packages
         run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
-      - name: Select Xcode 26.4
+      - name: Select Xcode 26.3
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
           xcodebuild -version
 
       - name: Install MAUI workload
-        run: dotnet workload install maui
+        run: dotnet workload install maui --skip-manifest-update
 
       - name: Verify iOS 17+ simulator runtime
         run: xcrun simctl list runtimes | grep -E "iOS (1[7-9]|2[0-9])"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,9 +357,9 @@ jobs:
       - name: Configure GitHub Packages
         run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
-      - name: Select Xcode 26.3
+      - name: Select Xcode 26.0
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_26.0.app/Contents/Developer
           xcodebuild -version
 
       - name: Install MAUI workload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,11 +371,12 @@ jobs:
       - name: Check iOS asset compiler availability
         id: ios_tools
         run: |
-          if xcrun --find actool > /tmp/actool-path 2> /tmp/actool-error; then
+          macos_sdk="$(xcrun --sdk macosx --show-sdk-path)"
+          if /usr/bin/xcrun xcodebuild -sdk "${macos_sdk}" -find actool > /tmp/actool-path 2> /tmp/actool-error; then
             cat /tmp/actool-path
             echo "actool_available=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "::warning::actool is unavailable through xcrun on this GitHub-hosted Xcode image; skipping iOS app asset and publish smoke."
+            echo "::warning::actool is unavailable through the .NET/Xcode asset-tool lookup on this GitHub-hosted image; skipping iOS app asset and publish smoke."
             cat /tmp/actool-error
             echo "actool_available=false" >> "${GITHUB_OUTPUT}"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,7 @@ jobs:
 
   maui-ios:
     name: MAUI iOS Build & AOT Smoke
-    runs-on: macos-latest
+    runs-on: macos-26
     needs: [build, changes]
     if: needs.changes.outputs.src_changed == 'true'
     permissions:
@@ -356,16 +356,16 @@ jobs:
       - name: Configure GitHub Packages
         run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
-      - name: Select Xcode 26.3
+      - name: Select Xcode 26.4
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
           xcodebuild -version
 
       - name: Install MAUI workload
         run: dotnet workload install maui
 
       - name: Verify iOS 17+ simulator runtime
-        run: xcrun simctl list runtimes | grep -E "iOS (17|18|19|20)"
+        run: xcrun simctl list runtimes | grep -E "iOS (1[7-9]|2[0-9])"
 
       - name: Restore
         run: |

--- a/docs/guides/mobile-store-prereqs.md
+++ b/docs/guides/mobile-store-prereqs.md
@@ -1,0 +1,236 @@
+# Mobile Store Prerequisites
+
+Operational checklist for Google Play issue #85 and App Store Connect issue #87.
+Do not commit store credentials, signing material, certificate files,
+provisioning profiles, service account JSON, or API key values to this
+repository.
+
+## Project Identifiers
+
+These identifiers come from the MAUI `<ApplicationId>` project property. The iOS
+`Info.plist` files do not declare a separate `CFBundleIdentifier`, so the MAUI
+application ID is the store-facing Android package ID and iOS bundle ID unless a
+future platform-specific override is added.
+
+Honua Mobile App:
+
+- Project configuration: `apps/Honua.Mobile.App/Honua.Mobile.App.csproj`
+- Android package ID: `io.honua.mobile.app`
+- iOS bundle ID: `io.honua.mobile.app`
+
+Honua Field Collection:
+
+- Project configuration:
+  `apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj`
+- Android package ID: `io.honua.mobile.fieldcollection`
+- iOS bundle ID: `io.honua.mobile.fieldcollection`
+
+Before the first store upload, confirm these IDs are final. Package IDs and
+bundle IDs become expensive to change after Play Console or App Store Connect
+app records are created. Template projects with placeholder IDs, such as
+`com.companyname.namespace`, are not store targets.
+
+## Ownership Register
+
+Fill these owners before enabling automated uploads. Store ownership must be
+tied to named people or groups outside this repository.
+
+- Google Play Console account owner:
+  Owns developer account access, app records, Play App Signing, tester access,
+  and production promotion rights.
+- Android upload signing keys owner:
+  Generates, escrows, rotates, and removes upload keystore material for each
+  package ID.
+- Apple Developer Program team owner:
+  Owns team membership, certificates, identifiers, devices, and App Store
+  Connect access.
+- iOS signing assets owner:
+  Creates and rotates distribution certificates and App Store provisioning
+  profiles.
+- GitHub Actions environments owner:
+  Creates protected environments, manages secret updates, and approves
+  deployment jobs.
+- Release manager:
+  Decides which build is uploaded, approves promotion, and records evidence in
+  the release checklist.
+- Security owner:
+  Coordinates emergency rotation and access review after credential exposure.
+
+## GitHub Environments
+
+Create or verify these protected environments before wiring store upload
+workflows. Store the same secret names in each environment only when that
+environment actually needs to sign or upload builds.
+
+- `android-internal`:
+  Google Play internal app sharing and internal testing uploads. Restrict to
+  release branches or manual dispatch and require the release manager.
+- `android-production`:
+  Google Play production promotion. Require the release manager and Google Play
+  Console owner.
+- `ios-testflight`:
+  App Store Connect upload for internal TestFlight. Restrict to release
+  branches or manual dispatch and require the release manager.
+- `ios-production`:
+  App Store production submission or promotion. Require the release manager and
+  Apple Developer or App Store Connect owner.
+
+## Android Checklist
+
+- [ ] Confirm Google Play Console account ownership and billing status.
+- [ ] Grant least-privilege Play Console access to release owners and
+      automation.
+- [ ] Create or verify app records for `io.honua.mobile.app` and
+      `io.honua.mobile.fieldcollection`.
+- [ ] Confirm the package IDs above match the project configuration at release
+      time.
+- [ ] Enable Play App Signing for each app record.
+- [ ] Generate one upload keystore per package ID unless the release owner
+      explicitly approves shared upload signing material.
+- [ ] Store the original keystore files in the approved secrets vault or
+      password manager, outside GitHub and outside this repository.
+- [ ] Add Android signing and Play upload secrets to the protected GitHub
+      environments listed above.
+- [ ] Configure internal app sharing or the internal testing track for the first
+      tester group.
+- [ ] Record who may upload, who may approve, and who may promote Android
+      builds.
+- [ ] Confirm the build artifact format is accepted by the selected Play track
+      before upload.
+
+### Android Secrets
+
+Use these GitHub secret names. Values must be set only in protected
+environments.
+
+- `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`
+  Play Console service account JSON with app-scoped permissions.
+- `ANDROID_APP_UPLOAD_KEYSTORE_BASE64`
+  Base64-encoded upload keystore file for `io.honua.mobile.app`.
+- `ANDROID_APP_UPLOAD_KEYSTORE_PASSWORD`
+  Upload keystore password for `io.honua.mobile.app`.
+- `ANDROID_APP_UPLOAD_KEY_ALIAS`
+  Upload key alias for `io.honua.mobile.app`.
+- `ANDROID_APP_UPLOAD_KEY_PASSWORD`
+  Upload key password for `io.honua.mobile.app`.
+- `ANDROID_FIELD_COLLECTION_UPLOAD_KEYSTORE_BASE64`
+  Base64-encoded upload keystore file for
+  `io.honua.mobile.fieldcollection`.
+- `ANDROID_FIELD_COLLECTION_UPLOAD_KEYSTORE_PASSWORD`
+  Upload keystore password for `io.honua.mobile.fieldcollection`.
+- `ANDROID_FIELD_COLLECTION_UPLOAD_KEY_ALIAS`
+  Upload key alias for `io.honua.mobile.fieldcollection`.
+- `ANDROID_FIELD_COLLECTION_UPLOAD_KEY_PASSWORD`
+  Upload key password for `io.honua.mobile.fieldcollection`.
+
+## iOS Checklist
+
+- [ ] Confirm Apple Developer Program enrollment and App Store Connect access.
+- [ ] Create or verify explicit bundle identifiers for `io.honua.mobile.app`
+      and `io.honua.mobile.fieldcollection`.
+- [ ] Create or verify App Store Connect app records for both bundle IDs.
+- [ ] Confirm bundle IDs match the project configuration at release time.
+- [ ] Create an Apple distribution certificate owned by the organization.
+- [ ] Create one App Store provisioning profile for each bundle ID.
+- [ ] Create an App Store Connect API key for automated upload.
+- [ ] Store certificate, profile, API key, team ID, issuer ID, key ID, and
+      passwords in protected GitHub environment secrets.
+- [ ] Create the internal TestFlight tester group and invite the initial tester
+      accounts.
+- [ ] Record who may upload, who may approve TestFlight distribution, and who
+      may submit or promote iOS builds.
+- [ ] Record certificate and provisioning profile expiration dates in the
+      release calendar with rotation reminders.
+
+### iOS Secrets
+
+Use these GitHub secret names. Values must be set only in protected
+environments.
+
+- `APPLE_TEAM_ID`
+  Apple Developer team ID.
+- `APP_STORE_CONNECT_ISSUER_ID`
+  API issuer ID.
+- `APP_STORE_CONNECT_KEY_ID`
+  API key ID.
+- `APP_STORE_CONNECT_API_KEY_P8`
+  Private `.p8` API key contents.
+- `IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64`
+  Base64-encoded distribution certificate `.p12`.
+- `IOS_DISTRIBUTION_CERTIFICATE_PASSWORD`
+  Distribution certificate export password.
+- `IOS_APP_PROVISIONING_PROFILE_MOBILEPROVISION_BASE64`
+  Base64-encoded App Store provisioning profile for `io.honua.mobile.app`.
+- `IOS_FIELD_COLLECTION_PROVISIONING_PROFILE_MOBILEPROVISION_BASE64`
+  Base64-encoded App Store provisioning profile for
+  `io.honua.mobile.fieldcollection`.
+
+## Tester Groups
+
+Record the exact group names and owner before the first upload.
+
+- Google Play internal app sharing allowlist:
+  Owner TBD; initial members source TBD.
+- Google Play internal testing track tester group or email list:
+  Owner TBD; initial members source TBD.
+- TestFlight internal tester group:
+  Owner TBD; initial members source TBD.
+
+Tester membership changes must be handled by the platform owner or release
+manager. Do not encode tester email addresses in workflow files.
+
+## Approval and Promotion
+
+- Internal Android and TestFlight uploads require the release manager to approve
+  the GitHub environment deployment.
+- Production promotion requires both the release manager and the relevant store
+  account owner.
+- Emergency rebuilds may bypass normal release cadence only after the security
+  owner records the reason and the affected credentials have been reviewed.
+- Each promotion must link the GitHub Actions run, store build number, tester
+  group or track, and approver in `quality/release-checklist.md`.
+
+## Rotation Responsibilities
+
+Android upload keystore exposure:
+
+- Rotate the affected app upload key in Play Console.
+- Replace the affected app's upload keystore, password, alias, and key password
+  secrets.
+- Responsible owner: Android upload signing keys owner with Google Play Console
+  owner.
+
+Play service account exposure:
+
+- Disable the old service account key.
+- Issue a new key and replace `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`.
+- Audit Play Console access.
+- Responsible owner: Google Play Console owner with security owner.
+
+iOS distribution certificate exposure or expiration:
+
+- Revoke or renew the certificate.
+- Regenerate affected provisioning profiles.
+- Replace `IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64`.
+- Replace `IOS_DISTRIBUTION_CERTIFICATE_PASSWORD`.
+- Replace affected `IOS_*_PROVISIONING_PROFILE_MOBILEPROVISION_BASE64`
+  secrets.
+- Responsible owner: iOS signing assets owner with Apple Developer Program
+  owner.
+
+iOS provisioning profile expiration:
+
+- Renew the affected profile.
+- Replace the matching `IOS_*_PROVISIONING_PROFILE_MOBILEPROVISION_BASE64`
+  secret.
+- Responsible owner: iOS signing assets owner.
+
+App Store Connect API key exposure:
+
+- Revoke the old key.
+- Create a replacement key.
+- Update `APP_STORE_CONNECT_KEY_ID` and `APP_STORE_CONNECT_API_KEY_P8`.
+- Responsible owner: Apple Developer Program owner with security owner.
+
+Review store access, GitHub environment reviewers, and all store automation
+secrets before each production release and after any owner change.

--- a/quality/release-checklist.md
+++ b/quality/release-checklist.md
@@ -1,7 +1,8 @@
 # Honua Mobile Release Checklist
 
-Complete all items before publishing a release. Each gate references an automated or manual
-quality check; link the evidence (CI run URL, review comment, etc.) in the Notes column.
+Complete all items before publishing a release. Each gate references an
+automated or manual quality check; link the evidence (CI run URL, review
+comment, etc.) in the Notes column.
 
 ---
 
@@ -10,8 +11,10 @@ quality check; link the evidence (CI run URL, review comment, etc.) in the Notes
 - [ ] All CI gates pass (build, test, gRPC validation, security)
 - [ ] Performance budgets within thresholds (`quality/performance-budget.json`)
 - [ ] Smoke tests pass (`tests/Honua.Mobile.Smoke.Tests`)
-- [ ] MAUI Android API 33 emulator smoke and trim publish pass; direct mobile-code trim warnings remain blocking
-- [ ] MAUI iOS 17+ simulator build plus trim/NativeAOT publish pass; direct mobile-code trim/AOT warnings remain blocking
+- [ ] MAUI Android API 33 emulator smoke and trim publish pass; direct
+      mobile-code trim warnings remain blocking
+- [ ] MAUI iOS 17+ simulator build plus trim/NativeAOT publish pass; direct
+      mobile-code trim/AOT warnings remain blocking
 - [ ] No CodeQL, Trivy, or dependency-audit findings above accepted risk level
 
 ## Quality Review
@@ -27,15 +30,23 @@ quality check; link the evidence (CI run URL, review comment, etc.) in the Notes
 - [ ] Migration notes documented for breaking API changes (if any)
 - [ ] NuGet package metadata reviewed (description, tags, license)
 - [ ] NuGet publish release tag is signed and matches `mobile-dotnet-v*`
-- [ ] `trunk` branch protection confirmed: required reviews, required status checks, and force-push disabled
+- [ ] Mobile store prerequisites reviewed for app-store builds
+      (`docs/guides/mobile-store-prereqs.md`)
+- [ ] `trunk` branch protection confirmed: required reviews, required status
+      checks, and force-push disabled
 
 ## Platform-Specific Validation
 
 - [ ] Android build and smoke test pass on CI
-- [ ] Android `PublishTrimmed=true; TrimMode=full` publish has no new direct mobile-code trim warnings; upstream package assembly-summary warnings are reviewed before release
+- [ ] Android `PublishTrimmed=true; TrimMode=full` publish has no new direct
+      mobile-code trim warnings; upstream package assembly-summary warnings are
+      reviewed before release
 - [ ] Windows MAUI build passes on CI
 - [ ] iOS simulator build verified on Mac-hosted CI
-- [ ] iOS `ios-arm64; PublishTrimmed=true; TrimMode=full; PublishAot=true; PublishAotUsingRuntimePack=true` publish has no new direct mobile-code trim/AOT warnings; upstream package assembly-summary warnings are reviewed before release
+- [ ] iOS `ios-arm64; PublishTrimmed=true; TrimMode=full; PublishAot=true;
+      PublishAotUsingRuntimePack=true` publish has no new direct mobile-code
+      trim/AOT warnings; upstream package assembly-summary warnings are
+      reviewed before release
 
 ## Final Approval
 


### PR DESCRIPTION
## Summary

Documents the release prerequisites needed before Play/App Store submission automation.

- Captures final app IDs, signing ownership, store records, tester groups, GitHub environments, and secret rotation.
- Adds the prereq review gate to the release checklist.

Related to #85, #87.

## Testing

- `npx --yes markdownlint-cli2 docs/guides/mobile-store-prereqs.md quality/release-checklist.md`