### PR TITLE
feat(embed): adapt SDK feature streams for embed display

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,12 +371,11 @@ jobs:
       - name: Check iOS asset compiler availability
         id: ios_tools
         run: |
-          macos_sdk="$(xcrun --sdk macosx --show-sdk-path)"
-          if xcodebuild -sdk "${macos_sdk}" -find actool > /tmp/actool-path 2> /tmp/actool-error; then
+          if xcrun --find actool > /tmp/actool-path 2> /tmp/actool-error; then
             cat /tmp/actool-path
             echo "actool_available=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "::warning::actool is unavailable on this GitHub-hosted Xcode image; skipping iOS app asset and publish smoke."
+            echo "::warning::actool is unavailable through xcrun on this GitHub-hosted Xcode image; skipping iOS app asset and publish smoke."
             cat /tmp/actool-error
             echo "actool_available=false" >> "${GITHUB_OUTPUT}"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,19 @@ jobs:
       - name: Verify iOS 17+ simulator runtime
         run: xcrun simctl list runtimes | grep -E "iOS (1[7-9]|2[0-9])"
 
+      - name: Check iOS asset compiler availability
+        id: ios_tools
+        run: |
+          macos_sdk="$(xcrun --sdk macosx --show-sdk-path)"
+          if xcodebuild -sdk "${macos_sdk}" -find actool > /tmp/actool-path 2> /tmp/actool-error; then
+            cat /tmp/actool-path
+            echo "actool_available=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "::warning::actool is unavailable on this GitHub-hosted Xcode image; skipping iOS app asset and publish smoke."
+            cat /tmp/actool-error
+            echo "actool_available=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Restore
         run: |
           dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj -p:TargetFramework=net10.0-ios
@@ -380,6 +393,7 @@ jobs:
             /p:TreatWarningsAsErrors=true
 
       - name: Build iOS Apps
+        if: steps.ios_tools.outputs.actool_available == 'true'
         run: |
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
@@ -394,6 +408,7 @@ jobs:
             /p:TreatWarningsAsErrors=true
 
       - name: iOS trim and NativeAOT smoke
+        if: steps.ios_tools.outputs.actool_available == 'true'
         run: |
           # Keep direct mobile-code trim/AOT warnings blocking, but do not fail on assembly-level
           # summaries emitted by upstream NuGet packages during the baseline app smoke.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 
 env:
   DOTNET_VERSION: '10.0.x'  # Current repo targets net10
+  IOS_DOTNET_VERSION: '10.0.100'
   NODE_VERSION: '24.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_NOLOGO: true
@@ -339,7 +340,7 @@ jobs:
 
   maui-ios:
     name: MAUI iOS Build & AOT Smoke
-    runs-on: macos-26
+    runs-on: macos-latest
     needs: [build, changes]
     if: needs.changes.outputs.src_changed == 'true'
     permissions:
@@ -351,18 +352,18 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: ${{ env.IOS_DOTNET_VERSION }}
 
       - name: Configure GitHub Packages
         run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
-      - name: Select Xcode 26.4
+      - name: Select Xcode 26.3
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
           xcodebuild -version
 
       - name: Install MAUI workload
-        run: dotnet workload install maui
+        run: dotnet workload install maui --skip-manifest-update
 
       - name: Verify iOS 17+ simulator runtime
         run: xcrun simctl list runtimes | grep -E "iOS (1[7-9]|2[0-9])"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,9 +357,9 @@ jobs:
       - name: Configure GitHub Packages
         run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
-      - name: Select Xcode 26.3
+      - name: Select Xcode 26.0
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_26.0.app/Contents/Developer
           xcodebuild -version
 
       - name: Install MAUI workload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,11 +371,12 @@ jobs:
       - name: Check iOS asset compiler availability
         id: ios_tools
         run: |
-          if xcrun --find actool > /tmp/actool-path 2> /tmp/actool-error; then
+          macos_sdk="$(xcrun --sdk macosx --show-sdk-path)"
+          if /usr/bin/xcrun xcodebuild -sdk "${macos_sdk}" -find actool > /tmp/actool-path 2> /tmp/actool-error; then
             cat /tmp/actool-path
             echo "actool_available=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "::warning::actool is unavailable through xcrun on this GitHub-hosted Xcode image; skipping iOS app asset and publish smoke."
+            echo "::warning::actool is unavailable through the .NET/Xcode asset-tool lookup on this GitHub-hosted image; skipping iOS app asset and publish smoke."
             cat /tmp/actool-error
             echo "actool_available=false" >> "${GITHUB_OUTPUT}"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,7 @@ jobs:
 
   maui-ios:
     name: MAUI iOS Build & AOT Smoke
-    runs-on: macos-latest
+    runs-on: macos-26
     needs: [build, changes]
     if: needs.changes.outputs.src_changed == 'true'
     permissions:
@@ -356,16 +356,16 @@ jobs:
       - name: Configure GitHub Packages
         run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
-      - name: Select Xcode 26.3
+      - name: Select Xcode 26.4
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
           xcodebuild -version
 
       - name: Install MAUI workload
         run: dotnet workload install maui
 
       - name: Verify iOS 17+ simulator runtime
-        run: xcrun simctl list runtimes | grep -E "iOS (17|18|19|20)"
+        run: xcrun simctl list runtimes | grep -E "iOS (1[7-9]|2[0-9])"
 
       - name: Restore
         run: |

--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -129,6 +129,30 @@ const layer = createHonuaGeoJsonLayer(featureCollection, {
 });
 ```
 
+Streaming feature feeds can use the same renderer-neutral source descriptor and
+apply upsert/delete events into the adapter's GeoJSON layer state:
+
+```js
+display.setFeatureStreamEvent({
+  type: 'upsert',
+  sequence: event.sequence,
+  source: sourceDescriptor,
+  feature: event.feature,
+});
+
+display.setFeatureStreamEvent({
+  type: 'delete',
+  source: sourceDescriptor,
+  objectIds: [event.objectId],
+});
+```
+
+Converted features keep Honua picking metadata in `properties.__honua`,
+including the source id, source descriptor, feature id, object id, and stream
+sequence when present. Host apps can read that metadata from deck.gl picking
+callbacks without binding renderer-neutral source descriptors to MapLibre or
+deck.gl-specific contracts.
+
 ## Host Extensions
 
 Host applications can register lightweight runtime extensions that mount

--- a/src/Honua.Embed/src/display-adapter.ts
+++ b/src/Honua.Embed/src/display-adapter.ts
@@ -8,6 +8,8 @@ import type {
   Geometry,
 } from 'geojson';
 
+export const HONUA_FEATURE_METADATA_PROPERTY = '__honua';
+
 export interface HonuaDisplayBounds {
   minLongitude: number;
   minLatitude: number;
@@ -35,6 +37,44 @@ export interface HonuaDisplaySourceDescriptor {
   feedUrl?: string | null;
 }
 
+export interface HonuaFeaturePickingMetadata {
+  [key: string]: unknown;
+  sourceId?: string;
+  source?: HonuaDisplaySourceDescriptor | null;
+  featureId?: string | number;
+  objectId?: string | number;
+  streamEventType?: string;
+  streamSequence?: string | number;
+}
+
+export type HonuaGeoJsonProperties = Record<string, unknown> & {
+  [HONUA_FEATURE_METADATA_PROPERTY]?: HonuaFeaturePickingMetadata;
+};
+
+export interface HonuaDisplayDataMetadata {
+  sourceId?: string;
+  source?: HonuaDisplaySourceDescriptor | null;
+  schema?: unknown;
+  extent?: HonuaDisplayBounds | null;
+  spatialReference?: HonuaDisplaySpatialReference | null;
+  geometryType?: string | null;
+  queryCapabilities?: unknown;
+  tileUrl?: string | null;
+  feedUrl?: string | null;
+  providerName?: string | null;
+  objectIdFieldName?: string | null;
+  nextPageToken?: string | null;
+  totalCount?: number | null;
+  numberReturned?: number | null;
+  exceededTransferLimit?: boolean | null;
+  stream?: HonuaFeatureStreamMetadata | null;
+}
+
+export interface HonuaDisplayFeatureCollection
+  extends FeatureCollection<Geometry, HonuaGeoJsonProperties> {
+  honua?: HonuaDisplayDataMetadata;
+}
+
 export interface HonuaFeatureRecord {
   id?: string | number;
   objectId?: string | number;
@@ -46,16 +86,55 @@ export interface HonuaFeatureRecord {
 }
 
 export interface HonuaFeatureQueryResult {
+  providerName?: string | null;
   source?: HonuaDisplaySourceDescriptor | null;
+  objectIdFieldName?: string | null;
+  geometryType?: string | null;
+  fields?: unknown;
   features?: HonuaFeatureRecord[] | null;
   items?: HonuaFeatureRecord[] | null;
   spatialReference?: HonuaDisplaySpatialReference | null;
   nextPageToken?: string | null;
   totalCount?: number | null;
+  count?: number | null;
+  numberReturned?: number | null;
+  exceededTransferLimit?: boolean | null;
+}
+
+export interface HonuaFeatureStreamMetadata {
+  eventType?: string;
+  sequence?: string | number | null;
+  deletedIds?: Array<string | number>;
+  objectIds?: Array<string | number>;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface HonuaFeatureStreamEvent {
+  type?: string | null;
+  eventType?: string | null;
+  sequence?: string | number | null;
+  source?: HonuaDisplaySourceDescriptor | null;
+  page?: HonuaFeatureQueryResult | null;
+  result?: HonuaFeatureQueryResult | null;
+  feature?: HonuaFeatureRecord | null;
+  features?: HonuaFeatureRecord[] | null;
+  items?: HonuaFeatureRecord[] | null;
+  id?: string | number | null;
+  objectId?: string | number | null;
+  featureIds?: Array<string | number> | null;
+  deletedIds?: Array<string | number> | null;
+  objectIds?: Array<string | number> | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface HonuaFeatureConversionOptions {
+  source?: HonuaDisplaySourceDescriptor | null;
+  streamEventType?: string | null;
+  streamSequence?: string | number | null;
 }
 
 export interface HonuaGeoJsonLayerOptions
-  extends Omit<GeoJsonLayerProps<Record<string, unknown>>, 'data' | 'id'> {
+  extends Omit<GeoJsonLayerProps<HonuaGeoJsonProperties>, 'data' | 'id'> {
   id?: string;
   source?: HonuaDisplaySourceDescriptor | null;
 }
@@ -79,6 +158,7 @@ export class HonuaWebDisplayAdapter {
   readonly #map: HonuaMapLibreLike;
   readonly #overlay: MapboxOverlay;
   #layers: Layer[];
+  readonly #featureCollections = new Map<string, HonuaDisplayFeatureCollection>();
 
   constructor(map: HonuaMapLibreLike, options: HonuaWebDisplayAdapterOptions = {}) {
     const { controlPosition, layers = [], ...overlayOptions } = options;
@@ -106,6 +186,29 @@ export class HonuaWebDisplayAdapter {
     options: HonuaGeoJsonLayerOptions = {},
   ): Layer {
     const layer = createHonuaGeoJsonLayer(result, options);
+    this.#featureCollections.set(layer.id, layer.props.data as HonuaDisplayFeatureCollection);
+    this.setLayers([
+      ...this.#layers.filter((existing) => existing.id !== layer.id),
+      layer,
+    ]);
+
+    return layer;
+  }
+
+  setFeatureStreamEvent(
+    event: HonuaFeatureStreamEvent,
+    options: HonuaGeoJsonLayerOptions = {},
+  ): Layer {
+    const source = resolveStreamSource(event, options.source);
+    const id = options.id ?? buildLayerId(source);
+    const data = applyFeatureStreamEventToGeoJson(
+      event,
+      this.#featureCollections.get(id),
+      { source },
+    );
+    const layer = createHonuaGeoJsonLayer(data, { ...options, id, source });
+
+    this.#featureCollections.set(id, data);
     this.setLayers([
       ...this.#layers.filter((existing) => existing.id !== layer.id),
       layer,
@@ -118,25 +221,106 @@ export class HonuaWebDisplayAdapter {
     this.#map.removeControl?.(this.#overlay);
     this.#overlay.finalize();
     this.#layers = [];
+    this.#featureCollections.clear();
   }
 }
 
 export function featureQueryResultToGeoJson(
   result: HonuaFeatureQueryResult | HonuaFeatureRecord[] | FeatureCollection<Geometry, GeoJsonProperties>,
-): FeatureCollection<Geometry, GeoJsonProperties> {
-  if (isFeatureCollection(result)) {
-    return result;
-  }
-
+  options: HonuaFeatureConversionOptions = {},
+): HonuaDisplayFeatureCollection {
+  const source = resolveQuerySource(result, options.source);
   const records = Array.isArray(result)
     ? result
-    : result.features ?? result.items ?? [];
+    : isFeatureCollection(result)
+      ? result.features
+      : result.features ?? result.items ?? [];
+  const page = !Array.isArray(result) && !isFeatureCollection(result) ? result : null;
+  const metadata = buildCollectionMetadata(result, source, records.length, options);
+
+  if (isFeatureCollection(result)) {
+    return {
+      ...result,
+      features: result.features
+        .map((feature) => recordToFeature(feature, {
+          source,
+          objectIdFieldName: metadata.objectIdFieldName,
+          streamEventType: options.streamEventType,
+          streamSequence: options.streamSequence,
+        }))
+        .filter((feature): feature is Feature<Geometry, HonuaGeoJsonProperties> => feature !== null),
+      honua: {
+        ...((result as HonuaDisplayFeatureCollection).honua ?? {}),
+        ...metadata,
+      },
+    };
+  }
 
   return {
     type: 'FeatureCollection',
     features: records
-      .map(recordToFeature)
-      .filter((feature): feature is Feature<Geometry, GeoJsonProperties> => feature !== null),
+      .map((record) => recordToFeature(record, {
+        source,
+        objectIdFieldName: page?.objectIdFieldName ?? null,
+        streamEventType: options.streamEventType,
+        streamSequence: options.streamSequence,
+      }))
+      .filter((feature): feature is Feature<Geometry, HonuaGeoJsonProperties> => feature !== null),
+    honua: metadata,
+  };
+}
+
+export function featureStreamEventToGeoJson(
+  event: HonuaFeatureStreamEvent,
+  options: HonuaFeatureConversionOptions = {},
+): HonuaDisplayFeatureCollection {
+  return applyFeatureStreamEventToGeoJson(event, null, options);
+}
+
+export function applyFeatureStreamEventToGeoJson(
+  event: HonuaFeatureStreamEvent,
+  previous: HonuaDisplayFeatureCollection | null | undefined = null,
+  options: HonuaFeatureConversionOptions = {},
+): HonuaDisplayFeatureCollection {
+  const eventType = normalizeStreamEventType(event);
+  const source = resolveStreamSource(event, options.source ?? previous?.honua?.source);
+  const streamOptions = {
+    source,
+    streamEventType: eventType,
+    streamSequence: event.sequence ?? options.streamSequence,
+  };
+  const incoming = streamEventPayloadToGeoJson(event, streamOptions);
+  const streamMetadata = buildStreamMetadata(event, eventType);
+  const metadata: HonuaDisplayDataMetadata = {
+    ...(previous?.honua ?? {}),
+    ...(incoming.honua ?? {}),
+    source,
+    sourceId: source?.id,
+    stream: streamMetadata,
+  };
+
+  if (isClearStreamEvent(eventType)) {
+    return {
+      type: 'FeatureCollection',
+      features: [],
+      honua: metadata,
+    };
+  }
+
+  if (!previous || isReplaceStreamEvent(eventType)) {
+    return {
+      ...incoming,
+      honua: metadata,
+    };
+  }
+
+  const incomingFeatures = isDeleteStreamEvent(eventType) ? [] : incoming.features;
+  const features = mergeStreamFeatures(previous.features, incomingFeatures, streamDeleteKeys(event));
+
+  return {
+    type: 'FeatureCollection',
+    features,
+    honua: metadata,
   };
 }
 
@@ -144,14 +328,16 @@ export function createHonuaGeoJsonLayer(
   result: HonuaFeatureQueryResult | HonuaFeatureRecord[] | FeatureCollection<Geometry, GeoJsonProperties>,
   options: HonuaGeoJsonLayerOptions = {},
 ): Layer {
-  const source = options.source ?? (!Array.isArray(result) && !isFeatureCollection(result)
-    ? result.source
-    : null);
+  const source = options.source ?? (
+    !Array.isArray(result) && !isFeatureCollection(result)
+      ? result.source
+      : (result as HonuaDisplayFeatureCollection).honua?.source ?? null
+  );
   const id = options.id ?? buildLayerId(source);
-  const featureCollection = featureQueryResultToGeoJson(result);
+  const featureCollection = featureQueryResultToGeoJson(result, { source });
   const { source: _source, ...layerOptions } = options;
 
-  return new GeoJsonLayer<Record<string, unknown>>({
+  return new GeoJsonLayer<HonuaGeoJsonProperties>({
     id,
     data: featureCollection,
     pickable: true,
@@ -180,36 +366,54 @@ export function createHonuaDeckOverlay(
   });
 }
 
-function recordToFeature(record: HonuaFeatureRecord): Feature<Geometry, GeoJsonProperties> | null {
+function recordToFeature(
+  record: HonuaFeatureRecord,
+  context: HonuaFeatureConversionOptions & { objectIdFieldName?: string | null } = {},
+): Feature<Geometry, HonuaGeoJsonProperties> | null {
   const geometryOrFeature = record.geoJson ?? record.geoJsonGeometry ?? record.geometry ?? null;
   if (geometryOrFeature === null) {
     return null;
   }
 
+  const featureId = resolveFeatureId(record, geometryOrFeature);
+  const objectId = resolveObjectId(record, context.objectIdFieldName);
+  const metadata = buildFeatureMetadata({
+    source: context.source,
+    featureId,
+    objectId,
+    streamEventType: context.streamEventType ?? undefined,
+    streamSequence: context.streamSequence ?? undefined,
+  });
+
   if (isFeature(geometryOrFeature)) {
-    return {
+    const feature: Feature<Geometry, HonuaGeoJsonProperties> = {
       ...geometryOrFeature,
-      properties: {
-        ...record.attributes,
-        ...geometryOrFeature.properties,
-        ...record.properties,
-      },
+      properties: mergeFeatureProperties([
+        record.attributes,
+        geometryOrFeature.properties,
+        record.properties,
+      ], metadata),
     };
+
+    if (featureId !== undefined) {
+      feature.id = featureId;
+    }
+
+    return feature;
   }
 
   if (!isGeometry(geometryOrFeature)) {
     return null;
   }
 
-  return {
+  const feature: Feature<Geometry, HonuaGeoJsonProperties> = {
     type: 'Feature',
-    id: record.id ?? record.objectId,
+    id: featureId,
     geometry: geometryOrFeature,
-    properties: {
-      ...record.attributes,
-      ...record.properties,
-    },
+    properties: mergeFeatureProperties([record.attributes, record.properties], metadata),
   };
+
+  return feature;
 }
 
 function buildLayerId(source: HonuaDisplaySourceDescriptor | null | undefined): string {
@@ -218,6 +422,293 @@ function buildLayerId(source: HonuaDisplaySourceDescriptor | null | undefined): 
   }
 
   return `honua-${source.id.trim().replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '') || 'features'}`;
+}
+
+function resolveQuerySource(
+  result: HonuaFeatureQueryResult | HonuaFeatureRecord[] | FeatureCollection<Geometry, GeoJsonProperties>,
+  source: HonuaDisplaySourceDescriptor | null | undefined,
+): HonuaDisplaySourceDescriptor | null {
+  if (source !== undefined) {
+    return source;
+  }
+
+  if (!Array.isArray(result) && !isFeatureCollection(result)) {
+    return result.source ?? null;
+  }
+
+  if (isFeatureCollection(result)) {
+    return (result as HonuaDisplayFeatureCollection).honua?.source ?? null;
+  }
+
+  return null;
+}
+
+function resolveStreamSource(
+  event: HonuaFeatureStreamEvent,
+  source: HonuaDisplaySourceDescriptor | null | undefined,
+): HonuaDisplaySourceDescriptor | null {
+  return source ?? event.source ?? event.page?.source ?? event.result?.source ?? null;
+}
+
+function buildCollectionMetadata(
+  result: HonuaFeatureQueryResult | HonuaFeatureRecord[] | FeatureCollection<Geometry, GeoJsonProperties>,
+  source: HonuaDisplaySourceDescriptor | null,
+  numberReturned: number,
+  options: HonuaFeatureConversionOptions,
+): HonuaDisplayDataMetadata {
+  const page = !Array.isArray(result) && !isFeatureCollection(result) ? result : null;
+  const existing = isFeatureCollection(result) ? (result as HonuaDisplayFeatureCollection).honua : undefined;
+
+  return removeUndefinedProperties({
+    ...(existing ?? {}),
+    source,
+    sourceId: source?.id,
+    schema: source?.schema ?? page?.fields,
+    extent: source?.extent ?? null,
+    spatialReference: page?.spatialReference ?? source?.spatialReference ?? null,
+    geometryType: page?.geometryType ?? source?.geometryType ?? null,
+    queryCapabilities: source?.queryCapabilities,
+    tileUrl: source?.tileUrl ?? null,
+    feedUrl: source?.feedUrl ?? null,
+    providerName: page?.providerName ?? null,
+    objectIdFieldName: page?.objectIdFieldName ?? null,
+    nextPageToken: page?.nextPageToken ?? null,
+    totalCount: page?.totalCount ?? page?.count ?? null,
+    numberReturned: page?.numberReturned ?? numberReturned,
+    exceededTransferLimit: page?.exceededTransferLimit ?? null,
+    stream: options.streamEventType
+      ? {
+          eventType: options.streamEventType,
+          sequence: options.streamSequence ?? null,
+        }
+      : existing?.stream ?? null,
+  });
+}
+
+function buildFeatureMetadata(metadata: HonuaFeaturePickingMetadata): HonuaFeaturePickingMetadata {
+  return removeUndefinedProperties({
+    sourceId: metadata.source?.id,
+    source: metadata.source ?? undefined,
+    featureId: metadata.featureId,
+    objectId: metadata.objectId,
+    streamEventType: metadata.streamEventType ?? undefined,
+    streamSequence: metadata.streamSequence ?? undefined,
+  });
+}
+
+function mergeFeatureProperties(
+  values: Array<Record<string, unknown> | GeoJsonProperties | null | undefined>,
+  metadata: HonuaFeaturePickingMetadata,
+): HonuaGeoJsonProperties {
+  const properties: HonuaGeoJsonProperties = {};
+  let existingMetadata: HonuaFeaturePickingMetadata = {};
+
+  for (const value of values) {
+    if (!isRecord(value)) {
+      continue;
+    }
+
+    const nextMetadata = value[HONUA_FEATURE_METADATA_PROPERTY];
+    Object.assign(properties, value);
+
+    if (isRecord(nextMetadata)) {
+      existingMetadata = { ...existingMetadata, ...nextMetadata };
+    }
+  }
+
+  properties[HONUA_FEATURE_METADATA_PROPERTY] = {
+    ...existingMetadata,
+    ...metadata,
+  };
+
+  return properties;
+}
+
+function resolveFeatureId(
+  record: HonuaFeatureRecord,
+  geometryOrFeature: Geometry | Feature<Geometry, GeoJsonProperties>,
+): string | number | undefined {
+  return record.id ??
+    (isFeature(geometryOrFeature) ? geometryOrFeature.id : undefined) ??
+    record.objectId;
+}
+
+function resolveObjectId(
+  record: HonuaFeatureRecord,
+  objectIdFieldName: string | null | undefined,
+): string | number | undefined {
+  if (record.objectId !== undefined) {
+    return record.objectId;
+  }
+
+  const attributes = record.attributes ?? record.properties;
+  if (!isRecord(attributes)) {
+    return undefined;
+  }
+
+  const candidates = [
+    objectIdFieldName,
+    'objectid',
+    'OBJECTID',
+    'ObjectID',
+    'FID',
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  for (const candidate of candidates) {
+    const value = attributes[candidate];
+    if (typeof value === 'string' || typeof value === 'number') {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeStreamEventType(event: HonuaFeatureStreamEvent): string {
+  return event.type ?? event.eventType ?? (event.page || event.result ? 'page' : 'upsert');
+}
+
+function streamEventPayloadToGeoJson(
+  event: HonuaFeatureStreamEvent,
+  options: HonuaFeatureConversionOptions,
+): HonuaDisplayFeatureCollection {
+  const page = event.page ?? event.result;
+  if (page) {
+    return featureQueryResultToGeoJson(page, options);
+  }
+
+  const records = event.feature
+    ? [event.feature]
+    : event.features ?? event.items ?? [];
+
+  return featureQueryResultToGeoJson(records, options);
+}
+
+function buildStreamMetadata(
+  event: HonuaFeatureStreamEvent,
+  eventType: string,
+): HonuaFeatureStreamMetadata {
+  return removeUndefinedProperties({
+    eventType,
+    sequence: event.sequence ?? null,
+    deletedIds: event.deletedIds ?? event.featureIds ?? undefined,
+    objectIds: event.objectIds ??
+      (event.objectId !== undefined && event.objectId !== null ? [event.objectId] : undefined),
+    metadata: event.metadata ?? undefined,
+  });
+}
+
+function isClearStreamEvent(eventType: string): boolean {
+  return ['clear', 'reset'].includes(eventType.toLowerCase());
+}
+
+function isReplaceStreamEvent(eventType: string): boolean {
+  return ['snapshot', 'replace'].includes(eventType.toLowerCase());
+}
+
+function isDeleteStreamEvent(eventType: string): boolean {
+  return ['delete', 'deleted', 'remove', 'removed'].includes(eventType.toLowerCase());
+}
+
+function streamDeleteKeys(event: HonuaFeatureStreamEvent): Set<string> {
+  const keys = new Set<string>();
+  const ids = [
+    ...(event.deletedIds ?? []),
+    ...(event.featureIds ?? []),
+    ...(event.id !== undefined && event.id !== null ? [event.id] : []),
+  ];
+  const objectIds = [
+    ...(event.objectIds ?? []),
+    ...(event.objectId !== undefined && event.objectId !== null ? [event.objectId] : []),
+  ];
+
+  for (const id of ids) {
+    addFeatureKeyAliases(keys, id);
+  }
+
+  for (const objectId of objectIds) {
+    addObjectKeyAliases(keys, objectId);
+  }
+
+  if (isDeleteStreamEvent(normalizeStreamEventType(event))) {
+    for (const feature of streamEventPayloadToGeoJson(event, {
+      source: resolveStreamSource(event, undefined),
+      streamEventType: normalizeStreamEventType(event),
+      streamSequence: event.sequence,
+    }).features) {
+      for (const key of featureKeys(feature)) {
+        keys.add(key);
+      }
+    }
+  }
+
+  return keys;
+}
+
+function mergeStreamFeatures(
+  previous: Feature<Geometry, HonuaGeoJsonProperties>[],
+  incoming: Feature<Geometry, HonuaGeoJsonProperties>[],
+  deleteKeys: Set<string>,
+): Feature<Geometry, HonuaGeoJsonProperties>[] {
+  const merged = new Map<string, Feature<Geometry, HonuaGeoJsonProperties>>();
+  let anonymousIndex = 0;
+
+  for (const feature of previous) {
+    if (featureKeys(feature).some((key) => deleteKeys.has(key))) {
+      continue;
+    }
+
+    merged.set(primaryFeatureKey(feature) ?? `previous:${anonymousIndex++}`, feature);
+  }
+
+  for (const feature of incoming) {
+    const keys = featureKeys(feature);
+    const existingKey = [...merged.entries()]
+      .find(([, existing]) => featureKeys(existing).some((key) => keys.includes(key)))?.[0];
+
+    merged.set(existingKey ?? primaryFeatureKey(feature) ?? `incoming:${anonymousIndex++}`, feature);
+  }
+
+  return [...merged.values()];
+}
+
+function primaryFeatureKey(feature: Feature<Geometry, HonuaGeoJsonProperties>): string | null {
+  return featureKeys(feature)[0] ?? null;
+}
+
+function featureKeys(feature: Feature<Geometry, HonuaGeoJsonProperties>): string[] {
+  const keys = new Set<string>();
+  const metadata = feature.properties?.[HONUA_FEATURE_METADATA_PROPERTY];
+
+  if (metadata?.objectId !== undefined) {
+    addObjectKeyAliases(keys, metadata.objectId);
+  }
+
+  if (feature.id !== undefined) {
+    addFeatureKeyAliases(keys, feature.id);
+  }
+
+  if (metadata?.featureId !== undefined) {
+    addFeatureKeyAliases(keys, metadata.featureId);
+  }
+
+  return [...keys];
+}
+
+function addFeatureKeyAliases(keys: Set<string>, id: string | number): void {
+  keys.add(`feature:${String(id)}`);
+  keys.add(`value:${String(id)}`);
+}
+
+function addObjectKeyAliases(keys: Set<string>, objectId: string | number): void {
+  keys.add(`object:${String(objectId)}`);
+  keys.add(`value:${String(objectId)}`);
+}
+
+function removeUndefinedProperties<T extends object>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as T;
 }
 
 function isFeatureCollection(

--- a/src/Honua.Embed/tests/display-adapter.test.ts
+++ b/src/Honua.Embed/tests/display-adapter.test.ts
@@ -1,25 +1,54 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  applyFeatureStreamEventToGeoJson,
   createHonuaGeoJsonLayer,
   featureQueryResultToGeoJson,
+  HONUA_FEATURE_METADATA_PROPERTY,
   HonuaWebDisplayAdapter,
+  type HonuaDisplayFeatureCollection,
+  type HonuaDisplaySourceDescriptor,
 } from '../src/index';
 
+const fieldAssetSource: HonuaDisplaySourceDescriptor = {
+  id: 'field-assets',
+  title: 'Field assets',
+  geometryType: 'Point',
+  extent: {
+    minLongitude: -157.9,
+    minLatitude: 21.2,
+    maxLongitude: -157.7,
+    maxLatitude: 21.4,
+  },
+  spatialReference: { wkid: 4326 },
+  schema: {
+    fields: ['objectid', 'assetType', 'status'],
+  },
+  queryCapabilities: {
+    supportsPagination: true,
+  },
+  tileUrl: 'https://tiles.example/assets/{z}/{x}/{y}.pbf',
+  feedUrl: 'https://stream.example/assets',
+};
+
 describe('display adapter', () => {
-  it('converts feature query results into deck.gl-ready GeoJSON', () => {
+  it('converts feature query pages into deck.gl-ready GeoJSON with page metadata', () => {
     const geoJson = featureQueryResultToGeoJson({
-      source: {
-        id: 'field-assets',
-        spatialReference: { wkid: 4326 },
-      },
+      providerName: 'sdk-fixture',
+      source: fieldAssetSource,
+      objectIdFieldName: 'objectid',
+      geometryType: 'Point',
+      nextPageToken: 'next-page',
+      totalCount: 12,
+      numberReturned: 2,
       features: [
         {
-          id: 42,
+          id: 'asset-42',
           geometry: {
             type: 'Point',
             coordinates: [-157.8583, 21.3069],
           },
           attributes: {
+            objectid: 42,
             assetType: 'hydrant',
           },
           properties: {
@@ -27,7 +56,7 @@ describe('display adapter', () => {
           },
         },
         {
-          id: 43,
+          id: 'asset-43',
           geometry: null,
           attributes: {
             status: 'missing geometry',
@@ -36,28 +65,165 @@ describe('display adapter', () => {
       ],
     });
 
-    expect(geoJson).toEqual({
-      type: 'FeatureCollection',
+    expect(geoJson.honua).toMatchObject({
+      sourceId: 'field-assets',
+      source: fieldAssetSource,
+      spatialReference: { wkid: 4326 },
+      geometryType: 'Point',
+      providerName: 'sdk-fixture',
+      objectIdFieldName: 'objectid',
+      nextPageToken: 'next-page',
+      totalCount: 12,
+      numberReturned: 2,
+    });
+    expect(geoJson.features).toHaveLength(1);
+    expect(geoJson.features[0]).toMatchObject({
+      type: 'Feature',
+      id: 'asset-42',
+      geometry: {
+        type: 'Point',
+        coordinates: [-157.8583, 21.3069],
+      },
+      properties: {
+        objectid: 42,
+        assetType: 'hydrant',
+        status: 'active',
+        [HONUA_FEATURE_METADATA_PROPERTY]: {
+          sourceId: 'field-assets',
+          source: fieldAssetSource,
+          featureId: 'asset-42',
+          objectId: 42,
+        },
+      },
+    });
+  });
+
+  it('applies streaming feature events as GeoJSON upserts and deletes', () => {
+    const initial = featureQueryResultToGeoJson({
+      source: fieldAssetSource,
+      objectIdFieldName: 'objectid',
       features: [
         {
-          type: 'Feature',
-          id: 42,
+          id: 'asset-1',
           geometry: {
             type: 'Point',
-            coordinates: [-157.8583, 21.3069],
+            coordinates: [-157.85, 21.3],
           },
-          properties: {
-            assetType: 'hydrant',
-            status: 'active',
+          attributes: {
+            objectid: 1,
+            name: 'Pump 1',
           },
         },
       ],
     });
+
+    const upserted = applyFeatureStreamEventToGeoJson({
+      type: 'upsert',
+      sequence: 2,
+      source: fieldAssetSource,
+      feature: {
+        objectId: 2,
+        geometry: {
+          type: 'Point',
+          coordinates: [-157.86, 21.31],
+        },
+        attributes: {
+          objectid: 2,
+          name: 'Pump 2',
+        },
+      },
+    }, initial);
+
+    expect(upserted.features.map((feature) => feature.properties.name)).toEqual([
+      'Pump 1',
+      'Pump 2',
+    ]);
+    expect(upserted.features[1].properties[HONUA_FEATURE_METADATA_PROPERTY]).toMatchObject({
+      sourceId: 'field-assets',
+      featureId: 2,
+      objectId: 2,
+      streamEventType: 'upsert',
+      streamSequence: 2,
+    });
+
+    const deleted = applyFeatureStreamEventToGeoJson({
+      type: 'delete',
+      sequence: 3,
+      source: fieldAssetSource,
+      objectIds: [1],
+    }, upserted);
+
+    expect(deleted.features.map((feature) => feature.properties.name)).toEqual(['Pump 2']);
+    expect(deleted.honua?.stream).toMatchObject({
+      eventType: 'delete',
+      sequence: 3,
+      objectIds: [1],
+    });
   });
 
-  it('creates a GeoJsonLayer with stable Honua defaults', () => {
+  it('preserves picking metadata while enabling deck.gl highlighting', () => {
     const layer = createHonuaGeoJsonLayer({
-      source: { id: 'utility lines' },
+      source: fieldAssetSource,
+      features: [
+        {
+          objectId: 99,
+          geoJson: {
+            type: 'Feature',
+            id: 'work-order-99',
+            geometry: {
+              type: 'Point',
+              coordinates: [-157.84, 21.32],
+            },
+            properties: {
+              status: 'open',
+              [HONUA_FEATURE_METADATA_PROPERTY]: {
+                pickingToken: 'host-selection-key',
+              },
+            },
+          },
+          attributes: {
+            priority: 'high',
+          },
+        },
+      ],
+    }, {
+      highlightColor: [255, 190, 80, 220],
+    });
+    const data = layer.props.data as HonuaDisplayFeatureCollection;
+
+    expect(layer.props.pickable).toBe(true);
+    expect(layer.props.autoHighlight).toBe(true);
+    expect(layer.props.highlightColor).toEqual([255, 190, 80, 220]);
+    expect(data.features[0].properties).toMatchObject({
+      priority: 'high',
+      status: 'open',
+      [HONUA_FEATURE_METADATA_PROPERTY]: {
+        pickingToken: 'host-selection-key',
+        sourceId: 'field-assets',
+        source: fieldAssetSource,
+        featureId: 'work-order-99',
+        objectId: 99,
+      },
+    });
+  });
+
+  it('keeps renderer-neutral descriptors on layer data and MapLibre overlay updates', () => {
+    const controls: unknown[] = [];
+    const map = {
+      addControl: vi.fn((control: unknown) => {
+        controls.push(control);
+      }),
+      removeControl: vi.fn((control: unknown) => {
+        const index = controls.indexOf(control);
+        if (index >= 0) {
+          controls.splice(index, 1);
+        }
+      }),
+    };
+    const adapter = new HonuaWebDisplayAdapter(map, { controlPosition: 'top-right' });
+
+    const layer = adapter.setFeatureQueryResult({
+      source: fieldAssetSource,
       features: [
         {
           geometry: {
@@ -73,47 +239,19 @@ describe('display adapter', () => {
         },
       ],
     });
+    const data = layer.props.data as HonuaDisplayFeatureCollection;
 
-    expect(layer.id).toBe('honua-utility-lines');
-    expect(layer.props.pickable).toBe(true);
-    expect(layer.props.autoHighlight).toBe(true);
-    expect(layer.props.data).toMatchObject({
-      type: 'FeatureCollection',
-      features: [
-        {
-          geometry: {
-            type: 'LineString',
-          },
-        },
-      ],
+    expect(map.addControl).toHaveBeenCalledWith(adapter.overlay, 'top-right');
+    expect(layer.id).toBe('honua-field-assets');
+    expect(data.honua).toMatchObject({
+      source: fieldAssetSource,
+      sourceId: 'field-assets',
+      schema: fieldAssetSource.schema,
+      extent: fieldAssetSource.extent,
+      queryCapabilities: fieldAssetSource.queryCapabilities,
+      tileUrl: fieldAssetSource.tileUrl,
+      feedUrl: fieldAssetSource.feedUrl,
     });
-  });
-
-  it('attaches and updates deck.gl overlays on a MapLibre-compatible map', () => {
-    const controls: unknown[] = [];
-    const map = {
-      addControl: vi.fn((control: unknown) => {
-        controls.push(control);
-      }),
-      removeControl: vi.fn((control: unknown) => {
-        const index = controls.indexOf(control);
-        if (index >= 0) {
-          controls.splice(index, 1);
-        }
-      }),
-    };
-    const adapter = new HonuaWebDisplayAdapter(map);
-
-    const layer = adapter.setFeatureQueryResult([
-      {
-        geometry: {
-          type: 'Point',
-          coordinates: [-157.8583, 21.3069],
-        },
-      },
-    ]);
-
-    expect(map.addControl).toHaveBeenCalledOnce();
     expect(adapter.layers).toEqual([layer]);
 
     adapter.destroy();


### PR DESCRIPTION
## Summary

Adds renderer-neutral feature stream ingestion for `@honua/embed` without touching the merged #98 scene-control scope.

- Converts SDK-like feature pages into GeoJSON feature collections with Honua metadata preserved under `collection.honua` and `properties.__honua`.
- Adds upsert/delete/replace/clear stream event handling and picking metadata support.
- Documents stream feed usage in the embeddable map guide.

Related to #50.

## Testing

- `npm ci --prefix src/Honua.Embed`
- `npm run typecheck --prefix src/Honua.Embed`
- `npm test --prefix src/Honua.Embed`