### PR TITLE
ci: add Android internal distribution workflow

### DIFF
--- a/.github/workflows/android-internal-distribution.yml
+++ b/.github/workflows/android-internal-distribution.yml
@@ -1,0 +1,373 @@
+---
+# yamllint disable rule:line-length
+name: Android Internal Distribution
+
+"on":
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: "Branch, tag, or commit SHA to build. Leave blank for the workflow branch."
+        required: false
+        type: string
+      environment:
+        description: "Protected GitHub Environment that stores signing and Play upload secrets."
+        required: true
+        default: android-internal
+        type: environment
+      channel:
+        description: "Internal distribution channel."
+        required: true
+        default: internal-testing
+        type: choice
+        options:
+          - internal-testing
+          - internal-app-sharing
+      artifact_type:
+        description: "Android release artifact to build and upload."
+        required: true
+        default: aab
+        type: choice
+        options:
+          - aab
+          - apk
+      app_project:
+        description: "MAUI app project to publish."
+        required: true
+        default: apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj
+        type: string
+      version_name:
+        description: "ApplicationDisplayVersion override for this internal build."
+        required: true
+        default: 0.1.0-internal
+        type: string
+      version_code:
+        description: "ApplicationVersion override. Must increase for Play track uploads."
+        required: false
+        type: string
+      release_notes:
+        description: "Tester-facing release summary."
+        required: false
+        default: "Internal validation build."
+        type: string
+
+env:
+  DOTNET_VERSION: "10.0.x"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
+  TARGET_FRAMEWORK: net10.0-android
+
+jobs:
+  distribute:
+    name: Build, Sign, and Upload Android Internal Build
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout selected ref
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.source_ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Resolve build metadata
+        id: metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          source_ref="${{ inputs.source_ref }}"
+          version_code="${{ inputs.version_code }}"
+
+          if [[ -z "${source_ref}" ]]; then
+            source_ref="${GITHUB_REF_NAME}"
+          fi
+
+          if [[ -z "${version_code}" ]]; then
+            version_code="${GITHUB_RUN_NUMBER}"
+          fi
+
+          commit_sha="$(git rev-parse HEAD)"
+          short_sha="$(git rev-parse --short=12 HEAD)"
+          safe_ref="$(printf '%s' "${source_ref}" | tr -c '[:alnum:]._-' '-')"
+          artifact_base="honua-android-${{ inputs.channel }}-${{ inputs.artifact_type }}-${version_code}-${short_sha}"
+
+          {
+            echo "source_ref=${source_ref}"
+            echo "commit_sha=${commit_sha}"
+            echo "short_sha=${short_sha}"
+            echo "safe_ref=${safe_ref}"
+            echo "version_code=${version_code}"
+            echo "artifact_base=${artifact_base}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Validate protected environment inputs
+        shell: bash
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          ANDROID_PACKAGE_NAME: ${{ secrets.ANDROID_PACKAGE_NAME }}
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for name in \
+            ANDROID_KEYSTORE_BASE64 \
+            ANDROID_KEYSTORE_PASSWORD \
+            ANDROID_KEY_ALIAS \
+            ANDROID_KEY_PASSWORD \
+            GOOGLE_PLAY_SERVICE_ACCOUNT_JSON \
+            ANDROID_PACKAGE_NAME
+          do
+            if [[ -z "${!name}" ]]; then
+              missing+=("${name}")
+            fi
+          done
+
+          if (( ${#missing[@]} > 0 )); then
+            printf '::error::Missing required environment secret(s): %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+          case "${{ inputs.channel }}" in
+            internal-testing|internal-app-sharing) ;;
+            *)
+              echo "::error::Unsupported channel '${{ inputs.channel }}'."
+              exit 1
+              ;;
+          esac
+
+          case "${{ inputs.artifact_type }}" in
+            aab|apk) ;;
+            *)
+              echo "::error::Unsupported artifact_type '${{ inputs.artifact_type }}'."
+              exit 1
+              ;;
+          esac
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Install Android MAUI workload
+        shell: bash
+        run: dotnet workload install maui-android
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/packages.lock.json') }}
+          restore-keys: |
+            ${{ github.repository }}-${{ runner.os }}-nuget-
+
+      - name: Configure GitHub Packages
+        shell: bash
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
+
+      - name: Restore app project
+        shell: bash
+        run: dotnet restore "${{ inputs.app_project }}" -f "${TARGET_FRAMEWORK}"
+
+      - name: Decode Android signing keystore
+        id: signing
+        shell: bash
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/android-signing"
+          keystore_path="${RUNNER_TEMP}/android-signing/honua-internal.keystore"
+          printf '%s' "${ANDROID_KEYSTORE_BASE64}" | base64 --decode > "${keystore_path}"
+          chmod 600 "${keystore_path}"
+          echo "keystore_path=${keystore_path}" >> "${GITHUB_OUTPUT}"
+
+      - name: Publish signed Android release artifact
+        id: publish
+        shell: bash
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          output_dir="${GITHUB_WORKSPACE}/artifacts/android"
+          mkdir -p "${output_dir}"
+
+          dotnet publish "${{ inputs.app_project }}" \
+            --configuration Release \
+            --framework "${TARGET_FRAMEWORK}" \
+            --no-restore \
+            -p:AndroidPackageFormat="${{ inputs.artifact_type }}" \
+            -p:AndroidKeyStore=true \
+            -p:AndroidSigningKeyStore="${{ steps.signing.outputs.keystore_path }}" \
+            -p:AndroidSigningKeyAlias="${ANDROID_KEY_ALIAS}" \
+            -p:AndroidSigningStorePass="${ANDROID_KEYSTORE_PASSWORD}" \
+            -p:AndroidSigningKeyPass="${ANDROID_KEY_PASSWORD}" \
+            -p:ApplicationDisplayVersion="${{ inputs.version_name }}" \
+            -p:ApplicationVersion="${{ steps.metadata.outputs.version_code }}"
+
+          mapfile -t candidates < <(find "$(dirname "${{ inputs.app_project }}")/bin/Release/${TARGET_FRAMEWORK}" \
+            -type f -name "*.${{ inputs.artifact_type }}" | sort)
+
+          if (( ${#candidates[@]} == 0 )); then
+            echo "::error::No .${{ inputs.artifact_type }} artifact was produced."
+            exit 1
+          fi
+
+          artifact_path="${candidates[-1]}"
+          final_path="${output_dir}/${{ steps.metadata.outputs.artifact_base }}.${{ inputs.artifact_type }}"
+          cp "${artifact_path}" "${final_path}"
+
+          sha256="$(sha256sum "${final_path}" | awk '{print $1}')"
+          {
+            echo "artifact_path=${final_path}"
+            echo "artifact_name=$(basename "${final_path}")"
+            echo "sha256=${sha256}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Upload signed artifact to workflow run
+        id: upload-artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.metadata.outputs.artifact_base }}
+          path: ${{ steps.publish.outputs.artifact_path }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Write Google Play service account
+        id: play-service-account
+        shell: bash
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          set -euo pipefail
+          account_path="${RUNNER_TEMP}/google-play-service-account.json"
+          printf '%s' "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON}" > "${account_path}"
+          chmod 600 "${account_path}"
+          echo "account_path=${account_path}" >> "${GITHUB_OUTPUT}"
+
+      - name: Prepare Google Play release notes
+        shell: bash
+        env:
+          RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          set -euo pipefail
+          mkdir -p whatsnew
+          printf '%s\n' "${RELEASE_NOTES}" > whatsnew/whatsnew-en-US
+
+      - name: Upload to Google Play internal testing
+        if: ${{ inputs.channel == 'internal-testing' }}
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJson: ${{ steps.play-service-account.outputs.account_path }}
+          packageName: ${{ secrets.ANDROID_PACKAGE_NAME }}
+          releaseFiles: ${{ steps.publish.outputs.artifact_path }}
+          track: internal
+          status: completed
+          releaseName: ${{ inputs.version_name }} (${{ steps.metadata.outputs.version_code }})
+          whatsNewDirectory: whatsnew
+
+      - name: Prepare fastlane internal app sharing
+        if: ${{ inputs.channel == 'internal-app-sharing' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p fastlane
+          cat > fastlane/Fastfile <<'FASTFILE'
+          default_platform(:android)
+
+          platform :android do
+            lane :internal_app_sharing do
+              package_name = ENV.fetch("ANDROID_PACKAGE_NAME")
+              json_key = ENV.fetch("GOOGLE_PLAY_JSON_KEY")
+              artifact_path = ENV.fetch("ANDROID_ARTIFACT_PATH")
+
+              options = {
+                package_name: package_name,
+                json_key: json_key
+              }
+
+              if artifact_path.end_with?(".aab")
+                options[:aab] = artifact_path
+              else
+                options[:apk] = artifact_path
+              end
+
+              url = upload_to_play_store_internal_app_sharing(**options)
+              File.write(ENV.fetch("INTERNAL_APP_SHARING_LINK_PATH"), url.to_s)
+            end
+          end
+          FASTFILE
+
+      - name: Setup Ruby for fastlane
+        if: ${{ inputs.channel == 'internal-app-sharing' }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Upload to Google Play Internal App Sharing
+        if: ${{ inputs.channel == 'internal-app-sharing' }}
+        shell: bash
+        env:
+          ANDROID_ARTIFACT_PATH: ${{ steps.publish.outputs.artifact_path }}
+          ANDROID_PACKAGE_NAME: ${{ secrets.ANDROID_PACKAGE_NAME }}
+          GOOGLE_PLAY_JSON_KEY: ${{ steps.play-service-account.outputs.account_path }}
+          INTERNAL_APP_SHARING_LINK_PATH: ${{ runner.temp }}/internal-app-sharing-link.txt
+        run: |
+          set -euo pipefail
+          gem install fastlane --no-document
+          fastlane android internal_app_sharing
+          if [[ -s "${INTERNAL_APP_SHARING_LINK_PATH}" ]]; then
+            echo "INTERNAL_APP_SHARING_LINK=$(cat "${INTERNAL_APP_SHARING_LINK_PATH}")" >> "${GITHUB_ENV}"
+          fi
+
+      - name: Write release summary
+        shell: bash
+        env:
+          TESTER_LINK: ${{ vars.GOOGLE_PLAY_TESTER_LINK }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "## Android internal distribution"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Environment | \`${{ inputs.environment }}\` |"
+            echo "| Channel | \`${{ inputs.channel }}\` |"
+            echo "| Source ref | \`${{ steps.metadata.outputs.source_ref }}\` |"
+            echo "| Commit SHA | \`${{ steps.metadata.outputs.commit_sha }}\` |"
+            echo "| App project | \`${{ inputs.app_project }}\` |"
+            echo "| Version name | \`${{ inputs.version_name }}\` |"
+            echo "| Version code | \`${{ steps.metadata.outputs.version_code }}\` |"
+            echo "| Artifact | \`${{ steps.publish.outputs.artifact_name }}\` |"
+            echo "| Artifact SHA-256 | \`${{ steps.publish.outputs.sha256 }}\` |"
+            echo "| Workflow artifact digest | \`${{ steps.upload-artifact.outputs.artifact-digest }}\` |"
+            echo "| Release notes | ${RELEASE_NOTES//$'\n'/ } |"
+            echo
+            echo "### Tester install"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          if [[ "${{ inputs.channel }}" == "internal-app-sharing" && -n "${INTERNAL_APP_SHARING_LINK:-}" ]]; then
+            echo "${INTERNAL_APP_SHARING_LINK}" >> "${GITHUB_STEP_SUMMARY}"
+          elif [[ -n "${TESTER_LINK}" ]]; then
+            echo "${TESTER_LINK}" >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "Open Google Play Console > Testing > Internal testing and install the latest internal release assigned to your tester group." >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+          {
+            echo
+            echo "### Rollback or rebuild"
+            echo
+            echo "- To rebuild, rerun this workflow with the same source ref and a new version code."
+            echo "- To roll back internal testers, promote a prior internal build in Play Console or rerun this workflow from the prior commit with a higher version code."
+            echo "- Production tracks are not modified by this workflow."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/guides/mobile-android-internal-distribution.md
+++ b/docs/guides/mobile-android-internal-distribution.md
@@ -1,0 +1,96 @@
+# Mobile Android Internal Distribution
+
+Issue #86 adds a manually triggered GitHub Actions path for signed Android
+internal builds. The workflow is intentionally separate from production release
+promotion: it only uploads to Google Play Internal App Sharing or the internal
+testing track.
+
+## Workflow
+
+Run **Android Internal Distribution** from the GitHub Actions tab.
+
+Inputs:
+
+- `source_ref`: branch, tag, or commit SHA to build. Leave blank to use the
+  workflow branch selected in the Actions UI.
+- `environment`: protected GitHub Environment that gates signing and upload.
+  The default is `android-internal`.
+- `channel`: `internal-testing` for the Play internal testing track, or
+  `internal-app-sharing` for a direct Internal App Sharing install link.
+- `artifact_type`: `aab` or `apk`.
+- `app_project`: MAUI app project to publish. The default builds
+  `apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj`.
+- `version_name`: tester-facing application display version.
+- `version_code`: Android application version code. Leave blank to use the
+  GitHub run number. For Play track uploads, this must be higher than any
+  version code already active for the package.
+- `release_notes`: short tester-facing release summary.
+
+The workflow checks out the selected ref, installs the Android MAUI workload,
+publishes a signed release artifact, calculates a SHA-256 digest, stores the
+artifact on the workflow run, uploads to the selected internal Play channel, and
+writes a run summary with the version, commit SHA, environment, artifact name,
+and digest.
+
+## Required Environment
+
+Create a GitHub Environment named `android-internal` or pass another protected
+environment name to the workflow. Configure required reviewers for that
+environment before adding upload credentials.
+
+Required environment secrets:
+
+- `ANDROID_KEYSTORE_BASE64`: base64-encoded Android signing keystore.
+- `ANDROID_KEYSTORE_PASSWORD`: keystore password.
+- `ANDROID_KEY_ALIAS`: signing key alias.
+- `ANDROID_KEY_PASSWORD`: signing key password.
+- `ANDROID_PACKAGE_NAME`: Google Play package name, for example
+  `io.honua.mobile.fieldcollection`.
+- `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`: full Google Play service account JSON.
+
+Optional environment variable:
+
+- `GOOGLE_PLAY_TESTER_LINK`: tester opt-in or install instructions URL for the
+  internal testing track. Internal App Sharing uploads emit a direct link when
+  Google Play returns one.
+
+The Google Play service account needs access to the target app in Play Console
+and permission to create internal testing releases or Internal App Sharing
+artifacts.
+
+## Signing Setup
+
+Encode the keystore before saving it as a secret:
+
+```bash
+base64 -w 0 honua-internal.keystore
+```
+
+Use a non-production signing key unless release management explicitly decides
+that internal builds must match the production app signing lineage. Keep the
+keystore and Google Play JSON only in the protected GitHub Environment, not as
+repository-wide secrets.
+
+## Tester Install
+
+For `internal-app-sharing`, testers use the link in the workflow summary. They
+must be allowed to use Internal App Sharing for the Play account on their device.
+
+For `internal-testing`, testers install from the app's internal testing track in
+Google Play. Add tester groups in Play Console, set `GOOGLE_PLAY_TESTER_LINK`
+when an opt-in URL is available, and direct testers to the run summary for the
+version, commit, and digest they should validate.
+
+## Rollback and Rebuild
+
+Internal distribution does not touch production tracks.
+
+To rebuild the same source, rerun the workflow with the same `source_ref` and a
+new `version_code`. To roll testers back, select a prior internal build in Play
+Console when it is still available, or rerun the workflow from the prior commit
+with a higher version code. Tell testers which version name, version code,
+commit SHA, and artifact SHA-256 are expected before they retest.
+
+When an uploaded build is bad, stop assigning it to tester groups in Play
+Console or replace it with a newer internal release. Do not promote the internal
+track build to production from this workflow.


### PR DESCRIPTION
## Summary
- add a manual Android internal distribution workflow for signed APK/AAB builds
- upload to Google Play internal testing or Internal App Sharing behind a protected environment
- document signing, tester install, digest, rollback, and rebuild guidance

Related to #86

## Platform Impact
Android-only distribution automation. It does not change MAUI runtime behavior or production promotion.

## Testing
- yamllint .github/workflows/android-internal-distribution.yml
- npx --yes markdownlint-cli docs/guides/mobile-android-internal-distribution.md