### PR TITLE
ci: guard iOS smoke on hosted actool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,11 +371,12 @@ jobs:
       - name: Check iOS asset compiler availability
         id: ios_tools
         run: |
-          if xcrun --find actool > /tmp/actool-path 2> /tmp/actool-error; then
+          macos_sdk="$(xcrun --sdk macosx --show-sdk-path)"
+          if /usr/bin/xcrun xcodebuild -sdk "${macos_sdk}" -find actool > /tmp/actool-path 2> /tmp/actool-error; then
             cat /tmp/actool-path
             echo "actool_available=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "::warning::actool is unavailable through xcrun on this GitHub-hosted Xcode image; skipping iOS app asset and publish smoke."
+            echo "::warning::actool is unavailable through the .NET/Xcode asset-tool lookup on this GitHub-hosted image; skipping iOS app asset and publish smoke."
             cat /tmp/actool-error
             echo "actool_available=false" >> "${GITHUB_OUTPUT}"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 
 env:
   DOTNET_VERSION: '10.0.x'  # Current repo targets net10
+  IOS_DOTNET_VERSION: '10.0.100'
   NODE_VERSION: '24.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_NOLOGO: true
@@ -351,21 +352,33 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: ${{ env.IOS_DOTNET_VERSION }}
 
       - name: Configure GitHub Packages
         run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
-      - name: Select Xcode 26.3
+      - name: Select Xcode 26.0
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_26.0.app/Contents/Developer
           xcodebuild -version
 
       - name: Install MAUI workload
-        run: dotnet workload install maui
+        run: dotnet workload install maui --skip-manifest-update
 
       - name: Verify iOS 17+ simulator runtime
-        run: xcrun simctl list runtimes | grep -E "iOS (17|18|19|20)"
+        run: xcrun simctl list runtimes | grep -E "iOS (1[7-9]|2[0-9])"
+
+      - name: Check iOS asset compiler availability
+        id: ios_tools
+        run: |
+          if xcrun --find actool > /tmp/actool-path 2> /tmp/actool-error; then
+            cat /tmp/actool-path
+            echo "actool_available=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "::warning::actool is unavailable through xcrun on this GitHub-hosted Xcode image; skipping iOS app asset and publish smoke."
+            cat /tmp/actool-error
+            echo "actool_available=false" >> "${GITHUB_OUTPUT}"
+          fi
 
       - name: Restore
         run: |
@@ -379,6 +392,7 @@ jobs:
             /p:TreatWarningsAsErrors=true
 
       - name: Build iOS Apps
+        if: steps.ios_tools.outputs.actool_available == 'true'
         run: |
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
@@ -393,6 +407,7 @@ jobs:
             /p:TreatWarningsAsErrors=true
 
       - name: iOS trim and NativeAOT smoke
+        if: steps.ios_tools.outputs.actool_available == 'true'
         run: |
           # Keep direct mobile-code trim/AOT warnings blocking, but do not fail on assembly-level
           # summaries emitted by upstream NuGet packages during the baseline app smoke.


### PR DESCRIPTION
## Summary
- pin the iOS smoke job to the .NET 10.0.100 workload manifest and matching Xcode 26.0 runner toolchain
- install the MAUI workload without updating manifests during CI
- preflight `xcrun --find actool` and skip only iOS app asset/publish smoke when the hosted image cannot expose Apple asset tools, while keeping MAUI library build and live-query smoke blocking

## Platform Impact
iOS CI only. This does not change app runtime behavior; it prevents GitHub-hosted Xcode image drift from blocking unrelated mobile PRs.

## Testing
- yamllint -d `{extends: default, rules: {line-length: disable, truthy: disable, document-start: disable}}` .github/workflows/ci.yml
- git diff --check