### PR TITLE
feat: add mobile exception reporting primitives

### DIFF
--- a/docs/guides/mobile-exception-reporting.md
+++ b/docs/guides/mobile-exception-reporting.md
@@ -1,0 +1,95 @@
+# Mobile Exception Reporting
+
+Honua mobile exception reporting is opt-in. The first mobile slice provides a
+sanitized local reporting surface and offline queue for MAUI/mobile apps. It
+does not define or implement the Honua Server ingestion endpoint.
+
+## Enablement
+
+Register the disabled default when an app wants the reporting abstraction
+available without capturing reports:
+
+```csharp
+services.AddHonuaMobileExceptionReporting();
+```
+
+Register local-only capture when tester consent, app configuration, and the
+environment kill switch all allow exception reporting:
+
+```csharp
+services.AddHonuaMobileExceptionReporting(new MobileExceptionReportingOptions
+{
+    Mode = MobileExceptionReportingMode.LocalOnly,
+    QueueDirectory = exceptionQueueDirectory,
+    Metadata = new MobileExceptionReportMetadata
+    {
+        AppId = "honua.field",
+        AppVersion = appVersion,
+        BuildNumber = buildNumber,
+        CommitSha = commitSha,
+        Branch = branch,
+        EnvironmentName = environmentName,
+        Platform = platform,
+        OsVersion = osVersion,
+        DeviceClass = deviceClass,
+    },
+});
+```
+
+Apps can report handled exceptions through `IMobileExceptionReporter` with a
+source, operation, correlation id, request id, and small diagnostic properties.
+Unhandled exception hooks are available through
+`MobileExceptionReportingExceptionHooks.Register()`, but apps should install
+them only after consent/configuration has enabled reporting. The hooks record
+`AppDomain.CurrentDomain.UnhandledException` and
+`TaskScheduler.UnobservedTaskException` into the same local queue.
+
+## Privacy Defaults
+
+Reports are sanitized before they are stored on device. The redactor removes or
+masks:
+
+- bearer/basic authorization values, access tokens, refresh tokens, API keys,
+  passwords, secrets, and credential-like key/value pairs.
+- URL user-info credentials such as `https://user:password@example.test`.
+- sensitive URL query parameters such as `token`, `api_key`, `password`,
+  `secret`, signatures, and authorization codes.
+- precise location properties such as latitude, longitude, GPS, coordinates, and
+  location keys unless `IncludePreciseLocation` is explicitly enabled.
+- form payload and user-entered field value properties unless
+  `IncludeFormPayloads` is explicitly enabled.
+- attachment, media, photo, image, and file byte content unless
+  `IncludeAttachmentContent` is explicitly enabled.
+
+Even when precise location or form payload capture is explicitly enabled, token
+and credential redaction still applies. Do not pass full record payloads,
+attachments, raw request bodies, or precise coordinates as routine context.
+Prefer stable identifiers, operation names, correlation ids, and coarse state.
+
+## Offline Queue And Retry Expectations
+
+`LocalOnly` mode writes sanitized `MobileExceptionReport` files through
+`IMobileExceptionReportQueue`. The file-backed queue trims old reports using
+`MaxQueuedReports` and suppresses repeated reports from the same source,
+exception type, message, and first stack frame inside `DuplicateWindow`.
+
+The queue is intentionally transport-neutral. A later uploader can read pending
+items, attempt delivery when connectivity and battery policy allow, and delete
+items only after successful ingestion. Retry/backoff policy should live in that
+uploader or a background worker, not in UI flows or app startup. Exception
+reporting must never block app launch, sync, auth refresh, or field capture.
+
+## Server Dependency
+
+Server ingestion is a separate dependency for issue #91. The mobile repo should
+not add a server API client, shared server DTO, or long-lived copied contract for
+that endpoint. The server-side slice needs to define the ingestion route, auth
+requirements, retention rules, log sink mapping, searchable metadata fields, and
+operational triage behavior. Mobile upload work should consume that versioned
+contract/package once it exists.
+
+Recommended PR body note:
+
+```text
+Related to #91
+```

--- a/src/Honua.Mobile.Maui/Diagnostics/FileMobileExceptionReportQueue.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/FileMobileExceptionReportQueue.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 
 namespace Honua.Mobile.Maui.Diagnostics;
@@ -9,8 +10,6 @@ namespace Honua.Mobile.Maui.Diagnostics;
 /// </summary>
 public sealed class FileMobileExceptionReportQueue : IMobileExceptionReportQueue
 {
-    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
-
     private readonly MobileExceptionReportingOptions _options;
     private readonly ILogger<FileMobileExceptionReportQueue>? _logger;
 
@@ -31,7 +30,7 @@ public sealed class FileMobileExceptionReportQueue : IMobileExceptionReportQueue
         Directory.CreateDirectory(directory);
 
         var path = Path.Combine(directory, $"{report.OccurredAtUtc:yyyyMMddHHmmssfff}-{report.Id}.json");
-        var json = JsonSerializer.Serialize(report, SerializerOptions);
+        var json = JsonSerializer.Serialize(report, HonuaMobileMauiDiagnosticsJsonContext.Default.MobileExceptionReport);
         await File.WriteAllTextAsync(path, json, cancellationToken);
         TrimQueue(directory);
     }
@@ -53,7 +52,7 @@ public sealed class FileMobileExceptionReportQueue : IMobileExceptionReportQueue
             try
             {
                 var json = await File.ReadAllTextAsync(path, cancellationToken);
-                report = JsonSerializer.Deserialize<MobileExceptionReport>(json, SerializerOptions);
+                report = JsonSerializer.Deserialize(json, HonuaMobileMauiDiagnosticsJsonContext.Default.MobileExceptionReport);
             }
             catch (Exception ex) when (ex is IOException or JsonException or UnauthorizedAccessException)
             {
@@ -122,3 +121,9 @@ public sealed class FileMobileExceptionReportQueue : IMobileExceptionReportQueue
         }
     }
 }
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(MobileExceptionReport))]
+[JsonSerializable(typeof(MobileExceptionReportMetadata))]
+[JsonSerializable(typeof(Dictionary<string, string?>))]
+internal sealed partial class HonuaMobileMauiDiagnosticsJsonContext : JsonSerializerContext;

--- a/src/Honua.Mobile.Maui/Diagnostics/FileMobileExceptionReportQueue.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/FileMobileExceptionReportQueue.cs
@@ -1,0 +1,124 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Mobile.Maui.Diagnostics;
+
+/// <summary>
+/// File-backed local queue for sanitized mobile exception reports.
+/// </summary>
+public sealed class FileMobileExceptionReportQueue : IMobileExceptionReportQueue
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly MobileExceptionReportingOptions _options;
+    private readonly ILogger<FileMobileExceptionReportQueue>? _logger;
+
+    public FileMobileExceptionReportQueue(
+        MobileExceptionReportingOptions options,
+        ILogger<FileMobileExceptionReportQueue>? logger = null)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _options.Validate();
+        _logger = logger;
+    }
+
+    public async Task EnqueueAsync(MobileExceptionReport report, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        var directory = GetQueueDirectory();
+        Directory.CreateDirectory(directory);
+
+        var path = Path.Combine(directory, $"{report.OccurredAtUtc:yyyyMMddHHmmssfff}-{report.Id}.json");
+        var json = JsonSerializer.Serialize(report, SerializerOptions);
+        await File.WriteAllTextAsync(path, json, cancellationToken);
+        TrimQueue(directory);
+    }
+
+    public async IAsyncEnumerable<QueuedMobileExceptionReport> ReadPendingAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var directory = GetQueueDirectory();
+        if (!Directory.Exists(directory))
+        {
+            yield break;
+        }
+
+        foreach (var path in Directory.EnumerateFiles(directory, "*.json").OrderBy(static path => path, StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            MobileExceptionReport? report = null;
+            try
+            {
+                var json = await File.ReadAllTextAsync(path, cancellationToken);
+                report = JsonSerializer.Deserialize<MobileExceptionReport>(json, SerializerOptions);
+            }
+            catch (Exception ex) when (ex is IOException or JsonException or UnauthorizedAccessException)
+            {
+                _logger?.LogWarning(ex, "Discarding unreadable mobile exception report {Path}", path);
+                DeleteFile(path);
+            }
+
+            if (report is not null)
+            {
+                yield return new QueuedMobileExceptionReport(path, report);
+            }
+        }
+    }
+
+    public Task DeleteAsync(QueuedMobileExceptionReport report, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        cancellationToken.ThrowIfCancellationRequested();
+        DeleteFile(report.QueueId);
+        return Task.CompletedTask;
+    }
+
+    private string GetQueueDirectory()
+    {
+        if (!string.IsNullOrWhiteSpace(_options.QueueDirectory))
+        {
+            return _options.QueueDirectory;
+        }
+
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrWhiteSpace(localAppData))
+        {
+            localAppData = Path.GetTempPath();
+        }
+
+        return Path.Combine(localAppData, "Honua", "exception-reports");
+    }
+
+    private void TrimQueue(string directory)
+    {
+        var files = Directory.EnumerateFiles(directory, "*.json")
+            .OrderByDescending(static path => path, StringComparer.Ordinal)
+            .Skip(_options.MaxQueuedReports)
+            .ToArray();
+
+        foreach (var file in files)
+        {
+            DeleteFile(file);
+        }
+    }
+
+    private static void DeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReportQueue.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReportQueue.cs
@@ -1,0 +1,15 @@
+namespace Honua.Mobile.Maui.Diagnostics;
+
+/// <summary>
+/// Offline queue boundary used by local exception reporting and future retry/upload workers.
+/// </summary>
+public interface IMobileExceptionReportQueue
+{
+    Task EnqueueAsync(MobileExceptionReport report, CancellationToken cancellationToken = default);
+
+    IAsyncEnumerable<QueuedMobileExceptionReport> ReadPendingAsync(CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(QueuedMobileExceptionReport report, CancellationToken cancellationToken = default);
+}
+
+public sealed record QueuedMobileExceptionReport(string QueueId, MobileExceptionReport Report);

--- a/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReporter.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReporter.cs
@@ -1,0 +1,27 @@
+namespace Honua.Mobile.Maui.Diagnostics;
+
+/// <summary>
+/// Mobile boundary for reporting handled and unhandled exceptions without coupling to server transport.
+/// </summary>
+public interface IMobileExceptionReporter
+{
+    Task ReportAsync(
+        Exception exception,
+        MobileExceptionReportContext? context = null,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Disabled exception reporter used when mobile exception reporting is not opted in.
+/// </summary>
+public sealed class NoOpMobileExceptionReporter : IMobileExceptionReporter
+{
+    public Task ReportAsync(
+        Exception exception,
+        MobileExceptionReportContext? context = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Honua.Mobile.Maui/Diagnostics/LocalMobileExceptionReporter.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/LocalMobileExceptionReporter.cs
@@ -53,6 +53,7 @@ public sealed class LocalMobileExceptionReporter : IMobileExceptionReporter
         try
         {
             await _queue.EnqueueAsync(report, cancellationToken);
+            TrackFingerprint(report.Fingerprint, now);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
         {
@@ -130,12 +131,23 @@ public sealed class LocalMobileExceptionReporter : IMobileExceptionReporter
             if (_recentFingerprints.TryGetValue(fingerprint, out var previous) &&
                 occurredAtUtc - previous <= _options.DuplicateWindow)
             {
-                _recentFingerprints[fingerprint] = occurredAtUtc;
                 return true;
             }
 
-            _recentFingerprints[fingerprint] = occurredAtUtc;
             return false;
+        }
+    }
+
+    private void TrackFingerprint(string fingerprint, DateTimeOffset occurredAtUtc)
+    {
+        if (_options.DuplicateWindow == TimeSpan.Zero)
+        {
+            return;
+        }
+
+        lock (_dedupeGate)
+        {
+            _recentFingerprints[fingerprint] = occurredAtUtc;
         }
     }
 

--- a/src/Honua.Mobile.Maui/Diagnostics/LocalMobileExceptionReporter.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/LocalMobileExceptionReporter.cs
@@ -1,0 +1,161 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Mobile.Maui.Diagnostics;
+
+/// <summary>
+/// Builds sanitized exception reports and stores them in the local offline queue.
+/// </summary>
+public sealed class LocalMobileExceptionReporter : IMobileExceptionReporter
+{
+    private readonly IMobileExceptionReportQueue _queue;
+    private readonly MobileExceptionReportingOptions _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<LocalMobileExceptionReporter>? _logger;
+    private readonly object _dedupeGate = new();
+    private readonly Dictionary<string, DateTimeOffset> _recentFingerprints = new(StringComparer.Ordinal);
+
+    public LocalMobileExceptionReporter(
+        IMobileExceptionReportQueue queue,
+        MobileExceptionReportingOptions options,
+        TimeProvider? timeProvider = null,
+        ILogger<LocalMobileExceptionReporter>? logger = null)
+    {
+        _queue = queue ?? throw new ArgumentNullException(nameof(queue));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _options.Validate();
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _logger = logger;
+    }
+
+    public async Task ReportAsync(
+        Exception exception,
+        MobileExceptionReportContext? context = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        if (_options.Mode != MobileExceptionReportingMode.LocalOnly)
+        {
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        var reportContext = context ?? new MobileExceptionReportContext();
+        var report = BuildReport(exception, reportContext, now);
+
+        if (IsDuplicate(report.Fingerprint, now))
+        {
+            return;
+        }
+
+        try
+        {
+            await _queue.EnqueueAsync(report, cancellationToken);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            _logger?.LogWarning(ex, "Failed to queue sanitized mobile exception report");
+        }
+    }
+
+    private MobileExceptionReport BuildReport(
+        Exception exception,
+        MobileExceptionReportContext context,
+        DateTimeOffset occurredAtUtc)
+    {
+        var source = string.IsNullOrWhiteSpace(context.Source) ? "Unknown" : context.Source;
+        var sanitizedMessage = MobileExceptionRedactor.RedactText(exception.Message, _options, _options.MaxMessageLength);
+        var sanitizedStackTrace = MobileExceptionRedactor.RedactText(exception.StackTrace, _options, _options.MaxStackTraceLength);
+        var sanitizedInnerMessage = MobileExceptionRedactor.RedactText(
+            exception.InnerException?.Message,
+            _options,
+            _options.MaxMessageLength);
+
+        return new MobileExceptionReport
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Fingerprint = CreateFingerprint(exception, source, sanitizedMessage),
+            OccurredAtUtc = occurredAtUtc,
+            Source = source,
+            Operation = MobileExceptionRedactor.RedactText(context.Operation, _options, _options.MaxMessageLength),
+            CorrelationId = MobileExceptionRedactor.RedactText(context.CorrelationId, _options, _options.MaxMessageLength),
+            RequestId = MobileExceptionRedactor.RedactText(context.RequestId, _options, _options.MaxMessageLength),
+            Severity = context.Severity,
+            ExceptionType = exception.GetType().FullName ?? exception.GetType().Name,
+            Message = sanitizedMessage,
+            StackTrace = sanitizedStackTrace,
+            InnerExceptionType = exception.InnerException?.GetType().FullName,
+            InnerExceptionMessage = sanitizedInnerMessage,
+            Metadata = RedactMetadata(_options.Metadata),
+            Context = MobileExceptionRedactor.RedactProperties(context.Properties, _options),
+        };
+    }
+
+    private MobileExceptionReportMetadata RedactMetadata(MobileExceptionReportMetadata metadata)
+    {
+        return metadata with
+        {
+            AppId = MobileExceptionRedactor.RedactText(metadata.AppId, _options, _options.MaxMessageLength),
+            AppVersion = MobileExceptionRedactor.RedactText(metadata.AppVersion, _options, _options.MaxMessageLength),
+            BuildNumber = MobileExceptionRedactor.RedactText(metadata.BuildNumber, _options, _options.MaxMessageLength),
+            CommitSha = MobileExceptionRedactor.RedactText(metadata.CommitSha, _options, _options.MaxMessageLength),
+            Branch = MobileExceptionRedactor.RedactText(metadata.Branch, _options, _options.MaxMessageLength),
+            EnvironmentName = MobileExceptionRedactor.RedactText(metadata.EnvironmentName, _options, _options.MaxMessageLength),
+            Platform = MobileExceptionRedactor.RedactText(metadata.Platform, _options, _options.MaxMessageLength),
+            OsVersion = MobileExceptionRedactor.RedactText(metadata.OsVersion, _options, _options.MaxMessageLength),
+            DeviceClass = MobileExceptionRedactor.RedactText(metadata.DeviceClass, _options, _options.MaxMessageLength),
+            Properties = MobileExceptionRedactor.RedactMetadata(metadata.Properties, _options),
+        };
+    }
+
+    private bool IsDuplicate(string fingerprint, DateTimeOffset occurredAtUtc)
+    {
+        if (_options.DuplicateWindow == TimeSpan.Zero)
+        {
+            return false;
+        }
+
+        lock (_dedupeGate)
+        {
+            foreach (var (knownFingerprint, lastSeen) in _recentFingerprints.ToArray())
+            {
+                if (occurredAtUtc - lastSeen > _options.DuplicateWindow)
+                {
+                    _recentFingerprints.Remove(knownFingerprint);
+                }
+            }
+
+            if (_recentFingerprints.TryGetValue(fingerprint, out var previous) &&
+                occurredAtUtc - previous <= _options.DuplicateWindow)
+            {
+                _recentFingerprints[fingerprint] = occurredAtUtc;
+                return true;
+            }
+
+            _recentFingerprints[fingerprint] = occurredAtUtc;
+            return false;
+        }
+    }
+
+    private static string CreateFingerprint(Exception exception, string source, string? sanitizedMessage)
+    {
+        var fingerprintSource = string.Join(
+            '\n',
+            source,
+            exception.GetType().FullName,
+            sanitizedMessage,
+            FirstStackFrame(exception));
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(fingerprintSource));
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static string? FirstStackFrame(Exception exception)
+    {
+        return exception.StackTrace?
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault();
+    }
+}

--- a/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionRedactor.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionRedactor.cs
@@ -1,0 +1,189 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Honua.Mobile.Maui.Diagnostics;
+
+/// <summary>
+/// Applies mobile privacy redaction before exception details are stored or uploaded.
+/// </summary>
+public static partial class MobileExceptionRedactor
+{
+    public const string RedactedValue = "[redacted]";
+    public const string PreciseLocationRedactedValue = "[redacted: precise location disabled]";
+    public const string FormPayloadRedactedValue = "[redacted: form payload disabled]";
+    public const string AttachmentContentRedactedValue = "[redacted: attachment content disabled]";
+
+    public static string? RedactText(string? value, MobileExceptionReportingOptions options, int? maxLength = null)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        var redacted = UrlUserInfoRegex().Replace(value, "${scheme}[redacted]@");
+        redacted = AuthorizationHeaderRegex().Replace(redacted, "${prefix}${scheme} [redacted]");
+        redacted = BearerOrBasicRegex().Replace(redacted, "${scheme} [redacted]");
+        redacted = SensitiveKeyValueRegex().Replace(redacted, "${key}=${quote}[redacted]${quote}");
+        redacted = SensitiveQueryStringRegex().Replace(redacted, "${prefix}[redacted]");
+
+        if (!options.IncludePreciseLocation)
+        {
+            redacted = PreciseLocationTextRegex().Replace(redacted, "${key}=[redacted]");
+        }
+
+        return Truncate(redacted, maxLength);
+    }
+
+    public static IReadOnlyDictionary<string, string?> RedactProperties(
+        IReadOnlyDictionary<string, object?>? properties,
+        MobileExceptionReportingOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (properties is null || properties.Count == 0)
+        {
+            return new Dictionary<string, string?>();
+        }
+
+        var redacted = new Dictionary<string, string?>(StringComparer.Ordinal);
+        foreach (var (key, value) in properties)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                continue;
+            }
+
+            if (LooksLikeSensitiveKey(key))
+            {
+                redacted[key] = RedactedValue;
+                continue;
+            }
+
+            if (!options.IncludePreciseLocation && LooksLikePreciseLocationKey(key))
+            {
+                redacted[key] = PreciseLocationRedactedValue;
+                continue;
+            }
+
+            if (!options.IncludeFormPayloads && LooksLikeFormPayloadKey(key))
+            {
+                redacted[key] = FormPayloadRedactedValue;
+                continue;
+            }
+
+            if (!options.IncludeAttachmentContent && LooksLikeAttachmentContentKey(key))
+            {
+                redacted[key] = AttachmentContentRedactedValue;
+                continue;
+            }
+
+            redacted[key] = RedactText(ConvertToString(value), options, options.MaxMessageLength);
+        }
+
+        return redacted;
+    }
+
+    public static IReadOnlyDictionary<string, string?> RedactMetadata(
+        IReadOnlyDictionary<string, string?>? properties,
+        MobileExceptionReportingOptions options)
+    {
+        if (properties is null || properties.Count == 0)
+        {
+            return new Dictionary<string, string?>();
+        }
+
+        return RedactProperties(
+            properties.ToDictionary(item => item.Key, item => (object?)item.Value, StringComparer.Ordinal),
+            options);
+    }
+
+    private static string? ConvertToString(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            string text => text,
+            IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+            _ => value.ToString(),
+        };
+    }
+
+    private static string? Truncate(string? value, int? maxLength)
+    {
+        if (string.IsNullOrEmpty(value) || maxLength is null || value.Length <= maxLength.Value)
+        {
+            return value;
+        }
+
+        return value[..maxLength.Value];
+    }
+
+    private static bool LooksLikeSensitiveKey(string key)
+    {
+        var normalized = NormalizeKey(key);
+        return normalized.Contains("token", StringComparison.Ordinal) ||
+            normalized.Contains("apikey", StringComparison.Ordinal) ||
+            normalized.Contains("authorization", StringComparison.Ordinal) ||
+            normalized.Contains("credential", StringComparison.Ordinal) ||
+            normalized.Contains("password", StringComparison.Ordinal) ||
+            normalized.Contains("passwd", StringComparison.Ordinal) ||
+            normalized.Contains("secret", StringComparison.Ordinal);
+    }
+
+    private static bool LooksLikePreciseLocationKey(string key)
+    {
+        var normalized = NormalizeKey(key);
+        return normalized is "lat" or "latitude" or "lon" or "lng" or "long" or "longitude" ||
+            normalized.Contains("gps", StringComparison.Ordinal) ||
+            normalized.Contains("coordinate", StringComparison.Ordinal) ||
+            normalized.Contains("geolocation", StringComparison.Ordinal) ||
+            normalized.Contains("location", StringComparison.Ordinal);
+    }
+
+    private static bool LooksLikeFormPayloadKey(string key)
+    {
+        var normalized = NormalizeKey(key);
+        return normalized.Contains("formpayload", StringComparison.Ordinal) ||
+            normalized.Contains("formdata", StringComparison.Ordinal) ||
+            normalized.Contains("fieldvalues", StringComparison.Ordinal) ||
+            normalized.Contains("userinput", StringComparison.Ordinal) ||
+            normalized.Contains("surveyresponse", StringComparison.Ordinal) ||
+            normalized.Contains("recordattributes", StringComparison.Ordinal);
+    }
+
+    private static bool LooksLikeAttachmentContentKey(string key)
+    {
+        var normalized = NormalizeKey(key);
+        return normalized.Contains("attachmentcontent", StringComparison.Ordinal) ||
+            normalized.Contains("attachmentbytes", StringComparison.Ordinal) ||
+            normalized.Contains("filebytes", StringComparison.Ordinal) ||
+            normalized.Contains("imagebytes", StringComparison.Ordinal) ||
+            normalized.Contains("photobytes", StringComparison.Ordinal) ||
+            normalized.Contains("mediabytes", StringComparison.Ordinal);
+    }
+
+    private static string NormalizeKey(string key)
+    {
+        return new string(key.Where(char.IsLetterOrDigit).Select(char.ToLowerInvariant).ToArray());
+    }
+
+    [GeneratedRegex(@"(?<scheme>https?://)(?<userinfo>[^/?#\s@]+@)", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 250)]
+    private static partial Regex UrlUserInfoRegex();
+
+    [GeneratedRegex(@"(?<prefix>\bauthorization\s*[:=]\s*)(?<scheme>bearer|basic)?\s*[A-Za-z0-9._~+/=-]+", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 250)]
+    private static partial Regex AuthorizationHeaderRegex();
+
+    [GeneratedRegex(@"\b(?<scheme>bearer|basic)\s+[A-Za-z0-9._~+/=-]+", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 250)]
+    private static partial Regex BearerOrBasicRegex();
+
+    [GeneratedRegex(@"\b(?<key>access[_-]?token|refresh[_-]?token|token|api[_-]?key|apikey|password|passwd|secret|client[_-]?secret|credential)\b\s*[:=]\s*(?<quote>[""']?)[^\s,;&""']+(?<quote2>[""']?)", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 250)]
+    private static partial Regex SensitiveKeyValueRegex();
+
+    [GeneratedRegex(@"(?<prefix>[?&;](?:access[_-]?token|refresh[_-]?token|token|api[_-]?key|apikey|password|secret|client[_-]?secret|sig|signature|code|key)=)[^&#\s]+", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 250)]
+    private static partial Regex SensitiveQueryStringRegex();
+
+    [GeneratedRegex(@"\b(?<key>lat(?:itude)?|lon(?:gitude)?|lng)\s*[:=]\s*-?\d{1,3}(?:\.\d{4,})?\b", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 250)]
+    private static partial Regex PreciseLocationTextRegex();
+}

--- a/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReport.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReport.cs
@@ -1,0 +1,91 @@
+namespace Honua.Mobile.Maui.Diagnostics;
+
+/// <summary>
+/// Severity label for locally captured exception reports.
+/// </summary>
+public enum MobileExceptionSeverity
+{
+    Error,
+    Warning,
+    Critical,
+}
+
+/// <summary>
+/// Build, runtime, and device metadata attached to a mobile exception report.
+/// </summary>
+public sealed record MobileExceptionReportMetadata
+{
+    public string? AppId { get; init; }
+
+    public string? AppVersion { get; init; }
+
+    public string? BuildNumber { get; init; }
+
+    public string? CommitSha { get; init; }
+
+    public string? Branch { get; init; }
+
+    public string? EnvironmentName { get; init; }
+
+    public string? Platform { get; init; }
+
+    public string? OsVersion { get; init; }
+
+    public string? DeviceClass { get; init; }
+
+    public IReadOnlyDictionary<string, string?> Properties { get; init; } = new Dictionary<string, string?>();
+}
+
+/// <summary>
+/// Caller-supplied context for handled or unhandled mobile exception reporting.
+/// </summary>
+public sealed record MobileExceptionReportContext
+{
+    public string Source { get; init; } = "Unknown";
+
+    public string? Operation { get; init; }
+
+    public string? CorrelationId { get; init; }
+
+    public string? RequestId { get; init; }
+
+    public MobileExceptionSeverity Severity { get; init; } = MobileExceptionSeverity.Error;
+
+    public IReadOnlyDictionary<string, object?> Properties { get; init; } = new Dictionary<string, object?>();
+}
+
+/// <summary>
+/// Sanitized mobile exception report stored on device. This is not a server ingestion contract.
+/// </summary>
+public sealed record MobileExceptionReport
+{
+    public required string Id { get; init; }
+
+    public required string Fingerprint { get; init; }
+
+    public required DateTimeOffset OccurredAtUtc { get; init; }
+
+    public required string Source { get; init; }
+
+    public string? Operation { get; init; }
+
+    public string? CorrelationId { get; init; }
+
+    public string? RequestId { get; init; }
+
+    public MobileExceptionSeverity Severity { get; init; } = MobileExceptionSeverity.Error;
+
+    public required string ExceptionType { get; init; }
+
+    public string? Message { get; init; }
+
+    public string? StackTrace { get; init; }
+
+    public string? InnerExceptionType { get; init; }
+
+    public string? InnerExceptionMessage { get; init; }
+
+    public MobileExceptionReportMetadata Metadata { get; init; } = new();
+
+    public IReadOnlyDictionary<string, string?> Context { get; init; } = new Dictionary<string, string?>();
+}

--- a/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportingExceptionHooks.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportingExceptionHooks.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Mobile.Maui.Diagnostics;
+
+/// <summary>
+/// Optional process-level hooks for unhandled AppDomain and unobserved task exceptions.
+/// </summary>
+public sealed class MobileExceptionReportingExceptionHooks : IDisposable
+{
+    private readonly IMobileExceptionReporter _reporter;
+    private readonly ILogger<MobileExceptionReportingExceptionHooks>? _logger;
+    private int _registered;
+
+    public MobileExceptionReportingExceptionHooks(
+        IMobileExceptionReporter reporter,
+        ILogger<MobileExceptionReportingExceptionHooks>? logger = null)
+    {
+        _reporter = reporter ?? throw new ArgumentNullException(nameof(reporter));
+        _logger = logger;
+    }
+
+    public void Register()
+    {
+        if (Interlocked.Exchange(ref _registered, 1) == 1)
+        {
+            return;
+        }
+
+        AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+        TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _registered, 0) == 0)
+        {
+            return;
+        }
+
+        AppDomain.CurrentDomain.UnhandledException -= OnUnhandledException;
+        TaskScheduler.UnobservedTaskException -= OnUnobservedTaskException;
+    }
+
+    private void OnUnhandledException(object sender, UnhandledExceptionEventArgs args)
+    {
+        if (args.ExceptionObject is Exception exception)
+        {
+            ReportInBackground(exception, "AppDomain.UnhandledException", args.IsTerminating);
+        }
+    }
+
+    private void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs args)
+    {
+        ReportInBackground(args.Exception, "TaskScheduler.UnobservedTaskException", isTerminating: false);
+    }
+
+    private void ReportInBackground(Exception exception, string source, bool isTerminating)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await _reporter.ReportAsync(
+                    exception,
+                    new MobileExceptionReportContext
+                    {
+                        Source = source,
+                        Severity = isTerminating ? MobileExceptionSeverity.Critical : MobileExceptionSeverity.Error,
+                        Properties = new Dictionary<string, object?>
+                        {
+                            ["isTerminating"] = isTerminating,
+                        },
+                    });
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Mobile exception reporting hook failed");
+            }
+        });
+    }
+}

--- a/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportingOptions.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportingOptions.cs
@@ -1,0 +1,62 @@
+namespace Honua.Mobile.Maui.Diagnostics;
+
+/// <summary>
+/// Opt-in reporting modes for mobile exception capture.
+/// </summary>
+public enum MobileExceptionReportingMode
+{
+    /// <summary>Do not capture exception reports.</summary>
+    Disabled,
+
+    /// <summary>Capture sanitized reports into the local mobile queue only.</summary>
+    LocalOnly,
+}
+
+/// <summary>
+/// Controls local mobile exception report capture, sanitization, and queue retention.
+/// </summary>
+public sealed record MobileExceptionReportingOptions
+{
+    public MobileExceptionReportingMode Mode { get; init; } = MobileExceptionReportingMode.Disabled;
+
+    public string? QueueDirectory { get; init; }
+
+    public int MaxQueuedReports { get; init; } = 100;
+
+    public int MaxMessageLength { get; init; } = 2_000;
+
+    public int MaxStackTraceLength { get; init; } = 8_000;
+
+    public TimeSpan DuplicateWindow { get; init; } = TimeSpan.FromMinutes(5);
+
+    public bool IncludePreciseLocation { get; init; }
+
+    public bool IncludeFormPayloads { get; init; }
+
+    public bool IncludeAttachmentContent { get; init; }
+
+    public MobileExceptionReportMetadata Metadata { get; init; } = new();
+
+    public void Validate()
+    {
+        if (MaxQueuedReports <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(MaxQueuedReports), "The local exception queue size must be positive.");
+        }
+
+        if (MaxMessageLength <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(MaxMessageLength), "The exception message limit must be positive.");
+        }
+
+        if (MaxStackTraceLength <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(MaxStackTraceLength), "The exception stack trace limit must be positive.");
+        }
+
+        if (DuplicateWindow < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(DuplicateWindow), "The duplicate window cannot be negative.");
+        }
+    }
+}

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -176,11 +176,13 @@ public static class HonuaMobileServiceCollectionExtensions
             services.TryAddSingleton(TimeProvider.System);
             services.TryAddSingleton<IMobileExceptionReportQueue, FileMobileExceptionReportQueue>();
             services.TryAddSingleton<LocalMobileExceptionReporter>();
-            services.TryAddSingleton<IMobileExceptionReporter>(sp => sp.GetRequiredService<LocalMobileExceptionReporter>());
+            services.RemoveAll<IMobileExceptionReporter>();
+            services.AddSingleton<IMobileExceptionReporter>(sp => sp.GetRequiredService<LocalMobileExceptionReporter>());
         }
         else
         {
-            services.TryAddSingleton<IMobileExceptionReporter, NoOpMobileExceptionReporter>();
+            services.RemoveAll<IMobileExceptionReporter>();
+            services.AddSingleton<IMobileExceptionReporter, NoOpMobileExceptionReporter>();
         }
 
         services.TryAddSingleton<MobileExceptionReportingExceptionHooks>();

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Honua.Mobile.Field.Capture;
 using Honua.Mobile.Maui.Auth;
 using Honua.Mobile.Maui.Annotations;
+using Honua.Mobile.Maui.Diagnostics;
 using Honua.Mobile.Maui.Display;
 using Honua.Mobile.Maui.Location;
 using Honua.Mobile.Offline.GeoPackage;
@@ -15,6 +16,7 @@ using Honua.Sdk.Abstractions.Scenes;
 using Honua.Sdk.Field.Records;
 using Honua.Sdk.GeoServices.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using SdkFeatureClient = Honua.Mobile.Sdk.Features.HonuaMobileSdkFeatureClient;
 using SdkOfflineChangeJournal = Honua.Sdk.Offline.Abstractions.IOfflineChangeJournal;
@@ -149,6 +151,39 @@ public static class HonuaMobileServiceCollectionExtensions
 
         services.AddSingleton<DuplicateDetector>();
         services.AddSingleton<MobileFieldCaptureWorkflow>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers opt-in mobile exception reporting primitives. Disabled mode registers a no-op reporter;
+    /// local-only mode stores sanitized reports in the on-device offline queue.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="options">Exception reporting options. Defaults to disabled.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaMobileExceptionReporting(
+        this IServiceCollection services,
+        MobileExceptionReportingOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        options ??= new MobileExceptionReportingOptions();
+        options.Validate();
+        services.AddSingleton(options);
+
+        if (options.Mode == MobileExceptionReportingMode.LocalOnly)
+        {
+            services.TryAddSingleton(TimeProvider.System);
+            services.TryAddSingleton<IMobileExceptionReportQueue, FileMobileExceptionReportQueue>();
+            services.TryAddSingleton<LocalMobileExceptionReporter>();
+            services.TryAddSingleton<IMobileExceptionReporter>(sp => sp.GetRequiredService<LocalMobileExceptionReporter>());
+        }
+        else
+        {
+            services.TryAddSingleton<IMobileExceptionReporter, NoOpMobileExceptionReporter>();
+        }
+
+        services.TryAddSingleton<MobileExceptionReportingExceptionHooks>();
         return services;
     }
 

--- a/tests/Honua.Mobile.Maui.Tests/Diagnostics/LocalMobileExceptionReporterTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/Diagnostics/LocalMobileExceptionReporterTests.cs
@@ -59,6 +59,29 @@ public sealed class LocalMobileExceptionReporterTests
     }
 
     [Fact]
+    public void LocalRegistration_OverridesExistingReporterRegistration()
+    {
+        var queueDirectory = CreateQueueDirectoryPath();
+        try
+        {
+            using var provider = new ServiceCollection()
+                .AddSingleton<IMobileExceptionReporter, PreRegisteredExceptionReporter>()
+                .AddHonuaMobileExceptionReporting(new MobileExceptionReportingOptions
+                {
+                    Mode = MobileExceptionReportingMode.LocalOnly,
+                    QueueDirectory = queueDirectory,
+                })
+                .BuildServiceProvider();
+
+            Assert.IsType<LocalMobileExceptionReporter>(provider.GetRequiredService<IMobileExceptionReporter>());
+        }
+        finally
+        {
+            DeleteDirectory(queueDirectory);
+        }
+    }
+
+    [Fact]
     public async Task ReportAsync_QueuesSanitizedReport()
     {
         var queueDirectory = CreateQueueDirectoryPath();
@@ -148,6 +171,25 @@ public sealed class LocalMobileExceptionReporterTests
         }
     }
 
+    [Fact]
+    public async Task ReportAsync_DoesNotDeduplicateWhenInitialQueueWriteFails()
+    {
+        var options = new MobileExceptionReportingOptions
+        {
+            Mode = MobileExceptionReportingMode.LocalOnly,
+            DuplicateWindow = TimeSpan.FromMinutes(10),
+        };
+        var queue = new FailingOnceExceptionReportQueue();
+        var reporter = new LocalMobileExceptionReporter(queue, options);
+        var exception = new InvalidOperationException("same failure");
+        var context = new MobileExceptionReportContext { Source = "auth-refresh" };
+
+        await reporter.ReportAsync(exception, context);
+        await reporter.ReportAsync(exception, context);
+
+        Assert.Single(queue.Reports);
+    }
+
     private static async Task<List<MobileExceptionReport>> ReadReportsAsync(IMobileExceptionReportQueue queue)
     {
         var reports = new List<MobileExceptionReport>();
@@ -169,6 +211,50 @@ public sealed class LocalMobileExceptionReporterTests
         if (Directory.Exists(path))
         {
             Directory.Delete(path, recursive: true);
+        }
+    }
+
+    private sealed class PreRegisteredExceptionReporter : IMobileExceptionReporter
+    {
+        public Task ReportAsync(
+            Exception exception,
+            MobileExceptionReportContext? context = null,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class FailingOnceExceptionReportQueue : IMobileExceptionReportQueue
+    {
+        private bool _hasFailed;
+
+        public List<MobileExceptionReport> Reports { get; } = [];
+
+        public Task EnqueueAsync(MobileExceptionReport report, CancellationToken cancellationToken = default)
+        {
+            if (!_hasFailed)
+            {
+                _hasFailed = true;
+                throw new IOException("queue unavailable");
+            }
+
+            Reports.Add(report);
+            return Task.CompletedTask;
+        }
+
+        public async IAsyncEnumerable<QueuedMobileExceptionReport> ReadPendingAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            foreach (var report in Reports)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return new QueuedMobileExceptionReport(report.Id, report);
+                await Task.Yield();
+            }
+        }
+
+        public Task DeleteAsync(QueuedMobileExceptionReport report, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/tests/Honua.Mobile.Maui.Tests/Diagnostics/LocalMobileExceptionReporterTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/Diagnostics/LocalMobileExceptionReporterTests.cs
@@ -1,0 +1,174 @@
+using Honua.Mobile.Maui;
+using Honua.Mobile.Maui.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Mobile.Maui.Tests.Diagnostics;
+
+public sealed class LocalMobileExceptionReporterTests
+{
+    [Fact]
+    public async Task DisabledRegistration_UsesNoOpReporterAndDoesNotCreateQueue()
+    {
+        var queueDirectory = CreateQueueDirectoryPath();
+        try
+        {
+            using var provider = new ServiceCollection()
+                .AddHonuaMobileExceptionReporting(new MobileExceptionReportingOptions
+                {
+                    Mode = MobileExceptionReportingMode.Disabled,
+                    QueueDirectory = queueDirectory,
+                })
+                .BuildServiceProvider();
+
+            var reporter = provider.GetRequiredService<IMobileExceptionReporter>();
+
+            await reporter.ReportAsync(new InvalidOperationException("boom"));
+
+            Assert.IsType<NoOpMobileExceptionReporter>(reporter);
+            Assert.False(Directory.Exists(queueDirectory));
+        }
+        finally
+        {
+            DeleteDirectory(queueDirectory);
+        }
+    }
+
+    [Fact]
+    public void LocalRegistration_WiresReporterQueueAndExceptionHooks()
+    {
+        var queueDirectory = CreateQueueDirectoryPath();
+        try
+        {
+            using var provider = new ServiceCollection()
+                .AddLogging()
+                .AddHonuaMobileExceptionReporting(new MobileExceptionReportingOptions
+                {
+                    Mode = MobileExceptionReportingMode.LocalOnly,
+                    QueueDirectory = queueDirectory,
+                })
+                .BuildServiceProvider();
+
+            Assert.IsType<LocalMobileExceptionReporter>(provider.GetRequiredService<IMobileExceptionReporter>());
+            Assert.IsType<FileMobileExceptionReportQueue>(provider.GetRequiredService<IMobileExceptionReportQueue>());
+            Assert.NotNull(provider.GetRequiredService<MobileExceptionReportingExceptionHooks>());
+        }
+        finally
+        {
+            DeleteDirectory(queueDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task ReportAsync_QueuesSanitizedReport()
+    {
+        var queueDirectory = CreateQueueDirectoryPath();
+        try
+        {
+            var options = new MobileExceptionReportingOptions
+            {
+                Mode = MobileExceptionReportingMode.LocalOnly,
+                QueueDirectory = queueDirectory,
+                Metadata = new MobileExceptionReportMetadata
+                {
+                    AppId = "honua.field",
+                    AppVersion = "1.2.3",
+                    BuildNumber = "456",
+                    CommitSha = "abc123",
+                    Branch = "codex/mobile-exception-reporting",
+                    EnvironmentName = "beta",
+                    Platform = "android",
+                    OsVersion = "15",
+                    DeviceClass = "phone",
+                },
+            };
+            var queue = new FileMobileExceptionReportQueue(options);
+            var reporter = new LocalMobileExceptionReporter(queue, options);
+
+            await reporter.ReportAsync(
+                new InvalidOperationException("failed token=raw-token at https://user:pass@example.test/sync?api_key=secret"),
+                new MobileExceptionReportContext
+                {
+                    Source = "offline-sync",
+                    Operation = "delta-upload",
+                    CorrelationId = "corr-123",
+                    Properties = new Dictionary<string, object?>
+                    {
+                        ["apiKey"] = "test-api-key",
+                        ["latitude"] = 21.3069,
+                        ["formPayload"] = "{\"owner\":\"Kai\"}",
+                        ["layer"] = "hydrants",
+                    },
+                });
+
+            var report = Assert.Single(await ReadReportsAsync(queue));
+
+            Assert.Equal("offline-sync", report.Source);
+            Assert.Equal("delta-upload", report.Operation);
+            Assert.Equal("corr-123", report.CorrelationId);
+            Assert.Equal("honua.field", report.Metadata.AppId);
+            Assert.DoesNotContain("raw-token", report.Message);
+            Assert.DoesNotContain("user:pass", report.Message);
+            Assert.DoesNotContain("secret", report.Message);
+            Assert.Equal(MobileExceptionRedactor.RedactedValue, report.Context["apiKey"]);
+            Assert.Equal(MobileExceptionRedactor.PreciseLocationRedactedValue, report.Context["latitude"]);
+            Assert.Equal(MobileExceptionRedactor.FormPayloadRedactedValue, report.Context["formPayload"]);
+            Assert.Equal("hydrants", report.Context["layer"]);
+        }
+        finally
+        {
+            DeleteDirectory(queueDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task ReportAsync_DeduplicatesSameExceptionWithinWindow()
+    {
+        var queueDirectory = CreateQueueDirectoryPath();
+        try
+        {
+            var options = new MobileExceptionReportingOptions
+            {
+                Mode = MobileExceptionReportingMode.LocalOnly,
+                QueueDirectory = queueDirectory,
+                DuplicateWindow = TimeSpan.FromMinutes(10),
+            };
+            var queue = new FileMobileExceptionReportQueue(options);
+            var reporter = new LocalMobileExceptionReporter(queue, options);
+            var exception = new InvalidOperationException("same failure");
+            var context = new MobileExceptionReportContext { Source = "auth-refresh" };
+
+            await reporter.ReportAsync(exception, context);
+            await reporter.ReportAsync(exception, context);
+
+            Assert.Single(await ReadReportsAsync(queue));
+        }
+        finally
+        {
+            DeleteDirectory(queueDirectory);
+        }
+    }
+
+    private static async Task<List<MobileExceptionReport>> ReadReportsAsync(IMobileExceptionReportQueue queue)
+    {
+        var reports = new List<MobileExceptionReport>();
+        await foreach (var queued in queue.ReadPendingAsync())
+        {
+            reports.Add(queued.Report);
+        }
+
+        return reports;
+    }
+
+    private static string CreateQueueDirectoryPath()
+    {
+        return Path.Combine(Path.GetTempPath(), $"honua-mobile-exception-tests-{Guid.NewGuid():N}");
+    }
+
+    private static void DeleteDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+}

--- a/tests/Honua.Mobile.Maui.Tests/Diagnostics/MobileExceptionRedactorTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/Diagnostics/MobileExceptionRedactorTests.cs
@@ -1,0 +1,69 @@
+using Honua.Mobile.Maui.Diagnostics;
+
+namespace Honua.Mobile.Maui.Tests.Diagnostics;
+
+public sealed class MobileExceptionRedactorTests
+{
+    [Fact]
+    public void RedactText_RemovesTokensCredentialsAndPreciseCoordinates()
+    {
+        var text = "GET https://alice:secret@example.test/sync?api_key=key-123&layer=sites Authorization: Bearer raw-token password=hunter2 lat=21.30691 lon=-157.85830";
+
+        var redacted = MobileExceptionRedactor.RedactText(text, new MobileExceptionReportingOptions());
+
+        Assert.NotNull(redacted);
+        Assert.DoesNotContain("alice:secret", redacted);
+        Assert.DoesNotContain("key-123", redacted);
+        Assert.DoesNotContain("raw-token", redacted);
+        Assert.DoesNotContain("hunter2", redacted);
+        Assert.DoesNotContain("21.30691", redacted);
+        Assert.DoesNotContain("-157.85830", redacted);
+        Assert.Contains("layer=sites", redacted);
+        Assert.Contains(MobileExceptionRedactor.RedactedValue, redacted);
+    }
+
+    [Fact]
+    public void RedactProperties_DropsSensitiveLocationFormAndAttachmentValuesByDefault()
+    {
+        var properties = new Dictionary<string, object?>
+        {
+            ["apiKey"] = "test-api-key",
+            ["latitude"] = 21.3069,
+            ["formPayload"] = "{\"owner\":\"Kai\"}",
+            ["attachmentBytes"] = "raw-bytes",
+            ["safeUrl"] = "https://bob:password@example.test/path?token=secret&layer=hydrants",
+        };
+
+        var redacted = MobileExceptionRedactor.RedactProperties(properties, new MobileExceptionReportingOptions());
+
+        Assert.Equal(MobileExceptionRedactor.RedactedValue, redacted["apiKey"]);
+        Assert.Equal(MobileExceptionRedactor.PreciseLocationRedactedValue, redacted["latitude"]);
+        Assert.Equal(MobileExceptionRedactor.FormPayloadRedactedValue, redacted["formPayload"]);
+        Assert.Equal(MobileExceptionRedactor.AttachmentContentRedactedValue, redacted["attachmentBytes"]);
+        Assert.DoesNotContain("bob:password", redacted["safeUrl"]);
+        Assert.DoesNotContain("secret", redacted["safeUrl"]);
+        Assert.Contains("layer=hydrants", redacted["safeUrl"]);
+    }
+
+    [Fact]
+    public void RedactProperties_AllowsPreciseLocationAndFormPayloadOnlyWhenExplicitlyEnabled()
+    {
+        var options = new MobileExceptionReportingOptions
+        {
+            IncludePreciseLocation = true,
+            IncludeFormPayloads = true,
+        };
+        var properties = new Dictionary<string, object?>
+        {
+            ["latitude"] = 21.3069,
+            ["formPayload"] = "{\"owner\":\"Kai\"}",
+            ["apiKey"] = "still-redacted",
+        };
+
+        var redacted = MobileExceptionRedactor.RedactProperties(properties, options);
+
+        Assert.Equal("21.3069", redacted["latitude"]);
+        Assert.Contains("Kai", redacted["formPayload"]);
+        Assert.Equal(MobileExceptionRedactor.RedactedValue, redacted["apiKey"]);
+    }
+}


### PR DESCRIPTION
## Summary

- Add opt-in mobile exception reporting primitives with disabled and local-only modes.
- Queue sanitized exception reports locally with redaction, deduplication, retention, and unhandled exception hooks.
- Document privacy behavior, mobile-owned scope, and the server ingestion dependency.

## Testing

- `dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --no-restore --logger "console;verbosity=minimal"`
- `dotnet format tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --verify-no-changes --no-restore --verbosity minimal`
- `git diff --check origin/main..HEAD`

Related to #91