### PR TITLE
feat(embed): add browser scene package cache helpers

### DIFF
--- a/docs/guides/3d-scene-embed.md
+++ b/docs/guides/3d-scene-embed.md
@@ -79,6 +79,7 @@ date.
 ```js
 import {
   createCacheStorageScenePackageResolver,
+  matchCacheStorageScenePackageRequest,
   HonuaScenePackageCacheError,
 } from '@honua-io/embed';
 
@@ -86,6 +87,7 @@ const scene = document.querySelector('honua-scene');
 const resolver = createCacheStorageScenePackageResolver({
   cacheName: 'honua-scene-packages',
   urlPrefix: '/honua-scene-packages/',
+  responseMode: 'cache-url',
 });
 
 scene.packageAssetResolver = resolver;
@@ -115,10 +117,29 @@ scene.addEventListener('honua-scene-load-error', (event) => {
 
 The resolver API is intentionally host-controlled so MAUI WebView bridges,
 service workers, Cache Storage, IndexedDB, and caller-provided object URLs can
-share the same `<honua-scene>` surface. When using object URLs for `tileset.json`,
-ensure nested 3D Tiles references are also rewritten or served through a stable
-package-local URL prefix. Call `resolver.dispose?.()` when a host tears down a
-Cache Storage resolver that created object URLs.
+share the same `<honua-scene>` surface. `responseMode: 'cache-url'` is the
+recommended browser mode for 3D Tiles and terrain because Cesium keeps nested
+relative references under the package-local URL prefix. A service worker or
+WebView route should serve that prefix from Cache Storage:
+
+```js
+self.addEventListener('fetch', (event) => {
+  if (!event.request.url.includes('/honua-scene-packages/')) {
+    return;
+  }
+
+  event.respondWith(
+    matchCacheStorageScenePackageRequest(event.request, {
+      cacheName: 'honua-scene-packages',
+      urlPrefix: '/honua-scene-packages/',
+    }).then((response) => response ?? Response.error()),
+  );
+});
+```
+
+Object URL mode remains available for standalone assets or hosts that rewrite
+nested references themselves. Call `resolver.dispose?.()` when a host tears down
+a Cache Storage resolver that created object URLs.
 
 ## Scene Controls
 

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -73,11 +73,19 @@ import { createCacheStorageScenePackageResolver } from '@honua-io/embed';
 const scene = document.querySelector('honua-scene');
 scene.packageAssetResolver = createCacheStorageScenePackageResolver({
   cacheName: 'honua-scene-packages',
+  responseMode: 'cache-url',
 });
 scene.setAttribute('package-id', manifest.packageId);
 scene.setAttribute('tileset-asset', primaryTileset.path);
 scene.setAttribute('package-expires-at', manifest.offlineUseExpiresAtUtc);
 ```
+
+`responseMode: 'cache-url'` returns stable package-local URLs so Cesium can
+resolve nested 3D Tiles, terrain, textures, and metadata relative to the entry
+asset. Serve the configured URL prefix from a service worker or WebView bridge
+with `matchCacheStorageScenePackageRequest(...)`. Use `responseMode:
+'object-url'` only for standalone assets or hosts that rewrite nested
+references.
 
 ## Map Attributes
 

--- a/src/Honua.Embed/src/scene-package-cache.ts
+++ b/src/Honua.Embed/src/scene-package-cache.ts
@@ -50,6 +50,8 @@ export interface CacheStorageScenePackageRequestOptions {
 }
 
 const DEFAULT_CACHE_STORAGE_URL_PREFIX = '/honua-scene-packages/';
+const UNSAFE_CACHE_STORAGE_URL_PATH_CHARACTER_PATTERN =
+  /[\u0000-\u0020"#<>?`{}^\u007f-\u{10ffff}]/gu;
 
 export class HonuaScenePackageCacheError extends Error {
   readonly code: HonuaScenePackageCacheErrorCode;
@@ -143,9 +145,10 @@ export function createCacheStorageScenePackageAssetUrl(
   );
   const path = normalizeScenePackageAssetPath(options.path);
   const prefix = createCacheStorageScenePackageUrlPrefix(options.urlPrefix, options.baseUrl);
-  const encodedPath = path.split('/').map(encodeURIComponent).join('/');
+  validateCacheStorageUrlPathSegment(packageId, 'scene package ID');
+  const packageUrl = new URL(`${encodeURIComponent(packageId)}/`, prefix).toString();
 
-  return new URL(`${encodeURIComponent(packageId)}/${encodedPath}`, prefix).toString();
+  return `${packageUrl}${encodeCacheStorageAssetPath(path)}`;
 }
 
 export function isCacheStorageScenePackageRequest(
@@ -193,7 +196,7 @@ export function normalizeScenePackageAssetPath(path: string): string {
     .split('/')
     .filter((segment) => segment.length > 0);
 
-  if (segments.some((segment) => segment === '.' || segment === '..')) {
+  if (segments.some((segment) => isCacheStorageUrlDotSegment(segment))) {
     throw new HonuaScenePackageCacheError(
       'invalid-package',
       `Scene package asset path '${path}' must stay under the package root.`,
@@ -201,6 +204,29 @@ export function normalizeScenePackageAssetPath(path: string): string {
   }
 
   return segments.join('/');
+}
+
+function encodeCacheStorageAssetPath(path: string): string {
+  return path.replace(
+    UNSAFE_CACHE_STORAGE_URL_PATH_CHARACTER_PATTERN,
+    (character) => encodeURIComponent(character),
+  );
+}
+
+function validateCacheStorageUrlPathSegment(segment: string, label: string): void {
+  if (!isCacheStorageUrlDotSegment(segment)) {
+    return;
+  }
+
+  throw new HonuaScenePackageCacheError(
+    'invalid-package',
+    `The ${label} '${segment}' must not be a URL dot segment.`,
+  );
+}
+
+function isCacheStorageUrlDotSegment(segment: string): boolean {
+  const urlNormalizedSegment = segment.replace(/%2e/gi, '.');
+  return urlNormalizedSegment === '.' || urlNormalizedSegment === '..';
 }
 
 function normalizeCacheStorageResponseMode(

--- a/src/Honua.Embed/src/scene-package-cache.ts
+++ b/src/Honua.Embed/src/scene-package-cache.ts
@@ -8,6 +8,8 @@ export type HonuaScenePackageCacheErrorCode =
   | 'expired-package'
   | 'invalid-package';
 
+export type HonuaScenePackageCacheStorageResponseMode = 'cache-url' | 'object-url';
+
 export interface HonuaScenePackageAssetResolverRequest {
   packageId: string;
   path: string;
@@ -26,11 +28,28 @@ export type HonuaScenePackageAssetResolverInput =
   | HonuaScenePackageAssetResolver
   | ((request: HonuaScenePackageAssetResolverRequest) => Promise<string | URL> | string | URL);
 
+export interface CacheStorageScenePackageAssetUrlOptions {
+  packageId: string;
+  path: string;
+  urlPrefix?: string;
+  baseUrl?: string | URL;
+}
+
 export interface CacheStorageScenePackageResolverOptions {
   cacheName: string;
   urlPrefix?: string;
+  baseUrl?: string | URL;
+  responseMode?: HonuaScenePackageCacheStorageResponseMode;
   createObjectUrls?: boolean;
 }
+
+export interface CacheStorageScenePackageRequestOptions {
+  cacheName: string;
+  urlPrefix?: string;
+  baseUrl?: string | URL;
+}
+
+const DEFAULT_CACHE_STORAGE_URL_PREFIX = '/honua-scene-packages/';
 
 export class HonuaScenePackageCacheError extends Error {
   readonly code: HonuaScenePackageCacheErrorCode;
@@ -64,45 +83,37 @@ export async function resolveScenePackageAsset(
 export function createCacheStorageScenePackageResolver(
   options: CacheStorageScenePackageResolverOptions,
 ): HonuaScenePackageAssetResolver {
-  if (!options.cacheName.trim()) {
-    throw new HonuaScenePackageCacheError(
-      'invalid-package',
-      'A Cache Storage cache name is required.',
-    );
-  }
+  const cacheName = normalizeRequiredText(
+    options.cacheName,
+    'A Cache Storage cache name is required.',
+  );
+  const responseMode = normalizeCacheStorageResponseMode(options);
 
   const objectUrls = new Set<string>();
-  const createObjectUrls = options.createObjectUrls ?? true;
 
   return {
     async resolveAsset(request) {
-      if (!('caches' in globalThis)) {
-        throw new HonuaScenePackageCacheError(
-          'unsupported-browser-storage',
-          'Cache Storage is not available in this browser or WebView.',
-        );
-      }
-
       const path = normalizeScenePackageAssetPath(request.path);
-      const cache = await globalThis.caches.open(options.cacheName);
-      const cacheUrl = buildCacheStorageAssetUrl(
-        options.urlPrefix ?? '/honua-scene-packages/',
-        request.packageId,
+      const cacheUrl = createCacheStorageScenePackageAssetUrl({
+        packageId: request.packageId,
         path,
-      );
+        urlPrefix: options.urlPrefix,
+        baseUrl: options.baseUrl,
+      });
+      const cache = await getCacheStorage().open(cacheName);
       const response = await cache.match(cacheUrl);
       if (!response) {
         throw new HonuaScenePackageCacheError(
           'cache-miss',
-          `Scene package asset '${path}' was not found in cache '${options.cacheName}'.`,
+          `Scene package asset '${path}' was not found in cache '${cacheName}'.`,
         );
       }
 
-      if (!createObjectUrls) {
+      if (responseMode === 'cache-url') {
         return cacheUrl;
       }
 
-      if (!URL.createObjectURL) {
+      if (typeof URL.createObjectURL !== 'function') {
         throw new HonuaScenePackageCacheError(
           'unsupported-browser-storage',
           'Object URLs are not available in this browser or WebView.',
@@ -121,6 +132,47 @@ export function createCacheStorageScenePackageResolver(
       objectUrls.clear();
     },
   };
+}
+
+export function createCacheStorageScenePackageAssetUrl(
+  options: CacheStorageScenePackageAssetUrlOptions,
+): string {
+  const packageId = normalizeRequiredText(
+    options.packageId,
+    'A scene package ID is required.',
+  );
+  const path = normalizeScenePackageAssetPath(options.path);
+  const prefix = createCacheStorageScenePackageUrlPrefix(options.urlPrefix, options.baseUrl);
+  const encodedPath = path.split('/').map(encodeURIComponent).join('/');
+
+  return new URL(`${encodeURIComponent(packageId)}/${encodedPath}`, prefix).toString();
+}
+
+export function isCacheStorageScenePackageRequest(
+  request: RequestInfo | URL,
+  options: Omit<CacheStorageScenePackageRequestOptions, 'cacheName'> = {},
+): boolean {
+  const requestUrl = requestInfoToUrl(request, options.baseUrl);
+  const prefix = createCacheStorageScenePackageUrlPrefix(options.urlPrefix, options.baseUrl);
+
+  return requestUrl.startsWith(prefix);
+}
+
+export async function matchCacheStorageScenePackageRequest(
+  request: RequestInfo | URL,
+  options: CacheStorageScenePackageRequestOptions,
+): Promise<Response | null> {
+  const cacheName = normalizeRequiredText(
+    options.cacheName,
+    'A Cache Storage cache name is required.',
+  );
+
+  if (!isCacheStorageScenePackageRequest(request, options)) {
+    return null;
+  }
+
+  const cache = await getCacheStorage().open(cacheName);
+  return await cache.match(requestInfoToCacheMatchInput(request, options.baseUrl)) ?? null;
 }
 
 export function normalizeScenePackageAssetPath(path: string): string {
@@ -151,12 +203,90 @@ export function normalizeScenePackageAssetPath(path: string): string {
   return segments.join('/');
 }
 
-function buildCacheStorageAssetUrl(
-  urlPrefix: string,
-  packageId: string,
-  path: string,
+function normalizeCacheStorageResponseMode(
+  options: CacheStorageScenePackageResolverOptions,
+): HonuaScenePackageCacheStorageResponseMode {
+  const mode = options.responseMode
+    ?? (options.createObjectUrls === false ? 'cache-url' : 'object-url');
+  if (mode !== 'cache-url' && mode !== 'object-url') {
+    throw new HonuaScenePackageCacheError(
+      'invalid-package',
+      `Unsupported Cache Storage response mode '${mode}'.`,
+    );
+  }
+
+  return mode;
+}
+
+function createCacheStorageScenePackageUrlPrefix(
+  urlPrefix = DEFAULT_CACHE_STORAGE_URL_PREFIX,
+  baseUrl?: string | URL,
 ): string {
-  const origin = typeof location === 'undefined' ? 'http://localhost' : location.origin;
-  const prefix = urlPrefix.trim().replace(/^\/?/, '/').replace(/\/?$/, '/');
-  return new URL(`${prefix}${encodeURIComponent(packageId)}/${path}`, origin).toString();
+  const rawPrefix = urlPrefix.trim() || DEFAULT_CACHE_STORAGE_URL_PREFIX;
+  const slashTerminated = rawPrefix.endsWith('/') ? rawPrefix : `${rawPrefix}/`;
+
+  if (/^[a-z][a-z0-9+.-]*:/i.test(slashTerminated)) {
+    return new URL(slashTerminated).toString();
+  }
+
+  const rootRelativePrefix = slashTerminated.startsWith('/')
+    ? slashTerminated
+    : `/${slashTerminated}`;
+
+  return new URL(rootRelativePrefix, defaultBaseUrl(baseUrl)).toString();
+}
+
+function requestInfoToUrl(request: RequestInfo | URL, baseUrl?: string | URL): string {
+  if (request instanceof URL) {
+    return request.toString();
+  }
+
+  if (typeof request === 'string') {
+    return new URL(request, defaultBaseUrl(baseUrl)).toString();
+  }
+
+  return request.url;
+}
+
+function requestInfoToCacheMatchInput(
+  request: RequestInfo | URL,
+  baseUrl?: string | URL,
+): RequestInfo {
+  if (request instanceof URL || typeof request === 'string') {
+    return requestInfoToUrl(request, baseUrl);
+  }
+
+  return request;
+}
+
+function defaultBaseUrl(baseUrl?: string | URL): string {
+  if (baseUrl) {
+    return baseUrl.toString();
+  }
+
+  if (typeof location !== 'undefined') {
+    return location.href;
+  }
+
+  return 'http://localhost/';
+}
+
+function getCacheStorage(): CacheStorage {
+  if (!('caches' in globalThis) || !globalThis.caches) {
+    throw new HonuaScenePackageCacheError(
+      'unsupported-browser-storage',
+      'Cache Storage is not available in this browser or WebView.',
+    );
+  }
+
+  return globalThis.caches;
+}
+
+function normalizeRequiredText(value: string, message: string): string {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new HonuaScenePackageCacheError('invalid-package', message);
+  }
+
+  return normalized;
 }

--- a/src/Honua.Embed/tests/scene-package-cache.test.ts
+++ b/src/Honua.Embed/tests/scene-package-cache.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { HonuaSceneConfig } from '../src/index';
+import {
+  createCacheStorageScenePackageAssetUrl,
+  createCacheStorageScenePackageResolver,
+  HonuaScenePackageCacheError,
+  isCacheStorageScenePackageRequest,
+  matchCacheStorageScenePackageRequest,
+  normalizeScenePackageAssetPath,
+  resolveScenePackageAsset,
+} from '../src/index';
+
+const ORIGINAL_CACHES = globalThis.caches;
+const ORIGINAL_CREATE_OBJECT_URL = URL.createObjectURL;
+const ORIGINAL_REVOKE_OBJECT_URL = URL.revokeObjectURL;
+
+describe('scene package cache adapter', () => {
+  afterEach(() => {
+    restoreGlobalCacheStorage();
+    setUrlStatic('createObjectURL', ORIGINAL_CREATE_OBJECT_URL);
+    setUrlStatic('revokeObjectURL', ORIGINAL_REVOKE_OBJECT_URL);
+    vi.restoreAllMocks();
+  });
+
+  it('normalizes package-local asset paths and rejects non-package URLs', () => {
+    expect(normalizeScenePackageAssetPath(' tilesets//buildings/tileset.json ')).toBe(
+      'tilesets/buildings/tileset.json',
+    );
+
+    expect(() => normalizeScenePackageAssetPath('https://example.test/tileset.json'))
+      .toThrow(HonuaScenePackageCacheError);
+    expect(() => normalizeScenePackageAssetPath('../tileset.json'))
+      .toThrow(HonuaScenePackageCacheError);
+    expect(() => normalizeScenePackageAssetPath('/tileset.json'))
+      .toThrow(HonuaScenePackageCacheError);
+  });
+
+  it('builds stable package cache URLs for service workers and WebView routes', () => {
+    expect(createCacheStorageScenePackageAssetUrl({
+      baseUrl: 'https://app.example.test/viewer/index.html',
+      packageId: 'pkg/downtown 42',
+      path: 'tilesets/Main Hall/tileset.json',
+    })).toBe(
+      'https://app.example.test/honua-scene-packages/pkg%2Fdowntown%2042/tilesets/Main%20Hall/tileset.json',
+    );
+
+    expect(createCacheStorageScenePackageAssetUrl({
+      baseUrl: 'https://app.example.test/viewer/index.html',
+      packageId: 'pkg-downtown',
+      path: 'terrain/layer.json',
+      urlPrefix: 'https://cache.example.test/scenes/',
+    })).toBe('https://cache.example.test/scenes/pkg-downtown/terrain/layer.json');
+  });
+
+  it('resolves cached assets as stable cache URLs when requested', async () => {
+    const assetUrl = createCacheStorageScenePackageAssetUrl({
+      baseUrl: 'https://app.example.test/viewer/index.html',
+      packageId: 'pkg-downtown',
+      path: 'tilesets/buildings/tileset.json',
+    });
+    const cache = installCacheStorage({
+      [assetUrl]: new Response('{}', { headers: { 'content-type': 'application/json' } }),
+    });
+    const resolver = createCacheStorageScenePackageResolver({
+      cacheName: 'honua-scene-packages',
+      baseUrl: 'https://app.example.test/viewer/index.html',
+      responseMode: 'cache-url',
+    });
+
+    await expect(resolveScenePackageAsset(resolver, {
+      packageId: 'pkg-downtown',
+      path: 'tilesets/buildings/tileset.json',
+      kind: 'tileset',
+      config: sceneConfig(),
+    })).resolves.toBe(assetUrl);
+
+    expect(cache.open).toHaveBeenCalledWith('honua-scene-packages');
+    expect(cache.match).toHaveBeenCalledWith(assetUrl);
+  });
+
+  it('creates and revokes object URLs for standalone cached assets', async () => {
+    const assetUrl = createCacheStorageScenePackageAssetUrl({
+      baseUrl: 'https://app.example.test/',
+      packageId: 'pkg-downtown',
+      path: 'metadata/scene.json',
+    });
+    installCacheStorage({
+      [assetUrl]: new Response('{"id":"scene"}', {
+        headers: { 'content-type': 'application/json' },
+      }),
+    });
+    const createObjectURL = vi.fn(() => 'blob:https://app.example.test/scene-metadata');
+    const revokeObjectURL = vi.fn();
+    setUrlStatic('createObjectURL', createObjectURL);
+    setUrlStatic('revokeObjectURL', revokeObjectURL);
+    const resolver = createCacheStorageScenePackageResolver({
+      cacheName: 'honua-scene-packages',
+      baseUrl: 'https://app.example.test/',
+      responseMode: 'object-url',
+    });
+
+    await expect(resolveScenePackageAsset(resolver, {
+      packageId: 'pkg-downtown',
+      path: 'metadata/scene.json',
+      kind: 'metadata',
+      config: sceneConfig(),
+    })).resolves.toBe('blob:https://app.example.test/scene-metadata');
+
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    resolver.dispose?.();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:https://app.example.test/scene-metadata');
+  });
+
+  it('surfaces cache misses and unsupported Cache Storage through typed errors', async () => {
+    installCacheStorage({});
+    const resolver = createCacheStorageScenePackageResolver({
+      cacheName: 'honua-scene-packages',
+      baseUrl: 'https://app.example.test/',
+      responseMode: 'cache-url',
+    });
+
+    await expect(resolveScenePackageAsset(resolver, {
+      packageId: 'pkg-downtown',
+      path: 'tilesets/missing/tileset.json',
+      kind: 'tileset',
+      config: sceneConfig(),
+    })).rejects.toMatchObject({ code: 'cache-miss' });
+
+    restoreGlobalCacheStorage();
+    await expect(resolveScenePackageAsset(resolver, {
+      packageId: 'pkg-downtown',
+      path: 'tilesets/buildings/tileset.json',
+      kind: 'tileset',
+      config: sceneConfig(),
+    })).rejects.toMatchObject({ code: 'unsupported-browser-storage' });
+  });
+
+  it('matches package cache requests for service worker fetch handlers', async () => {
+    const assetUrl = createCacheStorageScenePackageAssetUrl({
+      baseUrl: 'https://app.example.test/viewer/',
+      packageId: 'pkg-downtown',
+      path: 'tilesets/buildings/0/0.b3dm',
+    });
+    installCacheStorage({
+      [assetUrl]: new Response('tile-binary'),
+    });
+
+    expect(isCacheStorageScenePackageRequest(assetUrl, {
+      baseUrl: 'https://app.example.test/viewer/',
+    })).toBe(true);
+    expect(isCacheStorageScenePackageRequest('https://app.example.test/assets/0.b3dm', {
+      baseUrl: 'https://app.example.test/viewer/',
+    })).toBe(false);
+
+    const response = await matchCacheStorageScenePackageRequest(new Request(assetUrl), {
+      cacheName: 'honua-scene-packages',
+      baseUrl: 'https://app.example.test/viewer/',
+    });
+    expect(await response?.text()).toBe('tile-binary');
+
+    await expect(matchCacheStorageScenePackageRequest('https://app.example.test/assets/0.b3dm', {
+      cacheName: 'honua-scene-packages',
+      baseUrl: 'https://app.example.test/viewer/',
+    })).resolves.toBeNull();
+  });
+});
+
+function installCacheStorage(entries: Record<string, Response>): {
+  open: ReturnType<typeof vi.fn>;
+  match: ReturnType<typeof vi.fn>;
+} {
+  const match = vi.fn(async (request: RequestInfo) => {
+    const url = typeof request === 'string' ? request : request.url;
+    return entries[url] ?? undefined;
+  });
+  const open = vi.fn(async () => ({ match }) as unknown as Cache);
+
+  Object.defineProperty(globalThis, 'caches', {
+    configurable: true,
+    value: { open } as unknown as CacheStorage,
+  });
+
+  return { open, match };
+}
+
+function restoreGlobalCacheStorage(): void {
+  if (ORIGINAL_CACHES === undefined) {
+    Reflect.deleteProperty(globalThis, 'caches');
+    return;
+  }
+
+  Object.defineProperty(globalThis, 'caches', {
+    configurable: true,
+    value: ORIGINAL_CACHES,
+  });
+}
+
+function setUrlStatic(
+  key: 'createObjectURL' | 'revokeObjectURL',
+  value: typeof URL.createObjectURL | typeof URL.revokeObjectURL,
+): void {
+  Object.defineProperty(URL, key, {
+    configurable: true,
+    value,
+  });
+}
+
+function sceneConfig(): HonuaSceneConfig {
+  return {
+    tilesetUrl: null,
+    terrainUrl: null,
+    packageId: 'pkg-downtown',
+    tilesetAssetPath: null,
+    terrainAssetPath: null,
+    packageExpiresAtUtc: null,
+    ionToken: null,
+    cesiumBaseUrl: null,
+    center: null,
+    height: 1200,
+    orientation: {
+      heading: 0,
+      pitch: -45,
+      roll: 0,
+    },
+    theme: 'dark',
+    autoload: false,
+  };
+}

--- a/src/Honua.Embed/tests/scene-package-cache.test.ts
+++ b/src/Honua.Embed/tests/scene-package-cache.test.ts
@@ -33,6 +33,8 @@ describe('scene package cache adapter', () => {
       .toThrow(HonuaScenePackageCacheError);
     expect(() => normalizeScenePackageAssetPath('/tileset.json'))
       .toThrow(HonuaScenePackageCacheError);
+    expect(() => normalizeScenePackageAssetPath('%2e%2e/tileset.json'))
+      .toThrow(HonuaScenePackageCacheError);
   });
 
   it('builds stable package cache URLs for service workers and WebView routes', () => {
@@ -50,6 +52,30 @@ describe('scene package cache adapter', () => {
       path: 'terrain/layer.json',
       urlPrefix: 'https://cache.example.test/scenes/',
     })).toBe('https://cache.example.test/scenes/pkg-downtown/terrain/layer.json');
+  });
+
+  it('preserves literal package asset path characters in cache URLs', () => {
+    expect(createCacheStorageScenePackageAssetUrl({
+      baseUrl: 'https://app.example.test/viewer/index.html',
+      packageId: 'pkg-downtown',
+      path: 'tilesets/a+b.b3dm',
+    })).toBe('https://app.example.test/honua-scene-packages/pkg-downtown/tilesets/a+b.b3dm');
+
+    expect(createCacheStorageScenePackageAssetUrl({
+      baseUrl: 'https://app.example.test/viewer/index.html',
+      packageId: 'pkg-downtown',
+      path: 'tilesets/already%20encoded%2Ftile.b3dm',
+    })).toBe(
+      'https://app.example.test/honua-scene-packages/pkg-downtown/tilesets/already%20encoded%2Ftile.b3dm',
+    );
+
+    expect(createCacheStorageScenePackageAssetUrl({
+      baseUrl: 'https://app.example.test/viewer/index.html',
+      packageId: 'pkg-downtown',
+      path: 'tilesets/query?and#fragment.b3dm',
+    })).toBe(
+      'https://app.example.test/honua-scene-packages/pkg-downtown/tilesets/query%3Fand%23fragment.b3dm',
+    );
   });
 
   it('resolves cached assets as stable cache URLs when requested', async () => {


### PR DESCRIPTION
## Summary

- Add stable Cache Storage scene package URL helpers for Cesium-relative 3D Tiles, terrain, textures, and metadata assets.
- Add `responseMode: cache-url` plus service worker/WebView request matching for package-local Cache Storage routes.
- Keep object URL mode for standalone assets and cover cleanup, cache misses, and unsupported storage errors.

## Testing

- `npm run typecheck`
- `npm test -- --run tests/scene-package-cache.test.ts`
- `npm run build`
- `git diff --check origin/main..HEAD`

Related to #42