### PR TITLE
feat: add background location lifecycle orchestration

### DIFF
--- a/docs/guides/native-display-and-location.md
+++ b/docs/guides/native-display-and-location.md
@@ -100,6 +100,9 @@ leaving platform APIs behind app-provided adapters:
   OS geofencing facilities.
 - `HonuaDeviceLocationCoordinator` enforces permission order and validates
   request options before invoking the platform adapters.
+- `HonuaBackgroundLocationLifecycleController` owns the active background
+  session/geofence lifecycle, including suspend shutdown and battery-saver
+  deferral.
 
 ```csharp
 builder.Services
@@ -138,6 +141,29 @@ await using var session = await locations.StartBackgroundUpdatesAsync(
     ct);
 ```
 
+Lifecycle-managed background runtime:
+
+```csharp
+await backgroundLocation.StartAsync(
+    new HonuaBackgroundLocationLifecycleRequest
+    {
+        BackgroundUpdates = new HonuaBackgroundLocationOptions
+        {
+            Accuracy = HonuaLocationAccuracy.Balanced,
+            MinimumInterval = TimeSpan.FromMinutes(5),
+            MinimumDistanceMeters = 25,
+            AllowBatterySaverDeferral = true,
+            Purpose = "offline field workflow updates",
+        },
+        Geofences = jobSiteGeofences,
+    },
+    ct);
+
+await backgroundLocation.HandleLifecycleEventAsync(
+    HonuaLocationLifecycleEvent.BatterySaverEnabled,
+    ct);
+```
+
 Geofence registration:
 
 ```csharp
@@ -161,6 +187,12 @@ await locations.StartGeofencingAsync(
     ct);
 ```
 
+Native geofence transitions are forwarded through
+`HonuaDeviceLocationCoordinator.GeofenceTransitioned`. Enter, exit, dwell, and
+proximity signals remain mobile acquisition events; map them into SDK geofence
+evaluation/event contracts at the adapter edge once those contracts are present
+in the consumed `Honua.Sdk.*` packages.
+
 ### Lifecycle Rules
 
 - Request foreground permission before one-shot foreground capture.
@@ -169,8 +201,24 @@ await locations.StartGeofencingAsync(
   access.
 - Keep platform-specific permission copy, manifest entries, foreground service
   notifications, and background mode declarations in the app layer.
+- Route app suspend, foreground/background, battery-saver, and shutdown signals
+  into `HonuaBackgroundLocationLifecycleController` when the workflow needs a
+  managed background runtime.
+- Let `AllowBatterySaverDeferral` pause active background updates/geofences and
+  restart them when battery saver is disabled. Set it to `false` only for
+  workflows with an explicit product requirement to keep native monitoring
+  active through power-saver mode.
 - Use OS geofencing APIs for enter, exit, and dwell detection. This package does
   not implement geometry predicates or distance checks.
 - Dispose the background session when the workflow no longer needs updates.
 - Map `HonuaDeviceLocation` into SDK field, routing, or future geometry
   contracts at the adapter edge when those SDK contracts are available.
+
+### SDK Versus Native Ownership
+
+| Behavior | Owner |
+|----------|-------|
+| Geofence rule models, geometry predicates, buffers, CRS transforms, and portable event evaluation | `honua-sdk-dotnet` packages |
+| iOS/Android permission prompts, manifest/background mode declarations, foreground services, and native sensor acquisition | Mobile app/platform adapters |
+| Background session lifecycle, suspend/shutdown behavior, battery-saver deferral, and OS geofence start/stop | `Honua.Mobile.Maui.Location` |
+| Mapping native enter/exit/dwell/proximity events into SDK event contracts | Mobile adapter edge after the SDK contracts are available |

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -366,6 +366,9 @@ public static class HonuaMobileServiceCollectionExtensions
             sp.GetRequiredService<IHonuaDeviceLocationProvider>(),
             sp.GetService<IHonuaBackgroundLocationProvider>(),
             sp.GetService<IHonuaGeofenceMonitor>()));
+        services.AddSingleton(sp => new HonuaBackgroundLocationLifecycleController(
+            sp.GetRequiredService<HonuaDeviceLocationCoordinator>(),
+            sp.GetService<ILogger<HonuaBackgroundLocationLifecycleController>>()));
         return services;
     }
 }

--- a/src/Honua.Mobile.Maui/Location/DeviceLocationContracts.cs
+++ b/src/Honua.Mobile.Maui/Location/DeviceLocationContracts.cs
@@ -34,6 +34,41 @@ public enum HonuaLocationAccuracy
 }
 
 /// <summary>
+/// Mobile lifecycle or power event that can affect native background location work.
+/// </summary>
+public enum HonuaLocationLifecycleEvent
+{
+    EnteredForeground,
+    EnteredBackground,
+    Suspended,
+    BatterySaverEnabled,
+    BatterySaverDisabled,
+    Shutdown,
+}
+
+/// <summary>
+/// Runtime state for the mobile-owned background location lifecycle controller.
+/// </summary>
+public enum HonuaBackgroundLocationRuntimeState
+{
+    Stopped,
+    Running,
+    DeferredForBatterySaver,
+}
+
+/// <summary>
+/// Reason an active background location runtime was stopped.
+/// </summary>
+public enum HonuaBackgroundLocationStopReason
+{
+    UserStopped,
+    Restarting,
+    LifecycleSuspended,
+    BatterySaver,
+    Shutdown,
+}
+
+/// <summary>
 /// Device location fix acquired from a native platform provider.
 /// </summary>
 public sealed record HonuaDeviceLocation
@@ -221,6 +256,7 @@ public enum HonuaGeofenceTransitionKind
     Enter,
     Exit,
     Dwell,
+    Proximity,
 }
 
 /// <summary>
@@ -235,6 +271,39 @@ public sealed record HonuaGeofenceTransition
     public HonuaDeviceLocation? Location { get; init; }
 
     public DateTimeOffset OccurredAt { get; init; } = DateTimeOffset.UtcNow;
+
+    public void Validate()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(RegionId);
+        Location?.Validate();
+    }
+}
+
+/// <summary>
+/// Desired native background location runtime configuration.
+/// </summary>
+public sealed record HonuaBackgroundLocationLifecycleRequest
+{
+    public HonuaBackgroundLocationOptions? BackgroundUpdates { get; init; } = new();
+
+    public HonuaGeofenceMonitoringRequest? Geofences { get; init; }
+
+    public bool AllowBatterySaverDeferral { get; init; } = true;
+
+    public IReadOnlyDictionary<string, object?> Metadata { get; init; } = new Dictionary<string, object?>();
+
+    public void Validate()
+    {
+        if (BackgroundUpdates is null && Geofences is null)
+        {
+            throw new ArgumentException(
+                "Background location lifecycle requires background updates, geofences, or both.",
+                nameof(HonuaBackgroundLocationLifecycleRequest));
+        }
+
+        BackgroundUpdates?.Validate();
+        Geofences?.Validate();
+    }
 }
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Location/HonuaBackgroundLocationLifecycleController.cs
+++ b/src/Honua.Mobile.Maui/Location/HonuaBackgroundLocationLifecycleController.cs
@@ -205,22 +205,17 @@ public sealed class HonuaBackgroundLocationLifecycleController : IDisposable, IA
     {
         var session = _session;
         var activeRegionIds = _activeRegionIds;
-        _session = null;
-        _activeRegionIds = [];
 
-        try
+        if (activeRegionIds.Count > 0)
         {
-            if (activeRegionIds.Count > 0)
-            {
-                await _locations.StopGeofencingAsync(activeRegionIds, ct).ConfigureAwait(false);
-            }
+            await _locations.StopGeofencingAsync(activeRegionIds, ct).ConfigureAwait(false);
+            _activeRegionIds = [];
         }
-        finally
+
+        if (session is not null)
         {
-            if (session is not null)
-            {
-                await session.DisposeAsync().ConfigureAwait(false);
-            }
+            await session.DisposeAsync().ConfigureAwait(false);
+            _session = null;
         }
 
         if (reason != HonuaBackgroundLocationStopReason.Restarting)

--- a/src/Honua.Mobile.Maui/Location/HonuaBackgroundLocationLifecycleController.cs
+++ b/src/Honua.Mobile.Maui/Location/HonuaBackgroundLocationLifecycleController.cs
@@ -1,0 +1,262 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Mobile.Maui.Location;
+
+/// <summary>
+/// Owns mobile lifecycle behavior for native background location sessions and OS geofence monitoring.
+/// </summary>
+public sealed class HonuaBackgroundLocationLifecycleController : IDisposable, IAsyncDisposable
+{
+    private readonly HonuaDeviceLocationCoordinator _locations;
+    private readonly ILogger<HonuaBackgroundLocationLifecycleController> _logger;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private IHonuaBackgroundLocationSession? _session;
+    private HonuaBackgroundLocationLifecycleRequest? _requested;
+    private IReadOnlyList<string> _activeRegionIds = [];
+    private bool _batterySaverDeferralActive;
+    private bool _disposed;
+    private HonuaBackgroundLocationRuntimeState _state = HonuaBackgroundLocationRuntimeState.Stopped;
+
+    public HonuaBackgroundLocationLifecycleController(
+        HonuaDeviceLocationCoordinator locations,
+        ILogger<HonuaBackgroundLocationLifecycleController>? logger = null)
+    {
+        _locations = locations ?? throw new ArgumentNullException(nameof(locations));
+        _logger = logger ?? NullLogger<HonuaBackgroundLocationLifecycleController>.Instance;
+    }
+
+    /// <summary>
+    /// Current runtime state for the native background location workflow.
+    /// </summary>
+    public HonuaBackgroundLocationRuntimeState State => _state;
+
+    /// <summary>
+    /// Starts background location updates, geofence monitoring, or both.
+    /// </summary>
+    public async ValueTask StartAsync(
+        HonuaBackgroundLocationLifecycleRequest? request = null,
+        CancellationToken ct = default)
+    {
+        request ??= new HonuaBackgroundLocationLifecycleRequest();
+        request.Validate();
+
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            _requested = request;
+
+            if (_batterySaverDeferralActive && AllowsBatterySaverDeferral(request))
+            {
+                await StopActiveAsync(HonuaBackgroundLocationStopReason.BatterySaver, ct).ConfigureAwait(false);
+                _state = HonuaBackgroundLocationRuntimeState.DeferredForBatterySaver;
+                _logger.LogInformation("Deferring background location startup while battery saver is enabled.");
+                return;
+            }
+
+            await StartActiveAsync(request, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Applies a mobile lifecycle or power event to the active background location runtime.
+    /// </summary>
+    public async ValueTask HandleLifecycleEventAsync(
+        HonuaLocationLifecycleEvent lifecycleEvent,
+        CancellationToken ct = default)
+    {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            switch (lifecycleEvent)
+            {
+                case HonuaLocationLifecycleEvent.EnteredForeground:
+                case HonuaLocationLifecycleEvent.EnteredBackground:
+                    _logger.LogDebug("Background location lifecycle event {LifecycleEvent} does not change the active session.", lifecycleEvent);
+                    break;
+
+                case HonuaLocationLifecycleEvent.BatterySaverEnabled:
+                    await DeferForBatterySaverAsync(ct).ConfigureAwait(false);
+                    break;
+
+                case HonuaLocationLifecycleEvent.BatterySaverDisabled:
+                    await ResumeAfterBatterySaverAsync(ct).ConfigureAwait(false);
+                    break;
+
+                case HonuaLocationLifecycleEvent.Suspended:
+                    await StopActiveAsync(HonuaBackgroundLocationStopReason.LifecycleSuspended, ct).ConfigureAwait(false);
+                    _requested = null;
+                    _state = HonuaBackgroundLocationRuntimeState.Stopped;
+                    break;
+
+                case HonuaLocationLifecycleEvent.Shutdown:
+                    await StopActiveAsync(HonuaBackgroundLocationStopReason.Shutdown, ct).ConfigureAwait(false);
+                    _requested = null;
+                    _batterySaverDeferralActive = false;
+                    _state = HonuaBackgroundLocationRuntimeState.Stopped;
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(lifecycleEvent), lifecycleEvent, null);
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Stops any active background update session and geofence monitoring.
+    /// </summary>
+    public async ValueTask StopAsync(
+        HonuaBackgroundLocationStopReason reason = HonuaBackgroundLocationStopReason.UserStopped,
+        CancellationToken ct = default)
+    {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await StopActiveAsync(reason, ct).ConfigureAwait(false);
+            _requested = null;
+            _state = HonuaBackgroundLocationRuntimeState.Stopped;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        StopAsync(HonuaBackgroundLocationStopReason.Shutdown).AsTask().GetAwaiter().GetResult();
+        _gate.Dispose();
+        _disposed = true;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        await StopAsync(HonuaBackgroundLocationStopReason.Shutdown).ConfigureAwait(false);
+        _gate.Dispose();
+        _disposed = true;
+    }
+
+    private async ValueTask StartActiveAsync(
+        HonuaBackgroundLocationLifecycleRequest request,
+        CancellationToken ct)
+    {
+        await StopActiveAsync(HonuaBackgroundLocationStopReason.Restarting, ct).ConfigureAwait(false);
+
+        IHonuaBackgroundLocationSession? startedSession = null;
+        IReadOnlyList<string> startedRegionIds = [];
+
+        try
+        {
+            if (request.BackgroundUpdates is not null)
+            {
+                startedSession = await _locations.StartBackgroundUpdatesAsync(request.BackgroundUpdates, ct).ConfigureAwait(false);
+            }
+
+            if (request.Geofences is not null)
+            {
+                await _locations.StartGeofencingAsync(request.Geofences, ct).ConfigureAwait(false);
+                startedRegionIds = request.Geofences.Regions.Select(static region => region.Id).ToArray();
+            }
+
+            _session = startedSession;
+            _activeRegionIds = startedRegionIds;
+            _state = HonuaBackgroundLocationRuntimeState.Running;
+        }
+        catch
+        {
+            if (startedRegionIds.Count > 0)
+            {
+                await _locations.StopGeofencingAsync(startedRegionIds, ct).ConfigureAwait(false);
+            }
+
+            if (startedSession is not null)
+            {
+                await startedSession.DisposeAsync().ConfigureAwait(false);
+            }
+
+            _state = HonuaBackgroundLocationRuntimeState.Stopped;
+            throw;
+        }
+    }
+
+    private async ValueTask StopActiveAsync(
+        HonuaBackgroundLocationStopReason reason,
+        CancellationToken ct)
+    {
+        var session = _session;
+        var activeRegionIds = _activeRegionIds;
+        _session = null;
+        _activeRegionIds = [];
+
+        try
+        {
+            if (activeRegionIds.Count > 0)
+            {
+                await _locations.StopGeofencingAsync(activeRegionIds, ct).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            if (session is not null)
+            {
+                await session.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        if (reason != HonuaBackgroundLocationStopReason.Restarting)
+        {
+            _logger.LogInformation("Stopped background location runtime for reason {StopReason}.", reason);
+        }
+    }
+
+    private async ValueTask DeferForBatterySaverAsync(CancellationToken ct)
+    {
+        _batterySaverDeferralActive = true;
+
+        if (_requested is null || !AllowsBatterySaverDeferral(_requested))
+        {
+            return;
+        }
+
+        await StopActiveAsync(HonuaBackgroundLocationStopReason.BatterySaver, ct).ConfigureAwait(false);
+        _state = HonuaBackgroundLocationRuntimeState.DeferredForBatterySaver;
+    }
+
+    private async ValueTask ResumeAfterBatterySaverAsync(CancellationToken ct)
+    {
+        _batterySaverDeferralActive = false;
+
+        if (_state == HonuaBackgroundLocationRuntimeState.DeferredForBatterySaver && _requested is not null)
+        {
+            await StartActiveAsync(_requested, ct).ConfigureAwait(false);
+        }
+        else if (_state == HonuaBackgroundLocationRuntimeState.DeferredForBatterySaver)
+        {
+            _state = HonuaBackgroundLocationRuntimeState.Stopped;
+        }
+    }
+
+    private static bool AllowsBatterySaverDeferral(HonuaBackgroundLocationLifecycleRequest request)
+        => request.AllowBatterySaverDeferral
+            && request.BackgroundUpdates?.AllowBatterySaverDeferral != false;
+}

--- a/src/Honua.Mobile.Maui/Location/HonuaDeviceLocationCoordinator.cs
+++ b/src/Honua.Mobile.Maui/Location/HonuaDeviceLocationCoordinator.cs
@@ -20,7 +20,17 @@ public sealed class HonuaDeviceLocationCoordinator
         _locationProvider = locationProvider ?? throw new ArgumentNullException(nameof(locationProvider));
         _backgroundProvider = backgroundProvider;
         _geofenceMonitor = geofenceMonitor;
+
+        if (_geofenceMonitor is not null)
+        {
+            _geofenceMonitor.Transitioned += OnGeofenceTransitioned;
+        }
     }
+
+    /// <summary>
+    /// Re-emits native geofence transitions after validating the mobile event shape.
+    /// </summary>
+    public event EventHandler<HonuaGeofenceTransition>? GeofenceTransitioned;
 
     /// <summary>
     /// Acquires a single device location after ensuring the requested permission scope is granted.
@@ -87,6 +97,35 @@ public sealed class HonuaDeviceLocationCoordinator
         await _geofenceMonitor.StartMonitoringAsync(request, ct).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Stops native OS geofence monitoring for the supplied region identifiers.
+    /// </summary>
+    /// <param name="regionIds">Region identifiers to stop monitoring.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async ValueTask StopGeofencingAsync(
+        IReadOnlyList<string> regionIds,
+        CancellationToken ct = default)
+    {
+        if (_geofenceMonitor is null)
+        {
+            throw new InvalidOperationException("No geofence monitor is registered.");
+        }
+
+        ArgumentNullException.ThrowIfNull(regionIds);
+
+        if (regionIds.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var regionId in regionIds)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(regionId);
+        }
+
+        await _geofenceMonitor.StopMonitoringAsync(regionIds, ct).ConfigureAwait(false);
+    }
+
     public static bool PermissionAllows(
         HonuaLocationPermissionStatus status,
         HonuaLocationAccess access)
@@ -98,6 +137,12 @@ public sealed class HonuaDeviceLocationCoordinator
             HonuaLocationAccess.Background => status is HonuaLocationPermissionStatus.Background,
             _ => false,
         };
+    }
+
+    private void OnGeofenceTransitioned(object? sender, HonuaGeofenceTransition transition)
+    {
+        transition.Validate();
+        GeofenceTransitioned?.Invoke(this, transition);
     }
 
     private async ValueTask EnsurePermissionAsync(HonuaLocationAccess access, CancellationToken ct)

--- a/tests/Honua.Mobile.Maui.Tests/HonuaDeviceLocationTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaDeviceLocationTests.cs
@@ -246,6 +246,44 @@ public sealed class HonuaDeviceLocationTests
     }
 
     [Fact]
+    public async Task BackgroundLocationLifecycleController_StopAsync_WhenGeofenceStopFails_RetainsActiveRuntimeForRetry()
+    {
+        var backgroundProvider = new RecordingBackgroundLocationProvider();
+        var monitor = new RecordingGeofenceMonitor();
+        var coordinator = new HonuaDeviceLocationCoordinator(
+            new RecordingPermissionService
+            {
+                CheckStatus = HonuaLocationPermissionStatus.Background,
+            },
+            new RecordingLocationProvider(),
+            backgroundProvider,
+            monitor);
+        var controller = new HonuaBackgroundLocationLifecycleController(coordinator);
+
+        await controller.StartAsync(new HonuaBackgroundLocationLifecycleRequest
+        {
+            Geofences = CreateGeofenceRequest(),
+        });
+        var session = backgroundProvider.Sessions.Single();
+        monitor.StopException = new InvalidOperationException("native geofence stop failed");
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await controller.StopAsync());
+
+        Assert.Equal("native geofence stop failed", ex.Message);
+        Assert.Equal(HonuaBackgroundLocationRuntimeState.Running, controller.State);
+        Assert.False(session.IsDisposed);
+        Assert.Equal(["job-site"], monitor.StoppedRegionIds.Single());
+
+        await controller.StopAsync();
+
+        Assert.Equal(HonuaBackgroundLocationRuntimeState.Stopped, controller.State);
+        Assert.True(session.IsDisposed);
+        Assert.Equal(2, monitor.StoppedRegionIds.Count);
+        Assert.Equal(["job-site"], monitor.StoppedRegionIds.Last());
+    }
+
+    [Fact]
     public async Task BackgroundLocationLifecycleController_Suspended_StopsAndClearsRequestedRuntime()
     {
         var backgroundProvider = new RecordingBackgroundLocationProvider();
@@ -417,6 +455,8 @@ public sealed class HonuaDeviceLocationTests
 
         public List<IReadOnlyList<string>> StoppedRegionIds { get; } = [];
 
+        public Exception? StopException { get; set; }
+
         public void Emit(HonuaGeofenceTransition transition)
             => Transitioned?.Invoke(this, transition);
 
@@ -433,6 +473,14 @@ public sealed class HonuaDeviceLocationTests
             CancellationToken ct = default)
         {
             StoppedRegionIds.Add(regionIds);
+
+            if (StopException is not null)
+            {
+                var exception = StopException;
+                StopException = null;
+                throw exception;
+            }
+
             return ValueTask.CompletedTask;
         }
     }

--- a/tests/Honua.Mobile.Maui.Tests/HonuaDeviceLocationTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaDeviceLocationTests.cs
@@ -99,6 +99,52 @@ public sealed class HonuaDeviceLocationTests
         Assert.Empty(permissions.RequestedAccesses);
     }
 
+    [Fact]
+    public async Task StopGeofencingAsync_DelegatesRegionIdsToMonitor()
+    {
+        var monitor = new RecordingGeofenceMonitor();
+        var coordinator = new HonuaDeviceLocationCoordinator(
+            new RecordingPermissionService(),
+            new RecordingLocationProvider(),
+            geofenceMonitor: monitor);
+
+        await coordinator.StopGeofencingAsync(["job-site", "yard"]);
+
+        Assert.Equal(["job-site", "yard"], monitor.StoppedRegionIds.Single());
+    }
+
+    [Theory]
+    [MemberData(nameof(NativeGeofenceTransitionFixture))]
+    public void GeofenceTransitioned_ForwardsNativeEnterExitAndProximityEvents(HonuaGeofenceTransitionKind kind)
+    {
+        var monitor = new RecordingGeofenceMonitor();
+        var coordinator = new HonuaDeviceLocationCoordinator(
+            new RecordingPermissionService(),
+            new RecordingLocationProvider(),
+            geofenceMonitor: monitor);
+        var forwarded = new List<HonuaGeofenceTransition>();
+
+        coordinator.GeofenceTransitioned += (_, transition) => forwarded.Add(transition);
+
+        monitor.Emit(new HonuaGeofenceTransition
+        {
+            RegionId = "job-site",
+            Kind = kind,
+            Location = new HonuaDeviceLocation
+            {
+                Coordinate = new HonuaMapCoordinate(21.3069, -157.8583),
+                AccuracyMeters = 6,
+                IsBackground = true,
+            },
+            OccurredAt = DateTimeOffset.Parse("2026-04-28T19:46:34Z"),
+        });
+
+        var transition = Assert.Single(forwarded);
+        Assert.Equal(kind, transition.Kind);
+        Assert.Equal("job-site", transition.RegionId);
+        Assert.True(transition.Location?.IsBackground);
+    }
+
     [Theory]
     [InlineData(double.NaN)]
     [InlineData(double.PositiveInfinity)]
@@ -128,6 +174,108 @@ public sealed class HonuaDeviceLocationTests
     }
 
     [Fact]
+    public async Task BackgroundLocationLifecycleController_StartAsync_StartsUpdatesAndGeofences()
+    {
+        var permissions = new RecordingPermissionService
+        {
+            CheckStatus = HonuaLocationPermissionStatus.Background,
+        };
+        var backgroundProvider = new RecordingBackgroundLocationProvider();
+        var monitor = new RecordingGeofenceMonitor();
+        var coordinator = new HonuaDeviceLocationCoordinator(
+            permissions,
+            new RecordingLocationProvider(),
+            backgroundProvider,
+            monitor);
+        var controller = new HonuaBackgroundLocationLifecycleController(coordinator);
+        var geofenceRequest = CreateGeofenceRequest();
+
+        await controller.StartAsync(new HonuaBackgroundLocationLifecycleRequest
+        {
+            BackgroundUpdates = new HonuaBackgroundLocationOptions
+            {
+                MinimumInterval = TimeSpan.FromMinutes(15),
+                MinimumDistanceMeters = 75,
+                Purpose = "field crew route continuity",
+            },
+            Geofences = geofenceRequest,
+        });
+
+        Assert.Equal(HonuaBackgroundLocationRuntimeState.Running, controller.State);
+        Assert.Equal(TimeSpan.FromMinutes(15), backgroundProvider.Options.Single().MinimumInterval);
+        Assert.Same(geofenceRequest, monitor.Requests.Single());
+    }
+
+    [Fact]
+    public async Task BackgroundLocationLifecycleController_BatterySaverEnabled_DefersAndRestarts()
+    {
+        var backgroundProvider = new RecordingBackgroundLocationProvider();
+        var monitor = new RecordingGeofenceMonitor();
+        var coordinator = new HonuaDeviceLocationCoordinator(
+            new RecordingPermissionService
+            {
+                CheckStatus = HonuaLocationPermissionStatus.Background,
+            },
+            new RecordingLocationProvider(),
+            backgroundProvider,
+            monitor);
+        var controller = new HonuaBackgroundLocationLifecycleController(coordinator);
+
+        await controller.StartAsync(new HonuaBackgroundLocationLifecycleRequest
+        {
+            BackgroundUpdates = new HonuaBackgroundLocationOptions
+            {
+                AllowBatterySaverDeferral = true,
+            },
+            Geofences = CreateGeofenceRequest(),
+        });
+        var firstSession = backgroundProvider.Sessions.Single();
+
+        await controller.HandleLifecycleEventAsync(HonuaLocationLifecycleEvent.BatterySaverEnabled);
+
+        Assert.Equal(HonuaBackgroundLocationRuntimeState.DeferredForBatterySaver, controller.State);
+        Assert.True(firstSession.IsDisposed);
+        Assert.Equal(["job-site"], monitor.StoppedRegionIds.Single());
+
+        await controller.HandleLifecycleEventAsync(HonuaLocationLifecycleEvent.BatterySaverDisabled);
+
+        Assert.Equal(HonuaBackgroundLocationRuntimeState.Running, controller.State);
+        Assert.Equal(2, backgroundProvider.Options.Count);
+        Assert.Equal(2, monitor.Requests.Count);
+        Assert.False(backgroundProvider.Sessions.Last().IsDisposed);
+    }
+
+    [Fact]
+    public async Task BackgroundLocationLifecycleController_Suspended_StopsAndClearsRequestedRuntime()
+    {
+        var backgroundProvider = new RecordingBackgroundLocationProvider();
+        var monitor = new RecordingGeofenceMonitor();
+        var coordinator = new HonuaDeviceLocationCoordinator(
+            new RecordingPermissionService
+            {
+                CheckStatus = HonuaLocationPermissionStatus.Background,
+            },
+            new RecordingLocationProvider(),
+            backgroundProvider,
+            monitor);
+        var controller = new HonuaBackgroundLocationLifecycleController(coordinator);
+
+        await controller.StartAsync(new HonuaBackgroundLocationLifecycleRequest
+        {
+            Geofences = CreateGeofenceRequest(),
+        });
+
+        await controller.HandleLifecycleEventAsync(HonuaLocationLifecycleEvent.Suspended);
+        await controller.HandleLifecycleEventAsync(HonuaLocationLifecycleEvent.EnteredForeground);
+
+        Assert.Equal(HonuaBackgroundLocationRuntimeState.Stopped, controller.State);
+        Assert.True(backgroundProvider.Sessions.Single().IsDisposed);
+        Assert.Equal(["job-site"], monitor.StoppedRegionIds.Single());
+        Assert.Single(backgroundProvider.Options);
+        Assert.Single(monitor.Requests);
+    }
+
+    [Fact]
     public void AddHonuaDeviceLocation_RegistersCoordinatorWithOptionalProviders()
     {
         using var provider = new ServiceCollection()
@@ -139,6 +287,7 @@ public sealed class HonuaDeviceLocationTests
             .BuildServiceProvider();
 
         Assert.NotNull(provider.GetRequiredService<HonuaDeviceLocationCoordinator>());
+        Assert.NotNull(provider.GetRequiredService<HonuaBackgroundLocationLifecycleController>());
     }
 
     [Fact]
@@ -155,6 +304,30 @@ public sealed class HonuaDeviceLocationTests
         await Assert.ThrowsAsync<UnauthorizedAccessException>(async () =>
             await coordinator.AcquireCurrentLocationAsync());
     }
+
+    public static TheoryData<HonuaGeofenceTransitionKind> NativeGeofenceTransitionFixture()
+        => new()
+        {
+            HonuaGeofenceTransitionKind.Enter,
+            HonuaGeofenceTransitionKind.Exit,
+            HonuaGeofenceTransitionKind.Proximity,
+        };
+
+    private static HonuaGeofenceMonitoringRequest CreateGeofenceRequest()
+        => new()
+        {
+            Regions =
+            [
+                new HonuaGeofenceRegion
+                {
+                    Id = "job-site",
+                    Center = new HonuaMapCoordinate(21.3069, -157.8583),
+                    RadiusMeters = 100,
+                    NotifyOnEntry = true,
+                    NotifyOnExit = true,
+                },
+            ],
+        };
 
     private sealed class RecordingPermissionService : IHonuaDeviceLocationPermissionService
     {
@@ -205,12 +378,16 @@ public sealed class HonuaDeviceLocationTests
     {
         public List<HonuaBackgroundLocationOptions> Options { get; } = [];
 
+        public List<RecordingSession> Sessions { get; } = [];
+
         public ValueTask<IHonuaBackgroundLocationSession> StartUpdatesAsync(
             HonuaBackgroundLocationOptions options,
             CancellationToken ct = default)
         {
             Options.Add(options);
-            return ValueTask.FromResult<IHonuaBackgroundLocationSession>(new RecordingSession("session-1"));
+            var session = new RecordingSession($"session-{Sessions.Count + 1}");
+            Sessions.Add(session);
+            return ValueTask.FromResult<IHonuaBackgroundLocationSession>(session);
         }
     }
 
@@ -223,18 +400,25 @@ public sealed class HonuaDeviceLocationTests
 
         public string SessionId { get; }
 
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public bool IsDisposed { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            IsDisposed = true;
+            return ValueTask.CompletedTask;
+        }
     }
 
     private sealed class RecordingGeofenceMonitor : IHonuaGeofenceMonitor
     {
-        public event EventHandler<HonuaGeofenceTransition>? Transitioned
-        {
-            add { }
-            remove { }
-        }
+        public event EventHandler<HonuaGeofenceTransition>? Transitioned;
 
         public List<HonuaGeofenceMonitoringRequest> Requests { get; } = [];
+
+        public List<IReadOnlyList<string>> StoppedRegionIds { get; } = [];
+
+        public void Emit(HonuaGeofenceTransition transition)
+            => Transitioned?.Invoke(this, transition);
 
         public ValueTask StartMonitoringAsync(
             HonuaGeofenceMonitoringRequest request,
@@ -247,6 +431,9 @@ public sealed class HonuaDeviceLocationTests
         public ValueTask StopMonitoringAsync(
             IReadOnlyList<string> regionIds,
             CancellationToken ct = default)
-            => ValueTask.CompletedTask;
+        {
+            StoppedRegionIds.Add(regionIds);
+            return ValueTask.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add mobile-owned lifecycle orchestration for background location and geofencing start/stop, suspend, shutdown, and battery-saver deferral.
- Add native geofence stop support and validated transition forwarding for enter, exit, and proximity flows.
- Document SDK-vs-mobile ownership for background location and geofencing behavior.

## Testing

- `dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --no-restore --verbosity minimal`
- `dotnet format Honua.Mobile.sln --verify-no-changes --no-restore --include src/Honua.Mobile.Maui/Location/DeviceLocationContracts.cs src/Honua.Mobile.Maui/Location/HonuaBackgroundLocationLifecycleController.cs src/Honua.Mobile.Maui/Location/HonuaDeviceLocationCoordinator.cs src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs tests/Honua.Mobile.Maui.Tests/HonuaDeviceLocationTests.cs --verbosity minimal`
- `git diff --check origin/main..HEAD`

Related to #51