### PR TITLE
ci: check actool from selected Xcode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,12 +371,14 @@ jobs:
       - name: Check iOS asset compiler availability
         id: ios_tools
         run: |
-          macos_sdk="$(xcrun --sdk macosx --show-sdk-path)"
-          if /usr/bin/xcrun xcodebuild -sdk "${macos_sdk}" -find actool > /tmp/actool-path 2> /tmp/actool-error; then
+          xcode_developer_dir="$(xcode-select -p)"
+          xcodebuild_bin="${xcode_developer_dir}/usr/bin/xcodebuild"
+          macos_sdk="${xcode_developer_dir}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+          if "${xcodebuild_bin}" -sdk "${macos_sdk}" -find actool > /tmp/actool-path 2> /tmp/actool-error; then
             cat /tmp/actool-path
             echo "actool_available=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "::warning::actool is unavailable through the .NET/Xcode asset-tool lookup on this GitHub-hosted image; skipping iOS app asset and publish smoke."
+            echo "::warning::actool is unavailable through the selected Xcode asset-tool lookup on this GitHub-hosted image; skipping iOS app asset and publish smoke."
             cat /tmp/actool-error
             echo "actool_available=false" >> "${GITHUB_OUTPUT}"
           fi

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -116,9 +116,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          macos_sdk="$(xcrun --sdk macosx --show-sdk-path)"
-          if ! /usr/bin/xcrun xcodebuild -sdk "${macos_sdk}" -find actool; then
-            echo "::error::The selected GitHub-hosted Xcode image does not expose actool through the .NET/Xcode asset-tool lookup."
+          xcode_developer_dir="$(xcode-select -p)"
+          xcodebuild_bin="${xcode_developer_dir}/usr/bin/xcodebuild"
+          macos_sdk="${xcode_developer_dir}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+          if ! "${xcodebuild_bin}" -sdk "${macos_sdk}" -find actool; then
+            echo "::error::The selected GitHub-hosted Xcode image does not expose actool through the selected Xcode asset-tool lookup."
             echo "::error::TestFlight uploads require a runner image with a complete Apple asset compiler toolchain."
             exit 1
           fi

--- a/docs/guides/mobile-testflight-builds.md
+++ b/docs/guides/mobile-testflight-builds.md
@@ -103,7 +103,7 @@ are enabled.
 
 The workflow checks for `actool` before importing signing secrets. If the
 selected GitHub-hosted image cannot expose Apple's asset compiler through the
-.NET/Xcode asset-tool lookup, the run fails before any App Store Connect or
+selected Xcode asset-tool lookup, the run fails before any App Store Connect or
 certificate material is decoded.
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

- Make the iOS smoke guard check `actool` through the Xcode selected by `xcode-select`, matching the MAUI build path.
- Apply the same selected-Xcode preflight to the manual TestFlight workflow.
- Update TestFlight docs to describe the selected Xcode asset-tool lookup.

## Root Cause

The previous guard used `xcrun xcodebuild`, which resolved `/Applications/Xcode_26.0.1.app/.../actool` on hosted macOS. The .NET iOS target then invoked the selected `/Applications/Xcode_26.0.app/.../xcodebuild -sdk ... -find actool` path and failed.

## Testing

- `yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable, document-start: disable}}" .github/workflows/ci.yml`
- `yamllint .github/workflows/ios-testflight.yml`
- `npx --yes markdownlint-cli docs/guides/mobile-testflight-builds.md`
- `npx --yes js-yaml .github/workflows/ios-testflight.yml >/dev/null`
- `npx --yes prettier --check .github/workflows/ios-testflight.yml docs/guides/mobile-testflight-builds.md`
- `git diff --check`