### PR TITLE
ci: require actool inside selected Xcode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,8 +375,14 @@ jobs:
           xcodebuild_bin="${xcode_developer_dir}/usr/bin/xcodebuild"
           macos_sdk="${xcode_developer_dir}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
           if "${xcodebuild_bin}" -sdk "${macos_sdk}" -find actool > /tmp/actool-path 2> /tmp/actool-error; then
-            cat /tmp/actool-path
-            echo "actool_available=true" >> "${GITHUB_OUTPUT}"
+            actool_path="$(head -n 1 /tmp/actool-path)"
+            echo "${actool_path}"
+            if [[ -n "${actool_path}" && "${actool_path}" == "${xcode_developer_dir}/"* ]]; then
+              echo "actool_available=true" >> "${GITHUB_OUTPUT}"
+            else
+              echo "::warning::actool resolved outside the selected Xcode developer directory (${actool_path:-<empty>}); skipping iOS app asset and publish smoke."
+              echo "actool_available=false" >> "${GITHUB_OUTPUT}"
+            fi
           else
             echo "::warning::actool is unavailable through the selected Xcode asset-tool lookup on this GitHub-hosted image; skipping iOS app asset and publish smoke."
             cat /tmp/actool-error

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -119,9 +119,18 @@ jobs:
           xcode_developer_dir="$(xcode-select -p)"
           xcodebuild_bin="${xcode_developer_dir}/usr/bin/xcodebuild"
           macos_sdk="${xcode_developer_dir}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
-          if ! "${xcodebuild_bin}" -sdk "${macos_sdk}" -find actool; then
+          if ! "${xcodebuild_bin}" -sdk "${macos_sdk}" -find actool > /tmp/actool-path 2> /tmp/actool-error; then
             echo "::error::The selected GitHub-hosted Xcode image does not expose actool through the selected Xcode asset-tool lookup."
+            cat /tmp/actool-error
             echo "::error::TestFlight uploads require a runner image with a complete Apple asset compiler toolchain."
+            exit 1
+          fi
+
+          actool_path="$(head -n 1 /tmp/actool-path)"
+          echo "${actool_path}"
+          if [[ -z "${actool_path}" || "${actool_path}" != "${xcode_developer_dir}/"* ]]; then
+            echo "::error::actool resolved outside the selected Xcode developer directory (${actool_path:-<empty>})."
+            echo "::error::TestFlight uploads require the selected Xcode image to contain the Apple asset compiler used by the .NET iOS workload."
             exit 1
           fi
 

--- a/docs/guides/mobile-testflight-builds.md
+++ b/docs/guides/mobile-testflight-builds.md
@@ -102,9 +102,9 @@ hosted image includes the complete Xcode toolchain before TestFlight uploads
 are enabled.
 
 The workflow checks for `actool` before importing signing secrets. If the
-selected GitHub-hosted image cannot expose Apple's asset compiler through the
-selected Xcode asset-tool lookup, the run fails before any App Store Connect or
-certificate material is decoded.
+selected GitHub-hosted image cannot expose Apple's asset compiler inside the
+selected Xcode developer directory, the run fails before any App Store Connect
+or certificate material is decoded.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- tighten the iOS smoke guard to require actool to resolve inside the selected Xcode developer directory
- fail the manual TestFlight workflow before signing secrets are decoded if actool resolves outside selected Xcode
- update the TestFlight guide with the stricter hosted-runner requirement

## Testing
- git diff --check
- actionlint not available locally

## Related
- Follow-up to #114; unblocks the current iOS smoke failures on open PRs.