### PR TITLE
feat: add mobile build metadata configuration

### DIFF
--- a/apps/Honua.Mobile.App/Honua.Mobile.App.csproj
+++ b/apps/Honua.Mobile.App/Honua.Mobile.App.csproj
@@ -76,4 +76,6 @@
 	  <ProjectReference Include="..\..\src\Honua.Mobile.Sdk\Honua.Mobile.Sdk.csproj" />
 	</ItemGroup>
 
+	<Import Project="..\..\build\Honua.Mobile.BuildMetadata.props" />
+
 </Project>

--- a/apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj
+++ b/apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj
@@ -93,4 +93,6 @@
         <PackageReference Include="Honua.Mobile.Maui" Version="1.0.0-preview.1" />
     </ItemGroup>
 
+    <Import Project="../../build/Honua.Mobile.BuildMetadata.props" />
+
 </Project>

--- a/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
+++ b/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
@@ -1,12 +1,13 @@
 using CommunityToolkit.Maui;
-using System.Net.Http;
 using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.FieldCollection.Services.Configuration;
 using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using Honua.Mobile.FieldCollection.Services.Features;
 using Honua.Mobile.FieldCollection.Services.Storage;
 using Honua.Mobile.FieldCollection.Services.Sync;
 using Honua.Mobile.FieldCollection.ViewModels;
 using Honua.Mobile.FieldCollection.Views;
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.Extensions.Logging;
 
 namespace Honua.Mobile.FieldCollection;
@@ -90,6 +91,10 @@ public static class MauiProgram
         services.AddSingleton<IAttachmentService, AttachmentService>();
 
         // Configuration services
+        services.AddSingleton(_ => MobileBuildConfiguration.FromAssembly(
+            typeof(App).Assembly,
+            GetAppInfoValue(() => AppInfo.Current.VersionString, "unknown"),
+            GetAppInfoValue(() => AppInfo.Current.BuildString, "unknown")));
         services.AddSingleton<ISettingsService, SettingsService>();
         services.AddSingleton<IConnectivityService, ConnectivityService>();
 
@@ -111,6 +116,18 @@ public static class MauiProgram
         });
 
         // Platform-specific services will be registered by platform startup
+    }
+
+    private static string GetAppInfoValue(Func<string> valueFactory, string fallback)
+    {
+        try
+        {
+            return valueFactory();
+        }
+        catch
+        {
+            return fallback;
+        }
     }
 
     private static void RegisterViewModels(IServiceCollection services)

--- a/apps/Honua.Mobile.FieldCollection/Services/Configuration/MobileBuildConfiguration.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Configuration/MobileBuildConfiguration.cs
@@ -251,14 +251,14 @@ public sealed class MobileServiceEndpointConfiguration
     {
         get
         {
-            if (!IsConfigured)
+            if (!IsValid)
             {
-                return $"{EnvironmentDisplayName}: no endpoint embedded";
+                return $"{EnvironmentDisplayName}: invalid endpoint metadata";
             }
 
-            return IsValid
+            return IsConfigured
                 ? $"{EnvironmentDisplayName}: {ApiBaseUrl}"
-                : $"{EnvironmentDisplayName}: invalid endpoint metadata";
+                : $"{EnvironmentDisplayName}: no endpoint embedded";
         }
     }
 

--- a/apps/Honua.Mobile.FieldCollection/Services/Configuration/MobileBuildConfiguration.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Configuration/MobileBuildConfiguration.cs
@@ -1,0 +1,371 @@
+using System.Reflection;
+
+namespace Honua.Mobile.FieldCollection.Services.Configuration;
+
+public sealed class MobileBuildConfiguration
+{
+    public static readonly MobileBuildConfiguration Empty = FromAttributes(
+        new Dictionary<string, string?>(),
+        "unknown",
+        "unknown");
+
+    public MobileBuildConfiguration(
+        MobileBuildMetadata metadata,
+        MobileServiceEndpointConfiguration serviceEndpoint)
+    {
+        Metadata = metadata;
+        ServiceEndpoint = serviceEndpoint;
+    }
+
+    public MobileBuildMetadata Metadata { get; }
+
+    public MobileServiceEndpointConfiguration ServiceEndpoint { get; }
+
+    public static MobileBuildConfiguration FromAssembly(
+        Assembly assembly,
+        string applicationDisplayVersion,
+        string applicationVersion)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        var attributes = assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .GroupBy(attribute => attribute.Key, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Last().Value,
+                StringComparer.OrdinalIgnoreCase);
+
+        return FromAttributes(attributes, applicationDisplayVersion, applicationVersion);
+    }
+
+    public static MobileBuildConfiguration FromAttributes(
+        IReadOnlyDictionary<string, string?> attributes,
+        string applicationDisplayVersion,
+        string applicationVersion)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+
+        var displayVersion = FirstNonBlank(
+            Get(attributes, "HonuaMobile.ApplicationDisplayVersion"),
+            applicationDisplayVersion,
+            "unknown");
+        var buildNumber = FirstNonBlank(
+            Get(attributes, "HonuaMobile.BuildNumber"),
+            applicationVersion,
+            "unknown");
+        var buildEnvironment = FirstNonBlank(
+            Get(attributes, "HonuaMobile.BuildEnvironment"),
+            "unspecified");
+        var configuration = FirstNonBlank(
+            Get(attributes, "HonuaMobile.Configuration"),
+            "unknown");
+
+        var metadata = new MobileBuildMetadata(
+            applicationDisplayVersion: displayVersion,
+            applicationVersion: buildNumber,
+            buildEnvironment: buildEnvironment,
+            repository: FirstNonBlank(Get(attributes, "HonuaMobile.Repository")),
+            branch: FirstNonBlank(Get(attributes, "HonuaMobile.Branch")),
+            commitSha: FirstNonBlank(Get(attributes, "HonuaMobile.CommitSha")),
+            workflowRunNumber: FirstNonBlank(Get(attributes, "HonuaMobile.WorkflowRunNumber")),
+            workflowRunId: FirstNonBlank(Get(attributes, "HonuaMobile.WorkflowRunId")),
+            workflowRunAttempt: FirstNonBlank(Get(attributes, "HonuaMobile.WorkflowRunAttempt")),
+            configuration: configuration,
+            targetFramework: FirstNonBlank(Get(attributes, "HonuaMobile.TargetFramework")));
+
+        var serviceEndpoint = MobileServiceEndpointConfiguration.Create(
+            buildEnvironment,
+            Get(attributes, "HonuaMobile.ApiBaseUrl"),
+            configuration);
+
+        return new MobileBuildConfiguration(metadata, serviceEndpoint);
+    }
+
+    private static string? Get(IReadOnlyDictionary<string, string?> attributes, string key)
+        => attributes.TryGetValue(key, out var value) ? value : null;
+
+    private static string FirstNonBlank(params string?[] values)
+        => values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))?.Trim() ?? string.Empty;
+}
+
+public sealed class MobileBuildMetadata
+{
+    public MobileBuildMetadata(
+        string applicationDisplayVersion,
+        string applicationVersion,
+        string buildEnvironment,
+        string repository,
+        string branch,
+        string commitSha,
+        string workflowRunNumber,
+        string workflowRunId,
+        string workflowRunAttempt,
+        string configuration,
+        string targetFramework)
+    {
+        ApplicationDisplayVersion = applicationDisplayVersion;
+        ApplicationVersion = applicationVersion;
+        BuildEnvironment = buildEnvironment;
+        Repository = repository;
+        Branch = branch;
+        CommitSha = commitSha;
+        WorkflowRunNumber = workflowRunNumber;
+        WorkflowRunId = workflowRunId;
+        WorkflowRunAttempt = workflowRunAttempt;
+        Configuration = configuration;
+        TargetFramework = targetFramework;
+    }
+
+    public string ApplicationDisplayVersion { get; }
+
+    public string ApplicationVersion { get; }
+
+    public string BuildEnvironment { get; }
+
+    public string Repository { get; }
+
+    public string Branch { get; }
+
+    public string CommitSha { get; }
+
+    public string WorkflowRunNumber { get; }
+
+    public string WorkflowRunId { get; }
+
+    public string WorkflowRunAttempt { get; }
+
+    public string Configuration { get; }
+
+    public string TargetFramework { get; }
+
+    public string ShortCommitSha
+        => string.IsNullOrWhiteSpace(CommitSha)
+            ? "unknown"
+            : CommitSha[..Math.Min(12, CommitSha.Length)];
+
+    public bool IsGitHubActionsBuild
+        => !string.IsNullOrWhiteSpace(WorkflowRunId) || !string.IsNullOrWhiteSpace(WorkflowRunNumber);
+
+    public bool IsTraceable
+        => !string.IsNullOrWhiteSpace(Repository)
+            && !string.IsNullOrWhiteSpace(Branch)
+            && !string.IsNullOrWhiteSpace(CommitSha)
+            && !string.IsNullOrWhiteSpace(WorkflowRunId)
+            && !string.IsNullOrWhiteSpace(BuildEnvironment);
+
+    public string VersionDisplay => $"{ApplicationDisplayVersion} ({ApplicationVersion})";
+
+    public string SourceDisplay
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(Repository) && string.IsNullOrWhiteSpace(CommitSha))
+            {
+                return "Source not stamped";
+            }
+
+            var repository = string.IsNullOrWhiteSpace(Repository) ? "unknown repository" : Repository;
+            var branch = string.IsNullOrWhiteSpace(Branch) ? "unknown branch" : Branch;
+            return $"{repository}@{ShortCommitSha} on {branch}";
+        }
+    }
+
+    public string WorkflowRunDisplay
+    {
+        get
+        {
+            if (!IsGitHubActionsBuild)
+            {
+                return "Local build";
+            }
+
+            var run = string.IsNullOrWhiteSpace(WorkflowRunNumber) ? WorkflowRunId : WorkflowRunNumber;
+            return string.IsNullOrWhiteSpace(WorkflowRunAttempt)
+                ? $"GitHub Actions run {run}"
+                : $"GitHub Actions run {run}, attempt {WorkflowRunAttempt}";
+        }
+    }
+
+    public Uri? WorkflowRunUri
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(Repository) || string.IsNullOrWhiteSpace(WorkflowRunId))
+            {
+                return null;
+            }
+
+            return Uri.TryCreate(
+                $"https://github.com/{Repository}/actions/runs/{WorkflowRunId}",
+                UriKind.Absolute,
+                out var uri)
+                ? uri
+                : null;
+        }
+    }
+}
+
+public sealed class MobileServiceEndpointConfiguration
+{
+    private MobileServiceEndpointConfiguration(
+        string environment,
+        MobileBuildEnvironmentKind environmentKind,
+        Uri? apiBaseUrl,
+        bool isValid,
+        string validationMessage)
+    {
+        Environment = environment;
+        EnvironmentKind = environmentKind;
+        ApiBaseUrl = apiBaseUrl;
+        IsValid = isValid;
+        ValidationMessage = validationMessage;
+    }
+
+    public string Environment { get; }
+
+    public MobileBuildEnvironmentKind EnvironmentKind { get; }
+
+    public string EnvironmentDisplayName => EnvironmentKind switch
+    {
+        MobileBuildEnvironmentKind.Development => "Development",
+        MobileBuildEnvironmentKind.Staging => "Staging",
+        MobileBuildEnvironmentKind.Production => "Production",
+        MobileBuildEnvironmentKind.CustomNonProduction => string.IsNullOrWhiteSpace(Environment)
+            ? "Custom non-production"
+            : Environment,
+        _ => "Unspecified"
+    };
+
+    public Uri? ApiBaseUrl { get; }
+
+    public bool IsConfigured => ApiBaseUrl != null;
+
+    public bool IsProduction => EnvironmentKind == MobileBuildEnvironmentKind.Production;
+
+    public bool IsValid { get; }
+
+    public string ValidationMessage { get; }
+
+    public string DisplayValue
+    {
+        get
+        {
+            if (!IsConfigured)
+            {
+                return $"{EnvironmentDisplayName}: no endpoint embedded";
+            }
+
+            return IsValid
+                ? $"{EnvironmentDisplayName}: {ApiBaseUrl}"
+                : $"{EnvironmentDisplayName}: invalid endpoint metadata";
+        }
+    }
+
+    public static MobileServiceEndpointConfiguration Create(
+        string? environment,
+        string? apiBaseUrl,
+        string? buildConfiguration)
+    {
+        var normalizedEnvironment = string.IsNullOrWhiteSpace(environment)
+            ? "unspecified"
+            : environment.Trim();
+        var kind = MobileBuildEnvironmentKindExtensions.FromBuildEnvironment(normalizedEnvironment);
+        var isDebugBuild = string.Equals(buildConfiguration, "Debug", StringComparison.OrdinalIgnoreCase);
+
+        if (isDebugBuild && kind == MobileBuildEnvironmentKind.Production)
+        {
+            return new MobileServiceEndpointConfiguration(
+                normalizedEnvironment,
+                kind,
+                null,
+                false,
+                "Debug mobile builds cannot target production.");
+        }
+
+        if (string.IsNullOrWhiteSpace(apiBaseUrl))
+        {
+            var message = kind == MobileBuildEnvironmentKind.Unspecified
+                ? "No build environment or service endpoint is embedded."
+                : "No service endpoint is embedded for this build.";
+
+            return new MobileServiceEndpointConfiguration(normalizedEnvironment, kind, null, true, message);
+        }
+
+        if (!Uri.TryCreate(apiBaseUrl.Trim(), UriKind.Absolute, out var endpoint))
+        {
+            return new MobileServiceEndpointConfiguration(
+                normalizedEnvironment,
+                kind,
+                null,
+                false,
+                "HonuaMobileApiBaseUrl must be an absolute URI.");
+        }
+
+        var loopbackDevelopment = kind == MobileBuildEnvironmentKind.Development
+            && endpoint.Scheme == Uri.UriSchemeHttp
+            && endpoint.IsLoopback;
+        if (endpoint.Scheme != Uri.UriSchemeHttps && !loopbackDevelopment)
+        {
+            return new MobileServiceEndpointConfiguration(
+                normalizedEnvironment,
+                kind,
+                endpoint,
+                false,
+                "Mobile service endpoints must use HTTPS unless they are development loopback URLs.");
+        }
+
+        if (kind != MobileBuildEnvironmentKind.Production && LooksLikeProductionHost(endpoint.Host))
+        {
+            return new MobileServiceEndpointConfiguration(
+                normalizedEnvironment,
+                kind,
+                endpoint,
+                false,
+                "Non-production mobile builds cannot embed a production Honua endpoint.");
+        }
+
+        return new MobileServiceEndpointConfiguration(normalizedEnvironment, kind, endpoint, true, "Endpoint metadata is valid.");
+    }
+
+    private static bool LooksLikeProductionHost(string host)
+    {
+        var normalizedHost = host.TrimEnd('.').ToLowerInvariant();
+        return normalizedHost is "api.honua.io" or "honua.io" or "www.honua.io"
+            || normalizedHost.StartsWith("prod.", StringComparison.Ordinal)
+            || normalizedHost.StartsWith("production.", StringComparison.Ordinal);
+    }
+}
+
+public enum MobileBuildEnvironmentKind
+{
+    Unspecified,
+    Development,
+    Staging,
+    Production,
+    CustomNonProduction
+}
+
+public static class MobileBuildEnvironmentKindExtensions
+{
+    public static MobileBuildEnvironmentKind FromBuildEnvironment(string? environment)
+    {
+        if (string.IsNullOrWhiteSpace(environment))
+        {
+            return MobileBuildEnvironmentKind.Unspecified;
+        }
+
+        var normalized = environment.Trim().ToLowerInvariant().Replace('_', '-');
+        return normalized switch
+        {
+            "dev" or "development" or "local" or "dev-local" => MobileBuildEnvironmentKind.Development,
+            "stage" or "staging" => MobileBuildEnvironmentKind.Staging,
+            "prod" or "production" or "ios-production" => MobileBuildEnvironmentKind.Production,
+            "custom-nonprod" or "custom-non-production" or "nonprod" or "non-production" or "ios-testflight" => MobileBuildEnvironmentKind.CustomNonProduction,
+            "unspecified" => MobileBuildEnvironmentKind.Unspecified,
+            _ when normalized.Contains("production", StringComparison.Ordinal)
+                || normalized.StartsWith("prod-", StringComparison.Ordinal) => MobileBuildEnvironmentKind.Production,
+            _ => MobileBuildEnvironmentKind.CustomNonProduction
+        };
+    }
+}

--- a/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/DiagnosticService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/DiagnosticService.cs
@@ -1,4 +1,5 @@
 using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Mobile.FieldCollection.Services.Configuration;
 using System.Text.Json;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Devices;
@@ -17,6 +18,7 @@ public class DiagnosticService
     private readonly ISyncService _syncService;
     private readonly IConnectivityService _connectivityService;
     private readonly IAuthenticationService _authService;
+    private readonly MobileBuildConfiguration _buildConfiguration;
     private readonly ILogger<DiagnosticService>? _logger;
 
     public DiagnosticService(
@@ -24,12 +26,14 @@ public class DiagnosticService
         ISyncService syncService,
         IConnectivityService connectivityService,
         IAuthenticationService authService,
+        MobileBuildConfiguration? buildConfiguration = null,
         ILogger<DiagnosticService>? logger = null)
     {
         _databaseService = databaseService;
         _syncService = syncService;
         _connectivityService = connectivityService;
         _authService = authService;
+        _buildConfiguration = buildConfiguration ?? MobileBuildConfiguration.Empty;
         _logger = logger;
     }
 
@@ -47,6 +51,8 @@ public class DiagnosticService
             Manufacturer = DeviceInfo.Manufacturer,
             DeviceName = DeviceInfo.Name,
             DeviceType = DeviceInfo.DeviceType.ToString(),
+            Build = _buildConfiguration.Metadata,
+            ServiceEndpoint = _buildConfiguration.ServiceEndpoint,
             Timestamp = DateTime.UtcNow
         };
 
@@ -216,6 +222,7 @@ public class DiagnosticService
         {
             GeneratedAt = DateTime.UtcNow,
             AppVersion = GetAppVersion(),
+            Build = _buildConfiguration,
             System = await GetSystemDiagnosticsAsync(),
             Connectivity = await GetConnectivityDiagnosticsAsync(),
             Sync = await GetSyncDiagnosticsAsync(),
@@ -346,6 +353,8 @@ public class SystemDiagnostics
     public double MemoryUsageMB { get; set; }
     public double AvailableMemoryMB { get; set; }
     public DatabaseInfo? DatabaseInfo { get; set; }
+    public MobileBuildMetadata Build { get; set; } = MobileBuildConfiguration.Empty.Metadata;
+    public MobileServiceEndpointConfiguration ServiceEndpoint { get; set; } = MobileBuildConfiguration.Empty.ServiceEndpoint;
     public DateTime Timestamp { get; set; }
 }
 
@@ -400,6 +409,7 @@ public class DiagnosticReport
 {
     public DateTime GeneratedAt { get; set; }
     public string AppVersion { get; set; } = string.Empty;
+    public MobileBuildConfiguration Build { get; set; } = MobileBuildConfiguration.Empty;
     public SystemDiagnostics System { get; set; } = new();
     public ConnectivityDiagnostics Connectivity { get; set; } = new();
     public SyncDiagnostics Sync { get; set; } = new();

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/SettingsViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/SettingsViewModel.cs
@@ -1,7 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Honua.Mobile.FieldCollection.Services;
-using Microsoft.Maui.ApplicationModel;
+using Honua.Mobile.FieldCollection.Services.Configuration;
 using Microsoft.Maui.Storage;
 using FieldDeviceInfo = Honua.Mobile.FieldCollection.Models.DeviceInfo;
 
@@ -29,6 +29,9 @@ public partial class SettingsViewModel : BaseViewModel
     private string appVersion = string.Empty;
 
     [ObservableProperty]
+    private MobileBuildConfiguration buildConfiguration = MobileBuildConfiguration.Empty;
+
+    [ObservableProperty]
     private FieldDeviceInfo deviceInfo = new();
 
     [ObservableProperty]
@@ -53,12 +56,14 @@ public partial class SettingsViewModel : BaseViewModel
         INavigationService navigationService,
         IAuthenticationService authService,
         ISettingsService settingsService,
-        IConnectivityService connectivityService)
+        IConnectivityService connectivityService,
+        MobileBuildConfiguration buildConfiguration)
         : base(navigationService)
     {
         _authService = authService;
         _settingsService = settingsService;
         _connectivityService = connectivityService;
+        BuildConfiguration = buildConfiguration;
 
         Title = "Settings";
 
@@ -69,7 +74,7 @@ public partial class SettingsViewModel : BaseViewModel
         // Initialize properties
         UpdateFromAuthService();
         IsOnline = _connectivityService.IsConnected;
-        AppVersion = GetAppVersion();
+        AppVersion = BuildConfiguration.Metadata.VersionDisplay;
         InitializeDeviceInfo();
     }
 
@@ -93,18 +98,6 @@ public partial class SettingsViewModel : BaseViewModel
         IsAuthenticated = _authService.IsAuthenticated;
         UserName = _authService.CurrentUserName ?? "Not signed in";
         ServerUrl = _authService.ServerUrl ?? "Not configured";
-    }
-
-    private string GetAppVersion()
-    {
-        try
-        {
-            return AppInfo.Current.VersionString;
-        }
-        catch
-        {
-            return "1.0.0";
-        }
     }
 
     private void InitializeDeviceInfo()

--- a/apps/Honua.Mobile.FieldCollection/Views/SettingsPage.xaml
+++ b/apps/Honua.Mobile.FieldCollection/Views/SettingsPage.xaml
@@ -130,7 +130,7 @@
                     <VerticalStackLayout Spacing="15">
                         <Label Text="Device Information" Style="{StaticResource SectionHeaderStyle}" />
 
-                        <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*"
+                        <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*"
                               RowSpacing="8" ColumnSpacing="10">
 
                             <Label Grid.Row="0" Grid.Column="0" Text="📱" FontSize="14" />
@@ -152,6 +152,24 @@
                             <Label Grid.Row="4" Grid.Column="0" Text="🆔" FontSize="14" />
                             <Label Grid.Row="4" Grid.Column="1" Text="{Binding DeviceInfo.DeviceId}"
                                    FontSize="10" TextColor="{StaticResource Gray600}" />
+
+                            <Label Grid.Row="5" Grid.Column="0" Text="🏷️" FontSize="14" />
+                            <Label Grid.Row="5" Grid.Column="1"
+                                   Text="{Binding BuildConfiguration.Metadata.SourceDisplay}"
+                                   FontSize="12" TextColor="{StaticResource Gray600}"
+                                   LineBreakMode="TailTruncation" />
+
+                            <Label Grid.Row="6" Grid.Column="0" Text="🏃" FontSize="14" />
+                            <Label Grid.Row="6" Grid.Column="1"
+                                   Text="{Binding BuildConfiguration.Metadata.WorkflowRunDisplay}"
+                                   FontSize="12" TextColor="{StaticResource Gray600}"
+                                   LineBreakMode="TailTruncation" />
+
+                            <Label Grid.Row="7" Grid.Column="0" Text="🌐" FontSize="14" />
+                            <Label Grid.Row="7" Grid.Column="1"
+                                   Text="{Binding BuildConfiguration.ServiceEndpoint.DisplayValue}"
+                                   FontSize="12" TextColor="{StaticResource Gray600}"
+                                   LineBreakMode="TailTruncation" />
                         </Grid>
                     </VerticalStackLayout>
                 </Frame>

--- a/build/Honua.Mobile.BuildMetadata.props
+++ b/build/Honua.Mobile.BuildMetadata.props
@@ -1,0 +1,73 @@
+<Project>
+  <PropertyGroup>
+    <HonuaMobileBuildEnvironment Condition="'$(HonuaMobileBuildEnvironment)' == '' and '$(Configuration)' == 'Debug'">dev-local</HonuaMobileBuildEnvironment>
+    <HonuaMobileBuildEnvironment Condition="'$(HonuaMobileBuildEnvironment)' == ''">unspecified</HonuaMobileBuildEnvironment>
+    <HonuaMobileBuildRepository Condition="'$(HonuaMobileBuildRepository)' == '' and '$(GITHUB_REPOSITORY)' != ''">$(GITHUB_REPOSITORY)</HonuaMobileBuildRepository>
+    <HonuaMobileBuildBranch Condition="'$(HonuaMobileBuildBranch)' == '' and '$(GITHUB_REF_NAME)' != ''">$(GITHUB_REF_NAME)</HonuaMobileBuildBranch>
+    <HonuaMobileBuildSha Condition="'$(HonuaMobileBuildSha)' == '' and '$(GITHUB_SHA)' != ''">$(GITHUB_SHA)</HonuaMobileBuildSha>
+    <HonuaMobileBuildRunNumber Condition="'$(HonuaMobileBuildRunNumber)' == '' and '$(GITHUB_RUN_NUMBER)' != ''">$(GITHUB_RUN_NUMBER)</HonuaMobileBuildRunNumber>
+    <HonuaMobileBuildRunId Condition="'$(HonuaMobileBuildRunId)' == '' and '$(GITHUB_RUN_ID)' != ''">$(GITHUB_RUN_ID)</HonuaMobileBuildRunId>
+    <HonuaMobileBuildRunAttempt Condition="'$(HonuaMobileBuildRunAttempt)' == '' and '$(GITHUB_RUN_ATTEMPT)' != ''">$(GITHUB_RUN_ATTEMPT)</HonuaMobileBuildRunAttempt>
+    <HonuaMobileBuildNumber Condition="'$(HonuaMobileBuildNumber)' == ''">$(ApplicationVersion)</HonuaMobileBuildNumber>
+    <HonuaMobileBuildDisplayVersion Condition="'$(HonuaMobileBuildDisplayVersion)' == ''">$(ApplicationDisplayVersion)</HonuaMobileBuildDisplayVersion>
+    <HonuaMobileBuildConfiguration Condition="'$(HonuaMobileBuildConfiguration)' == ''">$(Configuration)</HonuaMobileBuildConfiguration>
+    <HonuaMobileBuildTargetFramework Condition="'$(HonuaMobileBuildTargetFramework)' == ''">$(TargetFramework)</HonuaMobileBuildTargetFramework>
+  </PropertyGroup>
+
+  <Target Name="ValidateHonuaMobileBuildEnvironment" BeforeTargets="GenerateAssemblyInfo">
+    <Error
+      Condition="'$(Configuration)' == 'Debug' and ('$(HonuaMobileBuildEnvironment)' == 'production' or '$(HonuaMobileBuildEnvironment)' == 'Production' or '$(HonuaMobileBuildEnvironment)' == 'prod' or '$(HonuaMobileBuildEnvironment)' == 'Prod' or '$(HonuaMobileBuildEnvironment)' == 'ios-production')"
+      Text="Debug mobile builds cannot be stamped with a production HonuaMobileBuildEnvironment." />
+  </Target>
+
+  <ItemGroup Condition="'$(HonuaMobileStampAssemblyMetadata)' != 'false'">
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>HonuaMobile.BuildEnvironment</_Parameter1>
+      <_Parameter2>$(HonuaMobileBuildEnvironment)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>HonuaMobile.Repository</_Parameter1>
+      <_Parameter2>$(HonuaMobileBuildRepository)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>HonuaMobile.Branch</_Parameter1>
+      <_Parameter2>$(HonuaMobileBuildBranch)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>HonuaMobile.CommitSha</_Parameter1>
+      <_Parameter2>$(HonuaMobileBuildSha)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>HonuaMobile.WorkflowRunNumber</_Parameter1>
+      <_Parameter2>$(HonuaMobileBuildRunNumber)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>HonuaMobile.WorkflowRunId</_Parameter1>
+      <_Parameter2>$(HonuaMobileBuildRunId)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>HonuaMobile.WorkflowRunAttempt</_Parameter1>
+      <_Parameter2>$(HonuaMobileBuildRunAttempt)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>HonuaMobile.BuildNumber</_Parameter1>
+      <_Parameter2>$(HonuaMobileBuildNumber)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>HonuaMobile.ApplicationDisplayVersion</_Parameter1>
+      <_Parameter2>$(HonuaMobileBuildDisplayVersion)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>HonuaMobile.Configuration</_Parameter1>
+      <_Parameter2>$(HonuaMobileBuildConfiguration)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>HonuaMobile.TargetFramework</_Parameter1>
+      <_Parameter2>$(HonuaMobileBuildTargetFramework)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>HonuaMobile.ApiBaseUrl</_Parameter1>
+      <_Parameter2>$(HonuaMobileApiBaseUrl)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+</Project>

--- a/docs/guides/mobile-devops-builds.md
+++ b/docs/guides/mobile-devops-builds.md
@@ -52,9 +52,25 @@ APK workflow emits this metadata beside the APK:
 | `artifact_name` | Deterministic artifact name |
 | `apk_name` | Copied APK filename inside the artifact |
 
-For this CI/docs slice of #84, metadata is attached to the build artifact.
-Future in-app diagnostics work can surface the same fields inside the app
-without changing the artifact naming contract.
+The FieldCollection app also stamps these fields into assembly metadata through
+`build/Honua.Mobile.BuildMetadata.props`. The Settings screen and exported
+diagnostic report surface the version, repository, branch, commit SHA, workflow
+run, environment, and any embedded service endpoint metadata.
+
+Workflows stamp the app with MSBuild properties:
+
+| MSBuild property | Purpose |
+| --- | --- |
+| `ApplicationDisplayVersion` | User-visible version string. |
+| `ApplicationVersion` | Platform build number/version code. |
+| `HonuaMobileBuildEnvironment` | `dev`, `staging`, `production`, or a named protected lane such as `ios-testflight`. |
+| `HonuaMobileBuildRepository` | GitHub repository, usually `github.repository`. |
+| `HonuaMobileBuildBranch` | Source branch/ref name. |
+| `HonuaMobileBuildSha` | Full source commit SHA. |
+| `HonuaMobileBuildRunNumber` | Monotonic workflow run number for the lane. |
+| `HonuaMobileBuildRunId` | GitHub workflow run ID for direct traceability. |
+| `HonuaMobileBuildRunAttempt` | Retry attempt for the run, when available. |
+| `HonuaMobileApiBaseUrl` | Optional embedded service endpoint metadata. Leave blank when testers enter the server URL manually. |
 
 ## Version Numbers
 
@@ -71,15 +87,19 @@ version code.
 
 The debug APK workflow does not offer a production environment option. The
 allowed values are `dev`, `staging`, and `custom-nonprod`; the API base URL is a
-required HTTPS input.
+required HTTPS input for install notes and artifact metadata.
 
 The workflow refuses to build when endpoint metadata is blank, non-HTTPS, or
 matches production-looking Honua hosts such as `api.honua.io`, `honua.io`,
 `www.honua.io`, `prod.*`, or `production.*`. That keeps phone artifacts from
 quietly defaulting to production metadata.
 
-The current FieldCollection app stores the server URL only after the tester
-enters it in the app. Debug artifacts therefore ship with install notes and
-metadata that point testers to the selected non-production endpoint, rather
-than embedding a production default. Production endpoint selection belongs in a
-separate signed release lane with explicit release-owner approval.
+The FieldCollection app stores the server URL only after the tester enters it in
+the app unless `HonuaMobileApiBaseUrl` is explicitly supplied during build.
+Blank endpoint metadata is displayed as "no endpoint embedded" and never falls
+back to production. Debug builds stamped with a production environment fail at
+build time, and the runtime endpoint policy marks production-looking Honua hosts
+invalid for non-production environments.
+
+Production endpoint selection belongs in a separate signed release lane with
+explicit release-owner approval.

--- a/tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj
+++ b/tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Models\CoreModels.cs" Link="App\Models\CoreModels.cs" />
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\CoreServices.cs" Link="App\Services\CoreServices.cs" />
+    <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\Configuration\MobileBuildConfiguration.cs" Link="App\Services\Configuration\MobileBuildConfiguration.cs" />
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\IAuthenticationService.cs" Link="App\Services\IAuthenticationService.cs" />
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\ISyncService.cs" Link="App\Services\ISyncService.cs" />
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\Diagnostics\OfflineCacheDiagnostics.cs" Link="App\Services\Diagnostics\OfflineCacheDiagnostics.cs" />

--- a/tests/Honua.Mobile.FieldCollection.Tests/MobileBuildConfigurationTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/MobileBuildConfigurationTests.cs
@@ -1,0 +1,110 @@
+using Honua.Mobile.FieldCollection.Services.Configuration;
+
+namespace Honua.Mobile.FieldCollection.Tests;
+
+public sealed class MobileBuildConfigurationTests
+{
+    [Theory]
+    [InlineData("dev", MobileBuildEnvironmentKind.Development)]
+    [InlineData("staging", MobileBuildEnvironmentKind.Staging)]
+    [InlineData("production", MobileBuildEnvironmentKind.Production)]
+    [InlineData("ios-production", MobileBuildEnvironmentKind.Production)]
+    [InlineData("ios-testflight", MobileBuildEnvironmentKind.CustomNonProduction)]
+    public void EnvironmentKind_NormalizesWorkflowEnvironmentNames(
+        string environment,
+        MobileBuildEnvironmentKind expectedKind)
+    {
+        var kind = MobileBuildEnvironmentKindExtensions.FromBuildEnvironment(environment);
+
+        Assert.Equal(expectedKind, kind);
+    }
+
+    [Fact]
+    public void FromAttributes_UsesStampedGitHubBuildMetadata()
+    {
+        var attributes = new Dictionary<string, string?>
+        {
+            ["HonuaMobile.ApplicationDisplayVersion"] = "0.0.0-debug.42",
+            ["HonuaMobile.BuildNumber"] = "42",
+            ["HonuaMobile.BuildEnvironment"] = "staging",
+            ["HonuaMobile.Repository"] = "honua-io/honua-mobile",
+            ["HonuaMobile.Branch"] = "feature/mobile-builds",
+            ["HonuaMobile.CommitSha"] = "0123456789abcdef0123456789abcdef01234567",
+            ["HonuaMobile.WorkflowRunNumber"] = "42",
+            ["HonuaMobile.WorkflowRunId"] = "100200300",
+            ["HonuaMobile.WorkflowRunAttempt"] = "2",
+            ["HonuaMobile.Configuration"] = "Debug",
+            ["HonuaMobile.TargetFramework"] = "net10.0-android"
+        };
+
+        var configuration = MobileBuildConfiguration.FromAttributes(attributes, "1.0", "1");
+
+        Assert.Equal("0.0.0-debug.42 (42)", configuration.Metadata.VersionDisplay);
+        Assert.Equal("0123456789ab", configuration.Metadata.ShortCommitSha);
+        Assert.Equal("honua-io/honua-mobile@0123456789ab on feature/mobile-builds", configuration.Metadata.SourceDisplay);
+        Assert.Equal("GitHub Actions run 42, attempt 2", configuration.Metadata.WorkflowRunDisplay);
+        Assert.Equal(new Uri("https://github.com/honua-io/honua-mobile/actions/runs/100200300"), configuration.Metadata.WorkflowRunUri);
+        Assert.True(configuration.Metadata.IsTraceable);
+        Assert.Equal(MobileBuildEnvironmentKind.Staging, configuration.ServiceEndpoint.EnvironmentKind);
+    }
+
+    [Fact]
+    public void FromAttributes_DoesNotDefaultBlankEndpointToProduction()
+    {
+        var attributes = new Dictionary<string, string?>
+        {
+            ["HonuaMobile.BuildEnvironment"] = "dev",
+            ["HonuaMobile.Configuration"] = "Debug"
+        };
+
+        var configuration = MobileBuildConfiguration.FromAttributes(attributes, "1.0", "1");
+
+        Assert.True(configuration.ServiceEndpoint.IsValid);
+        Assert.False(configuration.ServiceEndpoint.IsConfigured);
+        Assert.Equal(MobileBuildEnvironmentKind.Development, configuration.ServiceEndpoint.EnvironmentKind);
+        Assert.Equal("Development: no endpoint embedded", configuration.ServiceEndpoint.DisplayValue);
+    }
+
+    [Fact]
+    public void ServiceEndpoint_RejectsProductionHostForNonProductionEnvironment()
+    {
+        var endpoint = MobileServiceEndpointConfiguration.Create(
+            "dev",
+            "https://api.honua.io",
+            "Debug");
+
+        Assert.False(endpoint.IsValid);
+        Assert.Contains("Non-production", endpoint.ValidationMessage);
+    }
+
+    [Fact]
+    public void ServiceEndpoint_RejectsProductionDebugBuild()
+    {
+        var endpoint = MobileServiceEndpointConfiguration.Create(
+            "production",
+            "https://api.honua.io",
+            "Debug");
+
+        Assert.False(endpoint.IsValid);
+        Assert.Contains("Debug", endpoint.ValidationMessage);
+        Assert.False(endpoint.IsConfigured);
+    }
+
+    [Fact]
+    public void ServiceEndpoint_AllowsLoopbackHttpOnlyForDevelopment()
+    {
+        var development = MobileServiceEndpointConfiguration.Create(
+            "development",
+            "http://localhost:5000",
+            "Debug");
+        var staging = MobileServiceEndpointConfiguration.Create(
+            "staging",
+            "http://staging.honua.test",
+            "Debug");
+
+        Assert.True(development.IsValid);
+        Assert.Equal(new Uri("http://localhost:5000"), development.ApiBaseUrl);
+        Assert.False(staging.IsValid);
+        Assert.Contains("HTTPS", staging.ValidationMessage);
+    }
+}

--- a/tests/Honua.Mobile.FieldCollection.Tests/MobileBuildConfigurationTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/MobileBuildConfigurationTests.cs
@@ -91,6 +91,20 @@ public sealed class MobileBuildConfigurationTests
     }
 
     [Fact]
+    public void ServiceEndpoint_DisplayValueSurfacesInvalidUnparseableEndpointMetadata()
+    {
+        var endpoint = MobileServiceEndpointConfiguration.Create(
+            "staging",
+            "not a uri",
+            "Release");
+
+        Assert.False(endpoint.IsValid);
+        Assert.False(endpoint.IsConfigured);
+        Assert.Contains("absolute URI", endpoint.ValidationMessage);
+        Assert.Equal("Staging: invalid endpoint metadata", endpoint.DisplayValue);
+    }
+
+    [Fact]
     public void ServiceEndpoint_AllowsLoopbackHttpOnlyForDevelopment()
     {
         var development = MobileServiceEndpointConfiguration.Create(


### PR DESCRIPTION
## Summary
- Stamp MAUI app assemblies with HonuaMobile build metadata from MSBuild/GitHub Actions properties.
- Add FieldCollection runtime build configuration and endpoint policy, with Settings and diagnostics report exposure.
- Document metadata properties and endpoint safety behavior.
- Add unit coverage for traceability metadata, environment normalization, and non-production endpoint guards.

## Validation
- dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore --verbosity minimal
- git diff --check origin/main..HEAD
- dotnet msbuild target GenerateAssemblyInfo with stamped metadata
- dotnet msbuild target ValidateHonuaMobileBuildEnvironment with production Debug env, expected failure

## Note
Android target build could not complete locally because the Android SDK is not installed on this machine.

Related to #84.