### PR TITLE
feat: add native AR scene anchoring boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Current mobile SDK roadmap coordination is tracked from
 | **Honua.Mobile.Sdk** | Transport, auth, gRPC-first client, REST fallback, routing, and SDK scene metadata adapter |
 | **Honua.Mobile.Field** | Mobile adapters for SDK-owned field forms, validation, media capture metadata, and workflow |
 | **Honua.Mobile.Offline** | GeoPackage storage, sync queue, map area download, conflict resolution |
-| **Honua.Mobile.Maui** | MAUI service registration, DI extensions, native display boundaries, and device location orchestration |
+| **Honua.Mobile.Maui** | MAUI service registration, DI extensions, native display boundaries, native scene anchoring, and device location orchestration |
 | **@honua/embed** | Framework-agnostic `<honua-map>` and `<honua-scene>` web components for ISV embeds |
 
 ## Quick Start
@@ -148,7 +148,7 @@ src/
   Honua.Mobile.Sdk/           Core mobile client
   Honua.Mobile.Field/         SDK field workflow adapters
   Honua.Mobile.Offline/       GeoPackage sync engine
-  Honua.Mobile.Maui/          MAUI platform integration
+  Honua.Mobile.Maui/          MAUI platform integration, native display, location, and scene anchoring
   Honua.Mobile.IoT/           IoT sensor abstractions (interface-only, future)
 apps/
   Honua.Mobile.App/           Reference MAUI application
@@ -158,7 +158,7 @@ tests/
   Honua.Mobile.FieldCollection.Tests/ FieldCollection auth, sync, storage, diagnostics (10 tests)
   Honua.Mobile.ServerIntegration.Tests/ Loopback Honua server integration surface (8 tests)
   Honua.Mobile.Offline.Tests/ Sync engine, conflicts, map download, GeoPackage (65 tests)
-  Honua.Mobile.Maui.Tests/    MAUI integration helpers, map annotations, native display, location (32 tests)
+  Honua.Mobile.Maui.Tests/    MAUI integration helpers, map annotations, native display, location, scene anchoring (40 tests)
   Honua.Mobile.Smoke.Tests/   End-to-end smoke paths and optional live Honua query (7 tests)
 proto/
   honua/v1/                   gRPC protocol definitions

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -12,7 +12,7 @@ In-depth guides for building with the Honua Mobile SDK.
 | [Mobile 3D and AR Dependency Matrix](mobile-3d-ar-dependency-matrix.md) | Server, SDK, platform, offline, and edition dependencies for scene and AR work |
 | [Mobile Contract Harmonization](mobile-contract-harmonization.md) | Ownership and compatibility baseline between `honua-mobile` and `honua-sdk-dotnet` contracts |
 | [Mobile SDK Backlog Roadmap](mobile-sdk-backlog-roadmap.md) | Epic #1 backlog sequencing, acceptance matrix, dependencies, and closure readiness |
-| [Native Display and Location Integration](native-display-and-location.md) | Native .NET display adapter boundary, Mapsui evaluation, and device location/geofencing lifecycle |
+| [Native Display and Location Integration](native-display-and-location.md) | Native .NET display adapter boundary, scene anchoring adapter, Mapsui evaluation, and device location/geofencing lifecycle |
 | [Native Scene Anchoring Requirements](native-scene-anchoring-requirements.md) | ARKit, ARCore, WebXR, MAUI, calibration, offline, and runtime ticket split for native AR scene anchoring |
 | [Offline 3D Scene Packages](offline-3d-scene-packages.md) | Package manifest, cache, expiry, and platform policy for offline 3D scenes |
 | [Offline Sync](offline-sync.md) | GeoPackage storage, sync engine configuration, and conflict resolution |

--- a/docs/guides/native-display-and-location.md
+++ b/docs/guides/native-display-and-location.md
@@ -85,6 +85,75 @@ before the SDK geometry contracts have graduated. The safer shape is:
 - benchmark pan/zoom refresh, offline GeoPackage layer loading, and annotation
   redraw before making Mapsui the default renderer.
 
+## Native Scene Anchoring Adapter
+
+`Honua.Mobile.Maui.SceneAnchoring` provides the mobile-owned boundary for #38
+and #23 native AR anchoring work. It does not define scene metadata, package
+manifests, geometry primitives, or server clients. Apps resolve scenes and
+packages through `Honua.Sdk.*`, then pass scene/package IDs and mobile runtime
+state into the platform adapter.
+
+- `IHonuaNativeArSceneAnchorAdapter` is the ARKit/ARCore boundary implemented by
+  app or platform packages.
+- `HonuaNativeArSceneAnchoringController` checks support, starts the native
+  session, handles app background/resume/stop transitions, and evaluates
+  readiness for mobile UX gates.
+- `HonuaNativeArReadiness` gates coarse rendering, evidence capture, and
+  precision tools from runtime status, horizontal/yaw accuracy, package state,
+  control-point count, and calibration residual.
+- `HonuaNativeArSceneAnchorRequest` carries scene id, scene revision, optional
+  offline package id, selected anchoring mode, and control-point IDs. The SDK or
+  app remains responsible for resolving the authoritative scene/package data.
+
+```csharp
+using Honua.Mobile.Maui;
+using Honua.Mobile.Maui.SceneAnchoring;
+
+builder.Services
+    .AddSingleton<IHonuaNativeArSceneAnchorAdapter, AndroidArCoreSceneAnchorAdapter>()
+    .AddHonuaNativeSceneAnchoring(new HonuaNativeArSessionOptions
+    {
+        CoarsePreviewHorizontalAccuracyMeters = 10,
+        SiteReviewHorizontalAccuracyMeters = 2,
+        PrecisionCalibrationResidualMeters = 0.5,
+    });
+```
+
+```csharp
+var readiness = await sceneAnchoring.StartAsync(
+    new HonuaNativeArSceneAnchorRequest
+    {
+        SceneId = sceneId,
+        SceneRevision = sceneRevision,
+        PackageId = packageId,
+        IsOffline = packageId is not null,
+        PreferredAnchoringMode = HonuaNativeArAnchoringMode.PlatformGeospatial,
+        ControlPointIds = selectedControlPointIds,
+    },
+    ct);
+
+if (readiness.CanRenderOverlay)
+{
+    // Render through the app's native AR adapter with the readiness state visible in the UI.
+}
+```
+
+Lifecycle integration:
+
+```csharp
+await sceneAnchoring.HandleAppLifecycleAsync(
+    HonuaNativeArAppLifecycleEvent.EnteringBackground,
+    ct);
+
+await sceneAnchoring.HandleAppLifecycleAsync(
+    HonuaNativeArAppLifecycleEvent.ResumingForeground,
+    ct);
+```
+
+GPS-only readiness never enables precision tools. Offline rendering requires a
+valid package state, and stale, expired, partial, or revoked packages block AR
+overlays until the package is refreshed.
+
 ## Device Location and Geofencing
 
 `Honua.Mobile.Maui.Location` owns mobile runtime acquisition behavior while

--- a/docs/guides/native-scene-anchoring-requirements.md
+++ b/docs/guides/native-scene-anchoring-requirements.md
@@ -35,6 +35,23 @@ experiments after #42, but browser `immersive-ar` support is not consistent
 enough across iOS, Android, WebView, and managed enterprise devices to be the
 primary mobile field path.
 
+## Mobile Adapter Boundary
+
+The initial mobile-owned implementation slice is
+`Honua.Mobile.Maui.SceneAnchoring`. It provides an ARKit/ARCore adapter
+interface, app lifecycle controller, and readiness policy for field UX gates.
+It intentionally accepts scene id, scene revision, package id, control-point
+ids, package quality, and accuracy telemetry only; authoritative scene
+metadata, package manifests, geometry, and vertical datum transforms remain in
+`Honua.Sdk.*` packages or server-backed contracts.
+
+Use `HonuaNativeArSceneAnchoringController` to start the native adapter after
+the app resolves scene/package inputs, then bind `HonuaNativeArReadiness` to the
+field UI. `CoarsePreview` may render uncertainty-aware overlays, `SiteReview`
+may capture evidence, and `PrecisionInspection` requires survey-quality source
+data, enough confirmed control points, and a calibration residual under the
+configured threshold.
+
 ## Target Prototype
 
 | Decision | Requirement |

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Honua.Mobile.Maui.Auth;
 using Honua.Mobile.Maui.Annotations;
 using Honua.Mobile.Maui.Display;
 using Honua.Mobile.Maui.Location;
+using Honua.Mobile.Maui.SceneAnchoring;
 using Honua.Mobile.Offline.GeoPackage;
 using Honua.Mobile.Offline.MapAreas;
 using Honua.Mobile.Offline.ScenePackages;
@@ -349,6 +350,24 @@ public static class HonuaMobileServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddTransient<HonuaNativeMapDisplayController>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the native AR scene anchoring controller.
+    /// Applications must also register an <see cref="IHonuaNativeArSceneAnchorAdapter"/> for ARKit or ARCore.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="options">Optional readiness thresholds for the AR workflow.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaNativeSceneAnchoring(
+        this IServiceCollection services,
+        HonuaNativeArSessionOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton(options ?? new HonuaNativeArSessionOptions());
+        services.AddSingleton<HonuaNativeArSceneAnchoringController>();
         return services;
     }
 

--- a/src/Honua.Mobile.Maui/SceneAnchoring/HonuaNativeArSceneAnchoringController.cs
+++ b/src/Honua.Mobile.Maui/SceneAnchoring/HonuaNativeArSceneAnchoringController.cs
@@ -1,0 +1,384 @@
+namespace Honua.Mobile.Maui.SceneAnchoring;
+
+/// <summary>
+/// Coordinates mobile-owned AR scene anchoring policy with a platform-native AR adapter.
+/// </summary>
+public sealed class HonuaNativeArSceneAnchoringController
+{
+    private readonly IHonuaNativeArSceneAnchorAdapter _adapter;
+    private readonly HonuaNativeArSessionOptions _options;
+    private HonuaNativeArSceneAnchorRequest? _activeRequest;
+    private bool _resumeAfterLifecyclePause;
+
+    public HonuaNativeArSceneAnchoringController(
+        IHonuaNativeArSceneAnchorAdapter adapter,
+        HonuaNativeArSessionOptions? options = null)
+    {
+        _adapter = adapter ?? throw new ArgumentNullException(nameof(adapter));
+        _options = options ?? new HonuaNativeArSessionOptions();
+        _options.Validate();
+    }
+
+    /// <summary>
+    /// Checks platform support, starts the native AR session, and returns the UI readiness gate.
+    /// </summary>
+    public async ValueTask<HonuaNativeArReadiness> StartAsync(
+        HonuaNativeArSceneAnchorRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        request.Validate();
+
+        var support = await _adapter.CheckSupportAsync(ct).ConfigureAwait(false);
+        support.Validate();
+
+        var supportBlockers = BuildSupportBlockers(support);
+        if (supportBlockers.Count > 0)
+        {
+            return CreateReadiness(HonuaNativeArReadinessLevel.Unsupported, supportBlockers, []);
+        }
+
+        _activeRequest = request;
+        _resumeAfterLifecyclePause = false;
+
+        var status = await _adapter.StartSessionAsync(request, ct).ConfigureAwait(false);
+        return EvaluateReadiness(status, request, _options);
+    }
+
+    /// <summary>
+    /// Reads current native AR status and re-evaluates the UI readiness gate.
+    /// </summary>
+    public async ValueTask<HonuaNativeArReadiness> RefreshReadinessAsync(CancellationToken ct = default)
+    {
+        var request = _activeRequest
+            ?? throw new InvalidOperationException("No native AR scene anchoring session is active.");
+
+        var status = await _adapter.GetStatusAsync(ct).ConfigureAwait(false);
+        return EvaluateReadiness(status, request, _options);
+    }
+
+    /// <summary>
+    /// Pauses the active native AR session.
+    /// </summary>
+    public async ValueTask<HonuaNativeArReadiness> PauseAsync(CancellationToken ct = default)
+    {
+        var request = _activeRequest
+            ?? throw new InvalidOperationException("No native AR scene anchoring session is active.");
+
+        var status = await _adapter.PauseSessionAsync(ct).ConfigureAwait(false);
+        return EvaluateReadiness(status, request, _options);
+    }
+
+    /// <summary>
+    /// Resumes the active native AR session with the original scene anchoring request.
+    /// </summary>
+    public async ValueTask<HonuaNativeArReadiness> ResumeAsync(CancellationToken ct = default)
+    {
+        var request = _activeRequest
+            ?? throw new InvalidOperationException("No native AR scene anchoring session is active.");
+
+        var status = await _adapter.ResumeSessionAsync(request, ct).ConfigureAwait(false);
+        _resumeAfterLifecyclePause = false;
+        return EvaluateReadiness(status, request, _options);
+    }
+
+    /// <summary>
+    /// Stops the active native AR session and clears lifecycle resume state.
+    /// </summary>
+    public async ValueTask StopAsync(CancellationToken ct = default)
+    {
+        if (_activeRequest is null)
+        {
+            return;
+        }
+
+        await _adapter.StopSessionAsync(ct).ConfigureAwait(false);
+        _activeRequest = null;
+        _resumeAfterLifecyclePause = false;
+    }
+
+    /// <summary>
+    /// Applies app lifecycle transitions to camera/sensor-heavy native AR sessions.
+    /// </summary>
+    public async ValueTask HandleAppLifecycleAsync(
+        HonuaNativeArAppLifecycleEvent lifecycleEvent,
+        CancellationToken ct = default)
+    {
+        if (_activeRequest is null)
+        {
+            return;
+        }
+
+        switch (lifecycleEvent)
+        {
+            case HonuaNativeArAppLifecycleEvent.EnteringBackground:
+                var status = await _adapter.GetStatusAsync(ct).ConfigureAwait(false);
+                status.Validate();
+                if (status.State is HonuaNativeArSessionState.Running or HonuaNativeArSessionState.Starting)
+                {
+                    _resumeAfterLifecyclePause = true;
+                    await _adapter.PauseSessionAsync(ct).ConfigureAwait(false);
+                }
+
+                break;
+            case HonuaNativeArAppLifecycleEvent.ResumingForeground:
+                if (_resumeAfterLifecyclePause)
+                {
+                    await _adapter.ResumeSessionAsync(_activeRequest, ct).ConfigureAwait(false);
+                    _resumeAfterLifecyclePause = false;
+                }
+
+                break;
+            case HonuaNativeArAppLifecycleEvent.Stopping:
+                await StopAsync(ct).ConfigureAwait(false);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(lifecycleEvent), lifecycleEvent, "Unsupported AR lifecycle event.");
+        }
+    }
+
+    /// <summary>
+    /// Evaluates whether the current native AR session can render, capture, or enable precision tools.
+    /// </summary>
+    public static HonuaNativeArReadiness EvaluateReadiness(
+        HonuaNativeArSessionStatus status,
+        HonuaNativeArSceneAnchorRequest request,
+        HonuaNativeArSessionOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(status);
+        ArgumentNullException.ThrowIfNull(request);
+
+        options ??= new HonuaNativeArSessionOptions();
+        options.Validate();
+        request.Validate();
+        status.Validate();
+
+        var blockers = new List<string>();
+        var warnings = new List<string>(status.Warnings);
+
+        AddSessionBlockers(status, blockers);
+        AddSceneBlockers(status, request, blockers);
+        AddOfflineBlockers(status, request, blockers);
+
+        var horizontalAccuracy = status.Accuracy.HorizontalAccuracyMeters;
+        if (horizontalAccuracy is null)
+        {
+            blockers.Add("Horizontal accuracy is not available.");
+        }
+        else if (horizontalAccuracy.Value > options.CoarsePreviewHorizontalAccuracyMeters)
+        {
+            blockers.Add(
+                $"Horizontal accuracy {horizontalAccuracy.Value:0.##} m is above the coarse preview threshold.");
+        }
+
+        if (blockers.Count > 0)
+        {
+            return CreateReadiness(HonuaNativeArReadinessLevel.Blocked, blockers, warnings);
+        }
+
+        var level = HonuaNativeArReadinessLevel.CoarsePreview;
+
+        if (status.TrackingState == HonuaNativeArTrackingState.Limited)
+        {
+            warnings.Add("AR tracking is limited; keep overlays in coarse preview.");
+        }
+
+        if (status.ActiveAnchoringMode == HonuaNativeArAnchoringMode.GpsPreview)
+        {
+            warnings.Add("GPS-only anchoring is coarse preview only.");
+        }
+
+        if (CanEnterSiteReview(status, options, warnings))
+        {
+            level = HonuaNativeArReadinessLevel.SiteReview;
+        }
+
+        if (level == HonuaNativeArReadinessLevel.SiteReview
+            && CanEnterPrecisionInspection(status, request, options, warnings))
+        {
+            level = HonuaNativeArReadinessLevel.PrecisionInspection;
+        }
+
+        return CreateReadiness(level, blockers, warnings);
+    }
+
+    private static List<string> BuildSupportBlockers(HonuaNativeArCapabilityStatus support)
+    {
+        var blockers = new List<string>(support.MissingRequirements);
+
+        if (!support.IsSupported)
+        {
+            blockers.Add("Native AR is not supported on this device.");
+        }
+
+        if (!support.CameraPermissionGranted)
+        {
+            blockers.Add("Camera permission is required for native AR anchoring.");
+        }
+
+        if (!support.LocationPermissionGranted)
+        {
+            blockers.Add("Location permission is required for scene anchoring.");
+        }
+
+        if (!support.MotionTrackingAvailable)
+        {
+            blockers.Add("Visual-inertial motion tracking is required for native AR anchoring.");
+        }
+
+        return blockers
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static void AddSessionBlockers(HonuaNativeArSessionStatus status, List<string> blockers)
+    {
+        if (status.State != HonuaNativeArSessionState.Running)
+        {
+            blockers.Add($"AR session is {status.State}.");
+        }
+
+        if (status.TrackingState is HonuaNativeArTrackingState.Unsupported or HonuaNativeArTrackingState.Failed)
+        {
+            blockers.Add("AR tracking is unavailable.");
+        }
+    }
+
+    private static void AddSceneBlockers(
+        HonuaNativeArSessionStatus status,
+        HonuaNativeArSceneAnchorRequest request,
+        List<string> blockers)
+    {
+        if (!string.IsNullOrWhiteSpace(status.SceneId)
+            && !string.Equals(status.SceneId, request.SceneId, StringComparison.Ordinal))
+        {
+            blockers.Add("AR session is not rendering the requested scene.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(status.SceneRevision)
+            && !string.IsNullOrWhiteSpace(request.SceneRevision)
+            && !string.Equals(status.SceneRevision, request.SceneRevision, StringComparison.Ordinal))
+        {
+            blockers.Add("AR session is not using the requested scene revision.");
+        }
+    }
+
+    private static void AddOfflineBlockers(
+        HonuaNativeArSessionStatus status,
+        HonuaNativeArSceneAnchorRequest request,
+        List<string> blockers)
+    {
+        if (!request.IsOffline)
+        {
+            return;
+        }
+
+        if (status.PackageState != HonuaNativeArScenePackageState.Valid)
+        {
+            blockers.Add($"Offline scene package is {status.PackageState}.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(status.PackageId)
+            && !string.Equals(status.PackageId, request.PackageId, StringComparison.Ordinal))
+        {
+            blockers.Add("AR session is not using the requested offline scene package.");
+        }
+    }
+
+    private static bool CanEnterSiteReview(
+        HonuaNativeArSessionStatus status,
+        HonuaNativeArSessionOptions options,
+        List<string> warnings)
+    {
+        if (status.TrackingState != HonuaNativeArTrackingState.Tracking)
+        {
+            return false;
+        }
+
+        if (status.ActiveAnchoringMode == HonuaNativeArAnchoringMode.GpsPreview
+            || status.ActiveAnchoringMode == HonuaNativeArAnchoringMode.VisualInertial
+            || status.ActiveAnchoringMode == HonuaNativeArAnchoringMode.Unknown)
+        {
+            return false;
+        }
+
+        if (status.Accuracy.HorizontalAccuracyMeters > options.SiteReviewHorizontalAccuracyMeters)
+        {
+            warnings.Add("Horizontal accuracy is not sufficient for site review.");
+            return false;
+        }
+
+        if (status.Accuracy.YawAccuracyDegrees > options.SiteReviewYawAccuracyDegrees)
+        {
+            warnings.Add("Yaw accuracy is not sufficient for site review.");
+            return false;
+        }
+
+        if (status.ActiveAnchoringMode == HonuaNativeArAnchoringMode.ControlPointCalibration
+            && status.ConfirmedControlPointCount < options.SiteReviewControlPointCount)
+        {
+            warnings.Add("At least one confirmed control point is required for site review.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool CanEnterPrecisionInspection(
+        HonuaNativeArSessionStatus status,
+        HonuaNativeArSceneAnchorRequest request,
+        HonuaNativeArSessionOptions options,
+        List<string> warnings)
+    {
+        if (status.ActiveAnchoringMode == HonuaNativeArAnchoringMode.GpsPreview
+            || status.ActiveAnchoringMode == HonuaNativeArAnchoringMode.VisualInertial)
+        {
+            return false;
+        }
+
+        if (!request.SourceDeclaresSurveyQuality)
+        {
+            warnings.Add("Precision tools require source data that declares survey quality.");
+            return false;
+        }
+
+        var requiredControlPoints = request.RequiresVerticalPlacement
+            ? options.PrecisionVerticalControlPointCount
+            : options.PrecisionHorizontalControlPointCount;
+
+        if (status.ConfirmedControlPointCount < requiredControlPoints)
+        {
+            warnings.Add("Precision tools require additional confirmed control points.");
+            return false;
+        }
+
+        if (status.Accuracy.CalibrationResidualMeters is null)
+        {
+            warnings.Add("Precision tools require a calibration residual.");
+            return false;
+        }
+
+        if (status.Accuracy.CalibrationResidualMeters.Value > options.PrecisionCalibrationResidualMeters)
+        {
+            warnings.Add("Calibration residual is above the precision threshold.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static HonuaNativeArReadiness CreateReadiness(
+        HonuaNativeArReadinessLevel level,
+        IReadOnlyList<string> blockers,
+        IReadOnlyList<string> warnings)
+    {
+        return new HonuaNativeArReadiness
+        {
+            Level = level,
+            Blockers = blockers,
+            Warnings = warnings
+                .Distinct(StringComparer.Ordinal)
+                .ToArray(),
+        };
+    }
+}

--- a/src/Honua.Mobile.Maui/SceneAnchoring/HonuaNativeArSceneAnchoringController.cs
+++ b/src/Honua.Mobile.Maui/SceneAnchoring/HonuaNativeArSceneAnchoringController.cs
@@ -38,10 +38,10 @@ public sealed class HonuaNativeArSceneAnchoringController
             return CreateReadiness(HonuaNativeArReadinessLevel.Unsupported, supportBlockers, []);
         }
 
+        var status = await _adapter.StartSessionAsync(request, ct).ConfigureAwait(false);
         _activeRequest = request;
         _resumeAfterLifecyclePause = false;
 
-        var status = await _adapter.StartSessionAsync(request, ct).ConfigureAwait(false);
         return EvaluateReadiness(status, request, _options);
     }
 
@@ -308,7 +308,14 @@ public sealed class HonuaNativeArSceneAnchoringController
             return false;
         }
 
-        if (status.Accuracy.YawAccuracyDegrees > options.SiteReviewYawAccuracyDegrees)
+        var yawAccuracy = status.Accuracy.YawAccuracyDegrees;
+        if (yawAccuracy is null)
+        {
+            warnings.Add("Yaw accuracy is not available for site review.");
+            return false;
+        }
+
+        if (yawAccuracy.Value > options.SiteReviewYawAccuracyDegrees)
         {
             warnings.Add("Yaw accuracy is not sufficient for site review.");
             return false;

--- a/src/Honua.Mobile.Maui/SceneAnchoring/NativeSceneAnchoringContracts.cs
+++ b/src/Honua.Mobile.Maui/SceneAnchoring/NativeSceneAnchoringContracts.cs
@@ -1,0 +1,355 @@
+namespace Honua.Mobile.Maui.SceneAnchoring;
+
+/// <summary>
+/// Native AR runtime family owned by the app host.
+/// </summary>
+public enum HonuaNativeArRuntime
+{
+    Unknown,
+    AndroidArCore,
+    IosArKit,
+}
+
+/// <summary>
+/// Anchor source currently used by a native AR session.
+/// </summary>
+public enum HonuaNativeArAnchoringMode
+{
+    Unknown,
+    GpsPreview,
+    VisualInertial,
+    PlatformGeospatial,
+    ControlPointCalibration,
+    AssetAnchor,
+}
+
+/// <summary>
+/// Native AR session lifecycle state reported by the platform adapter.
+/// </summary>
+public enum HonuaNativeArSessionState
+{
+    NotStarted,
+    Starting,
+    Running,
+    Paused,
+    Stopped,
+    Failed,
+}
+
+/// <summary>
+/// Native camera-pose tracking quality reported by the platform adapter.
+/// </summary>
+public enum HonuaNativeArTrackingState
+{
+    Unknown,
+    Unsupported,
+    Initializing,
+    Limited,
+    Tracking,
+    Paused,
+    Failed,
+}
+
+/// <summary>
+/// Local package quality state for AR overlays that render disconnected scene content.
+/// </summary>
+public enum HonuaNativeArScenePackageState
+{
+    NotRequired,
+    Unknown,
+    Valid,
+    Stale,
+    Expired,
+    Partial,
+    Revoked,
+}
+
+/// <summary>
+/// Readiness level the mobile UI can use to gate AR overlay actions.
+/// </summary>
+public enum HonuaNativeArReadinessLevel
+{
+    Unsupported,
+    Blocked,
+    CoarsePreview,
+    SiteReview,
+    PrecisionInspection,
+}
+
+/// <summary>
+/// Mobile app lifecycle event relevant to native camera and sensor sessions.
+/// </summary>
+public enum HonuaNativeArAppLifecycleEvent
+{
+    EnteringBackground,
+    ResumingForeground,
+    Stopping,
+}
+
+/// <summary>
+/// Workflow thresholds used by the mobile AR readiness policy.
+/// </summary>
+public sealed record HonuaNativeArSessionOptions
+{
+    public double CoarsePreviewHorizontalAccuracyMeters { get; init; } = 10;
+
+    public double SiteReviewHorizontalAccuracyMeters { get; init; } = 2;
+
+    public double SiteReviewYawAccuracyDegrees { get; init; } = 15;
+
+    public double PrecisionCalibrationResidualMeters { get; init; } = 0.5;
+
+    public int SiteReviewControlPointCount { get; init; } = 1;
+
+    public int PrecisionHorizontalControlPointCount { get; init; } = 2;
+
+    public int PrecisionVerticalControlPointCount { get; init; } = 3;
+
+    public void Validate()
+    {
+        ValidatePositive(CoarsePreviewHorizontalAccuracyMeters, nameof(CoarsePreviewHorizontalAccuracyMeters));
+        ValidatePositive(SiteReviewHorizontalAccuracyMeters, nameof(SiteReviewHorizontalAccuracyMeters));
+        ValidatePositive(SiteReviewYawAccuracyDegrees, nameof(SiteReviewYawAccuracyDegrees));
+        ValidatePositive(PrecisionCalibrationResidualMeters, nameof(PrecisionCalibrationResidualMeters));
+
+        if (SiteReviewControlPointCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(SiteReviewControlPointCount),
+                "Site review control point count must be non-negative.");
+        }
+
+        if (PrecisionHorizontalControlPointCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(PrecisionHorizontalControlPointCount),
+                "Precision horizontal control point count must be positive.");
+        }
+
+        if (PrecisionVerticalControlPointCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(PrecisionVerticalControlPointCount),
+                "Precision vertical control point count must be positive.");
+        }
+    }
+
+    private static void ValidatePositive(double value, string parameterName)
+    {
+        if (!double.IsFinite(value) || value <= 0)
+        {
+            throw new ArgumentOutOfRangeException(parameterName, "Thresholds must be finite and positive.");
+        }
+    }
+}
+
+/// <summary>
+/// Scene/runtime request handed to a native AR platform adapter.
+/// </summary>
+public sealed record HonuaNativeArSceneAnchorRequest
+{
+    public required string SceneId { get; init; }
+
+    public string? SceneRevision { get; init; }
+
+    public string? PackageId { get; init; }
+
+    public bool IsOffline { get; init; }
+
+    public bool RequiresVerticalPlacement { get; init; }
+
+    public bool SourceDeclaresSurveyQuality { get; init; }
+
+    public HonuaNativeArAnchoringMode PreferredAnchoringMode { get; init; } =
+        HonuaNativeArAnchoringMode.PlatformGeospatial;
+
+    public IReadOnlyList<string> ControlPointIds { get; init; } = [];
+
+    public IReadOnlyDictionary<string, object?> Metadata { get; init; } =
+        new Dictionary<string, object?>();
+
+    public void Validate()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(SceneId);
+        ArgumentNullException.ThrowIfNull(ControlPointIds);
+        ArgumentNullException.ThrowIfNull(Metadata);
+
+        if (IsOffline)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(PackageId);
+        }
+
+        var controlPointIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var id in ControlPointIds)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(id);
+            if (!controlPointIds.Add(id))
+            {
+                throw new InvalidOperationException($"Control point '{id}' is defined more than once.");
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Accuracy values reported by ARKit, ARCore, device location, or a calibration flow.
+/// </summary>
+public sealed record HonuaNativeArAccuracySample
+{
+    public double? HorizontalAccuracyMeters { get; init; }
+
+    public double? VerticalAccuracyMeters { get; init; }
+
+    public double? YawAccuracyDegrees { get; init; }
+
+    public double? CalibrationResidualMeters { get; init; }
+
+    public DateTimeOffset CapturedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    public void Validate()
+    {
+        ValidateNonNegative(HorizontalAccuracyMeters, nameof(HorizontalAccuracyMeters));
+        ValidateNonNegative(VerticalAccuracyMeters, nameof(VerticalAccuracyMeters));
+        ValidateNonNegative(YawAccuracyDegrees, nameof(YawAccuracyDegrees));
+        ValidateNonNegative(CalibrationResidualMeters, nameof(CalibrationResidualMeters));
+    }
+
+    private static void ValidateNonNegative(double? value, string parameterName)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        if (!double.IsFinite(value.Value) || value.Value < 0)
+        {
+            throw new ArgumentOutOfRangeException(parameterName, "Accuracy values must be finite and non-negative.");
+        }
+    }
+}
+
+/// <summary>
+/// Device and permission support state reported before starting a native AR session.
+/// </summary>
+public sealed record HonuaNativeArCapabilityStatus
+{
+    public HonuaNativeArRuntime Runtime { get; init; } = HonuaNativeArRuntime.Unknown;
+
+    public bool IsSupported { get; init; }
+
+    public bool CameraPermissionGranted { get; init; }
+
+    public bool LocationPermissionGranted { get; init; }
+
+    public bool PreciseLocationGranted { get; init; }
+
+    public bool MotionTrackingAvailable { get; init; }
+
+    public bool PlatformGeospatialAvailable { get; init; }
+
+    public bool DepthAvailable { get; init; }
+
+    public IReadOnlyList<string> MissingRequirements { get; init; } = [];
+
+    public void Validate()
+    {
+        ArgumentNullException.ThrowIfNull(MissingRequirements);
+        foreach (var requirement in MissingRequirements)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(requirement);
+        }
+    }
+}
+
+/// <summary>
+/// Native AR session status after the platform adapter has started or updated the session.
+/// </summary>
+public sealed record HonuaNativeArSessionStatus
+{
+    public HonuaNativeArRuntime Runtime { get; init; } = HonuaNativeArRuntime.Unknown;
+
+    public HonuaNativeArSessionState State { get; init; } = HonuaNativeArSessionState.NotStarted;
+
+    public HonuaNativeArTrackingState TrackingState { get; init; } = HonuaNativeArTrackingState.Unknown;
+
+    public HonuaNativeArAnchoringMode ActiveAnchoringMode { get; init; } = HonuaNativeArAnchoringMode.Unknown;
+
+    public HonuaNativeArAccuracySample Accuracy { get; init; } = new();
+
+    public HonuaNativeArScenePackageState PackageState { get; init; } = HonuaNativeArScenePackageState.NotRequired;
+
+    public int ConfirmedControlPointCount { get; init; }
+
+    public bool IsOnline { get; init; } = true;
+
+    public string? SceneId { get; init; }
+
+    public string? SceneRevision { get; init; }
+
+    public string? PackageId { get; init; }
+
+    public DateTimeOffset UpdatedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+
+    public void Validate()
+    {
+        ArgumentNullException.ThrowIfNull(Accuracy);
+        Accuracy.Validate();
+
+        ArgumentNullException.ThrowIfNull(Warnings);
+        foreach (var warning in Warnings)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(warning);
+        }
+
+        if (ConfirmedControlPointCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(ConfirmedControlPointCount),
+                "Confirmed control point count must be non-negative.");
+        }
+    }
+}
+
+/// <summary>
+/// Mobile UI gate derived from native AR status and workflow thresholds.
+/// </summary>
+public sealed record HonuaNativeArReadiness
+{
+    public HonuaNativeArReadinessLevel Level { get; init; }
+
+    public IReadOnlyList<string> Blockers { get; init; } = [];
+
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+
+    public bool CanRenderOverlay => Level >= HonuaNativeArReadinessLevel.CoarsePreview;
+
+    public bool CanCaptureEvidence => Level >= HonuaNativeArReadinessLevel.SiteReview;
+
+    public bool CanUsePrecisionTools => Level == HonuaNativeArReadinessLevel.PrecisionInspection;
+}
+
+/// <summary>
+/// Platform adapter for native ARKit/ARCore scene anchoring.
+/// </summary>
+public interface IHonuaNativeArSceneAnchorAdapter
+{
+    HonuaNativeArRuntime Runtime { get; }
+
+    ValueTask<HonuaNativeArCapabilityStatus> CheckSupportAsync(CancellationToken ct = default);
+
+    ValueTask<HonuaNativeArSessionStatus> StartSessionAsync(
+        HonuaNativeArSceneAnchorRequest request,
+        CancellationToken ct = default);
+
+    ValueTask<HonuaNativeArSessionStatus> GetStatusAsync(CancellationToken ct = default);
+
+    ValueTask<HonuaNativeArSessionStatus> PauseSessionAsync(CancellationToken ct = default);
+
+    ValueTask<HonuaNativeArSessionStatus> ResumeSessionAsync(
+        HonuaNativeArSceneAnchorRequest request,
+        CancellationToken ct = default);
+
+    ValueTask StopSessionAsync(CancellationToken ct = default);
+}

--- a/tests/Honua.Mobile.Maui.Tests/HonuaNativeSceneAnchoringTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaNativeSceneAnchoringTests.cs
@@ -1,0 +1,295 @@
+using Honua.Mobile.Maui;
+using Honua.Mobile.Maui.SceneAnchoring;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Mobile.Maui.Tests;
+
+public sealed class HonuaNativeSceneAnchoringTests
+{
+    [Fact]
+    public async Task StartAsync_WhenPlatformSupported_StartsAdapterAndReturnsSiteReviewReadiness()
+    {
+        var adapter = new RecordingNativeArSceneAnchorAdapter
+        {
+            StartStatus = CreateStatus(
+                activeAnchoringMode: HonuaNativeArAnchoringMode.PlatformGeospatial,
+                horizontalAccuracyMeters: 1.2,
+                yawAccuracyDegrees: 8),
+        };
+        var controller = new HonuaNativeArSceneAnchoringController(adapter);
+        var request = CreateRequest();
+
+        var readiness = await controller.StartAsync(request);
+
+        Assert.Equal(HonuaNativeArReadinessLevel.SiteReview, readiness.Level);
+        Assert.True(readiness.CanRenderOverlay);
+        Assert.True(readiness.CanCaptureEvidence);
+        Assert.False(readiness.CanUsePrecisionTools);
+        Assert.Same(request, Assert.Single(adapter.StartRequests));
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenPlatformUnsupported_DoesNotStartAdapter()
+    {
+        var adapter = new RecordingNativeArSceneAnchorAdapter
+        {
+            Support = new HonuaNativeArCapabilityStatus
+            {
+                Runtime = HonuaNativeArRuntime.AndroidArCore,
+                IsSupported = false,
+                CameraPermissionGranted = true,
+                LocationPermissionGranted = true,
+                MotionTrackingAvailable = true,
+                MissingRequirements = ["ARCore geospatial mode is unavailable"],
+            },
+        };
+        var controller = new HonuaNativeArSceneAnchoringController(adapter);
+
+        var readiness = await controller.StartAsync(CreateRequest());
+
+        Assert.Equal(HonuaNativeArReadinessLevel.Unsupported, readiness.Level);
+        Assert.Contains(readiness.Blockers, blocker => blocker.Contains("ARCore geospatial", StringComparison.Ordinal));
+        Assert.Empty(adapter.StartRequests);
+    }
+
+    [Fact]
+    public void EvaluateReadiness_GpsOnlyAnchoringNeverEnablesPrecisionTools()
+    {
+        var request = CreateRequest(
+            controlPointIds: ["cp-a", "cp-b", "cp-c"],
+            sourceDeclaresSurveyQuality: true);
+        var status = CreateStatus(
+            activeAnchoringMode: HonuaNativeArAnchoringMode.GpsPreview,
+            horizontalAccuracyMeters: 0.8,
+            yawAccuracyDegrees: 5,
+            calibrationResidualMeters: 0.2,
+            confirmedControlPointCount: 3);
+
+        var readiness = HonuaNativeArSceneAnchoringController.EvaluateReadiness(status, request);
+
+        Assert.Equal(HonuaNativeArReadinessLevel.CoarsePreview, readiness.Level);
+        Assert.True(readiness.CanRenderOverlay);
+        Assert.False(readiness.CanCaptureEvidence);
+        Assert.False(readiness.CanUsePrecisionTools);
+        Assert.Contains(readiness.Warnings, warning => warning.Contains("GPS-only", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void EvaluateReadiness_OfflinePackageMustBeValidBeforeRendering()
+    {
+        var request = CreateRequest(isOffline: true, packageId: "pkg-2026-05");
+        var status = CreateStatus(
+            packageState: HonuaNativeArScenePackageState.Expired,
+            packageId: "pkg-2026-05",
+            horizontalAccuracyMeters: 1);
+
+        var readiness = HonuaNativeArSceneAnchoringController.EvaluateReadiness(status, request);
+
+        Assert.Equal(HonuaNativeArReadinessLevel.Blocked, readiness.Level);
+        Assert.False(readiness.CanRenderOverlay);
+        Assert.Contains(readiness.Blockers, blocker => blocker.Contains("Expired", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void EvaluateReadiness_PrecisionRequiresSurveyQualityControlPointsAndResidual()
+    {
+        var request = CreateRequest(
+            controlPointIds: ["cp-a", "cp-b"],
+            sourceDeclaresSurveyQuality: true);
+        var status = CreateStatus(
+            activeAnchoringMode: HonuaNativeArAnchoringMode.ControlPointCalibration,
+            horizontalAccuracyMeters: 0.5,
+            yawAccuracyDegrees: 4,
+            calibrationResidualMeters: 0.25,
+            confirmedControlPointCount: 2);
+
+        var readiness = HonuaNativeArSceneAnchoringController.EvaluateReadiness(status, request);
+
+        Assert.Equal(HonuaNativeArReadinessLevel.PrecisionInspection, readiness.Level);
+        Assert.True(readiness.CanUsePrecisionTools);
+    }
+
+    [Fact]
+    public void EvaluateReadiness_VerticalPlacementRequiresThreeControlPointsForPrecision()
+    {
+        var request = CreateRequest(
+            controlPointIds: ["cp-a", "cp-b"],
+            requiresVerticalPlacement: true,
+            sourceDeclaresSurveyQuality: true);
+        var status = CreateStatus(
+            activeAnchoringMode: HonuaNativeArAnchoringMode.ControlPointCalibration,
+            horizontalAccuracyMeters: 0.5,
+            yawAccuracyDegrees: 4,
+            calibrationResidualMeters: 0.25,
+            confirmedControlPointCount: 2);
+
+        var readiness = HonuaNativeArSceneAnchoringController.EvaluateReadiness(status, request);
+
+        Assert.Equal(HonuaNativeArReadinessLevel.SiteReview, readiness.Level);
+        Assert.False(readiness.CanUsePrecisionTools);
+        Assert.Contains(readiness.Warnings, warning => warning.Contains("additional confirmed control points", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task HandleAppLifecycleAsync_PausesResumesAndStopsNativeSession()
+    {
+        var adapter = new RecordingNativeArSceneAnchorAdapter
+        {
+            Status = CreateStatus(activeAnchoringMode: HonuaNativeArAnchoringMode.PlatformGeospatial),
+            StartStatus = CreateStatus(activeAnchoringMode: HonuaNativeArAnchoringMode.PlatformGeospatial),
+            PauseStatus = CreateStatus(
+                state: HonuaNativeArSessionState.Paused,
+                trackingState: HonuaNativeArTrackingState.Paused,
+                activeAnchoringMode: HonuaNativeArAnchoringMode.PlatformGeospatial),
+            ResumeStatus = CreateStatus(activeAnchoringMode: HonuaNativeArAnchoringMode.PlatformGeospatial),
+        };
+        var controller = new HonuaNativeArSceneAnchoringController(adapter);
+        var request = CreateRequest();
+
+        await controller.StartAsync(request);
+        await controller.HandleAppLifecycleAsync(HonuaNativeArAppLifecycleEvent.EnteringBackground);
+        await controller.HandleAppLifecycleAsync(HonuaNativeArAppLifecycleEvent.ResumingForeground);
+        await controller.HandleAppLifecycleAsync(HonuaNativeArAppLifecycleEvent.Stopping);
+
+        Assert.Equal(1, adapter.GetStatusCalls);
+        Assert.Equal(1, adapter.PauseCalls);
+        Assert.Same(request, Assert.Single(adapter.ResumeRequests));
+        Assert.Equal(1, adapter.StopCalls);
+    }
+
+    [Fact]
+    public void AddHonuaNativeSceneAnchoring_RegistersControllerAndOptions()
+    {
+        var options = new HonuaNativeArSessionOptions
+        {
+            CoarsePreviewHorizontalAccuracyMeters = 12,
+        };
+
+        using var provider = new ServiceCollection()
+            .AddSingleton<IHonuaNativeArSceneAnchorAdapter, RecordingNativeArSceneAnchorAdapter>()
+            .AddHonuaNativeSceneAnchoring(options)
+            .BuildServiceProvider();
+
+        Assert.Same(options, provider.GetRequiredService<HonuaNativeArSessionOptions>());
+        Assert.NotNull(provider.GetRequiredService<HonuaNativeArSceneAnchoringController>());
+    }
+
+    private static HonuaNativeArSceneAnchorRequest CreateRequest(
+        bool isOffline = false,
+        string? packageId = null,
+        bool requiresVerticalPlacement = false,
+        bool sourceDeclaresSurveyQuality = false,
+        IReadOnlyList<string>? controlPointIds = null)
+        => new()
+        {
+            SceneId = "downtown-honolulu",
+            SceneRevision = "scene-rev-42",
+            PackageId = packageId,
+            IsOffline = isOffline,
+            RequiresVerticalPlacement = requiresVerticalPlacement,
+            SourceDeclaresSurveyQuality = sourceDeclaresSurveyQuality,
+            ControlPointIds = controlPointIds ?? [],
+        };
+
+    private static HonuaNativeArSessionStatus CreateStatus(
+        HonuaNativeArSessionState state = HonuaNativeArSessionState.Running,
+        HonuaNativeArTrackingState trackingState = HonuaNativeArTrackingState.Tracking,
+        HonuaNativeArAnchoringMode activeAnchoringMode = HonuaNativeArAnchoringMode.PlatformGeospatial,
+        HonuaNativeArScenePackageState packageState = HonuaNativeArScenePackageState.NotRequired,
+        string? packageId = null,
+        double? horizontalAccuracyMeters = 1,
+        double? yawAccuracyDegrees = null,
+        double? calibrationResidualMeters = null,
+        int confirmedControlPointCount = 0)
+        => new()
+        {
+            Runtime = HonuaNativeArRuntime.AndroidArCore,
+            State = state,
+            TrackingState = trackingState,
+            ActiveAnchoringMode = activeAnchoringMode,
+            SceneId = "downtown-honolulu",
+            SceneRevision = "scene-rev-42",
+            PackageId = packageId,
+            PackageState = packageState,
+            ConfirmedControlPointCount = confirmedControlPointCount,
+            Accuracy = new HonuaNativeArAccuracySample
+            {
+                HorizontalAccuracyMeters = horizontalAccuracyMeters,
+                YawAccuracyDegrees = yawAccuracyDegrees,
+                CalibrationResidualMeters = calibrationResidualMeters,
+            },
+        };
+
+    private sealed class RecordingNativeArSceneAnchorAdapter : IHonuaNativeArSceneAnchorAdapter
+    {
+        public HonuaNativeArRuntime Runtime => HonuaNativeArRuntime.AndroidArCore;
+
+        public HonuaNativeArCapabilityStatus Support { get; init; } = new()
+        {
+            Runtime = HonuaNativeArRuntime.AndroidArCore,
+            IsSupported = true,
+            CameraPermissionGranted = true,
+            LocationPermissionGranted = true,
+            PreciseLocationGranted = true,
+            MotionTrackingAvailable = true,
+            PlatformGeospatialAvailable = true,
+        };
+
+        public HonuaNativeArSessionStatus Status { get; init; } = CreateStatus();
+
+        public HonuaNativeArSessionStatus StartStatus { get; init; } = CreateStatus();
+
+        public HonuaNativeArSessionStatus PauseStatus { get; init; } = CreateStatus(
+            state: HonuaNativeArSessionState.Paused,
+            trackingState: HonuaNativeArTrackingState.Paused);
+
+        public HonuaNativeArSessionStatus ResumeStatus { get; init; } = CreateStatus();
+
+        public List<HonuaNativeArSceneAnchorRequest> StartRequests { get; } = [];
+
+        public List<HonuaNativeArSceneAnchorRequest> ResumeRequests { get; } = [];
+
+        public int GetStatusCalls { get; private set; }
+
+        public int PauseCalls { get; private set; }
+
+        public int StopCalls { get; private set; }
+
+        public ValueTask<HonuaNativeArCapabilityStatus> CheckSupportAsync(CancellationToken ct = default)
+            => ValueTask.FromResult(Support);
+
+        public ValueTask<HonuaNativeArSessionStatus> StartSessionAsync(
+            HonuaNativeArSceneAnchorRequest request,
+            CancellationToken ct = default)
+        {
+            StartRequests.Add(request);
+            return ValueTask.FromResult(StartStatus);
+        }
+
+        public ValueTask<HonuaNativeArSessionStatus> GetStatusAsync(CancellationToken ct = default)
+        {
+            GetStatusCalls++;
+            return ValueTask.FromResult(Status);
+        }
+
+        public ValueTask<HonuaNativeArSessionStatus> PauseSessionAsync(CancellationToken ct = default)
+        {
+            PauseCalls++;
+            return ValueTask.FromResult(PauseStatus);
+        }
+
+        public ValueTask<HonuaNativeArSessionStatus> ResumeSessionAsync(
+            HonuaNativeArSceneAnchorRequest request,
+            CancellationToken ct = default)
+        {
+            ResumeRequests.Add(request);
+            return ValueTask.FromResult(ResumeStatus);
+        }
+
+        public ValueTask StopSessionAsync(CancellationToken ct = default)
+        {
+            StopCalls++;
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/Honua.Mobile.Maui.Tests/HonuaNativeSceneAnchoringTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaNativeSceneAnchoringTests.cs
@@ -53,6 +53,21 @@ public sealed class HonuaNativeSceneAnchoringTests
     }
 
     [Fact]
+    public async Task StartAsync_WhenAdapterStartFails_DoesNotLeaveActiveSession()
+    {
+        var adapter = new RecordingNativeArSceneAnchorAdapter
+        {
+            StartException = new ApplicationException("Native AR session failed to start."),
+        };
+        var controller = new HonuaNativeArSceneAnchoringController(adapter);
+
+        await Assert.ThrowsAsync<ApplicationException>(async () => await controller.StartAsync(CreateRequest()));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await controller.RefreshReadinessAsync());
+        Assert.Equal(0, adapter.GetStatusCalls);
+    }
+
+    [Fact]
     public void EvaluateReadiness_GpsOnlyAnchoringNeverEnablesPrecisionTools()
     {
         var request = CreateRequest(
@@ -88,6 +103,21 @@ public sealed class HonuaNativeSceneAnchoringTests
         Assert.Equal(HonuaNativeArReadinessLevel.Blocked, readiness.Level);
         Assert.False(readiness.CanRenderOverlay);
         Assert.Contains(readiness.Blockers, blocker => blocker.Contains("Expired", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void EvaluateReadiness_MissingYawAccuracyDoesNotEnableSiteReview()
+    {
+        var readiness = HonuaNativeArSceneAnchoringController.EvaluateReadiness(
+            CreateStatus(
+                activeAnchoringMode: HonuaNativeArAnchoringMode.PlatformGeospatial,
+                horizontalAccuracyMeters: 1,
+                yawAccuracyDegrees: null),
+            CreateRequest());
+
+        Assert.Equal(HonuaNativeArReadinessLevel.CoarsePreview, readiness.Level);
+        Assert.False(readiness.CanCaptureEvidence);
+        Assert.Contains(readiness.Warnings, warning => warning.Contains("Yaw accuracy", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -239,6 +269,8 @@ public sealed class HonuaNativeSceneAnchoringTests
 
         public HonuaNativeArSessionStatus StartStatus { get; init; } = CreateStatus();
 
+        public Exception? StartException { get; init; }
+
         public HonuaNativeArSessionStatus PauseStatus { get; init; } = CreateStatus(
             state: HonuaNativeArSessionState.Paused,
             trackingState: HonuaNativeArTrackingState.Paused);
@@ -262,6 +294,11 @@ public sealed class HonuaNativeSceneAnchoringTests
             HonuaNativeArSceneAnchorRequest request,
             CancellationToken ct = default)
         {
+            if (StartException is not null)
+            {
+                throw StartException;
+            }
+
             StartRequests.Add(request);
             return ValueTask.FromResult(StartStatus);
         }


### PR DESCRIPTION
## Summary
- Add MAUI-owned native AR scene anchoring contracts and controller for ARKit/ARCore adapter implementations.
- Gate AR UX readiness for coarse preview, site review, and precision inspection using tracking state, accuracy, package state, control points, residuals, and survey-quality input.
- Document the #38/#23 mobile adapter boundary without adding server clients, SDK-neutral scene contracts, or geometry primitives.

## Validation
- git diff --check origin/main..HEAD
- dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj --no-restore
- dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --no-build
- dotnet format tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --verify-no-changes --no-restore

Related to #38.
Related to #23.