### PR TITLE
feat: add mobile plugin host primitives

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -17,6 +17,7 @@ In-depth guides for building with the Honua Mobile SDK.
 | [Offline 3D Scene Packages](offline-3d-scene-packages.md) | Package manifest, cache, expiry, and platform policy for offline 3D scenes |
 | [Offline Sync](offline-sync.md) | GeoPackage storage, sync engine configuration, and conflict resolution |
 | [Performance](performance.md) | Optimizing startup time, memory usage, and sync throughput |
+| [Plugin Client Extension Hosts](plugin-client-extension-hosts.md) | MAUI and web host/runtime plugin boundaries, SDK/server dependencies, and intentionally deferred contract work |
 | [Plugin and Host Extension Boundary](plugin-extension-api.md) | Web embed extension APIs and the SDK/mobile ownership split for plugin work |
 | [Protected 3D Scene Auth](protected-3d-scene-auth.md) | Signed URL, proxy, header, CORS, cache, and revocation policy for protected scene assets |
 | [Scene Controls](scene-controls.md) | `<honua-scene-*>` control surfaces, `HonuaSceneMetadata` schema, and typed scene events |

--- a/docs/guides/plugin-client-extension-hosts.md
+++ b/docs/guides/plugin-client-extension-hosts.md
@@ -1,0 +1,116 @@
+# Plugin Client Extension Hosts
+
+Issue [#16](https://github.com/honua-io/honua-mobile/issues/16) is scoped to
+client host/runtime extension points for mobile and web. Portable plugin
+contracts remain outside this repo.
+
+## Ownership Boundary
+
+| Surface | Owner | Notes |
+| --- | --- | --- |
+| MAUI map plugin activation, host registries, UI mounting, native renderer adapters, and failure isolation | `honua-mobile` | Implemented as thin runtime primitives under `Honua.Mobile.Maui.Plugins`. |
+| Web component and browser host extension details | `honua-mobile` / `@honua-io/embed` | Documented here only for this branch; active embed implementation work stays separate. |
+| Non-UI plugin manifests, permissions, compatibility checks, validators, calculated fields, data transforms, and workflow hooks | `honua-sdk-dotnet` | Track in [honua-sdk-dotnet#72](https://github.com/honua-io/honua-sdk-dotnet/issues/72) and consume as versioned `Honua.Sdk.*` NuGet packages. |
+| Server plugin endpoints, server-side hooks, validators, computed fields, marketplace/discovery APIs, and trusted package metadata | `honua-server` | Track in [honua-server#347](https://github.com/honua-io/honua-server/issues/347). |
+
+The mobile repo should not define durable copies of SDK-owned schemas. If a
+plugin needs source descriptors, field schema, validation, routing, scene,
+feature query/edit, permission, or manifest contracts, add or consume a
+published `Honua.Sdk.*` package and keep this repo limited to adapters and host
+registration.
+
+## MAUI Host APIs
+
+`Honua.Mobile.Maui.Plugins` provides host-owned extension points:
+
+- `IHonuaMapPlugin` for runtime map plugins.
+- `HonuaMapPluginHost` for activating registered plugins.
+- `HonuaMapPluginContributionRegistry` snapshots for toolbar buttons, UI
+  extensions, and native feature renderer adapters.
+- `AddHonuaMapPluginHost` and `AddHonuaMapPlugin<TPlugin>` DI helpers in a
+  separate plugin-host registration extension file.
+
+Example:
+
+```csharp
+using Honua.Mobile.Maui.Plugins;
+using Microsoft.Extensions.DependencyInjection;
+
+services
+    .AddHonuaMapPluginHost()
+    .AddHonuaMapPlugin<TenantInspectionMapPlugin>();
+
+public sealed class TenantInspectionMapPlugin : IHonuaMapPlugin
+{
+    public HonuaMapPluginDescriptor Descriptor { get; } = new()
+    {
+        Id = "tenant.inspections",
+        DisplayName = "Tenant inspections",
+        Version = new Version(1, 0, 0),
+        Priority = 20,
+    };
+
+    public ValueTask ActivateAsync(IHonuaMapPluginContext context, CancellationToken ct = default)
+    {
+        context.AddToolbarButton(new HonuaMapPluginToolbarButton
+        {
+            Id = "tenant.inspections.capture",
+            Title = "Capture inspection",
+            Icon = "camera",
+            ExecuteAsync = async (command, token) =>
+            {
+                var capture = command.Services.GetRequiredService<TenantInspectionCapture>();
+                await capture.StartAsync(token).ConfigureAwait(false);
+            },
+        });
+
+        context.AddUiExtension(new HonuaMapPluginUiExtension
+        {
+            Id = "tenant.inspections.panel",
+            Title = "Inspections",
+            Kind = HonuaMapPluginUiExtensionKind.Panel,
+            ViewModelType = typeof(TenantInspectionPanelViewModel),
+        });
+
+        return ValueTask.CompletedTask;
+    }
+}
+```
+
+`HonuaMapPluginHost.ActivateAsync` isolates failures per plugin. A plugin that
+throws while activating, or registers duplicate contributions, is reported in
+`HonuaMapPluginActivationReport.Failures`. Contributions from that failed
+plugin are not merged into the host snapshot, so other plugins can continue to
+load.
+
+This is runtime failure isolation, not a process sandbox. Code signing,
+enterprise trust, permission enforcement, and package provenance require the SDK
+and server work linked above.
+
+## Web Host Boundary
+
+Web hosts should expose browser/runtime extension points only:
+
+- ES module registration for map and scene host extensions.
+- React/Vue/Svelte component mounting adapters owned by the web host.
+- DOM events, CSS custom properties, toolbar controls, panels, and floating
+  widgets.
+- Failure events that identify which extension failed without tearing down the
+  host component.
+
+Web host plugins should consume SDK-owned TypeScript or generated contract
+packages when they need shared manifests, permissions, validation, feature
+queries, routing, scenes, or data transforms. This branch intentionally does not
+change `src/Honua.Embed` while embed PRs are active.
+
+## Intentionally Not Implemented Here
+
+- No mobile-local plugin manifest, permission, validator, data-transform, or
+  workflow hook contracts.
+- No new plain `net*` clients for server plugin APIs.
+- No local copies of SDK geometry, source, scene, field, routing, or feature
+  edit contracts.
+- No React Native bridge, web ES module loader, marketplace, code-signing,
+  package discovery, or hot-reload implementation in this branch.
+- No long-lived `ProjectReference` to `honua-sdk-dotnet`; consume published
+  `Honua.Sdk.*` packages as contracts become available.

--- a/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginContracts.cs
+++ b/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginContracts.cs
@@ -1,0 +1,142 @@
+namespace Honua.Mobile.Maui.Plugins;
+
+/// <summary>
+/// MAUI-owned metadata for a runtime map plugin. This is not a portable plugin manifest.
+/// </summary>
+public sealed record HonuaMapPluginDescriptor
+{
+    public required string Id { get; init; }
+
+    public required string DisplayName { get; init; }
+
+    public Version? Version { get; init; }
+
+    public int Priority { get; init; }
+
+    public void Validate()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(Id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(DisplayName);
+    }
+}
+
+/// <summary>
+/// Runtime map plugin extension point for MAUI hosts.
+/// </summary>
+public interface IHonuaMapPlugin
+{
+    HonuaMapPluginDescriptor Descriptor { get; }
+
+    ValueTask ActivateAsync(IHonuaMapPluginContext context, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Host capabilities exposed to a map plugin while it activates.
+/// </summary>
+public interface IHonuaMapPluginContext
+{
+    IServiceProvider Services { get; }
+
+    HonuaMapPluginDescriptor Plugin { get; }
+
+    void AddToolbarButton(HonuaMapPluginToolbarButton button);
+
+    void AddUiExtension(HonuaMapPluginUiExtension extension);
+
+    void AddFeatureRenderer(HonuaMapPluginFeatureRenderer renderer);
+}
+
+/// <summary>
+/// Context passed when a host invokes a plugin-owned map command.
+/// </summary>
+public sealed record HonuaMapPluginCommandContext
+{
+    public required IServiceProvider Services { get; init; }
+
+    public IReadOnlyDictionary<string, object?> Properties { get; init; } =
+        new Dictionary<string, object?>();
+}
+
+/// <summary>
+/// Toolbar command contributed by a map plugin.
+/// </summary>
+public sealed record HonuaMapPluginToolbarButton
+{
+    public required string Id { get; init; }
+
+    public required string Title { get; init; }
+
+    public string? Icon { get; init; }
+
+    public int Order { get; init; }
+
+    public required Func<HonuaMapPluginCommandContext, CancellationToken, ValueTask> ExecuteAsync { get; init; }
+
+    public void Validate()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(Id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(Title);
+        ArgumentNullException.ThrowIfNull(ExecuteAsync);
+    }
+}
+
+public enum HonuaMapPluginUiExtensionKind
+{
+    Panel,
+    FloatingWidget,
+    Dialog,
+    Form,
+    WorkflowScreen,
+}
+
+/// <summary>
+/// UI surface contributed by a map plugin for the MAUI host to mount.
+/// </summary>
+public sealed record HonuaMapPluginUiExtension
+{
+    public required string Id { get; init; }
+
+    public required string Title { get; init; }
+
+    public HonuaMapPluginUiExtensionKind Kind { get; init; } = HonuaMapPluginUiExtensionKind.Panel;
+
+    public Type? ViewType { get; init; }
+
+    public Type? ViewModelType { get; init; }
+
+    public string? Outlet { get; init; }
+
+    public int Order { get; init; }
+
+    public IReadOnlyDictionary<string, object?> Metadata { get; init; } =
+        new Dictionary<string, object?>();
+
+    public void Validate()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(Id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(Title);
+    }
+}
+
+/// <summary>
+/// Feature renderer adapter contributed by a map plugin for a native map host.
+/// </summary>
+public sealed record HonuaMapPluginFeatureRenderer
+{
+    public required string Id { get; init; }
+
+    public required Type RendererType { get; init; }
+
+    public string? LayerId { get; init; }
+
+    public int Order { get; init; }
+
+    public IReadOnlyDictionary<string, object?> RendererHints { get; init; } =
+        new Dictionary<string, object?>();
+
+    public void Validate()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(Id);
+        ArgumentNullException.ThrowIfNull(RendererType);
+    }
+}

--- a/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginContributionRegistry.cs
+++ b/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginContributionRegistry.cs
@@ -1,0 +1,117 @@
+namespace Honua.Mobile.Maui.Plugins;
+
+/// <summary>
+/// Plugin-owned contribution plus the plugin ID that registered it.
+/// </summary>
+/// <typeparam name="TContribution">Contribution descriptor type.</typeparam>
+public sealed record HonuaMapPluginContribution<TContribution>(
+    string PluginId,
+    TContribution Contribution);
+
+/// <summary>
+/// Immutable view of active map plugin contributions.
+/// </summary>
+public sealed record HonuaMapPluginContributionSnapshot
+{
+    public IReadOnlyList<HonuaMapPluginContribution<HonuaMapPluginToolbarButton>> ToolbarButtons { get; init; } =
+        [];
+
+    public IReadOnlyList<HonuaMapPluginContribution<HonuaMapPluginUiExtension>> UiExtensions { get; init; } =
+        [];
+
+    public IReadOnlyList<HonuaMapPluginContribution<HonuaMapPluginFeatureRenderer>> FeatureRenderers { get; init; } =
+        [];
+}
+
+/// <summary>
+/// In-memory registry for map plugin host contributions.
+/// </summary>
+public sealed class HonuaMapPluginContributionRegistry
+{
+    private readonly Dictionary<string, HonuaMapPluginContribution<HonuaMapPluginToolbarButton>> _toolbarButtons =
+        new(StringComparer.Ordinal);
+    private readonly Dictionary<string, HonuaMapPluginContribution<HonuaMapPluginUiExtension>> _uiExtensions =
+        new(StringComparer.Ordinal);
+    private readonly Dictionary<string, HonuaMapPluginContribution<HonuaMapPluginFeatureRenderer>> _featureRenderers =
+        new(StringComparer.Ordinal);
+
+    public void AddToolbarButton(string pluginId, HonuaMapPluginToolbarButton button)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pluginId);
+        ArgumentNullException.ThrowIfNull(button);
+
+        button.Validate();
+        Add(_toolbarButtons, pluginId, button.Id, button);
+    }
+
+    public void AddUiExtension(string pluginId, HonuaMapPluginUiExtension extension)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pluginId);
+        ArgumentNullException.ThrowIfNull(extension);
+
+        extension.Validate();
+        Add(_uiExtensions, pluginId, extension.Id, extension);
+    }
+
+    public void AddFeatureRenderer(string pluginId, HonuaMapPluginFeatureRenderer renderer)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pluginId);
+        ArgumentNullException.ThrowIfNull(renderer);
+
+        renderer.Validate();
+        Add(_featureRenderers, pluginId, renderer.Id, renderer);
+    }
+
+    public HonuaMapPluginContributionSnapshot Snapshot()
+        => new()
+        {
+            ToolbarButtons = _toolbarButtons.Values
+                .OrderBy(item => item.Contribution.Order)
+                .ThenBy(item => item.Contribution.Id, StringComparer.Ordinal)
+                .ToArray(),
+            UiExtensions = _uiExtensions.Values
+                .OrderBy(item => item.Contribution.Order)
+                .ThenBy(item => item.Contribution.Id, StringComparer.Ordinal)
+                .ToArray(),
+            FeatureRenderers = _featureRenderers.Values
+                .OrderBy(item => item.Contribution.Order)
+                .ThenBy(item => item.Contribution.Id, StringComparer.Ordinal)
+                .ToArray(),
+        };
+
+    internal void Merge(HonuaMapPluginContributionRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+
+        var snapshot = registry.Snapshot();
+        foreach (var item in snapshot.ToolbarButtons)
+        {
+            AddToolbarButton(item.PluginId, item.Contribution);
+        }
+
+        foreach (var item in snapshot.UiExtensions)
+        {
+            AddUiExtension(item.PluginId, item.Contribution);
+        }
+
+        foreach (var item in snapshot.FeatureRenderers)
+        {
+            AddFeatureRenderer(item.PluginId, item.Contribution);
+        }
+    }
+
+    private static void Add<TContribution>(
+        IDictionary<string, HonuaMapPluginContribution<TContribution>> contributions,
+        string pluginId,
+        string contributionId,
+        TContribution contribution)
+    {
+        if (!contributions.TryAdd(
+            contributionId,
+            new HonuaMapPluginContribution<TContribution>(pluginId, contribution)))
+        {
+            throw new InvalidOperationException(
+                $"Map plugin contribution '{contributionId}' is already registered.");
+        }
+    }
+}

--- a/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginHost.cs
+++ b/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginHost.cs
@@ -57,6 +57,15 @@ public sealed class HonuaMapPluginHost
         {
             ct.ThrowIfCancellationRequested();
 
+            if (plugin is null)
+            {
+                var ex = new InvalidOperationException("Map plugin registration resolved to null.");
+                const string pluginId = "<null>";
+                _logger?.LogError(ex, "Map plugin {PluginId} failed during activation.", pluginId);
+                failures.Add(new HonuaMapPluginActivationFailure(pluginId, ex.Message, ex));
+                continue;
+            }
+
             try
             {
                 var descriptor = plugin.Descriptor;

--- a/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginHost.cs
+++ b/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginHost.cs
@@ -1,0 +1,144 @@
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Mobile.Maui.Plugins;
+
+/// <summary>
+/// Activation failure captured for one map plugin without stopping the host.
+/// </summary>
+public sealed record HonuaMapPluginActivationFailure(
+    string PluginId,
+    string Message,
+    Exception Exception);
+
+/// <summary>
+/// Result of activating all registered map plugins.
+/// </summary>
+public sealed record HonuaMapPluginActivationReport
+{
+    public IReadOnlyList<HonuaMapPluginDescriptor> ActivatedPlugins { get; init; } = [];
+
+    public IReadOnlyList<HonuaMapPluginActivationFailure> Failures { get; init; } = [];
+
+    public HonuaMapPluginContributionSnapshot Contributions { get; init; } = new();
+
+    public bool HasFailures => Failures.Count > 0;
+}
+
+/// <summary>
+/// Activates MAUI map plugins and isolates failures to the plugin that caused them.
+/// </summary>
+public sealed class HonuaMapPluginHost
+{
+    private readonly IReadOnlyList<IHonuaMapPlugin> _plugins;
+    private readonly IServiceProvider _services;
+    private readonly ILogger<HonuaMapPluginHost>? _logger;
+
+    public HonuaMapPluginHost(
+        IEnumerable<IHonuaMapPlugin> plugins,
+        IServiceProvider services,
+        ILogger<HonuaMapPluginHost>? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(plugins);
+
+        _plugins = plugins.ToArray();
+        _services = services ?? throw new ArgumentNullException(nameof(services));
+        _logger = logger;
+    }
+
+    public async ValueTask<HonuaMapPluginActivationReport> ActivateAsync(CancellationToken ct = default)
+    {
+        var activated = new List<HonuaMapPluginDescriptor>();
+        var failures = new List<HonuaMapPluginActivationFailure>();
+        var contributions = new HonuaMapPluginContributionRegistry();
+        var candidates = new List<(HonuaMapPluginDescriptor Descriptor, IHonuaMapPlugin Plugin)>();
+        var pluginIds = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var plugin in _plugins)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            try
+            {
+                var descriptor = plugin.Descriptor;
+                ArgumentNullException.ThrowIfNull(descriptor);
+                descriptor.Validate();
+                candidates.Add((descriptor, plugin));
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                var pluginId = plugin.GetType().FullName ?? plugin.GetType().Name;
+                _logger?.LogError(ex, "Map plugin {PluginId} failed during activation.", pluginId);
+                failures.Add(new HonuaMapPluginActivationFailure(pluginId, ex.Message, ex));
+            }
+        }
+
+        foreach (var (descriptor, plugin) in candidates.OrderBy(item => item.Descriptor.Priority))
+        {
+            ct.ThrowIfCancellationRequested();
+
+            try
+            {
+                if (!pluginIds.Add(descriptor.Id))
+                {
+                    throw new InvalidOperationException(
+                        $"Map plugin '{descriptor.Id}' is already registered.");
+                }
+
+                var pluginContributions = new HonuaMapPluginContributionRegistry();
+                var context = new HonuaMapPluginContext(_services, descriptor, pluginContributions);
+                await plugin.ActivateAsync(context, ct).ConfigureAwait(false);
+
+                contributions.Merge(pluginContributions);
+                activated.Add(descriptor);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Map plugin {PluginId} failed during activation.", descriptor.Id);
+                failures.Add(new HonuaMapPluginActivationFailure(descriptor.Id, ex.Message, ex));
+            }
+        }
+
+        return new HonuaMapPluginActivationReport
+        {
+            ActivatedPlugins = activated.ToArray(),
+            Failures = failures.ToArray(),
+            Contributions = contributions.Snapshot(),
+        };
+    }
+
+    private sealed class HonuaMapPluginContext : IHonuaMapPluginContext
+    {
+        private readonly HonuaMapPluginContributionRegistry _registry;
+
+        public HonuaMapPluginContext(
+            IServiceProvider services,
+            HonuaMapPluginDescriptor plugin,
+            HonuaMapPluginContributionRegistry registry)
+        {
+            Services = services ?? throw new ArgumentNullException(nameof(services));
+            Plugin = plugin ?? throw new ArgumentNullException(nameof(plugin));
+            _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        }
+
+        public IServiceProvider Services { get; }
+
+        public HonuaMapPluginDescriptor Plugin { get; }
+
+        public void AddToolbarButton(HonuaMapPluginToolbarButton button)
+            => _registry.AddToolbarButton(Plugin.Id, button);
+
+        public void AddUiExtension(HonuaMapPluginUiExtension extension)
+            => _registry.AddUiExtension(Plugin.Id, extension);
+
+        public void AddFeatureRenderer(HonuaMapPluginFeatureRenderer renderer)
+            => _registry.AddFeatureRenderer(Plugin.Id, renderer);
+    }
+}

--- a/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Mobile.Maui.Plugins;
+
+/// <summary>
+/// Dependency injection helpers for MAUI map plugin hosts.
+/// </summary>
+public static class HonuaMapPluginServiceCollectionExtensions
+{
+    public static IServiceCollection AddHonuaMapPluginHost(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton(sp => new HonuaMapPluginHost(
+            sp.GetServices<IHonuaMapPlugin>(),
+            sp,
+            sp.GetService<ILogger<HonuaMapPluginHost>>()));
+        return services;
+    }
+
+    public static IServiceCollection AddHonuaMapPlugin<TPlugin>(this IServiceCollection services)
+        where TPlugin : class, IHonuaMapPlugin
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddHonuaMapPluginHost();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHonuaMapPlugin, TPlugin>());
+        return services;
+    }
+
+    public static IServiceCollection AddHonuaMapPlugin(
+        this IServiceCollection services,
+        IHonuaMapPlugin plugin)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(plugin);
+
+        services.AddHonuaMapPluginHost();
+        services.AddSingleton<IHonuaMapPlugin>(plugin);
+        return services;
+    }
+}

--- a/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
@@ -20,7 +21,9 @@ public static class HonuaMapPluginServiceCollectionExtensions
         return services;
     }
 
-    public static IServiceCollection AddHonuaMapPlugin<TPlugin>(this IServiceCollection services)
+    public static IServiceCollection AddHonuaMapPlugin<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TPlugin>(
+        this IServiceCollection services)
         where TPlugin : class, IHonuaMapPlugin
     {
         ArgumentNullException.ThrowIfNull(services);

--- a/tests/Honua.Mobile.Maui.Tests/HonuaMapPluginHostTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaMapPluginHostTests.cs
@@ -1,0 +1,187 @@
+using Honua.Mobile.Maui.Plugins;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Mobile.Maui.Tests;
+
+public sealed class HonuaMapPluginHostTests
+{
+    [Fact]
+    public async Task ActivateAsync_ActivatesHealthyPluginsInPriorityOrder()
+    {
+        using var provider = new ServiceCollection()
+            .AddHonuaMapPlugin(new RecordingMapPlugin("later", priority: 20))
+            .AddHonuaMapPlugin(new RecordingMapPlugin("first", priority: 5))
+            .BuildServiceProvider();
+
+        var report = await provider.GetRequiredService<HonuaMapPluginHost>().ActivateAsync();
+
+        Assert.False(report.HasFailures);
+        Assert.Equal(["first", "later"], report.ActivatedPlugins.Select(plugin => plugin.Id));
+        Assert.Equal(["first-action", "later-action"], report.Contributions.ToolbarButtons
+            .Select(item => item.Contribution.Id));
+        Assert.Equal(["first-panel", "later-panel"], report.Contributions.UiExtensions
+            .Select(item => item.Contribution.Id));
+        Assert.Equal(["first-renderer", "later-renderer"], report.Contributions.FeatureRenderers
+            .Select(item => item.Contribution.Id));
+    }
+
+    [Fact]
+    public async Task ActivateAsync_DropsContributionsFromPluginThatThrows()
+    {
+        using var provider = new ServiceCollection()
+            .AddHonuaMapPlugin(new RecordingMapPlugin("healthy"))
+            .AddHonuaMapPlugin(new ThrowingMapPlugin(addContributionBeforeFailure: true))
+            .BuildServiceProvider();
+
+        var report = await provider.GetRequiredService<HonuaMapPluginHost>().ActivateAsync();
+
+        var failure = Assert.Single(report.Failures);
+        Assert.Equal("broken", failure.PluginId);
+        Assert.IsType<InvalidOperationException>(failure.Exception);
+        Assert.Equal("healthy", Assert.Single(report.ActivatedPlugins).Id);
+        Assert.DoesNotContain(report.Contributions.ToolbarButtons, item =>
+            item.Contribution.Id == "broken-action");
+    }
+
+    [Fact]
+    public async Task ActivateAsync_TreatsDuplicateContributionAsPluginFailure()
+    {
+        using var provider = new ServiceCollection()
+            .AddHonuaMapPlugin(new ToolbarOnlyPlugin("first", "shared-action", priority: 1))
+            .AddHonuaMapPlugin(new ToolbarOnlyPlugin("second", "shared-action", priority: 2))
+            .BuildServiceProvider();
+
+        var report = await provider.GetRequiredService<HonuaMapPluginHost>().ActivateAsync();
+
+        Assert.Equal("first", Assert.Single(report.ActivatedPlugins).Id);
+        Assert.Equal("second", Assert.Single(report.Failures).PluginId);
+
+        var button = Assert.Single(report.Contributions.ToolbarButtons);
+        Assert.Equal("first", button.PluginId);
+        Assert.Equal("shared-action", button.Contribution.Id);
+    }
+
+    [Fact]
+    public async Task AddHonuaMapPlugin_RegistersPluginTypeAndHost()
+    {
+        using var provider = new ServiceCollection()
+            .AddHonuaMapPlugin<TypedMapPlugin>()
+            .BuildServiceProvider();
+
+        var host = provider.GetRequiredService<HonuaMapPluginHost>();
+        var report = await host.ActivateAsync();
+
+        Assert.Equal("typed", Assert.Single(report.ActivatedPlugins).Id);
+        Assert.Equal("typed-action", Assert.Single(report.Contributions.ToolbarButtons).Contribution.Id);
+    }
+
+    private sealed class RecordingMapPlugin : IHonuaMapPlugin
+    {
+        private readonly string _id;
+
+        public RecordingMapPlugin(string id, int priority = 0)
+        {
+            _id = id;
+            Descriptor = new HonuaMapPluginDescriptor
+            {
+                Id = id,
+                DisplayName = id,
+                Priority = priority,
+            };
+        }
+
+        public HonuaMapPluginDescriptor Descriptor { get; }
+
+        public ValueTask ActivateAsync(IHonuaMapPluginContext context, CancellationToken ct = default)
+        {
+            context.AddToolbarButton(CreateToolbarButton($"{_id}-action"));
+            context.AddUiExtension(new HonuaMapPluginUiExtension
+            {
+                Id = $"{_id}-panel",
+                Title = $"{_id} panel",
+                Kind = HonuaMapPluginUiExtensionKind.Panel,
+                ViewModelType = typeof(RecordingMapPlugin),
+            });
+            context.AddFeatureRenderer(new HonuaMapPluginFeatureRenderer
+            {
+                Id = $"{_id}-renderer",
+                RendererType = typeof(RecordingRenderer),
+            });
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class ToolbarOnlyPlugin : IHonuaMapPlugin
+    {
+        private readonly string _buttonId;
+
+        public ToolbarOnlyPlugin(string id, string buttonId, int priority)
+        {
+            _buttonId = buttonId;
+            Descriptor = new HonuaMapPluginDescriptor
+            {
+                Id = id,
+                DisplayName = id,
+                Priority = priority,
+            };
+        }
+
+        public HonuaMapPluginDescriptor Descriptor { get; }
+
+        public ValueTask ActivateAsync(IHonuaMapPluginContext context, CancellationToken ct = default)
+        {
+            context.AddToolbarButton(CreateToolbarButton(_buttonId));
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingMapPlugin : IHonuaMapPlugin
+    {
+        private readonly bool _addContributionBeforeFailure;
+
+        public ThrowingMapPlugin(bool addContributionBeforeFailure = false)
+            => _addContributionBeforeFailure = addContributionBeforeFailure;
+
+        public HonuaMapPluginDescriptor Descriptor { get; } = new()
+        {
+            Id = "broken",
+            DisplayName = "Broken",
+            Priority = 10,
+        };
+
+        public ValueTask ActivateAsync(IHonuaMapPluginContext context, CancellationToken ct = default)
+        {
+            if (_addContributionBeforeFailure)
+            {
+                context.AddToolbarButton(CreateToolbarButton("broken-action"));
+            }
+
+            throw new InvalidOperationException("Plugin activation failed.");
+        }
+    }
+
+    private sealed class TypedMapPlugin : IHonuaMapPlugin
+    {
+        public HonuaMapPluginDescriptor Descriptor { get; } = new()
+        {
+            Id = "typed",
+            DisplayName = "Typed",
+        };
+
+        public ValueTask ActivateAsync(IHonuaMapPluginContext context, CancellationToken ct = default)
+        {
+            context.AddToolbarButton(CreateToolbarButton("typed-action"));
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingRenderer;
+
+    private static HonuaMapPluginToolbarButton CreateToolbarButton(string id)
+        => new()
+        {
+            Id = id,
+            Title = id,
+            ExecuteAsync = (_, _) => ValueTask.CompletedTask,
+        };
+}

--- a/tests/Honua.Mobile.Maui.Tests/HonuaMapPluginHostTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaMapPluginHostTests.cs
@@ -44,6 +44,24 @@ public sealed class HonuaMapPluginHostTests
     }
 
     [Fact]
+    public async Task ActivateAsync_TreatsNullPluginRegistrationAsActivationFailure()
+    {
+        var services = new ServiceCollection()
+            .AddHonuaMapPluginHost();
+        services.AddSingleton<IHonuaMapPlugin>(_ => null!);
+        services.AddSingleton<IHonuaMapPlugin>(new RecordingMapPlugin("healthy"));
+        using var provider = services.BuildServiceProvider();
+
+        var report = await provider.GetRequiredService<HonuaMapPluginHost>().ActivateAsync();
+
+        var failure = Assert.Single(report.Failures);
+        Assert.Equal("<null>", failure.PluginId);
+        Assert.Equal("Map plugin registration resolved to null.", failure.Message);
+        Assert.IsType<InvalidOperationException>(failure.Exception);
+        Assert.Equal("healthy", Assert.Single(report.ActivatedPlugins).Id);
+    }
+
+    [Fact]
     public async Task ActivateAsync_TreatsDuplicateContributionAsPluginFailure()
     {
         using var provider = new ServiceCollection()


### PR DESCRIPTION
## Summary
- Add MAUI-owned map plugin host primitives under Honua.Mobile.Maui.Plugins.
- Add contribution snapshots for toolbar buttons, UI extensions, and native feature renderer adapters.
- Add plugin activation failure isolation so one bad plugin does not prevent other plugins from loading.
- Add separate DI helpers for plugin host registration, avoiding the main mobile service extension file.
- Document the mobile/web host boundary and SDK/server-owned contract dependencies.

## Scope Notes
Refs #16.

This keeps non-UI plugin manifests, permissions, validators, data transforms, workflow hooks, and shared contracts out of honua-mobile. Those remain SDK/server-owned and should be consumed through versioned Honua.Sdk.* packages when available.

## Validation
- git diff --check origin/main..HEAD
- dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --no-restore