### PR TITLE
feat(embed): add MapLibre display lifecycle helpers

### DIFF
--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -112,6 +112,8 @@ display.setFeatureQueryResult(page, {
     console.log(object?.properties);
   },
 });
+
+display.fitToSource(sourceDescriptor, { padding: 32, maxZoom: 15 });
 ```
 
 Use MapLibre GL JS for base map, style, camera, vector-tile styles, and normal
@@ -128,6 +130,28 @@ const layer = createHonuaGeoJsonLayer(featureCollection, {
   id: 'honua-work-orders',
 });
 ```
+
+The adapter also exposes a small layer lifecycle surface for host-owned map
+screens:
+
+```js
+display.setView({
+  center: { longitude: -157.8583, latitude: 21.3069 },
+  zoom: 13,
+});
+
+display.setFeatureQueryResults([assetPage, workOrderPage], (_page, index) => ({
+  source: index === 0 ? assetSource : workOrderSource,
+}));
+
+const assets = display.getFeatureCollection('honua-assets');
+display.removeLayer('honua-work-orders');
+display.clearFeatureLayers();
+```
+
+`clearFeatureLayers()` only removes layers created by feature query and stream
+helpers. Host-owned deck.gl layers passed to the adapter constructor remain in
+place.
 
 Streaming feature feeds can use the same renderer-neutral source descriptor and
 apply upsert/delete events into the adapter's GeoJSON layer state:

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -45,7 +45,14 @@ const display = new HonuaWebDisplayAdapter(map);
 display.setFeatureQueryResult(featureQueryResultPage, {
   source: sourceDescriptor,
 });
+display.fitToSource(sourceDescriptor, { padding: 32 });
 ```
+
+The adapter keeps MapLibre responsible for the base map and camera while deck.gl
+owns Honua feature overlays. Use `setView(...)` for imperative center/zoom or
+bounds changes, `setFeatureQueryResults(...)` for query batches,
+`getFeatureCollection(...)` for cached GeoJSON, and `removeLayer(...)` or
+`clearFeatureLayers()` when a host screen changes active sources.
 
 ## Scene Use
 

--- a/src/Honua.Embed/src/display-adapter.ts
+++ b/src/Honua.Embed/src/display-adapter.ts
@@ -144,15 +144,59 @@ export interface HonuaDeckOverlayOptions
   layers?: Layer[];
 }
 
+export type HonuaMapViewCenter =
+  | [number, number]
+  | { longitude: number; latitude: number }
+  | { lng: number; lat: number };
+
+export interface HonuaMapViewOptions {
+  center?: HonuaMapViewCenter | null;
+  zoom?: number | null;
+  bounds?: HonuaDisplayBounds | null;
+  fitOptions?: HonuaMapFitBoundsOptions;
+  jumpOptions?: HonuaMapJumpToOptions;
+}
+
+export interface HonuaMapFitBoundsOptions {
+  padding?: number | {
+    top?: number;
+    right?: number;
+    bottom?: number;
+    left?: number;
+  };
+  maxZoom?: number;
+  duration?: number;
+  essential?: boolean;
+  [key: string]: unknown;
+}
+
+export interface HonuaMapJumpToOptions {
+  center?: [number, number];
+  zoom?: number;
+  [key: string]: unknown;
+}
+
 export interface HonuaMapLibreLike {
   addControl(control: unknown, position?: string): unknown;
   removeControl?(control: unknown): unknown;
+  fitBounds?(
+    bounds: [[number, number], [number, number]],
+    options?: HonuaMapFitBoundsOptions,
+  ): unknown;
+  jumpTo?(options: HonuaMapJumpToOptions): unknown;
 }
 
 export interface HonuaWebDisplayAdapterOptions
   extends HonuaDeckOverlayOptions {
   controlPosition?: string;
 }
+
+export type HonuaFeatureQueryLayerOptions =
+  | HonuaGeoJsonLayerOptions
+  | ((
+    result: HonuaFeatureQueryResult | HonuaFeatureRecord[] | FeatureCollection<Geometry, GeoJsonProperties>,
+    index: number,
+  ) => HonuaGeoJsonLayerOptions);
 
 export class HonuaWebDisplayAdapter {
   readonly #map: HonuaMapLibreLike;
@@ -181,6 +225,48 @@ export class HonuaWebDisplayAdapter {
     this.#overlay.setProps({ layers: this.#layers });
   }
 
+  setView(view: HonuaMapViewOptions): boolean {
+    if (view.bounds && this.#map.fitBounds) {
+      this.#map.fitBounds(boundsToLngLatBounds(view.bounds), view.fitOptions);
+      return true;
+    }
+
+    const jumpOptions: HonuaMapJumpToOptions = {
+      ...(view.jumpOptions ?? {}),
+    };
+    const center = normalizeCenter(view.center);
+
+    if (center) {
+      jumpOptions.center = center;
+    }
+
+    if (typeof view.zoom === 'number' && Number.isFinite(view.zoom)) {
+      jumpOptions.zoom = view.zoom;
+    }
+
+    if ((jumpOptions.center || jumpOptions.zoom !== undefined) && this.#map.jumpTo) {
+      this.#map.jumpTo(jumpOptions);
+      return true;
+    }
+
+    return false;
+  }
+
+  fitToSource(
+    source: HonuaDisplaySourceDescriptor | HonuaDisplayFeatureCollection,
+    fitOptions?: HonuaMapFitBoundsOptions,
+  ): boolean {
+    const bounds = isFeatureCollection(source)
+      ? (source as HonuaDisplayFeatureCollection).honua?.extent
+      : source.extent;
+
+    if (!bounds) {
+      return false;
+    }
+
+    return this.setView({ bounds, fitOptions });
+  }
+
   setFeatureQueryResult(
     result: HonuaFeatureQueryResult | HonuaFeatureRecord[] | FeatureCollection<Geometry, GeoJsonProperties>,
     options: HonuaGeoJsonLayerOptions = {},
@@ -193,6 +279,16 @@ export class HonuaWebDisplayAdapter {
     ]);
 
     return layer;
+  }
+
+  setFeatureQueryResults(
+    results: Array<HonuaFeatureQueryResult | HonuaFeatureRecord[] | FeatureCollection<Geometry, GeoJsonProperties>>,
+    options: HonuaFeatureQueryLayerOptions = {},
+  ): Layer[] {
+    return results.map((result, index) => this.setFeatureQueryResult(
+      result,
+      typeof options === 'function' ? options(result, index) : options,
+    ));
   }
 
   setFeatureStreamEvent(
@@ -215,6 +311,34 @@ export class HonuaWebDisplayAdapter {
     ]);
 
     return layer;
+  }
+
+  getFeatureCollection(id: string): HonuaDisplayFeatureCollection | undefined {
+    return this.#featureCollections.get(id);
+  }
+
+  removeLayer(id: string): boolean {
+    const nextLayers = this.#layers.filter((layer) => layer.id !== id);
+    const removed = nextLayers.length !== this.#layers.length;
+
+    if (!removed) {
+      return false;
+    }
+
+    this.#featureCollections.delete(id);
+    this.setLayers(nextLayers);
+    return true;
+  }
+
+  clearFeatureLayers(): void {
+    const featureLayerIds = new Set(this.#featureCollections.keys());
+
+    if (featureLayerIds.size === 0) {
+      return;
+    }
+
+    this.#featureCollections.clear();
+    this.setLayers(this.#layers.filter((layer) => !featureLayerIds.has(layer.id)));
   }
 
   destroy(): void {
@@ -422,6 +546,36 @@ function buildLayerId(source: HonuaDisplaySourceDescriptor | null | undefined): 
   }
 
   return `honua-${source.id.trim().replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '') || 'features'}`;
+}
+
+function boundsToLngLatBounds(bounds: HonuaDisplayBounds): [[number, number], [number, number]] {
+  return [
+    [bounds.minLongitude, bounds.minLatitude],
+    [bounds.maxLongitude, bounds.maxLatitude],
+  ];
+}
+
+function normalizeCenter(center: HonuaMapViewCenter | null | undefined): [number, number] | null {
+  if (!center) {
+    return null;
+  }
+
+  if (Array.isArray(center)) {
+    const [longitude, latitude] = center;
+    return Number.isFinite(longitude) && Number.isFinite(latitude)
+      ? [longitude, latitude]
+      : null;
+  }
+
+  if ('longitude' in center && Number.isFinite(center.longitude) && Number.isFinite(center.latitude)) {
+    return [center.longitude, center.latitude];
+  }
+
+  if ('lng' in center && Number.isFinite(center.lng) && Number.isFinite(center.lat)) {
+    return [center.lng, center.lat];
+  }
+
+  return null;
 }
 
 function resolveQuerySource(

--- a/src/Honua.Embed/tests/display-adapter.test.ts
+++ b/src/Honua.Embed/tests/display-adapter.test.ts
@@ -259,4 +259,148 @@ describe('display adapter', () => {
     expect(map.removeControl).toHaveBeenCalledWith(adapter.overlay);
     expect(controls).toHaveLength(0);
   });
+
+  it('applies MapLibre camera helpers from SDK extents and centers', () => {
+    const map = {
+      addControl: vi.fn(),
+      fitBounds: vi.fn(),
+      jumpTo: vi.fn(),
+    };
+    const adapter = new HonuaWebDisplayAdapter(map);
+
+    expect(adapter.setView({
+      bounds: fieldAssetSource.extent,
+      fitOptions: {
+        padding: 24,
+        maxZoom: 15,
+      },
+    })).toBe(true);
+    expect(map.fitBounds).toHaveBeenCalledWith(
+      [[-157.9, 21.2], [-157.7, 21.4]],
+      {
+        padding: 24,
+        maxZoom: 15,
+      },
+    );
+
+    expect(adapter.setView({
+      center: { longitude: -157.8583, latitude: 21.3069 },
+      zoom: 13,
+      jumpOptions: {
+        duration: 0,
+      },
+    })).toBe(true);
+    expect(map.jumpTo).toHaveBeenCalledWith({
+      duration: 0,
+      center: [-157.8583, 21.3069],
+      zoom: 13,
+    });
+
+    const noCameraAdapter = new HonuaWebDisplayAdapter({ addControl: vi.fn() });
+
+    expect(noCameraAdapter.setView({
+      bounds: fieldAssetSource.extent,
+      center: [-157.8583, 21.3069],
+      zoom: 13,
+    })).toBe(false);
+  });
+
+  it('fits MapLibre to source descriptors and cached feature collections', () => {
+    const map = {
+      addControl: vi.fn(),
+      fitBounds: vi.fn(),
+    };
+    const adapter = new HonuaWebDisplayAdapter(map);
+    const collection = featureQueryResultToGeoJson({
+      source: fieldAssetSource,
+      features: [],
+    });
+
+    expect(adapter.fitToSource(fieldAssetSource, { padding: 32 })).toBe(true);
+    expect(adapter.fitToSource(collection, { maxZoom: 16 })).toBe(true);
+    expect(map.fitBounds).toHaveBeenNthCalledWith(
+      1,
+      [[-157.9, 21.2], [-157.7, 21.4]],
+      { padding: 32 },
+    );
+    expect(map.fitBounds).toHaveBeenNthCalledWith(
+      2,
+      [[-157.9, 21.2], [-157.7, 21.4]],
+      { maxZoom: 16 },
+    );
+    expect(adapter.fitToSource({
+      ...fieldAssetSource,
+      id: 'missing-extent',
+      extent: null,
+    })).toBe(false);
+  });
+
+  it('manages feature query layer batches without removing host-owned layers', () => {
+    const workOrderSource: HonuaDisplaySourceDescriptor = {
+      ...fieldAssetSource,
+      id: 'work-orders',
+      title: 'Work orders',
+    };
+    const externalLayer = createHonuaGeoJsonLayer([], {
+      id: 'external-overlay',
+    });
+    const adapter = new HonuaWebDisplayAdapter({ addControl: vi.fn() }, {
+      layers: [externalLayer],
+    });
+
+    const layers = adapter.setFeatureQueryResults([
+      {
+        source: fieldAssetSource,
+        features: [
+          {
+            id: 'asset-1',
+            geometry: {
+              type: 'Point',
+              coordinates: [-157.85, 21.3],
+            },
+          },
+        ],
+      },
+      {
+        features: [
+          {
+            id: 'work-order-1',
+            geometry: {
+              type: 'Point',
+              coordinates: [-157.86, 21.31],
+            },
+          },
+        ],
+      },
+    ], (_result, index) => ({
+      source: index === 0 ? fieldAssetSource : workOrderSource,
+    }));
+
+    expect(layers.map((layer) => layer.id)).toEqual([
+      'honua-field-assets',
+      'honua-work-orders',
+    ]);
+    expect(adapter.layers.map((layer) => layer.id)).toEqual([
+      'external-overlay',
+      'honua-field-assets',
+      'honua-work-orders',
+    ]);
+    expect(adapter.getFeatureCollection('honua-field-assets')?.honua).toMatchObject({
+      sourceId: 'field-assets',
+      source: fieldAssetSource,
+    });
+
+    expect(adapter.removeLayer('honua-field-assets')).toBe(true);
+    expect(adapter.getFeatureCollection('honua-field-assets')).toBeUndefined();
+    expect(adapter.removeLayer('missing-layer')).toBe(false);
+    expect(adapter.layers.map((layer) => layer.id)).toEqual([
+      'external-overlay',
+      'honua-work-orders',
+    ]);
+
+    adapter.clearFeatureLayers();
+
+    expect(adapter.layers.map((layer) => layer.id)).toEqual(['external-overlay']);
+    expect(adapter.getFeatureCollection('honua-work-orders')).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- add MapLibre camera helpers to `HonuaWebDisplayAdapter` for source extents, bounds, centers, and zoom
- add batch feature-query layer updates plus cached collection lookup and layer cleanup helpers
- document the adapter lifecycle APIs for production MapLibre/deck.gl host screens

Related to #50.

## Testing
- `npm test --prefix src/Honua.Embed -- tests/display-adapter.test.ts`
- `npm run typecheck --prefix src/Honua.Embed`
- `npm test --prefix src/Honua.Embed`
- `npm run build --prefix src/Honua.Embed`