### PR TITLE
feat(embed): add iframe fallback snippet helper

### DIFF
--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -67,6 +67,29 @@ applyHonuaMapOptions(document.querySelector('honua-map'), {
 });
 ```
 
+For hosts that cannot use web components, generate an iframe fallback with the
+same option shape. Map options are serialized into the iframe URL query string,
+and `apiKey` is omitted unless `includeCredentials: true` is set.
+
+```js
+import { createHonuaMapIframeSnippet } from '@honua-io/embed';
+
+const snippet = createHonuaMapIframeSnippet({
+  serviceUrl: 'https://services.honua.example/FeatureServer',
+  layerIds: ['assets', 'work-orders'],
+  center: { latitude: 21.3069, longitude: -157.8583 },
+  zoom: 12,
+  search: true,
+  identify: true,
+  label: 'City asset map',
+}, {
+  iframeUrl: 'https://cdn.honua.dev/embed/map.html',
+  iframe: {
+    title: 'City asset map',
+  },
+});
+```
+
 ## Integration Events
 
 ```js

--- a/src/Honua.Embed/src/snippets.ts
+++ b/src/Honua.Embed/src/snippets.ts
@@ -36,6 +36,27 @@ export interface HonuaMapSnippetOptions {
   indent?: string;
 }
 
+export interface HonuaMapIframeAttributes {
+  title?: string | null;
+  loading?: 'eager' | 'lazy' | null;
+  referrerPolicy?: ReferrerPolicy | null;
+  sandbox?: string | readonly string[] | null;
+  allow?: string | null;
+  width?: string | number | null;
+  height?: string | number | null;
+  id?: string | null;
+  name?: string | null;
+  className?: string | null;
+  style?: string | null;
+}
+
+export interface HonuaMapIframeSnippetOptions {
+  iframeUrl?: string;
+  includeCredentials?: boolean;
+  iframe?: HonuaMapIframeAttributes;
+  indent?: string;
+}
+
 export function applyHonuaMapOptions(
   element: HTMLElement,
   options: HonuaMapEmbedOptions,
@@ -109,6 +130,21 @@ export function createHonuaMapSnippet(
   return `${script}\n\n${element}`;
 }
 
+export function createHonuaMapIframeSnippet(
+  options: HonuaMapEmbedOptions,
+  snippetOptions: HonuaMapIframeSnippetOptions = {},
+): string {
+  const iframeUrl = snippetOptions.iframeUrl ?? 'https://cdn.honua.dev/embed/map.html';
+  const src = createIframeSrc(iframeUrl, options, snippetOptions.includeCredentials ?? false);
+  const attributes = iframeAttributes(src, snippetOptions.iframe);
+  const indent = snippetOptions.indent ?? '  ';
+  const lines = attributes.map(([name, value]) => (
+    `${indent}${name}="${escapeHtmlAttribute(value)}"`
+  ));
+
+  return `<iframe\n${lines.join('\n')}>\n</iframe>`;
+}
+
 function createElementMarkup(
   elementName: string,
   options: HonuaMapEmbedOptions,
@@ -129,6 +165,49 @@ function createElementMarkup(
     : `${config.indent}${name}="${escapeHtmlAttribute(value)}"`);
 
   return `<${elementName}\n${lines.join('\n')}>\n</${elementName}>`;
+}
+
+function createIframeSrc(
+  iframeUrl: string,
+  options: HonuaMapEmbedOptions,
+  includeCredentials: boolean,
+): string {
+  const url = new URL(iframeUrl, 'https://cdn.honua.dev');
+  for (const [name, value] of mapQueryParameters(options, includeCredentials)) {
+    url.searchParams.set(name, value);
+  }
+
+  if (isAbsoluteUrl(iframeUrl)) {
+    return url.toString();
+  }
+
+  const query = url.searchParams.toString();
+  const hash = url.hash;
+  const base = `${url.pathname}${query ? `?${query}` : ''}${hash}`;
+  return iframeUrl.startsWith('/') ? base : base.replace(/^\//, '');
+}
+
+function iframeAttributes(
+  src: string,
+  custom: HonuaMapIframeAttributes | undefined,
+): Array<[string, string]> {
+  return [
+    ['src', src],
+    ['title', custom?.title ?? 'Embedded map'],
+    ['loading', custom?.loading ?? 'lazy'],
+    ['referrerpolicy', custom?.referrerPolicy ?? 'strict-origin-when-cross-origin'],
+    ['sandbox', serializeSandbox(custom?.sandbox) ?? 'allow-scripts allow-same-origin allow-forms'],
+    ['allow', custom?.allow],
+    ['width', serializeAttributeValue(custom?.width)],
+    ['height', serializeAttributeValue(custom?.height)],
+    ['id', custom?.id],
+    ['name', custom?.name],
+    ['class', custom?.className],
+    ['style', custom?.style],
+  ].filter((entry): entry is [string, string] => {
+    const value = entry[1];
+    return value !== undefined && value !== null && value !== '';
+  });
 }
 
 function mapAttributes(
@@ -187,6 +266,22 @@ function mapThemeVariables(theme: HonuaMapThemeOptions | null | undefined): Reco
     '--honua-map-font-family': theme?.fontFamily,
     '--honua-map-control-size': theme?.controlSize,
   };
+}
+
+function mapQueryParameters(
+  options: HonuaMapEmbedOptions,
+  includeCredentials: boolean,
+): Array<[string, string]> {
+  const parameters = mapAttributes(options, includeCredentials)
+    .map(([name, value]): [string, string] => [name, value === true ? 'true' : value]);
+
+  for (const [property, value] of Object.entries(mapThemeVariables(options.style))) {
+    if (typeof value === 'string' && value !== '') {
+      parameters.push([property, value]);
+    }
+  }
+
+  return parameters;
 }
 
 function setOptionalAttribute(element: HTMLElement, name: string, value: string | null | undefined): void {
@@ -261,6 +356,33 @@ function serializeNumber(value: number | null | undefined): string | null | unde
   }
 
   return String(value);
+}
+
+function serializeSandbox(value: string | readonly string[] | null | undefined): string | null | undefined {
+  if (isReadonlyStringArray(value)) {
+    return value
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .join(' ') || null;
+  }
+
+  return value;
+}
+
+function serializeAttributeValue(value: string | number | null | undefined): string | null | undefined {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  return String(value);
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(value);
+}
+
+function isReadonlyStringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value);
 }
 
 function escapeHtmlAttribute(value: string | true): string {

--- a/src/Honua.Embed/src/snippets.ts
+++ b/src/Honua.Embed/src/snippets.ts
@@ -183,6 +183,10 @@ function createIframeSrc(
 
   const query = url.searchParams.toString();
   const hash = url.hash;
+  if (isProtocolRelativeUrl(iframeUrl)) {
+    return `//${url.host}${url.pathname}${query ? `?${query}` : ''}${hash}`;
+  }
+
   const base = `${url.pathname}${query ? `?${query}` : ''}${hash}`;
   return iframeUrl.startsWith('/') ? base : base.replace(/^\//, '');
 }
@@ -379,6 +383,10 @@ function serializeAttributeValue(value: string | number | null | undefined): str
 
 function isAbsoluteUrl(value: string): boolean {
   return /^[a-z][a-z0-9+.-]*:/i.test(value);
+}
+
+function isProtocolRelativeUrl(value: string): boolean {
+  return value.startsWith('//');
 }
 
 function isReadonlyStringArray(value: unknown): value is readonly string[] {

--- a/src/Honua.Embed/tests/honua-snippets.test.ts
+++ b/src/Honua.Embed/tests/honua-snippets.test.ts
@@ -222,6 +222,19 @@ describe('honua map snippets', () => {
     expect(iframe.className).toBe('embed-frame');
     expect(iframe.getAttribute('style')).toBe('border: 0');
   });
+
+  it('preserves protocol-relative iframe fallback URLs', () => {
+    const snippet = createHonuaMapIframeSnippet({
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      search: true,
+    }, {
+      iframeUrl: '//embed.example.test/map.html?tenant=city#map',
+    });
+
+    expect(readIframe(snippet).getAttribute('src')).toBe(
+      '//embed.example.test/map.html?tenant=city&service-url=https%3A%2F%2Fservices.example.test%2FFeatureServer&search=true#map',
+    );
+  });
 });
 
 function readIframe(snippet: string): HTMLIFrameElement {

--- a/src/Honua.Embed/tests/honua-snippets.test.ts
+++ b/src/Honua.Embed/tests/honua-snippets.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   applyHonuaMapOptions,
+  createHonuaMapIframeSnippet,
   createHonuaMapSnippet,
   defineHonuaMapElement,
 } from '../src/index';
@@ -90,4 +91,146 @@ describe('honua map snippets', () => {
     expect(element.style.getPropertyValue('--honua-map-background')).toBe('#eeeeee');
     expect(element.style.getPropertyValue('--honua-map-surface')).toBe('#ffffff');
   });
+
+  it('generates an iframe fallback snippet without credentials by default', () => {
+    const snippet = createHonuaMapIframeSnippet({
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      layerIds: ['assets'],
+      apiKey: 'secret-key',
+      interactive: true,
+    });
+
+    const iframe = readIframe(snippet);
+
+    expect(iframe.getAttribute('title')).toBe('Embedded map');
+    expect(iframe.getAttribute('loading')).toBe('lazy');
+    expect(iframe.getAttribute('referrerpolicy')).toBe('strict-origin-when-cross-origin');
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts allow-same-origin allow-forms');
+    expect(iframe.getAttribute('src')).not.toContain('secret-key');
+    expect(snippet).not.toContain('api-key');
+  });
+
+  it('includes iframe credentials only when explicitly requested', () => {
+    const snippet = createHonuaMapIframeSnippet({
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      apiKey: 'public-browser-key',
+    }, {
+      includeCredentials: true,
+    });
+
+    const src = readIframe(snippet).getAttribute('src');
+    const url = new URL(src ?? '');
+
+    expect(url.searchParams.get('api-key')).toBe('public-browser-key');
+  });
+
+  it('serializes map options into iframe query parameters', () => {
+    const snippet = createHonuaMapIframeSnippet({
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      layerIds: ['assets', 'work-orders'],
+      center: { latitude: 21.3069, longitude: -157.8583 },
+      zoom: 12,
+      bounds: {
+        minLongitude: -158.3,
+        minLatitude: 21.2,
+        maxLongitude: -157.6,
+        maxLatitude: 21.6,
+      },
+      basemap: 'streets',
+      interactive: true,
+      search: true,
+      identify: true,
+      attribution: 'City GIS',
+      theme: 'dark',
+      label: 'City asset map',
+      style: {
+        accent: '#0f766e',
+        fontFamily: 'Aptos, sans-serif',
+      },
+    }, {
+      iframeUrl: 'https://embed.example.test/map.html?tenant=city',
+    });
+
+    const src = readIframe(snippet).getAttribute('src');
+    const url = new URL(src ?? '');
+
+    expect(url.origin).toBe('https://embed.example.test');
+    expect(url.searchParams.get('tenant')).toBe('city');
+    expect(url.searchParams.get('service-url')).toBe('https://services.example.test/FeatureServer');
+    expect(url.searchParams.get('layer-ids')).toBe('assets,work-orders');
+    expect(url.searchParams.get('center')).toBe('21.3069,-157.8583');
+    expect(url.searchParams.get('zoom')).toBe('12');
+    expect(url.searchParams.get('bbox')).toBe('-158.3,21.2,-157.6,21.6');
+    expect(url.searchParams.get('basemap')).toBe('streets');
+    expect(url.searchParams.get('interactive')).toBe('true');
+    expect(url.searchParams.get('search')).toBe('true');
+    expect(url.searchParams.get('identify')).toBe('true');
+    expect(url.searchParams.get('attribution')).toBe('City GIS');
+    expect(url.searchParams.get('theme')).toBe('dark');
+    expect(url.searchParams.get('label')).toBe('City asset map');
+    expect(url.searchParams.get('--honua-map-accent')).toBe('#0f766e');
+    expect(url.searchParams.get('--honua-map-font-family')).toBe('Aptos, sans-serif');
+  });
+
+  it('escapes iframe fallback HTML attribute values', () => {
+    const snippet = createHonuaMapIframeSnippet({
+      label: 'City "Assets" <Map> & Team',
+    }, {
+      iframe: {
+        title: 'City "Assets" <Map> & Team',
+      },
+    });
+
+    expect(snippet).toContain('title="City &quot;Assets&quot; &lt;Map&gt; &amp; Team"');
+    expect(snippet).not.toContain('title="City "Assets" <Map> & Team"');
+  });
+
+  it('applies custom iframe fallback options', () => {
+    const snippet = createHonuaMapIframeSnippet({
+      basemap: 'satellite',
+    }, {
+      iframeUrl: '/embeds/map.html',
+      indent: '    ',
+      iframe: {
+        title: 'Asset map',
+        loading: 'eager',
+        referrerPolicy: 'no-referrer',
+        sandbox: ['allow-scripts', 'allow-same-origin', '', 'allow-popups'],
+        allow: 'geolocation',
+        width: '100%',
+        height: 420,
+        id: 'asset-map-frame',
+        name: 'asset-map',
+        className: 'embed-frame',
+        style: 'border: 0',
+      },
+    });
+
+    const iframe = readIframe(snippet);
+
+    expect(snippet).toContain('\n    src=');
+    expect(iframe.getAttribute('src')).toBe('/embeds/map.html?basemap=satellite');
+    expect(iframe.getAttribute('title')).toBe('Asset map');
+    expect(iframe.getAttribute('loading')).toBe('eager');
+    expect(iframe.getAttribute('referrerpolicy')).toBe('no-referrer');
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts allow-same-origin allow-popups');
+    expect(iframe.getAttribute('allow')).toBe('geolocation');
+    expect(iframe.getAttribute('width')).toBe('100%');
+    expect(iframe.getAttribute('height')).toBe('420');
+    expect(iframe.id).toBe('asset-map-frame');
+    expect(iframe.getAttribute('name')).toBe('asset-map');
+    expect(iframe.className).toBe('embed-frame');
+    expect(iframe.getAttribute('style')).toBe('border: 0');
+  });
 });
+
+function readIframe(snippet: string): HTMLIFrameElement {
+  const template = document.createElement('template');
+  template.innerHTML = snippet;
+  const iframe = template.content.querySelector('iframe');
+  if (!iframe) {
+    throw new Error('Expected iframe snippet');
+  }
+
+  return iframe;
+}


### PR DESCRIPTION
## Summary
- add a typed `createHonuaMapIframeSnippet` helper for hosts that cannot use web components
- serialize existing map embed options into iframe query parameters while omitting API keys by default
- add safe default iframe attributes and document the fallback snippet flow

Related to #10.

## Testing
- `npm test --prefix src/Honua.Embed -- tests/honua-snippets.test.ts`
- `npm run typecheck --prefix src/Honua.Embed`
- `npm test --prefix src/Honua.Embed`
- `npm run build --prefix src/Honua.Embed`
- `git diff --check`