### PR TITLE
ci(android): harden internal distribution app signing target

### DIFF
--- a/.github/workflows/android-internal-distribution.yml
+++ b/.github/workflows/android-internal-distribution.yml
@@ -30,11 +30,14 @@ name: Android Internal Distribution
         options:
           - aab
           - apk
-      app_project:
-        description: "MAUI app project to publish."
+      app_target:
+        description: "Known Android app target to build and upload."
         required: true
-        default: apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj
-        type: string
+        default: field-collection
+        type: choice
+        options:
+          - field-collection
+          - mobile-app
       version_name:
         description: "ApplicationDisplayVersion override for this internal build."
         required: true
@@ -71,6 +74,38 @@ jobs:
           ref: ${{ inputs.source_ref || github.ref }}
           fetch-depth: 0
 
+      - name: Resolve app target
+        id: app
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          case "${{ inputs.app_target }}" in
+            field-collection)
+              app_project="apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj"
+              package_name="io.honua.mobile.fieldcollection"
+              secret_stem="ANDROID_FIELD_COLLECTION_UPLOAD"
+              ;;
+            mobile-app)
+              app_project="apps/Honua.Mobile.App/Honua.Mobile.App.csproj"
+              package_name="io.honua.mobile.app"
+              secret_stem="ANDROID_APP_UPLOAD"
+              ;;
+            *)
+              echo "::error::Unsupported app_target '${{ inputs.app_target }}'."
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "app_project=${app_project}"
+            echo "package_name=${package_name}"
+            echo "keystore_base64_secret=${secret_stem}_KEYSTORE_BASE64"
+            echo "keystore_password_secret=${secret_stem}_KEYSTORE_PASSWORD"
+            echo "key_alias_secret=${secret_stem}_KEY_ALIAS"
+            echo "key_password_secret=${secret_stem}_KEY_PASSWORD"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Resolve build metadata
         id: metadata
         shell: bash
@@ -91,7 +126,7 @@ jobs:
           commit_sha="$(git rev-parse HEAD)"
           short_sha="$(git rev-parse --short=12 HEAD)"
           safe_ref="$(printf '%s' "${source_ref}" | tr -c '[:alnum:]._-' '-')"
-          artifact_base="honua-android-${{ inputs.channel }}-${{ inputs.artifact_type }}-${version_code}-${short_sha}"
+          artifact_base="honua-android-${{ inputs.app_target }}-${{ inputs.channel }}-${{ inputs.artifact_type }}-${version_code}-${short_sha}"
 
           {
             echo "source_ref=${source_ref}"
@@ -105,12 +140,11 @@ jobs:
       - name: Validate protected environment inputs
         shell: bash
         env:
-          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_KEYSTORE_BASE64: ${{ secrets[steps.app.outputs.keystore_base64_secret] }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets[steps.app.outputs.keystore_password_secret] }}
+          ANDROID_KEY_ALIAS: ${{ secrets[steps.app.outputs.key_alias_secret] }}
+          ANDROID_KEY_PASSWORD: ${{ secrets[steps.app.outputs.key_password_secret] }}
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-          ANDROID_PACKAGE_NAME: ${{ secrets.ANDROID_PACKAGE_NAME }}
         run: |
           set -euo pipefail
 
@@ -120,8 +154,7 @@ jobs:
             ANDROID_KEYSTORE_PASSWORD \
             ANDROID_KEY_ALIAS \
             ANDROID_KEY_PASSWORD \
-            GOOGLE_PLAY_SERVICE_ACCOUNT_JSON \
-            ANDROID_PACKAGE_NAME
+            GOOGLE_PLAY_SERVICE_ACCOUNT_JSON
           do
             if [[ -z "${!name}" ]]; then
               missing+=("${name}")
@@ -130,6 +163,12 @@ jobs:
 
           if (( ${#missing[@]} > 0 )); then
             printf '::error::Missing required environment secret(s): %s\n' "${missing[*]}"
+            printf '::error::Expected signing secret names for %s: %s, %s, %s, %s\n' \
+              "${{ inputs.app_target }}" \
+              "${{ steps.app.outputs.keystore_base64_secret }}" \
+              "${{ steps.app.outputs.keystore_password_secret }}" \
+              "${{ steps.app.outputs.key_alias_secret }}" \
+              "${{ steps.app.outputs.key_password_secret }}"
             exit 1
           fi
 
@@ -170,15 +209,31 @@ jobs:
         shell: bash
         run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
+      - name: Validate Android package identity
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          application_id="$(dotnet msbuild "${{ steps.app.outputs.app_project }}" \
+            -getProperty:ApplicationId \
+            -p:Configuration=Release \
+            -p:TargetFramework="${TARGET_FRAMEWORK}" \
+            -nologo)"
+
+          if [[ "${application_id}" != "${{ steps.app.outputs.package_name }}" ]]; then
+            echo "::error::${{ steps.app.outputs.app_project }} ApplicationId '${application_id}' does not match expected package '${{ steps.app.outputs.package_name }}' for app_target '${{ inputs.app_target }}'."
+            exit 1
+          fi
+
       - name: Restore app project
         shell: bash
-        run: dotnet restore "${{ inputs.app_project }}" -f "${TARGET_FRAMEWORK}"
+        run: dotnet restore "${{ steps.app.outputs.app_project }}" -f "${TARGET_FRAMEWORK}"
 
       - name: Decode Android signing keystore
         id: signing
         shell: bash
         env:
-          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_BASE64: ${{ secrets[steps.app.outputs.keystore_base64_secret] }}
         run: |
           set -euo pipefail
           mkdir -p "${RUNNER_TEMP}/android-signing"
@@ -191,15 +246,15 @@ jobs:
         id: publish
         shell: bash
         env:
-          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets[steps.app.outputs.keystore_password_secret] }}
+          ANDROID_KEY_ALIAS: ${{ secrets[steps.app.outputs.key_alias_secret] }}
+          ANDROID_KEY_PASSWORD: ${{ secrets[steps.app.outputs.key_password_secret] }}
         run: |
           set -euo pipefail
           output_dir="${GITHUB_WORKSPACE}/artifacts/android"
           mkdir -p "${output_dir}"
 
-          dotnet publish "${{ inputs.app_project }}" \
+          dotnet publish "${{ steps.app.outputs.app_project }}" \
             --configuration Release \
             --framework "${TARGET_FRAMEWORK}" \
             --no-restore \
@@ -212,7 +267,7 @@ jobs:
             -p:ApplicationDisplayVersion="${{ inputs.version_name }}" \
             -p:ApplicationVersion="${{ steps.metadata.outputs.version_code }}"
 
-          mapfile -t candidates < <(find "$(dirname "${{ inputs.app_project }}")/bin/Release/${TARGET_FRAMEWORK}" \
+          mapfile -t candidates < <(find "$(dirname "${{ steps.app.outputs.app_project }}")/bin/Release/${TARGET_FRAMEWORK}" \
             -type f -name "*.${{ inputs.artifact_type }}" | sort)
 
           if (( ${#candidates[@]} == 0 )); then
@@ -266,7 +321,7 @@ jobs:
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJson: ${{ steps.play-service-account.outputs.account_path }}
-          packageName: ${{ secrets.ANDROID_PACKAGE_NAME }}
+          packageName: ${{ steps.app.outputs.package_name }}
           releaseFiles: ${{ steps.publish.outputs.artifact_path }}
           track: internal
           status: completed
@@ -316,7 +371,7 @@ jobs:
         shell: bash
         env:
           ANDROID_ARTIFACT_PATH: ${{ steps.publish.outputs.artifact_path }}
-          ANDROID_PACKAGE_NAME: ${{ secrets.ANDROID_PACKAGE_NAME }}
+          ANDROID_PACKAGE_NAME: ${{ steps.app.outputs.package_name }}
           GOOGLE_PLAY_JSON_KEY: ${{ steps.play-service-account.outputs.account_path }}
           INTERNAL_APP_SHARING_LINK_PATH: ${{ runner.temp }}/internal-app-sharing-link.txt
         run: |
@@ -344,7 +399,9 @@ jobs:
             echo "| Channel | \`${{ inputs.channel }}\` |"
             echo "| Source ref | \`${{ steps.metadata.outputs.source_ref }}\` |"
             echo "| Commit SHA | \`${{ steps.metadata.outputs.commit_sha }}\` |"
-            echo "| App project | \`${{ inputs.app_project }}\` |"
+            echo "| App target | \`${{ inputs.app_target }}\` |"
+            echo "| App project | \`${{ steps.app.outputs.app_project }}\` |"
+            echo "| Package name | \`${{ steps.app.outputs.package_name }}\` |"
             echo "| Version name | \`${{ inputs.version_name }}\` |"
             echo "| Version code | \`${{ steps.metadata.outputs.version_code }}\` |"
             echo "| Artifact | \`${{ steps.publish.outputs.artifact_name }}\` |"

--- a/docs/guides/mobile-android-internal-distribution.md
+++ b/docs/guides/mobile-android-internal-distribution.md
@@ -18,19 +18,30 @@ Inputs:
 - `channel`: `internal-testing` for the Play internal testing track, or
   `internal-app-sharing` for a direct Internal App Sharing install link.
 - `artifact_type`: `aab` or `apk`.
-- `app_project`: MAUI app project to publish. The default builds
-  `apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj`.
+- `app_target`: known Android app target to publish. The workflow maps this
+  to a MAUI project, Google Play package name, and per-app signing secrets.
+  The default `field-collection` target builds
+  `apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj`
+  with package name `io.honua.mobile.fieldcollection`.
 - `version_name`: tester-facing application display version.
 - `version_code`: Android application version code. Leave blank to use the
   GitHub run number. For Play track uploads, this must be higher than any
   version code already active for the package.
 - `release_notes`: short tester-facing release summary.
 
-The workflow checks out the selected ref, installs the Android MAUI workload,
-publishes a signed release artifact, calculates a SHA-256 digest, stores the
-artifact on the workflow run, uploads to the selected internal Play channel, and
-writes a run summary with the version, commit SHA, environment, artifact name,
-and digest.
+The workflow checks out the selected ref, resolves the selected app target,
+installs the Android MAUI workload, validates the project `ApplicationId`
+against the expected Google Play package name, publishes a signed release
+artifact, calculates a SHA-256 digest, stores the artifact on the workflow run,
+uploads to the selected internal Play channel, and writes a run summary with the
+version, commit SHA, environment, package name, artifact name, and digest.
+
+Known Android app targets:
+
+| `app_target` | Project | Package name | Signing secret stem |
+| --- | --- | --- | --- |
+| `field-collection` | `apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj` | `io.honua.mobile.fieldcollection` | `ANDROID_FIELD_COLLECTION_UPLOAD` |
+| `mobile-app` | `apps/Honua.Mobile.App/Honua.Mobile.App.csproj` | `io.honua.mobile.app` | `ANDROID_APP_UPLOAD` |
 
 ## Required Environment
 
@@ -40,13 +51,28 @@ environment before adding upload credentials.
 
 Required environment secrets:
 
-- `ANDROID_KEYSTORE_BASE64`: base64-encoded Android signing keystore.
-- `ANDROID_KEYSTORE_PASSWORD`: keystore password.
-- `ANDROID_KEY_ALIAS`: signing key alias.
-- `ANDROID_KEY_PASSWORD`: signing key password.
-- `ANDROID_PACKAGE_NAME`: Google Play package name, for example
-  `io.honua.mobile.fieldcollection`.
 - `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`: full Google Play service account JSON.
+- `<SIGNING_SECRET_STEM>_KEYSTORE_BASE64`: base64-encoded Android
+  signing keystore for the selected app target.
+- `<SIGNING_SECRET_STEM>_KEYSTORE_PASSWORD`: keystore password.
+- `<SIGNING_SECRET_STEM>_KEY_ALIAS`: signing key alias.
+- `<SIGNING_SECRET_STEM>_KEY_PASSWORD`: signing key password.
+
+For the default `field-collection` target, configure these signing secrets:
+
+- `ANDROID_FIELD_COLLECTION_UPLOAD_KEYSTORE_BASE64`
+- `ANDROID_FIELD_COLLECTION_UPLOAD_KEYSTORE_PASSWORD`
+- `ANDROID_FIELD_COLLECTION_UPLOAD_KEY_ALIAS`
+- `ANDROID_FIELD_COLLECTION_UPLOAD_KEY_PASSWORD`
+
+For the `mobile-app` target, configure the equivalent
+`ANDROID_APP_UPLOAD_*` signing secrets. These names match
+`docs/guides/mobile-store-prereqs.md`.
+
+Do not configure a free-form Android package-name secret for this workflow. The
+package name is derived from `app_target`, and the workflow fails before restore,
+signing, or upload if the selected project's `ApplicationId` differs from that
+expected package name.
 
 Optional environment variable:
 


### PR DESCRIPTION
## Summary

- Replace free-form Android app project/package inputs with known app targets.
- Map each target to its MAUI project, package name, and existing per-app signing secret names.
- Validate the selected project ApplicationId before signing or Google Play upload.

## Platform Impact

- Android internal distribution workflow only.
- No MAUI app runtime behavior or SDK contracts change.
- The workflow now fails earlier if a selected target package ID drifts from project configuration or signing-secret mapping.

## Testing

- Checked both Android app project ApplicationId values with dotnet msbuild.
- CI handles repository build/test validation; real Google Play upload still depends on #85 external Play Console and signing setup.
- git diff --check
- python3 YAML parse for .github/workflows/android-internal-distribution.yml
- actionlint not available locally

Related to #85