### PR TITLE
feat(embed): add CDN snippet helpers

### DIFF
--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -53,6 +53,36 @@ name while still using the same implementation. `apiKey` is omitted from
 generated snippets unless `includeCredentials: true` is passed; generated markup
 should only contain renderer-safe public credentials.
 
+Use the CDN helper when a portal needs to emit a standalone `<script>` tag
+instead of an npm import. The default CDN URL is `https://cdn.honua.dev/embed.js`
+and can be replaced for tenant-specific or pinned asset paths.
+
+```js
+import { createHonuaMapCdnSnippet } from '@honua-io/embed/snippets';
+
+const snippet = createHonuaMapCdnSnippet({
+  serviceUrl: 'https://services.honua.example/FeatureServer',
+  layerIds: ['assets', 'work-orders'],
+  interactive: true,
+  identify: true,
+  label: 'City asset map',
+}, {
+  scriptUrl: 'https://cdn.honua.dev/embed.js',
+  scriptAttributes: {
+    integrity: 'sha384-...',
+    crossOrigin: 'anonymous',
+  },
+});
+```
+
+The generated CDN markup stays white-label; it does not add Honua attribution.
+When `elementName` is customized, the helper emits an inline module import that
+registers the branded tag name from the CDN bundle.
+
+Server-side builders that only generate markup can import from
+`@honua-io/embed/snippets`; that subpath avoids loading the browser custom
+element entrypoint.
+
 Runtime hosts can apply the same configuration shape to an existing element:
 
 ```js
@@ -72,7 +102,7 @@ same option shape. Map options are serialized into the iframe URL query string,
 and `apiKey` is omitted unless `includeCredentials: true` is set.
 
 ```js
-import { createHonuaMapIframeSnippet } from '@honua-io/embed';
+import { createHonuaMapIframeSnippet } from '@honua-io/embed/snippets';
 
 const snippet = createHonuaMapIframeSnippet({
   serviceUrl: 'https://services.honua.example/FeatureServer',

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -228,6 +228,53 @@ const snippet = createHonuaMapSnippet({
 Custom element names generate a script that calls `defineHonuaMapElement(...)`.
 `apiKey` is omitted unless `includeCredentials: true` is passed.
 
+For CDN distribution, use `createHonuaMapCdnSnippet`. It emits the CDN module
+script and the same white-label custom element markup. When a custom
+`elementName` is provided, the snippet imports `defineHonuaMapElement(...)` from
+the CDN bundle and registers that branded tag name.
+
+```ts
+import { createHonuaMapCdnSnippet } from '@honua-io/embed/snippets';
+
+const snippet = createHonuaMapCdnSnippet({
+  serviceUrl: 'https://services.honua.example/FeatureServer',
+  layerIds: ['assets'],
+  interactive: true,
+  label: 'City asset map',
+}, {
+  scriptUrl: 'https://cdn.honua.dev/embed.js',
+  scriptAttributes: {
+    integrity: 'sha384-...',
+    crossOrigin: 'anonymous',
+  },
+});
+```
+
+Server-side builders that only generate markup can import from
+`@honua-io/embed/snippets` to avoid loading the browser custom element
+entrypoint.
+
+For hosts that cannot load custom elements, use `createHonuaMapIframeSnippet`.
+Map options are encoded into the iframe URL query string, with `apiKey` omitted
+unless `includeCredentials: true` is passed.
+
+```ts
+import { createHonuaMapIframeSnippet } from '@honua-io/embed/snippets';
+
+const snippet = createHonuaMapIframeSnippet({
+  serviceUrl: 'https://services.honua.example/FeatureServer',
+  layerIds: ['assets'],
+  search: true,
+  identify: true,
+  label: 'City asset map',
+}, {
+  iframeUrl: 'https://cdn.honua.dev/embed/map.html',
+  iframe: {
+    title: 'City asset map',
+  },
+});
+```
+
 Use `applyHonuaMapOptions(element, options)` to apply the same options shape to
 an existing map element at runtime.
 

--- a/src/Honua.Embed/package.json
+++ b/src/Honua.Embed/package.json
@@ -18,6 +18,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./snippets": {
+      "types": "./dist/snippets.d.ts",
+      "import": "./dist/snippets.js"
     }
   },
   "files": [

--- a/src/Honua.Embed/src/snippets.ts
+++ b/src/Honua.Embed/src/snippets.ts
@@ -36,6 +36,22 @@ export interface HonuaMapSnippetOptions {
   indent?: string;
 }
 
+export interface HonuaMapCdnScriptAttributes {
+  nonce?: string | null;
+  integrity?: string | null;
+  crossOrigin?: 'anonymous' | 'use-credentials' | null;
+  referrerPolicy?: ReferrerPolicy | null;
+}
+
+export interface HonuaMapCdnSnippetOptions {
+  scriptUrl?: string;
+  elementName?: string;
+  includeScript?: boolean;
+  includeCredentials?: boolean;
+  indent?: string;
+  scriptAttributes?: HonuaMapCdnScriptAttributes;
+}
+
 export interface HonuaMapIframeAttributes {
   title?: string | null;
   loading?: 'eager' | 'lazy' | null;
@@ -130,6 +146,29 @@ export function createHonuaMapSnippet(
   return `${script}\n\n${element}`;
 }
 
+export function createHonuaMapCdnSnippet(
+  options: HonuaMapEmbedOptions,
+  snippetOptions: HonuaMapCdnSnippetOptions = {},
+): string {
+  const elementName = snippetOptions.elementName ?? 'honua-map';
+  assertCustomElementName(elementName);
+
+  const includeScript = snippetOptions.includeScript ?? true;
+  const scriptUrl = snippetOptions.scriptUrl ?? 'https://cdn.honua.dev/embed.js';
+  const indent = snippetOptions.indent ?? '  ';
+  const element = createElementMarkup(elementName, options, {
+    includeCredentials: snippetOptions.includeCredentials ?? false,
+    indent,
+  });
+
+  if (!includeScript) {
+    return element;
+  }
+
+  const script = createCdnScriptMarkup(scriptUrl, elementName, indent, snippetOptions.scriptAttributes);
+  return `${script}\n\n${element}`;
+}
+
 export function createHonuaMapIframeSnippet(
   options: HonuaMapEmbedOptions,
   snippetOptions: HonuaMapIframeSnippetOptions = {},
@@ -143,6 +182,43 @@ export function createHonuaMapIframeSnippet(
   ));
 
   return `<iframe\n${lines.join('\n')}>\n</iframe>`;
+}
+
+function createCdnScriptMarkup(
+  scriptUrl: string,
+  elementName: string,
+  indent: string,
+  attributes: HonuaMapCdnScriptAttributes | undefined,
+): string {
+  if (elementName !== 'honua-map') {
+    const nonce = attributes?.nonce
+      ? ` nonce="${escapeHtmlAttribute(attributes.nonce)}"`
+      : '';
+    return [
+      `<script type="module"${nonce}>`,
+      `${indent}import { defineHonuaMapElement } from '${escapeJsString(scriptUrl)}';`,
+      `${indent}defineHonuaMapElement('${escapeJsString(elementName)}');`,
+      '</script>',
+    ].join('\n');
+  }
+
+  const rawScriptAttributes: Array<[string, string | null | undefined]> = [
+    ['type', 'module'],
+    ['src', scriptUrl],
+    ['nonce', attributes?.nonce],
+    ['integrity', attributes?.integrity],
+    ['crossorigin', attributes?.crossOrigin],
+    ['referrerpolicy', attributes?.referrerPolicy],
+  ];
+  const scriptAttributes = rawScriptAttributes.filter((entry): entry is [string, string] => {
+    const value = entry[1];
+    return value !== undefined && value !== null && value !== '';
+  });
+  const serialized = scriptAttributes
+    .map(([name, value]) => `${name}="${escapeHtmlAttribute(value)}"`)
+    .join(' ');
+
+  return `<script ${serialized}></script>`;
 }
 
 function createElementMarkup(

--- a/src/Honua.Embed/tests/honua-snippets.test.ts
+++ b/src/Honua.Embed/tests/honua-snippets.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   applyHonuaMapOptions,
+  createHonuaMapCdnSnippet,
   createHonuaMapIframeSnippet,
   createHonuaMapSnippet,
   defineHonuaMapElement,
@@ -62,6 +63,64 @@ describe('honua map snippets', () => {
 
     expect(snippet).toContain('api-key="public-browser-key"');
     expect(snippet).not.toContain('<script');
+  });
+
+  it('generates a CDN custom-element snippet without credentials by default', () => {
+    const snippet = createHonuaMapCdnSnippet({
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      layerIds: ['assets'],
+      apiKey: 'secret-key',
+      interactive: true,
+      label: 'City asset map',
+    }, {
+      scriptAttributes: {
+        integrity: 'sha384-example',
+        crossOrigin: 'anonymous',
+        referrerPolicy: 'strict-origin',
+      },
+    });
+
+    expect(snippet).toContain(
+      '<script type="module" src="https://cdn.honua.dev/embed.js" integrity="sha384-example" crossorigin="anonymous" referrerpolicy="strict-origin"></script>',
+    );
+    expect(snippet).toContain('<honua-map');
+    expect(snippet).toContain('service-url="https://services.example.test/FeatureServer"');
+    expect(snippet).toContain('interactive');
+    expect(snippet).toContain('label="City asset map"');
+    expect(snippet).not.toContain('secret-key');
+  });
+
+  it('generates a CDN branded tag snippet with an inline define call', () => {
+    const snippet = createHonuaMapCdnSnippet({
+      basemap: 'dark',
+      apiKey: 'public-browser-key',
+    }, {
+      scriptUrl: 'https://cdn.example.test/honua/embed.js',
+      elementName: 'city-asset-map',
+      includeCredentials: true,
+      scriptAttributes: {
+        nonce: 'nonce-value',
+      },
+    });
+
+    expect(snippet).toContain('<script type="module" nonce="nonce-value">');
+    expect(snippet).toContain(
+      'import { defineHonuaMapElement } from \'https://cdn.example.test/honua/embed.js\';',
+    );
+    expect(snippet).toContain('defineHonuaMapElement(\'city-asset-map\')');
+    expect(snippet).toContain('<city-asset-map');
+    expect(snippet).toContain('basemap="dark"');
+    expect(snippet).toContain('api-key="public-browser-key"');
+  });
+
+  it('omits the CDN script when requested', () => {
+    const snippet = createHonuaMapCdnSnippet({
+      search: true,
+    }, {
+      includeScript: false,
+    });
+
+    expect(snippet).toBe('<honua-map\n  search>\n</honua-map>');
   });
 
   it('applies map options to an existing element and removes null values', () => {

--- a/src/Honua.Embed/vite.config.ts
+++ b/src/Honua.Embed/vite.config.ts
@@ -4,15 +4,18 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   build: {
     lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+        snippets: resolve(__dirname, 'src/snippets.ts'),
+      },
       formats: ['es'],
-      fileName: () => 'index.js',
+      fileName: (_format, entryName) => `${entryName}.js`,
     },
     rollupOptions: {
       output: {
         assetFileNames: '[name][extname]',
         chunkFileNames: '[name]-[hash].js',
-        entryFileNames: 'index.js',
+        entryFileNames: '[name].js',
       },
     },
     sourcemap: false,


### PR DESCRIPTION
## Summary

Adds a CDN-oriented snippet helper for `@honua-io/embed` so builders can emit standalone module-script markup for `<honua-map>` without including credentials by default.

## Changes

- Adds `createHonuaMapCdnSnippet(...)` with script URL and script attribute options.
- Adds an `@honua-io/embed/snippets` export and Vite multi-entry output for DOM-free snippet generation from builder/server contexts.
- Documents CDN and iframe snippet generation in the package README and embeddable map guide.

## Validation

- `npm run typecheck`
- `npm test` (`117 passed`)
- `npm run build`
- Node import check for `@honua-io/embed/snippets`

Related to #10