### PR TITLE
feat(embed): add display adapter layer data helpers

### DIFF
--- a/src/Honua.Embed/src/display-adapter.ts
+++ b/src/Honua.Embed/src/display-adapter.ts
@@ -139,6 +139,12 @@ export interface HonuaGeoJsonLayerOptions
   source?: HonuaDisplaySourceDescriptor | null;
 }
 
+export interface HonuaDeckGeoJsonLayerData {
+  id: string;
+  source: HonuaDisplaySourceDescriptor | null;
+  data: HonuaDisplayFeatureCollection;
+}
+
 export interface HonuaDeckOverlayOptions
   extends Omit<MapboxOverlayProps, 'layers'> {
   layers?: Layer[];
@@ -291,6 +297,36 @@ export class HonuaWebDisplayAdapter {
     ));
   }
 
+  appendFeatureQueryResult(
+    result: HonuaFeatureQueryResult | HonuaFeatureRecord[] | FeatureCollection<Geometry, GeoJsonProperties>,
+    options: HonuaGeoJsonLayerOptions = {},
+  ): Layer {
+    const source = resolveQuerySource(result, options.source ?? this.#singleFeatureCollectionSource());
+    const id = options.id ?? buildLayerId(source);
+    const data = appendFeatureQueryResultToGeoJson(
+      result,
+      this.#featureCollections.get(id),
+      { source },
+    );
+    const layer = createHonuaGeoJsonLayer(data, { ...options, id, source });
+
+    this.#featureCollections.set(id, layer.props.data as HonuaDisplayFeatureCollection);
+    this.setLayers([
+      ...this.#layers.filter((existing) => existing.id !== layer.id),
+      layer,
+    ]);
+
+    return layer;
+  }
+
+  #singleFeatureCollectionSource(): HonuaDisplaySourceDescriptor | null | undefined {
+    if (this.#featureCollections.size !== 1) {
+      return undefined;
+    }
+
+    return this.#featureCollections.values().next().value?.honua?.source ?? undefined;
+  }
+
   setFeatureStreamEvent(
     event: HonuaFeatureStreamEvent,
     options: HonuaGeoJsonLayerOptions = {},
@@ -304,7 +340,7 @@ export class HonuaWebDisplayAdapter {
     );
     const layer = createHonuaGeoJsonLayer(data, { ...options, id, source });
 
-    this.#featureCollections.set(id, data);
+    this.#featureCollections.set(id, layer.props.data as HonuaDisplayFeatureCollection);
     this.setLayers([
       ...this.#layers.filter((existing) => existing.id !== layer.id),
       layer,
@@ -401,6 +437,38 @@ export function featureStreamEventToGeoJson(
   return applyFeatureStreamEventToGeoJson(event, null, options);
 }
 
+export function appendFeatureQueryResultToGeoJson(
+  result: HonuaFeatureQueryResult | HonuaFeatureRecord[] | FeatureCollection<Geometry, GeoJsonProperties>,
+  previous: HonuaDisplayFeatureCollection | null | undefined = null,
+  options: HonuaFeatureConversionOptions = {},
+): HonuaDisplayFeatureCollection {
+  const source = resolveQuerySource(result, options.source ?? previous?.honua?.source);
+  const incoming = featureQueryResultToGeoJson(result, { ...options, source });
+
+  if (!previous) {
+    return incoming;
+  }
+
+  const features = mergeStreamFeatures(previous.features, incoming.features, new Set());
+  const metadata: HonuaDisplayDataMetadata = removeUndefinedProperties({
+    ...(previous.honua ?? {}),
+    ...(incoming.honua ?? {}),
+    source,
+    sourceId: source?.id,
+    nextPageToken: hasExplicitNextPageToken(result)
+      ? incoming.honua?.nextPageToken ?? null
+      : previous.honua?.nextPageToken ?? incoming.honua?.nextPageToken ?? null,
+    numberReturned: features.length,
+    stream: incoming.honua?.stream ?? previous.honua?.stream ?? null,
+  });
+
+  return {
+    type: 'FeatureCollection',
+    features,
+    honua: metadata,
+  };
+}
+
 export function applyFeatureStreamEventToGeoJson(
   event: HonuaFeatureStreamEvent,
   previous: HonuaDisplayFeatureCollection | null | undefined = null,
@@ -452,18 +520,12 @@ export function createHonuaGeoJsonLayer(
   result: HonuaFeatureQueryResult | HonuaFeatureRecord[] | FeatureCollection<Geometry, GeoJsonProperties>,
   options: HonuaGeoJsonLayerOptions = {},
 ): Layer {
-  const source = options.source ?? (
-    !Array.isArray(result) && !isFeatureCollection(result)
-      ? result.source
-      : (result as HonuaDisplayFeatureCollection).honua?.source ?? null
-  );
-  const id = options.id ?? buildLayerId(source);
-  const featureCollection = featureQueryResultToGeoJson(result, { source });
+  const layerData = createHonuaGeoJsonLayerData(result, options);
   const { source: _source, ...layerOptions } = options;
 
   return new GeoJsonLayer<HonuaGeoJsonProperties>({
-    id,
-    data: featureCollection,
+    id: layerData.id,
+    data: layerData.data,
     pickable: true,
     autoHighlight: true,
     stroked: true,
@@ -477,6 +539,24 @@ export function createHonuaGeoJsonLayer(
     pointRadiusUnits: 'pixels',
     ...layerOptions,
   });
+}
+
+export function createHonuaGeoJsonLayerData(
+  result: HonuaFeatureQueryResult | HonuaFeatureRecord[] | FeatureCollection<Geometry, GeoJsonProperties>,
+  options: Pick<HonuaGeoJsonLayerOptions, 'id' | 'source'> = {},
+): HonuaDeckGeoJsonLayerData {
+  const source = options.source ?? (
+    !Array.isArray(result) && !isFeatureCollection(result)
+      ? result.source
+      : (result as HonuaDisplayFeatureCollection).honua?.source ?? null
+  ) ?? null;
+  const id = options.id ?? buildLayerId(source);
+
+  return {
+    id,
+    source,
+    data: featureQueryResultToGeoJson(result, { source }),
+  };
 }
 
 export function createHonuaDeckOverlay(
@@ -624,12 +704,14 @@ function buildCollectionMetadata(
     queryCapabilities: source?.queryCapabilities,
     tileUrl: source?.tileUrl ?? null,
     feedUrl: source?.feedUrl ?? null,
-    providerName: page?.providerName ?? null,
-    objectIdFieldName: page?.objectIdFieldName ?? null,
-    nextPageToken: page?.nextPageToken ?? null,
-    totalCount: page?.totalCount ?? page?.count ?? null,
+    providerName: page?.providerName ?? existing?.providerName ?? null,
+    objectIdFieldName: page?.objectIdFieldName ?? existing?.objectIdFieldName ?? null,
+    nextPageToken: page && 'nextPageToken' in page
+      ? page.nextPageToken ?? null
+      : existing?.nextPageToken ?? null,
+    totalCount: page?.totalCount ?? page?.count ?? existing?.totalCount ?? null,
     numberReturned: page?.numberReturned ?? numberReturned,
-    exceededTransferLimit: page?.exceededTransferLimit ?? null,
+    exceededTransferLimit: page?.exceededTransferLimit ?? existing?.exceededTransferLimit ?? null,
     stream: options.streamEventType
       ? {
           eventType: options.streamEventType,
@@ -869,6 +951,12 @@ function isFeatureCollection(
   value: unknown,
 ): value is FeatureCollection<Geometry, GeoJsonProperties> {
   return isRecord(value) && value.type === 'FeatureCollection' && Array.isArray(value.features);
+}
+
+function hasExplicitNextPageToken(
+  result: HonuaFeatureQueryResult | HonuaFeatureRecord[] | FeatureCollection<Geometry, GeoJsonProperties>,
+): boolean {
+  return !Array.isArray(result) && !isFeatureCollection(result) && 'nextPageToken' in result;
 }
 
 function isFeature(value: unknown): value is Feature<Geometry, GeoJsonProperties> {

--- a/src/Honua.Embed/src/display-adapter.ts
+++ b/src/Honua.Embed/src/display-adapter.ts
@@ -301,7 +301,9 @@ export class HonuaWebDisplayAdapter {
     result: HonuaFeatureQueryResult | HonuaFeatureRecord[] | FeatureCollection<Geometry, GeoJsonProperties>,
     options: HonuaGeoJsonLayerOptions = {},
   ): Layer {
-    const source = resolveQuerySource(result, options.source ?? this.#singleFeatureCollectionSource());
+    const source = resolveQuerySource(result, options.source ?? undefined)
+      ?? this.#singleFeatureCollectionSource()
+      ?? null;
     const id = options.id ?? buildLayerId(source);
     const data = appendFeatureQueryResultToGeoJson(
       result,

--- a/src/Honua.Embed/tests/display-adapter.test.ts
+++ b/src/Honua.Embed/tests/display-adapter.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  appendFeatureQueryResultToGeoJson,
   applyFeatureStreamEventToGeoJson,
   createHonuaGeoJsonLayer,
+  createHonuaGeoJsonLayerData,
   featureQueryResultToGeoJson,
   HONUA_FEATURE_METADATA_PROPERTY,
   HonuaWebDisplayAdapter,
@@ -207,6 +209,118 @@ describe('display adapter', () => {
     });
   });
 
+  it('builds deck.gl GeoJsonLayer data without dropping renderer-neutral descriptors', () => {
+    const layerData = createHonuaGeoJsonLayerData({
+      source: fieldAssetSource,
+      features: [
+        {
+          id: 'asset-101',
+          geometry: {
+            type: 'Point',
+            coordinates: [-157.83, 21.33],
+          },
+          attributes: {
+            objectid: 101,
+          },
+        },
+      ],
+    });
+
+    expect(layerData.id).toBe('honua-field-assets');
+    expect(layerData.source).toBe(fieldAssetSource);
+    expect(layerData.data.honua).toMatchObject({
+      source: fieldAssetSource,
+      sourceId: 'field-assets',
+      schema: fieldAssetSource.schema,
+      extent: fieldAssetSource.extent,
+      spatialReference: fieldAssetSource.spatialReference,
+      geometryType: fieldAssetSource.geometryType,
+      queryCapabilities: fieldAssetSource.queryCapabilities,
+      tileUrl: fieldAssetSource.tileUrl,
+      feedUrl: fieldAssetSource.feedUrl,
+    });
+  });
+
+  it('appends feature query pages into stable GeoJSON layer data', () => {
+    const firstPage = featureQueryResultToGeoJson({
+      source: fieldAssetSource,
+      objectIdFieldName: 'objectid',
+      nextPageToken: 'page-2',
+      totalCount: 3,
+      numberReturned: 2,
+      features: [
+        {
+          id: 'asset-1',
+          geometry: {
+            type: 'Point',
+            coordinates: [-157.85, 21.3],
+          },
+          attributes: {
+            objectid: 1,
+            status: 'active',
+          },
+        },
+        {
+          id: 'asset-2',
+          geometry: {
+            type: 'Point',
+            coordinates: [-157.86, 21.31],
+          },
+          attributes: {
+            objectid: 2,
+            status: 'planned',
+          },
+        },
+      ],
+    });
+
+    const appended = appendFeatureQueryResultToGeoJson({
+      source: fieldAssetSource,
+      objectIdFieldName: 'objectid',
+      nextPageToken: null,
+      totalCount: 3,
+      numberReturned: 2,
+      features: [
+        {
+          id: 'asset-2',
+          geometry: {
+            type: 'Point',
+            coordinates: [-157.861, 21.311],
+          },
+          attributes: {
+            objectid: 2,
+            status: 'complete',
+          },
+        },
+        {
+          id: 'asset-3',
+          geometry: {
+            type: 'Point',
+            coordinates: [-157.87, 21.32],
+          },
+          attributes: {
+            objectid: 3,
+            status: 'active',
+          },
+        },
+      ],
+    }, firstPage);
+
+    expect(appended.features.map((feature) => feature.id)).toEqual([
+      'asset-1',
+      'asset-2',
+      'asset-3',
+    ]);
+    expect(appended.features[1].properties.status).toBe('complete');
+    expect(appended.honua).toMatchObject({
+      source: fieldAssetSource,
+      sourceId: 'field-assets',
+      nextPageToken: null,
+      totalCount: 3,
+      numberReturned: 3,
+    });
+  });
+
   it('keeps renderer-neutral descriptors on layer data and MapLibre overlay updates', () => {
     const controls: unknown[] = [];
     const map = {
@@ -402,5 +516,56 @@ describe('display adapter', () => {
 
     expect(adapter.layers.map((layer) => layer.id)).toEqual(['external-overlay']);
     expect(adapter.getFeatureCollection('honua-work-orders')).toBeUndefined();
+  });
+
+  it('appends query pages through the adapter without replacing external layers', () => {
+    const externalLayer = createHonuaGeoJsonLayer([], {
+      id: 'external-overlay',
+    });
+    const adapter = new HonuaWebDisplayAdapter({ addControl: vi.fn() }, {
+      layers: [externalLayer],
+    });
+
+    adapter.appendFeatureQueryResult({
+      source: fieldAssetSource,
+      objectIdFieldName: 'objectid',
+      nextPageToken: 'page-2',
+      features: [
+        {
+          id: 'asset-1',
+          geometry: {
+            type: 'Point',
+            coordinates: [-157.85, 21.3],
+          },
+          attributes: {
+            objectid: 1,
+          },
+        },
+      ],
+    });
+    const layer = adapter.appendFeatureQueryResult([
+      {
+        id: 'asset-2',
+        geometry: {
+          type: 'Point',
+          coordinates: [-157.86, 21.31],
+        },
+        attributes: {
+          objectid: 2,
+        },
+      },
+    ]);
+
+    expect(adapter.layers.map((candidate) => candidate.id)).toEqual([
+      'external-overlay',
+      'honua-field-assets',
+    ]);
+    expect(layer.props.data).toBe(adapter.getFeatureCollection('honua-field-assets'));
+    expect(adapter.getFeatureCollection('honua-field-assets')?.features).toHaveLength(2);
+    expect(adapter.getFeatureCollection('honua-field-assets')?.honua).toMatchObject({
+      source: fieldAssetSource,
+      sourceId: 'field-assets',
+      nextPageToken: 'page-2',
+    });
   });
 });

--- a/src/Honua.Embed/tests/display-adapter.test.ts
+++ b/src/Honua.Embed/tests/display-adapter.test.ts
@@ -568,4 +568,49 @@ describe('display adapter', () => {
       nextPageToken: 'page-2',
     });
   });
+
+  it('uses incoming result sources before falling back to the only cached layer source', () => {
+    const workOrderSource: HonuaDisplaySourceDescriptor = {
+      ...fieldAssetSource,
+      id: 'work-orders',
+      title: 'Work orders',
+    };
+    const adapter = new HonuaWebDisplayAdapter({ addControl: vi.fn() });
+
+    adapter.appendFeatureQueryResult({
+      source: fieldAssetSource,
+      features: [
+        {
+          id: 'asset-1',
+          geometry: {
+            type: 'Point',
+            coordinates: [-157.85, 21.3],
+          },
+        },
+      ],
+    });
+    const workOrderLayer = adapter.appendFeatureQueryResult({
+      source: workOrderSource,
+      features: [
+        {
+          id: 'work-order-1',
+          geometry: {
+            type: 'Point',
+            coordinates: [-157.86, 21.31],
+          },
+        },
+      ],
+    });
+
+    expect(workOrderLayer.id).toBe('honua-work-orders');
+    expect(adapter.layers.map((layer) => layer.id)).toEqual([
+      'honua-field-assets',
+      'honua-work-orders',
+    ]);
+    expect(adapter.getFeatureCollection('honua-field-assets')?.features).toHaveLength(1);
+    expect(adapter.getFeatureCollection('honua-work-orders')?.honua).toMatchObject({
+      source: workOrderSource,
+      sourceId: 'work-orders',
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds the next display-adapter slice for the MapLibre/deck.gl path by exposing deck.gl-compatible GeoJSON layer data helpers and query-page append behavior.

## Changes

- Adds `HonuaDeckGeoJsonLayerData` and `createHonuaGeoJsonLayerData(...)`.
- Adds `appendFeatureQueryResultToGeoJson(...)` and `HonuaWebDisplayAdapter.appendFeatureQueryResult(...)` for paginated feature data.
- Preserves renderer-neutral source descriptors and metadata through layer data conversion.
- Keeps external overlay layers intact while updating Honua feature layers.

## Validation

- `npm run typecheck`
- `npm test` (`117 passed`)
- `npm run build`

Related to #50