### PR TITLE
mobile: add exception report upload worker

### DIFF
--- a/docs/guides/mobile-exception-reporting.md
+++ b/docs/guides/mobile-exception-reporting.md
@@ -36,6 +36,23 @@ services.AddHonuaMobileExceptionReporting(new MobileExceptionReportingOptions
 });
 ```
 
+Register server-upload capture only when the environment has an approved mobile
+exception ingestion endpoint. `ServerUpload` still writes sanitized reports to
+the same local queue first; the upload worker deletes queued files only after a
+successful upload:
+
+```csharp
+services.AddHonuaMobileExceptionReporting(new MobileExceptionReportingOptions
+{
+    Mode = MobileExceptionReportingMode.ServerUpload,
+    QueueDirectory = exceptionQueueDirectory,
+    UploadEndpoint = new Uri("https://api.honua.example/mobile/exception-reports"),
+    MaxUploadBatchSize = 10,
+    UploadInitialBackoff = TimeSpan.FromSeconds(30),
+    UploadMaxBackoff = TimeSpan.FromMinutes(15),
+});
+```
+
 Apps can report handled exceptions through `IMobileExceptionReporter` with a
 source, operation, correlation id, request id, and small diagnostic properties.
 Unhandled exception hooks are available through
@@ -73,20 +90,32 @@ Prefer stable identifiers, operation names, correlation ids, and coarse state.
 `MaxQueuedReports` and suppresses repeated reports from the same source,
 exception type, message, and first stack frame inside `DuplicateWindow`.
 
-The queue is intentionally transport-neutral. A later uploader can read pending
-items, attempt delivery when connectivity and battery policy allow, and delete
-items only after successful ingestion. Retry/backoff policy should live in that
-uploader or a background worker, not in UI flows or app startup. Exception
-reporting must never block app launch, sync, auth refresh, or field capture.
+`ServerUpload` mode registers `IMobileExceptionReportUploadWorker`, which can be
+called by app lifecycle or background scheduling code when connectivity and
+battery policy allow. Each flush is bounded by `MaxUploadBatchSize`. Failed
+uploads remain queued and are retried with exponential in-memory backoff between
+`UploadInitialBackoff` and `UploadMaxBackoff`; reports are deleted only after
+`IMobileExceptionReportUploader.UploadAsync` returns success.
+
+The default `HttpMobileExceptionReportUploader` posts the already-sanitized
+`MobileExceptionReport` JSON to the explicit `UploadEndpoint`. The endpoint must
+use HTTPS unless it is localhost for development. Authentication headers,
+tenant routing, and ingestion schema versioning should be added through the
+uploader boundary once the server endpoint contract exists.
+
+Do not flush from a blocking UI path or synchronously during app startup. Start
+flush work from lifecycle/background scheduling code and allow it to stop on
+cancellation. Exception reporting must never block app launch, sync, auth
+refresh, or field capture.
 
 ## Server Dependency
 
 Server ingestion is a separate dependency for issue #91. The mobile repo should
 not add a server API client, shared server DTO, or long-lived copied contract for
 that endpoint. The server-side slice needs to define the ingestion route, auth
-requirements, retention rules, log sink mapping, searchable metadata fields, and
-operational triage behavior. Mobile upload work should consume that versioned
-contract/package once it exists.
+requirements, request headers, retention rules, log sink mapping, searchable
+metadata fields, schema versioning, and operational triage behavior. Mobile
+upload work should consume that versioned contract/package once it exists.
 
 Recommended PR body note:
 

--- a/src/Honua.Mobile.Maui/Diagnostics/HttpMobileExceptionReportUploader.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/HttpMobileExceptionReportUploader.cs
@@ -1,0 +1,74 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Mobile.Maui.Diagnostics;
+
+/// <summary>
+/// Posts sanitized mobile exception reports to an explicit server ingestion endpoint.
+/// </summary>
+public sealed class HttpMobileExceptionReportUploader : IMobileExceptionReportUploader
+{
+    private readonly HttpClient _httpClient;
+    private readonly MobileExceptionReportingOptions _options;
+    private readonly ILogger<HttpMobileExceptionReportUploader>? _logger;
+
+    public HttpMobileExceptionReportUploader(
+        HttpClient httpClient,
+        MobileExceptionReportingOptions options,
+        ILogger<HttpMobileExceptionReportUploader>? logger = null)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _options.Validate();
+        _logger = logger;
+    }
+
+    public async Task<bool> UploadAsync(MobileExceptionReport report, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        if (_options.Mode != MobileExceptionReportingMode.ServerUpload)
+        {
+            return false;
+        }
+
+        if (_options.UploadEndpoint is null)
+        {
+            _logger?.LogDebug("Mobile exception server upload is enabled but no upload endpoint is configured");
+            return false;
+        }
+
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, _options.UploadEndpoint);
+            var json = JsonSerializer.Serialize(report, HonuaMobileMauiDiagnosticsJsonContext.Default.MobileExceptionReport);
+            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            using var response = await _httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger?.LogWarning(
+                    "Mobile exception report upload failed with status {StatusCode}",
+                    (int)response.StatusCode);
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or IOException or TaskCanceledException or OperationCanceledException)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+
+            _logger?.LogWarning(ex, "Failed to upload mobile exception report");
+            return false;
+        }
+    }
+}

--- a/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReportUploadWorker.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReportUploadWorker.cs
@@ -1,0 +1,9 @@
+namespace Honua.Mobile.Maui.Diagnostics;
+
+/// <summary>
+/// Drains locally queued mobile exception reports without blocking app startup or foreground workflows.
+/// </summary>
+public interface IMobileExceptionReportUploadWorker
+{
+    Task FlushPendingAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReportUploader.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReportUploader.cs
@@ -1,0 +1,9 @@
+namespace Honua.Mobile.Maui.Diagnostics;
+
+/// <summary>
+/// Transport boundary for sending sanitized mobile exception reports to an app-configured ingestion point.
+/// </summary>
+public interface IMobileExceptionReportUploader
+{
+    Task<bool> UploadAsync(MobileExceptionReport report, CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Mobile.Maui/Diagnostics/LocalMobileExceptionReporter.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/LocalMobileExceptionReporter.cs
@@ -36,7 +36,7 @@ public sealed class LocalMobileExceptionReporter : IMobileExceptionReporter
     {
         ArgumentNullException.ThrowIfNull(exception);
 
-        if (_options.Mode != MobileExceptionReportingMode.LocalOnly)
+        if (_options.Mode is not (MobileExceptionReportingMode.LocalOnly or MobileExceptionReportingMode.ServerUpload))
         {
             return;
         }

--- a/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportUploadWorker.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportUploadWorker.cs
@@ -1,0 +1,128 @@
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Mobile.Maui.Diagnostics;
+
+/// <summary>
+/// Uploads pending sanitized exception reports and deletes queue files only after successful delivery.
+/// </summary>
+public sealed class MobileExceptionReportUploadWorker : IMobileExceptionReportUploadWorker
+{
+    private readonly IMobileExceptionReportQueue _queue;
+    private readonly IMobileExceptionReportUploader _uploader;
+    private readonly MobileExceptionReportingOptions _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<MobileExceptionReportUploadWorker>? _logger;
+    private readonly object _retryGate = new();
+    private readonly Dictionary<string, RetryState> _retryStates = new(StringComparer.Ordinal);
+
+    public MobileExceptionReportUploadWorker(
+        IMobileExceptionReportQueue queue,
+        IMobileExceptionReportUploader uploader,
+        MobileExceptionReportingOptions options,
+        TimeProvider? timeProvider = null,
+        ILogger<MobileExceptionReportUploadWorker>? logger = null)
+    {
+        _queue = queue ?? throw new ArgumentNullException(nameof(queue));
+        _uploader = uploader ?? throw new ArgumentNullException(nameof(uploader));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _options.Validate();
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _logger = logger;
+    }
+
+    public async Task FlushPendingAsync(CancellationToken cancellationToken = default)
+    {
+        if (_options.Mode != MobileExceptionReportingMode.ServerUpload)
+        {
+            return;
+        }
+
+        var attempted = 0;
+        await foreach (var queued in _queue.ReadPendingAsync(cancellationToken))
+        {
+            if (attempted >= _options.MaxUploadBatchSize)
+            {
+                break;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var now = _timeProvider.GetUtcNow();
+            if (!IsDue(queued.QueueId, now))
+            {
+                continue;
+            }
+
+            bool sent;
+            try
+            {
+                attempted++;
+                sent = await _uploader.UploadAsync(queued.Report, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Mobile exception uploader failed unexpectedly");
+                sent = false;
+            }
+
+            if (sent)
+            {
+                await _queue.DeleteAsync(queued, cancellationToken);
+                ClearRetry(queued.QueueId);
+                continue;
+            }
+
+            ScheduleRetry(queued.QueueId, now);
+        }
+    }
+
+    private bool IsDue(string queueId, DateTimeOffset now)
+    {
+        lock (_retryGate)
+        {
+            return !_retryStates.TryGetValue(queueId, out var state) || state.NextAttemptAtUtc <= now;
+        }
+    }
+
+    private void ScheduleRetry(string queueId, DateTimeOffset now)
+    {
+        lock (_retryGate)
+        {
+            _retryStates.TryGetValue(queueId, out var previous);
+            var attempt = previous.Attempt + 1;
+            var backoff = CalculateBackoff(attempt);
+            _retryStates[queueId] = new RetryState(attempt, now + backoff);
+        }
+    }
+
+    private void ClearRetry(string queueId)
+    {
+        lock (_retryGate)
+        {
+            _retryStates.Remove(queueId);
+        }
+    }
+
+    private TimeSpan CalculateBackoff(int attempt)
+    {
+        if (_options.UploadInitialBackoff == TimeSpan.Zero)
+        {
+            return TimeSpan.Zero;
+        }
+
+        var multiplier = Math.Pow(2, Math.Max(0, attempt - 1));
+        var ticks = _options.UploadInitialBackoff.Ticks * multiplier;
+        if (ticks >= _options.UploadMaxBackoff.Ticks)
+        {
+            return _options.UploadMaxBackoff;
+        }
+
+        return TimeSpan.FromTicks((long)ticks);
+    }
+
+    private readonly record struct RetryState(int Attempt, DateTimeOffset NextAttemptAtUtc);
+}

--- a/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportUploadWorker.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportUploadWorker.cs
@@ -12,6 +12,7 @@ public sealed class MobileExceptionReportUploadWorker : IMobileExceptionReportUp
     private readonly MobileExceptionReportingOptions _options;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<MobileExceptionReportUploadWorker>? _logger;
+    private readonly SemaphoreSlim _flushGate = new(1, 1);
     private readonly object _retryGate = new();
     private readonly Dictionary<string, RetryState> _retryStates = new(StringComparer.Ordinal);
 
@@ -31,6 +32,19 @@ public sealed class MobileExceptionReportUploadWorker : IMobileExceptionReportUp
     }
 
     public async Task FlushPendingAsync(CancellationToken cancellationToken = default)
+    {
+        await _flushGate.WaitAsync(cancellationToken);
+        try
+        {
+            await FlushPendingCoreAsync(cancellationToken);
+        }
+        finally
+        {
+            _flushGate.Release();
+        }
+    }
+
+    private async Task FlushPendingCoreAsync(CancellationToken cancellationToken)
     {
         if (_options.Mode != MobileExceptionReportingMode.ServerUpload)
         {

--- a/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportingOptions.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportingOptions.cs
@@ -10,6 +10,9 @@ public enum MobileExceptionReportingMode
 
     /// <summary>Capture sanitized reports into the local mobile queue only.</summary>
     LocalOnly,
+
+    /// <summary>Capture sanitized reports locally and allow an upload worker to drain the queue.</summary>
+    ServerUpload,
 }
 
 /// <summary>
@@ -21,13 +24,21 @@ public sealed record MobileExceptionReportingOptions
 
     public string? QueueDirectory { get; init; }
 
+    public Uri? UploadEndpoint { get; init; }
+
     public int MaxQueuedReports { get; init; } = 100;
+
+    public int MaxUploadBatchSize { get; init; } = 10;
 
     public int MaxMessageLength { get; init; } = 2_000;
 
     public int MaxStackTraceLength { get; init; } = 8_000;
 
     public TimeSpan DuplicateWindow { get; init; } = TimeSpan.FromMinutes(5);
+
+    public TimeSpan UploadInitialBackoff { get; init; } = TimeSpan.FromSeconds(30);
+
+    public TimeSpan UploadMaxBackoff { get; init; } = TimeSpan.FromMinutes(15);
 
     public bool IncludePreciseLocation { get; init; }
 
@@ -44,6 +55,11 @@ public sealed record MobileExceptionReportingOptions
             throw new ArgumentOutOfRangeException(nameof(MaxQueuedReports), "The local exception queue size must be positive.");
         }
 
+        if (MaxUploadBatchSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(MaxUploadBatchSize), "The exception upload batch size must be positive.");
+        }
+
         if (MaxMessageLength <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(MaxMessageLength), "The exception message limit must be positive.");
@@ -58,5 +74,26 @@ public sealed record MobileExceptionReportingOptions
         {
             throw new ArgumentOutOfRangeException(nameof(DuplicateWindow), "The duplicate window cannot be negative.");
         }
+
+        if (UploadInitialBackoff < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(UploadInitialBackoff), "The upload initial backoff cannot be negative.");
+        }
+
+        if (UploadMaxBackoff < UploadInitialBackoff)
+        {
+            throw new ArgumentOutOfRangeException(nameof(UploadMaxBackoff), "The upload max backoff cannot be less than the initial backoff.");
+        }
+
+        if (UploadEndpoint is not null && !IsAllowedUploadEndpoint(UploadEndpoint))
+        {
+            throw new InvalidOperationException("The mobile exception upload endpoint must use HTTPS unless it points to localhost.");
+        }
+    }
+
+    internal static bool IsAllowedUploadEndpoint(Uri endpoint)
+    {
+        return endpoint.Scheme == Uri.UriSchemeHttps ||
+            (endpoint.Scheme == Uri.UriSchemeHttp && endpoint.IsLoopback);
     }
 }

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -157,7 +157,8 @@ public static class HonuaMobileServiceCollectionExtensions
 
     /// <summary>
     /// Registers opt-in mobile exception reporting primitives. Disabled mode registers a no-op reporter;
-    /// local-only mode stores sanitized reports in the on-device offline queue.
+    /// local-only mode stores sanitized reports in the on-device offline queue, and server-upload mode
+    /// adds a bounded queue upload worker.
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <param name="options">Exception reporting options. Defaults to disabled.</param>
@@ -172,13 +173,27 @@ public static class HonuaMobileServiceCollectionExtensions
         options.Validate();
         services.AddSingleton(options);
 
-        if (options.Mode == MobileExceptionReportingMode.LocalOnly)
+        if (options.Mode is MobileExceptionReportingMode.LocalOnly or MobileExceptionReportingMode.ServerUpload)
         {
             services.TryAddSingleton(TimeProvider.System);
             services.TryAddSingleton<IMobileExceptionReportQueue, FileMobileExceptionReportQueue>();
             services.TryAddSingleton<LocalMobileExceptionReporter>();
             services.RemoveAll<IMobileExceptionReporter>();
             services.AddSingleton<IMobileExceptionReporter>(sp => sp.GetRequiredService<LocalMobileExceptionReporter>());
+
+            if (options.Mode == MobileExceptionReportingMode.ServerUpload)
+            {
+                services.AddHttpClient("HonuaMobileExceptionReportUploader");
+                services.TryAddSingleton<IMobileExceptionReportUploader>(sp =>
+                {
+                    var factory = sp.GetRequiredService<IHttpClientFactory>();
+                    return new HttpMobileExceptionReportUploader(
+                        factory.CreateClient("HonuaMobileExceptionReportUploader"),
+                        sp.GetRequiredService<MobileExceptionReportingOptions>(),
+                        sp.GetService<ILogger<HttpMobileExceptionReportUploader>>());
+                });
+                services.TryAddSingleton<IMobileExceptionReportUploadWorker, MobileExceptionReportUploadWorker>();
+            }
         }
         else
         {

--- a/tests/Honua.Mobile.Maui.Tests/Diagnostics/MobileExceptionReportUploadWorkerTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/Diagnostics/MobileExceptionReportUploadWorkerTests.cs
@@ -1,0 +1,275 @@
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using Honua.Mobile.Maui;
+using Honua.Mobile.Maui.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Mobile.Maui.Tests.Diagnostics;
+
+public sealed class MobileExceptionReportUploadWorkerTests
+{
+    [Fact]
+    public void ServerUploadRegistration_WiresQueueReporterUploaderAndWorker()
+    {
+        var queueDirectory = CreateQueueDirectoryPath();
+        try
+        {
+            using var provider = new ServiceCollection()
+                .AddLogging()
+                .AddHonuaMobileExceptionReporting(new MobileExceptionReportingOptions
+                {
+                    Mode = MobileExceptionReportingMode.ServerUpload,
+                    QueueDirectory = queueDirectory,
+                    UploadEndpoint = new Uri("https://api.honua.test/mobile/exception-reports"),
+                })
+                .BuildServiceProvider();
+
+            Assert.IsType<LocalMobileExceptionReporter>(provider.GetRequiredService<IMobileExceptionReporter>());
+            Assert.IsType<FileMobileExceptionReportQueue>(provider.GetRequiredService<IMobileExceptionReportQueue>());
+            Assert.IsType<HttpMobileExceptionReportUploader>(provider.GetRequiredService<IMobileExceptionReportUploader>());
+            Assert.IsType<MobileExceptionReportUploadWorker>(provider.GetRequiredService<IMobileExceptionReportUploadWorker>());
+        }
+        finally
+        {
+            DeleteDirectory(queueDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task ServerUploadReporter_QueuesSanitizedReportBeforeUpload()
+    {
+        var queueDirectory = CreateQueueDirectoryPath();
+        try
+        {
+            var options = new MobileExceptionReportingOptions
+            {
+                Mode = MobileExceptionReportingMode.ServerUpload,
+                QueueDirectory = queueDirectory,
+                UploadEndpoint = new Uri("https://api.honua.test/mobile/exception-reports"),
+            };
+            var queue = new FileMobileExceptionReportQueue(options);
+            var reporter = new LocalMobileExceptionReporter(queue, options);
+
+            await reporter.ReportAsync(new InvalidOperationException("failed token=raw-token"));
+
+            var queued = Assert.Single(await ReadQueuedReportsAsync(queue));
+            Assert.DoesNotContain("raw-token", queued.Report.Message);
+        }
+        finally
+        {
+            DeleteDirectory(queueDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task HttpUploader_PostsSanitizedReportJsonToConfiguredEndpoint()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        string? capturedBody = null;
+        using var http = new HttpClient(new StubHttpMessageHandler(async (request, _) =>
+        {
+            capturedRequest = request;
+            capturedBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.Accepted);
+        }));
+        var options = new MobileExceptionReportingOptions
+        {
+            Mode = MobileExceptionReportingMode.ServerUpload,
+            UploadEndpoint = new Uri("https://api.honua.test/mobile/exception-reports"),
+        };
+        var uploader = new HttpMobileExceptionReportUploader(http, options);
+        var report = CreateReport(message: "sanitized failure");
+
+        var uploaded = await uploader.UploadAsync(report);
+
+        Assert.True(uploaded);
+        Assert.Equal(HttpMethod.Post, capturedRequest?.Method);
+        Assert.Equal(options.UploadEndpoint, capturedRequest?.RequestUri);
+        Assert.Equal("application/json", capturedRequest?.Content?.Headers.ContentType?.MediaType);
+        Assert.NotNull(capturedBody);
+
+        using var document = JsonDocument.Parse(capturedBody);
+        Assert.Equal(report.Id, document.RootElement.GetProperty("id").GetString());
+        Assert.Equal("sanitized failure", document.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task HttpUploader_WithoutEndpointDoesNotSendRequest()
+    {
+        var sent = false;
+        using var http = new HttpClient(new StubHttpMessageHandler((_, _) =>
+        {
+            sent = true;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }));
+        var uploader = new HttpMobileExceptionReportUploader(
+            http,
+            new MobileExceptionReportingOptions
+            {
+                Mode = MobileExceptionReportingMode.ServerUpload,
+            });
+
+        var uploaded = await uploader.UploadAsync(CreateReport());
+
+        Assert.False(uploaded);
+        Assert.False(sent);
+    }
+
+    [Fact]
+    public async Task FlushPendingAsync_RetainsReportOnFailureAndDeletesAfterBackoffAndSuccess()
+    {
+        var timeProvider = new MutableTimeProvider(DateTimeOffset.Parse("2026-05-05T00:00:00Z", CultureInfo.InvariantCulture));
+        var queue = new InMemoryExceptionReportQueue();
+        var report = CreateReport();
+        await queue.EnqueueAsync(report);
+        var uploader = new SequenceUploader([false, true]);
+        var worker = new MobileExceptionReportUploadWorker(
+            queue,
+            uploader,
+            new MobileExceptionReportingOptions
+            {
+                Mode = MobileExceptionReportingMode.ServerUpload,
+                UploadEndpoint = new Uri("https://api.honua.test/mobile/exception-reports"),
+                UploadInitialBackoff = TimeSpan.FromMinutes(1),
+                UploadMaxBackoff = TimeSpan.FromMinutes(5),
+            },
+            timeProvider);
+
+        await worker.FlushPendingAsync();
+        Assert.Single(queue.Reports);
+        Assert.Equal(1, uploader.Attempts);
+
+        await worker.FlushPendingAsync();
+        Assert.Single(queue.Reports);
+        Assert.Equal(1, uploader.Attempts);
+
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+        await worker.FlushPendingAsync();
+
+        Assert.Empty(queue.Reports);
+        Assert.Equal(2, uploader.Attempts);
+    }
+
+    private static MobileExceptionReport CreateReport(string? message = "boom")
+    {
+        return new MobileExceptionReport
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Fingerprint = "fingerprint",
+            OccurredAtUtc = DateTimeOffset.Parse("2026-05-05T00:00:00Z", CultureInfo.InvariantCulture),
+            Source = "unit-test",
+            ExceptionType = typeof(InvalidOperationException).FullName!,
+            Message = message,
+        };
+    }
+
+    private static async Task<List<QueuedMobileExceptionReport>> ReadQueuedReportsAsync(IMobileExceptionReportQueue queue)
+    {
+        var reports = new List<QueuedMobileExceptionReport>();
+        await foreach (var queued in queue.ReadPendingAsync())
+        {
+            reports.Add(queued);
+        }
+
+        return reports;
+    }
+
+    private static string CreateQueueDirectoryPath()
+    {
+        return Path.Combine(Path.GetTempPath(), $"honua-mobile-upload-tests-{Guid.NewGuid():N}");
+    }
+
+    private static void DeleteDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;
+
+        public StubHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return _handler(request, cancellationToken);
+        }
+    }
+
+    private sealed class SequenceUploader : IMobileExceptionReportUploader
+    {
+        private readonly Queue<bool> _results;
+
+        public SequenceUploader(IEnumerable<bool> results)
+        {
+            _results = new Queue<bool>(results);
+        }
+
+        public int Attempts { get; private set; }
+
+        public Task<bool> UploadAsync(MobileExceptionReport report, CancellationToken cancellationToken = default)
+        {
+            Attempts++;
+            return Task.FromResult(_results.Count > 0 && _results.Dequeue());
+        }
+    }
+
+    private sealed class InMemoryExceptionReportQueue : IMobileExceptionReportQueue
+    {
+        public List<QueuedMobileExceptionReport> Reports { get; } = [];
+
+        public Task EnqueueAsync(MobileExceptionReport report, CancellationToken cancellationToken = default)
+        {
+            Reports.Add(new QueuedMobileExceptionReport(report.Id, report));
+            return Task.CompletedTask;
+        }
+
+        public async IAsyncEnumerable<QueuedMobileExceptionReport> ReadPendingAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            foreach (var report in Reports.ToArray())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return report;
+                await Task.Yield();
+            }
+        }
+
+        public Task DeleteAsync(QueuedMobileExceptionReport report, CancellationToken cancellationToken = default)
+        {
+            Reports.RemoveAll(item => item.QueueId == report.QueueId);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class MutableTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now;
+
+        public MutableTimeProvider(DateTimeOffset now)
+        {
+            _now = now;
+        }
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            return _now;
+        }
+
+        public void Advance(TimeSpan value)
+        {
+            _now += value;
+        }
+    }
+}

--- a/tests/Honua.Mobile.Maui.Tests/Diagnostics/MobileExceptionReportUploadWorkerTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/Diagnostics/MobileExceptionReportUploadWorkerTests.cs
@@ -153,6 +153,34 @@ public sealed class MobileExceptionReportUploadWorkerTests
         Assert.Equal(2, uploader.Attempts);
     }
 
+    [Fact]
+    public async Task FlushPendingAsync_SerializesConcurrentFlushes()
+    {
+        var queue = new InMemoryExceptionReportQueue();
+        await queue.EnqueueAsync(CreateReport());
+        var uploadStarted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseUpload = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var uploader = new BlockingUploader(uploadStarted, releaseUpload);
+        var worker = new MobileExceptionReportUploadWorker(
+            queue,
+            uploader,
+            new MobileExceptionReportingOptions
+            {
+                Mode = MobileExceptionReportingMode.ServerUpload,
+                UploadEndpoint = new Uri("https://api.honua.test/mobile/exception-reports"),
+            });
+
+        var firstFlush = worker.FlushPendingAsync();
+        await uploadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var secondFlush = worker.FlushPendingAsync();
+
+        releaseUpload.SetResult(null);
+        await Task.WhenAll(firstFlush, secondFlush).WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Empty(queue.Reports);
+        Assert.Equal(1, uploader.Attempts);
+    }
+
     private static MobileExceptionReport CreateReport(string? message = "boom")
     {
         return new MobileExceptionReport
@@ -222,6 +250,31 @@ public sealed class MobileExceptionReportUploadWorkerTests
         {
             Attempts++;
             return Task.FromResult(_results.Count > 0 && _results.Dequeue());
+        }
+    }
+
+    private sealed class BlockingUploader : IMobileExceptionReportUploader
+    {
+        private readonly TaskCompletionSource<object?> _started;
+        private readonly TaskCompletionSource<object?> _release;
+        private int _attempts;
+
+        public BlockingUploader(
+            TaskCompletionSource<object?> started,
+            TaskCompletionSource<object?> release)
+        {
+            _started = started;
+            _release = release;
+        }
+
+        public int Attempts => Volatile.Read(ref _attempts);
+
+        public async Task<bool> UploadAsync(MobileExceptionReport report, CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _attempts);
+            _started.TrySetResult(null);
+            await _release.Task.WaitAsync(cancellationToken);
+            return true;
         }
     }
 


### PR DESCRIPTION
## Summary

Adds the mobile-side upload boundary for opt-in exception reporting while keeping sanitized reports queued locally first.

## Changes

- Adds `ServerUpload` mode to mobile exception reporting options.
- Adds `IMobileExceptionReportUploader` and default HTTPS/localhost HTTP uploader.
- Adds `IMobileExceptionReportUploadWorker` with bounded flushes, delete-after-success behavior, and exponential in-memory retry backoff.
- Wires queue, reporter, uploader, and upload worker in MAUI DI.
- Documents the server ingestion dependency and privacy/operational behavior.

## Platform Impact

This is MAUI service registration and diagnostics plumbing only. Upload is opt-in, requires explicit configuration, and does not change app startup, sync, auth refresh, or field capture behavior unless an app schedules the worker.

## Validation

- `dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --filter "FullyQualifiedName~Diagnostics"` (`14 passed`)
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --filter "FullyQualifiedName~MobileExceptionReporterTests"` (`3 passed`)

Related to #91