### PR TITLE
test: add live Honua server interaction tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ tests/
   Honua.Mobile.Sdk.Tests/     HTTP client, transport security, gRPC translation, routing, scenes (79 tests)
   Honua.Mobile.Field.Tests/   SDK field adapter validation, calculated fields, workflow (11 tests)
   Honua.Mobile.FieldCollection.Tests/ FieldCollection auth, sync, storage, diagnostics (10 tests)
-  Honua.Mobile.ServerIntegration.Tests/ Loopback Honua server integration surface (8 tests)
+  Honua.Mobile.ServerIntegration.Tests/ Loopback and opt-in live Honua image integration surface
   Honua.Mobile.Offline.Tests/ Sync engine, conflicts, map download, GeoPackage (65 tests)
   Honua.Mobile.Maui.Tests/    MAUI integration helpers, map annotations, native display, location, scene anchoring (40 tests)
   Honua.Mobile.Smoke.Tests/   End-to-end smoke paths and optional live Honua query (7 tests)
@@ -182,12 +182,14 @@ without the MAUI workload.
 
 The server integration project starts a real ASP.NET Core loopback server and
 exercises the implemented SDK, offline, FieldCollection auth, and mobile
-exception-reporting HTTP paths without requiring external infrastructure.
+exception-reporting HTTP paths without requiring external infrastructure. It
+also includes opt-in live Honua image tests that use Testcontainers or a
+pre-started Honua URL when `HONUA_MOBILE_LIVE_SERVER_TESTS=1` is set; see
+`docs/guides/offline-sync.md`.
 The smoke test project can also run an optional live Honua query when
 `HONUA_MOBILE_SMOKE_BASE_URL`, `HONUA_MOBILE_SMOKE_SERVICE_ID`,
 `HONUA_MOBILE_SMOKE_LAYER_ID`, and optionally `HONUA_MOBILE_SMOKE_API_KEY` are
-set. This repository does not currently include Testcontainers or a devcontainer
-for provisioning Honua locally.
+set.
 
 ## Status
 

--- a/docs/guides/offline-sync.md
+++ b/docs/guides/offline-sync.md
@@ -210,6 +210,61 @@ contract. The loopback harness verifies request-level behavior locally; the
 cloud harness records the fixture assumption in the queued operation metadata
 and evidence artifact.
 
+## Live Honua Image Server Interaction Tests
+
+`tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs`
+adds opt-in live image coverage for the mobile server interaction surface. The
+tests are disabled unless `HONUA_MOBILE_LIVE_SERVER_TESTS=1` is set. When
+enabled without `HONUA_MOBILE_LIVE_SERVER_BASE_URL`, the fixture starts a
+PostGIS container plus a Honua Server container image through Testcontainers.
+When `HONUA_MOBILE_LIVE_SERVER_BASE_URL` is set, the tests use that already
+running Honua environment instead.
+
+The live suite covers health, FeatureServer REST query/edit, FeatureServer gRPC
+query/edit, OGC Features CRUD, attachments, replica sync, offline queued upload
+through the background orchestrator path, map area downloads, scene package
+asset downloads, scene metadata/resolve, routing, FieldCollection API-key
+validation, OAuth refresh, and both app-level and MAUI exception upload paths.
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `HONUA_MOBILE_LIVE_SERVER_TESTS` | Yes | Set to `1` or `true` to enable live image tests. |
+| `HONUA_MOBILE_LIVE_SERVER_BASE_URL` | No | Existing Honua base URL. If omitted, Testcontainers starts the image. |
+| `HONUA_MOBILE_LIVE_SERVER_IMAGE` | No | Honua Server image. Defaults to `honuaio/honua-server:latest`. |
+| `HONUA_MOBILE_LIVE_SERVER_POSTGRES_IMAGE` | No | PostGIS image for Testcontainers. Defaults to `postgis/postgis:17-3.5-alpine`. |
+| `HONUA_MOBILE_LIVE_SERVER_FIXTURE_SQL` | No | SQL fixture applied to the Testcontainers PostGIS database before tests run. Use the `honua-server#895` mobile fixture seed when available. |
+| `HONUA_MOBILE_LIVE_SERVER_READY_PATH` | No | Readiness path. Defaults to `/healthz/ready`. |
+| `HONUA_MOBILE_LIVE_SERVER_SERVICE_ID` | No | FeatureServer service id. Defaults to `mobile_offline_demo`. |
+| `HONUA_MOBILE_LIVE_SERVER_LAYER_ID` | No | Editable FeatureServer layer id. Defaults to `68910`. |
+| `HONUA_MOBILE_LIVE_SERVER_REPLICA_LAYER_IDS` | No | Comma-separated replica layer ids. Defaults to the editable layer plus `68920`. |
+| `HONUA_MOBILE_LIVE_SERVER_OGC_COLLECTION_ID` | No | OGC collection id. Defaults to the layer id. |
+| `HONUA_MOBILE_LIVE_SERVER_SCENE_ID` | No | Scene id used by scene metadata tests. Defaults to `downtown-honolulu`. |
+| `HONUA_MOBILE_LIVE_SERVER_SCENE_ASSET_BASE_URL` | No | Base URL that serves `metadata/scene.json` and `tilesets/buildings/tileset.json`. Defaults to `/scene-assets/pkg_downtown_honolulu_2026_04/` under the live base URL. |
+| `HONUA_MOBILE_LIVE_SERVER_GRPC_URL` | No | Separate gRPC endpoint. Defaults to the base URL. |
+| `HONUA_MOBILE_LIVE_SERVER_API_KEY` | No | API key sent as `X-API-Key`. |
+| `HONUA_MOBILE_LIVE_SERVER_BEARER_TOKEN` | No | Bearer token sent on client requests. |
+| `HONUA_MOBILE_LIVE_SERVER_OAUTH_REFRESH_PATH` | No | OAuth refresh path. Defaults to `/oauth/token`. |
+| `HONUA_MOBILE_LIVE_SERVER_EXCEPTION_UPLOAD_PATH` | No | Mobile exception ingestion path. Defaults to `/api/mobile/exceptions`. |
+
+Example using a local `honua-server` checkout fixture seed:
+
+```bash
+HONUA_MOBILE_LIVE_SERVER_TESTS=1 \
+HONUA_MOBILE_LIVE_SERVER_FIXTURE_SQL=/home/makani/honua-server/tests/seed/mobile-offline-demo-v1.sql \
+dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj
+```
+
+The live tests intentionally fail when an enabled server image does not expose a
+configured interaction route or fixture. That keeps the mobile repo from
+claiming live server coverage that is only satisfied by the loopback stub.
+When `HONUA_MOBILE_LIVE_SERVER_FIXTURE_SQL` is set, the seed must match the
+schema in the selected Honua Server image.
+
+The embed package also has an opt-in live metadata fetch check for
+`<honua-scene>`. Set `HONUA_EMBED_LIVE_SCENE_METADATA_URL` to a
+`honua-scene-metadata/v1` document and optionally set
+`HONUA_EMBED_LIVE_SCENE_ID` before running `npm test --prefix src/Honua.Embed`.
+
 ### Basic Setup
 
 Configure offline capabilities in `MauiProgram.cs`:

--- a/src/Honua.Embed/tests/honua-scene.test.ts
+++ b/src/Honua.Embed/tests/honua-scene.test.ts
@@ -1,8 +1,10 @@
+import { env } from 'node:process';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   defineHonuaSceneElement,
   HonuaSceneElement,
   HonuaScenePackageCacheError,
+  type HonuaSceneMetadataChangeDetail,
 } from '../src/index';
 
 interface MockCesiumWidgetSnapshot {
@@ -962,6 +964,40 @@ describe('honua-scene', () => {
     });
 
     fetchSpy.mockRestore();
+  });
+
+  it('fetches live Honua scene metadata when configured', async () => {
+    const metadataUrl = env.HONUA_EMBED_LIVE_SCENE_METADATA_URL;
+    if (!metadataUrl) {
+      return;
+    }
+
+    const element = document.createElement('honua-scene');
+    element.setAttribute('autoload', 'false');
+    document.body.append(element);
+
+    const changed = new Promise<CustomEvent<HonuaSceneMetadataChangeDetail>>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error(`Timed out waiting for live scene metadata from ${metadataUrl}`)),
+        10000,
+      );
+      element.addEventListener('honua-scene-metadata-error', (event) => {
+        clearTimeout(timeout);
+        reject(new Error(JSON.stringify((event as CustomEvent).detail)));
+      }, { once: true });
+      element.addEventListener('honua-scene-metadata-change', (event) => {
+        clearTimeout(timeout);
+        resolve(event as CustomEvent<HonuaSceneMetadataChangeDetail>);
+      }, { once: true });
+    });
+
+    element.setAttribute('metadata-url', metadataUrl);
+
+    const event = await changed;
+    expect(event.detail.source).toBe('fetch');
+    expect(event.detail.metadata?.id).toBe(env.HONUA_EMBED_LIVE_SCENE_ID ?? event.detail.metadata?.id);
+    expect(event.detail.metadata?.name).toEqual(expect.any(String));
+    expect(event.detail.metadata?.layers?.length ?? 0).toBeGreaterThan(0);
   });
 
   it('emits honua-scene-metadata-error when the document is invalid', async () => {

--- a/tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Honua.Sdk.Scenes" Version="0.1.8-alpha.1" />
     <PackageReference Include="Microsoft.Maui.Essentials" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Testcontainers" Version="4.11.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
@@ -28,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Honua.Mobile.Maui\Honua.Mobile.Maui.csproj" />
     <ProjectReference Include="..\..\src\Honua.Mobile.Offline\Honua.Mobile.Offline.csproj" />
     <ProjectReference Include="..\..\src\Honua.Mobile.Sdk\Honua.Mobile.Sdk.csproj" />
   </ItemGroup>

--- a/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerFixture.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerFixture.cs
@@ -1,0 +1,367 @@
+using System.Globalization;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+
+namespace Honua.Mobile.ServerIntegration.Tests;
+
+public sealed class LiveHonuaServerFixture : IAsyncLifetime
+{
+    private const string PostgresAlias = "postgres";
+    private const string PostgresDatabase = "honua_dev";
+    private const string PostgresUser = "honua_user";
+    private const string PostgresPassword = "honua_password";
+    private const int HonuaHttpPort = 8080;
+
+    private INetwork? _network;
+    private IContainer? _postgres;
+    private IContainer? _honua;
+
+    public LiveHonuaServerOptions Options { get; private set; } = LiveHonuaServerOptions.Disabled;
+
+    public bool Enabled => Options.Enabled;
+
+    public Uri BaseUri { get; private set; } = new("http://127.0.0.1/");
+
+    public async Task InitializeAsync()
+    {
+        Options = LiveHonuaServerOptions.FromEnvironment();
+        if (!Options.Enabled)
+        {
+            return;
+        }
+
+        if (Options.BaseUri is not null)
+        {
+            BaseUri = Options.BaseUri;
+            CompleteDerivedOptions();
+            await WaitForReadyAsync();
+            return;
+        }
+
+        await StartImageStackAsync();
+        CompleteDerivedOptions();
+        await WaitForReadyAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_honua is not null)
+        {
+            await _honua.DisposeAsync();
+        }
+
+        if (_postgres is not null)
+        {
+            await _postgres.DisposeAsync();
+        }
+
+        if (_network is not null)
+        {
+            await _network.DisposeAsync();
+        }
+    }
+
+    public Uri Uri(string relativePath)
+    {
+        if (System.Uri.TryCreate(relativePath, UriKind.Absolute, out var absoluteUri) &&
+            (string.Equals(absoluteUri.Scheme, System.Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(absoluteUri.Scheme, System.Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)))
+        {
+            return absoluteUri;
+        }
+
+        return new Uri(BaseUri, relativePath.TrimStart('/'));
+    }
+
+    private void CompleteDerivedOptions()
+    {
+        Options = Options with
+        {
+            SceneAssetBaseUri = Options.SceneAssetBaseUri
+                ?? Uri("/scene-assets/pkg_downtown_honolulu_2026_04/"),
+        };
+    }
+
+    private async Task StartImageStackAsync()
+    {
+        _network = new NetworkBuilder()
+            .WithName($"honua-mobile-live-{Guid.NewGuid():N}")
+            .Build();
+        await _network.CreateAsync();
+
+        _postgres = new ContainerBuilder(Options.PostgresImage)
+            .WithNetwork(_network)
+            .WithNetworkAliases(PostgresAlias)
+            .WithEnvironment("POSTGRES_DB", PostgresDatabase)
+            .WithEnvironment("POSTGRES_USER", PostgresUser)
+            .WithEnvironment("POSTGRES_PASSWORD", PostgresPassword)
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilCommandIsCompleted(["pg_isready", "-h", "127.0.0.1", "-U", PostgresUser, "-d", PostgresDatabase]))
+            .Build();
+        await _postgres.StartAsync();
+        await WaitForPostgresReadyAsync();
+
+        _honua = new ContainerBuilder(Options.Image)
+            .WithNetwork(_network)
+            .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
+            .WithEnvironment("ASPNETCORE_URLS", $"http://+:{HonuaHttpPort.ToString(CultureInfo.InvariantCulture)}")
+            .WithEnvironment("ConnectionStrings__DefaultConnection", BuildPostgresConnectionString())
+            .WithEnvironment("HONUA_ADMIN_PASSWORD", "live-image-test-admin-password")
+            .WithEnvironment("Security__ConnectionEncryption__MasterKey", "mobile-live-image-test-master-key-32")
+            .WithEnvironment("Security__ConnectionEncryption__Salt", "bW9iaWxlLWxpdmUtaW1hZ2Utc2FsdA==")
+            .WithPortBinding(HonuaHttpPort, assignRandomHostPort: true)
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilHttpRequestIsSucceeded(request => request
+                    .ForPort((ushort)HonuaHttpPort)
+                    .ForPath(Options.ReadyPath)))
+            .Build();
+        await _honua.StartAsync();
+
+        BaseUri = new Uri($"http://127.0.0.1:{_honua.GetMappedPublicPort(HonuaHttpPort).ToString(CultureInfo.InvariantCulture)}/");
+        await ApplyFixtureSeedAsync();
+    }
+
+    private async Task WaitForPostgresReadyAsync()
+    {
+        if (_postgres is null)
+        {
+            return;
+        }
+
+        string? lastError = null;
+        for (var attempt = 0; attempt < 30; attempt++)
+        {
+            var result = await _postgres.ExecAsync(
+                [
+                    "psql",
+                    "-v",
+                    "ON_ERROR_STOP=1",
+                    "-h",
+                    "127.0.0.1",
+                    "-p",
+                    "5432",
+                    "-U",
+                    PostgresUser,
+                    "-d",
+                    PostgresDatabase,
+                    "-c",
+                    "select 1;",
+                ],
+                CancellationToken.None);
+
+            if (result.ExitCode == 0)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(3));
+                return;
+            }
+
+            lastError = result.Stderr + result.Stdout;
+            await Task.Delay(TimeSpan.FromSeconds(1));
+        }
+
+        throw new InvalidOperationException($"PostGIS container did not accept SQL before Honua startup: {lastError}");
+    }
+
+    private static string BuildPostgresConnectionString()
+        => $"Host={PostgresAlias};Database={PostgresDatabase};Username={PostgresUser};Password={PostgresPassword}";
+
+    private async Task ApplyFixtureSeedAsync()
+    {
+        if (_postgres is null || string.IsNullOrWhiteSpace(Options.FixtureSqlPath))
+        {
+            return;
+        }
+
+        var seedFile = new FileInfo(Options.FixtureSqlPath);
+        if (!seedFile.Exists)
+        {
+            throw new InvalidOperationException(
+                $"HONUA_MOBILE_LIVE_SERVER_FIXTURE_SQL points to a missing file: {seedFile.FullName}");
+        }
+
+        const string containerSeedDirectory = "/tmp/honua-mobile-live-fixture";
+        var containerSeedPath = $"{containerSeedDirectory}/{seedFile.Name}";
+        await _postgres.CopyAsync(
+            seedFile,
+            containerSeedDirectory,
+            uid: 0,
+            gid: 0,
+            UnixFileModes.UserRead | UnixFileModes.UserWrite | UnixFileModes.GroupRead | UnixFileModes.OtherRead,
+            CancellationToken.None);
+
+        var result = await _postgres.ExecAsync(
+            [
+                "psql",
+                "-v",
+                "ON_ERROR_STOP=1",
+                "-U",
+                PostgresUser,
+                "-d",
+                PostgresDatabase,
+                "-f",
+                containerSeedPath,
+            ],
+            CancellationToken.None);
+
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Honua live fixture seed failed with exit code {result.ExitCode}: {result.Stderr}{result.Stdout}");
+        }
+    }
+
+    private async Task WaitForReadyAsync()
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+        var readyUri = Uri(Options.ReadyPath);
+        Exception? lastError = null;
+
+        for (var attempt = 0; attempt < 90; attempt++)
+        {
+            try
+            {
+                using var response = await http.GetAsync(readyUri);
+                if (response.IsSuccessStatusCode)
+                {
+                    return;
+                }
+            }
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or IOException)
+            {
+                lastError = ex;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(2));
+        }
+
+        throw new InvalidOperationException(
+            $"Honua live server did not become ready at {readyUri}.",
+            lastError);
+    }
+}
+
+public sealed record LiveHonuaServerOptions
+{
+    public static readonly LiveHonuaServerOptions Disabled = new();
+
+    public bool Enabled { get; init; }
+
+    public Uri? BaseUri { get; init; }
+
+    public string Image { get; init; } = "honuaio/honua-server:latest";
+
+    public string PostgresImage { get; init; } = "postgis/postgis:17-3.5-alpine";
+
+    public string? FixtureSqlPath { get; init; }
+
+    public string ReadyPath { get; init; } = "/healthz/ready";
+
+    public string ServiceId { get; init; } = "mobile_offline_demo";
+
+    public int LayerId { get; init; } = 68910;
+
+    public IReadOnlyList<int> ReplicaLayerIds { get; init; } = [68910, 68920];
+
+    public string OgcCollectionId { get; init; } = "68910";
+
+    public string SceneId { get; init; } = "downtown-honolulu";
+
+    public string RoutingServiceId { get; init; } = "Routing";
+
+    public Uri? GrpcEndpoint { get; init; }
+
+    public string ApiKey { get; init; } = "live-image-test-api-key";
+
+    public string BearerToken { get; init; } = "live-image-test-bearer-token";
+
+    public string OAuthRefreshPath { get; init; } = "/oauth/token";
+
+    public string ExceptionUploadPath { get; init; } = "/api/mobile/exceptions";
+
+    public Uri? SceneAssetBaseUri { get; init; }
+
+    public static LiveHonuaServerOptions FromEnvironment()
+    {
+        var enabled = IsTruthy(Environment.GetEnvironmentVariable("HONUA_MOBILE_LIVE_SERVER_TESTS"));
+        var baseUri = TryUri(Environment.GetEnvironmentVariable("HONUA_MOBILE_LIVE_SERVER_BASE_URL"));
+        var layerId = ReadInt("HONUA_MOBILE_LIVE_SERVER_LAYER_ID", 68910);
+
+        return new LiveHonuaServerOptions
+        {
+            Enabled = enabled,
+            BaseUri = baseUri,
+            Image = ReadString("HONUA_MOBILE_LIVE_SERVER_IMAGE", "honuaio/honua-server:latest"),
+            PostgresImage = ReadString("HONUA_MOBILE_LIVE_SERVER_POSTGRES_IMAGE", "postgis/postgis:17-3.5-alpine"),
+            FixtureSqlPath = EmptyToNull(Environment.GetEnvironmentVariable("HONUA_MOBILE_LIVE_SERVER_FIXTURE_SQL")),
+            ReadyPath = ReadPath("HONUA_MOBILE_LIVE_SERVER_READY_PATH", "/healthz/ready"),
+            ServiceId = ReadString("HONUA_MOBILE_LIVE_SERVER_SERVICE_ID", "mobile_offline_demo"),
+            LayerId = layerId,
+            ReplicaLayerIds = ReadIntList("HONUA_MOBILE_LIVE_SERVER_REPLICA_LAYER_IDS", [layerId, 68920]),
+            OgcCollectionId = ReadString("HONUA_MOBILE_LIVE_SERVER_OGC_COLLECTION_ID", layerId.ToString(CultureInfo.InvariantCulture)),
+            SceneId = ReadString("HONUA_MOBILE_LIVE_SERVER_SCENE_ID", "downtown-honolulu"),
+            RoutingServiceId = ReadString("HONUA_MOBILE_LIVE_SERVER_ROUTING_SERVICE_ID", "Routing"),
+            GrpcEndpoint = TryUri(Environment.GetEnvironmentVariable("HONUA_MOBILE_LIVE_SERVER_GRPC_URL")),
+            ApiKey = ReadString("HONUA_MOBILE_LIVE_SERVER_API_KEY", "live-image-test-api-key"),
+            BearerToken = ReadString("HONUA_MOBILE_LIVE_SERVER_BEARER_TOKEN", "live-image-test-bearer-token"),
+            OAuthRefreshPath = ReadPath("HONUA_MOBILE_LIVE_SERVER_OAUTH_REFRESH_PATH", "/oauth/token"),
+            ExceptionUploadPath = ReadPath("HONUA_MOBILE_LIVE_SERVER_EXCEPTION_UPLOAD_PATH", "/api/mobile/exceptions"),
+            SceneAssetBaseUri = TryUri(Environment.GetEnvironmentVariable("HONUA_MOBILE_LIVE_SERVER_SCENE_ASSET_BASE_URL")),
+        };
+    }
+
+    private static bool IsTruthy(string? value)
+        => value is not null &&
+           (string.Equals(value, "1", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "on", StringComparison.OrdinalIgnoreCase));
+
+    private static Uri? TryUri(string? value)
+    {
+        return Uri.TryCreate(EmptyToNull(value), UriKind.Absolute, out var uri)
+            ? EnsureDirectoryUri(uri)
+            : null;
+    }
+
+    private static Uri EnsureDirectoryUri(Uri uri)
+    {
+        if (string.IsNullOrEmpty(uri.Query) && string.IsNullOrEmpty(uri.Fragment) && !uri.AbsolutePath.EndsWith('/'))
+        {
+            return new Uri(uri.AbsoluteUri + "/");
+        }
+
+        return uri;
+    }
+
+    private static string ReadString(string name, string fallback)
+        => EmptyToNull(Environment.GetEnvironmentVariable(name)) ?? fallback;
+
+    private static string ReadPath(string name, string fallback)
+    {
+        var value = ReadString(name, fallback);
+        return value.StartsWith("/", StringComparison.Ordinal) ? value : "/" + value;
+    }
+
+    private static int ReadInt(string name, int fallback)
+        => int.TryParse(Environment.GetEnvironmentVariable(name), NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+            ? value
+            : fallback;
+
+    private static IReadOnlyList<int> ReadIntList(string name, IReadOnlyList<int> fallback)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return fallback;
+        }
+
+        return value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(part => int.Parse(part, CultureInfo.InvariantCulture))
+            .ToArray();
+    }
+
+    private static string? EmptyToNull(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
@@ -1,0 +1,952 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using AppDiagnostics = Honua.Mobile.FieldCollection.Services.Diagnostics;
+using FieldServices = Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.Maui.Diagnostics;
+using Honua.Mobile.Offline.GeoPackage;
+using Honua.Mobile.Offline.MapAreas;
+using Honua.Mobile.Offline.ScenePackages;
+using Honua.Mobile.Offline.Sync;
+using Honua.Mobile.Sdk;
+using Honua.Mobile.Sdk.Auth;
+using Honua.Mobile.Sdk.Models;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Abstractions.Routing;
+using Honua.Sdk.Abstractions.Scenes;
+using Honua.Sdk.GeoServices.FeatureServer.Models;
+using Honua.Sdk.OgcFeatures.Models;
+
+namespace Honua.Mobile.ServerIntegration.Tests;
+
+public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaServerFixture>, IDisposable
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 6, 12, 0, 0, TimeSpan.Zero);
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly LiveHonuaServerFixture _server;
+    private readonly string _rootDirectory;
+
+    public LiveHonuaServerInteractionTests(LiveHonuaServerFixture server)
+    {
+        _server = server;
+        _rootDirectory = Path.Combine(Path.GetTempPath(), $"honua-live-server-integration-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_rootDirectory);
+    }
+
+    [Fact]
+    public async Task LiveImage_HealthEndpoint_RespondsReady()
+    {
+        if (!_server.Enabled)
+        {
+            return;
+        }
+
+        using var http = CreateHttpClient();
+        using var response = await http.GetAsync(_server.Uri(_server.Options.ReadyPath));
+
+        Assert.True(response.IsSuccessStatusCode, $"Expected ready endpoint to succeed, got {(int)response.StatusCode}.");
+    }
+
+    [Fact]
+    public async Task LiveImage_FeatureServerRestAndSdkFeatureContracts_RoundTrip()
+    {
+        if (!_server.Enabled)
+        {
+            return;
+        }
+
+        using var client = CreateMobileClient(preferGrpc: false);
+        using var query = await client.QueryFeaturesAsync(new QueryFeaturesRequest
+        {
+            ServiceId = _server.Options.ServiceId,
+            LayerId = _server.Options.LayerId,
+            Where = "1=1",
+            OutFields = ["*"],
+            ReturnGeometry = true,
+            ResultRecordCount = 1,
+        });
+        Assert.Equal(JsonValueKind.Object, query.RootElement.ValueKind);
+
+        JsonDocument? streamPage = null;
+        await foreach (var page in client.QueryFeaturesStreamAsync(new QueryFeaturesRequest
+        {
+            ServiceId = _server.Options.ServiceId,
+            LayerId = _server.Options.LayerId,
+            ResultRecordCount = 1,
+        }))
+        {
+            streamPage = page;
+            break;
+        }
+
+        using (streamPage)
+        {
+            Assert.NotNull(streamPage);
+            Assert.Equal(JsonValueKind.Object, streamPage.RootElement.ValueKind);
+        }
+
+        var sdkQuery = await client.QueryAsync(new FeatureQueryRequest
+        {
+            Source = FeatureSource(),
+            Limit = 1,
+        });
+        Assert.NotEmpty(sdkQuery.Features);
+
+        FeatureQueryResult? sdkPage = null;
+        await foreach (var page in client.QueryPagesAsync(new FeatureQueryRequest
+        {
+            Source = FeatureSource(),
+            Limit = 1,
+        }))
+        {
+            sdkPage = page;
+            break;
+        }
+
+        Assert.NotNull(sdkPage);
+        Assert.NotEmpty(sdkPage.Features);
+
+        long? restObjectId = null;
+        long? sdkObjectId = null;
+        try
+        {
+            restObjectId = await AddFeatureServerFeatureAsync(client, "rest");
+            using var update = await client.ApplyEditsAsync(new ApplyEditsRequest
+            {
+                ServiceId = _server.Options.ServiceId,
+                LayerId = _server.Options.LayerId,
+                UpdatesJson = JsonSerializer.Serialize(new[]
+                {
+                    new
+                    {
+                        attributes = CreateFeatureAttributes("rest-update", restObjectId.Value),
+                        geometry = CreateFeatureServerGeometry(),
+                    },
+                }, JsonOptions),
+                ForceWrite = true,
+            });
+            AssertEditSucceeded(update, "updateResults");
+
+            var sdkEdit = await client.ApplyEditsAsync(new FeatureEditRequest
+            {
+                Source = FeatureSource(),
+                Adds =
+                [
+                    new FeatureEditFeature
+                    {
+                        Attributes = CreateSdkAttributes("sdk-add"),
+                        Geometry = JsonSerializer.SerializeToElement(CreateGeoJsonPoint(), JsonOptions),
+                    },
+                ],
+            });
+            Assert.True(sdkEdit.Succeeded, sdkEdit.Error?.Message);
+            sdkObjectId = Assert.Single(sdkEdit.AddResults).ObjectId;
+            Assert.True(sdkObjectId > 0);
+        }
+        finally
+        {
+            if (restObjectId is not null)
+            {
+                await DeleteFeatureServerFeatureAsync(client, restObjectId.Value);
+            }
+
+            if (sdkObjectId is not null)
+            {
+                await DeleteFeatureServerFeatureAsync(client, sdkObjectId.Value);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task LiveImage_GrpcFeatureQueryAndEdit_RoundTrip()
+    {
+        if (!_server.Enabled)
+        {
+            return;
+        }
+
+        using var client = CreateMobileClient(preferGrpc: true, allowRestFallbackOnGrpcFailure: false);
+        using var query = await client.QueryFeaturesAsync(new QueryFeaturesRequest
+        {
+            ServiceId = _server.Options.ServiceId,
+            LayerId = _server.Options.LayerId,
+            ResultRecordCount = 1,
+        });
+        Assert.Equal(JsonValueKind.Object, query.RootElement.ValueKind);
+
+        long? objectId = null;
+        try
+        {
+            using var add = await client.ApplyEditsAsync(new ApplyEditsRequest
+            {
+                ServiceId = _server.Options.ServiceId,
+                LayerId = _server.Options.LayerId,
+                Adds = [CreateFeatureServerFeature("grpc-add")],
+                ForceWrite = true,
+            });
+            objectId = AssertEditSucceeded(add, "addResults");
+        }
+        finally
+        {
+            if (objectId is not null)
+            {
+                using var restClient = CreateMobileClient(preferGrpc: false);
+                await DeleteFeatureServerFeatureAsync(restClient, objectId.Value);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task LiveImage_OgcFeaturesCrud_RoundTrip()
+    {
+        if (!_server.Enabled)
+        {
+            return;
+        }
+
+        using var client = CreateMobileClient(preferGrpc: false);
+        var ogcSource = new FeatureSource { CollectionId = _server.Options.OgcCollectionId };
+
+        using var collections = await client.GetOgcCollectionsAsync();
+        Assert.Equal(JsonValueKind.Object, collections.RootElement.ValueKind);
+
+        using var items = await client.GetOgcItemsAsync(new OgcItemsRequest
+        {
+            CollectionId = _server.Options.OgcCollectionId,
+            Limit = 1,
+        });
+        Assert.Equal("FeatureCollection", items.RootElement.GetProperty("type").GetString());
+
+        var sdkQuery = await client.QueryAsync(new FeatureQueryRequest
+        {
+            Source = ogcSource,
+            Limit = 1,
+        });
+        Assert.NotEmpty(sdkQuery.Features);
+
+        FeatureQueryResult? sdkPage = null;
+        await foreach (var page in client.QueryPagesAsync(new FeatureQueryRequest
+        {
+            Source = ogcSource,
+            Limit = 1,
+        }))
+        {
+            sdkPage = page;
+            break;
+        }
+
+        Assert.NotNull(sdkPage);
+        Assert.NotEmpty(sdkPage.Features);
+
+        var featureId = $"mobile-live-ogc-{Guid.NewGuid():N}";
+        var sdkFeatureId = $"mobile-live-ogc-sdk-{Guid.NewGuid():N}";
+        string? createdId = null;
+        string? sdkCreatedId = null;
+        try
+        {
+            using var created = await client.CreateOgcItemAsync(new OgcCreateItemRequest
+            {
+                CollectionId = _server.Options.OgcCollectionId,
+                Feature = CreateOgcFeature(featureId, "ogc-create"),
+            });
+            createdId = ReadId(created.RootElement) ?? featureId;
+
+            using var replaced = await client.ReplaceOgcItemAsync(new OgcReplaceItemRequest
+            {
+                CollectionId = _server.Options.OgcCollectionId,
+                FeatureId = createdId,
+                Feature = CreateOgcFeature(createdId, "ogc-replace"),
+            });
+            Assert.Equal(JsonValueKind.Object, replaced.RootElement.ValueKind);
+
+            using var patched = await client.PatchOgcItemAsync(new OgcPatchItemRequest
+            {
+                CollectionId = _server.Options.OgcCollectionId,
+                FeatureId = createdId,
+                Patch = JsonSerializer.SerializeToElement(new
+                {
+                    properties = new { notes = $"patched {Guid.NewGuid():N}" },
+                }, JsonOptions),
+            });
+            Assert.Equal(JsonValueKind.Object, patched.RootElement.ValueKind);
+
+            var sdkEdit = await client.ApplyEditsAsync(new FeatureEditRequest
+            {
+                Source = ogcSource,
+                Adds =
+                [
+                    new FeatureEditFeature
+                    {
+                        Id = sdkFeatureId,
+                        Attributes = CreateSdkAttributes("ogc-sdk-add"),
+                        Geometry = JsonSerializer.SerializeToElement(CreateGeoJsonPoint(), JsonOptions),
+                    },
+                ],
+            });
+            Assert.True(sdkEdit.Succeeded, sdkEdit.Error?.Message);
+            sdkCreatedId = Assert.Single(sdkEdit.AddResults).Id ?? sdkFeatureId;
+        }
+        finally
+        {
+            if (!string.IsNullOrWhiteSpace(sdkCreatedId))
+            {
+                var delete = await client.ApplyEditsAsync(new FeatureEditRequest
+                {
+                    Source = ogcSource,
+                    DeleteIds = [sdkCreatedId],
+                });
+                Assert.True(delete.Succeeded, delete.Error?.Message);
+            }
+
+            if (!string.IsNullOrWhiteSpace(createdId))
+            {
+                using var deleted = await client.DeleteOgcItemAsync(new OgcDeleteItemRequest
+                {
+                    CollectionId = _server.Options.OgcCollectionId,
+                    FeatureId = createdId,
+                });
+                Assert.Equal(JsonValueKind.Object, deleted.RootElement.ValueKind);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task LiveImage_FeatureAttachments_RoundTrip()
+    {
+        if (!_server.Enabled)
+        {
+            return;
+        }
+
+        using var client = CreateMobileClient(preferGrpc: false);
+        var source = FeatureSource();
+        long? objectId = null;
+
+        try
+        {
+            objectId = await AddFeatureServerFeatureAsync(client, "attachment-parent");
+
+            using var addStream = new MemoryStream(Encoding.UTF8.GetBytes("live attachment"));
+            var add = await client.AddAttachmentAsync(new FeatureAttachmentAddRequest
+            {
+                Source = source,
+                ObjectId = objectId.Value,
+                Name = "live-attachment.txt",
+                ContentType = "text/plain",
+                Content = addStream,
+                Keywords = "live-image",
+            });
+            Assert.True(add.Succeeded, add.Error?.Message);
+            var attachmentId = add.AttachmentId.GetValueOrDefault();
+            Assert.True(attachmentId > 0);
+
+            var listed = await client.ListAttachmentsAsync(new FeatureAttachmentListRequest
+            {
+                Source = source,
+                ObjectId = objectId.Value,
+            });
+            Assert.Contains(listed, attachment => attachment.AttachmentId == attachmentId);
+
+            var downloaded = await client.DownloadAttachmentAsync(new FeatureAttachmentDownloadRequest
+            {
+                Source = source,
+                ObjectId = objectId.Value,
+                AttachmentId = attachmentId,
+            });
+            using (downloaded.Content)
+            using (var reader = new StreamReader(downloaded.Content, Encoding.UTF8))
+            {
+                Assert.Contains("live attachment", await reader.ReadToEndAsync());
+            }
+
+            using var updateStream = new MemoryStream(Encoding.UTF8.GetBytes("updated live attachment"));
+            var update = await client.UpdateAttachmentAsync(new FeatureAttachmentUpdateRequest
+            {
+                Source = source,
+                ObjectId = objectId.Value,
+                AttachmentId = attachmentId,
+                Name = "live-attachment-updated.txt",
+                ContentType = "text/plain",
+                Content = updateStream,
+            });
+            Assert.True(update.Succeeded, update.Error?.Message);
+
+            var delete = await client.DeleteAttachmentAsync(new FeatureAttachmentDeleteRequest
+            {
+                Source = source,
+                ObjectId = objectId.Value,
+                AttachmentId = attachmentId,
+            });
+            Assert.True(delete.Succeeded, delete.Error?.Message);
+        }
+        finally
+        {
+            if (objectId is not null)
+            {
+                await DeleteFeatureServerFeatureAsync(client, objectId.Value);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task LiveImage_ReplicaSyncAndOfflineQueue_RoundTrip()
+    {
+        if (!_server.Enabled)
+        {
+            return;
+        }
+
+        using var http = CreateHttpClient();
+        var replicaClient = new ReplicaSyncClient(http);
+        var replica = await replicaClient.CreateReplicaAsync(
+            _server.Options.ServiceId,
+            $"mobile-live-{Guid.NewGuid():N}",
+            _server.Options.ReplicaLayerIds.ToArray());
+
+        try
+        {
+            Assert.False(string.IsNullOrWhiteSpace(replica.ReplicaId));
+
+            var changes = await replicaClient.ExtractChangesAsync(_server.Options.ServiceId, replica.ReplicaId);
+            Assert.True(changes.ServerGen >= 0);
+
+            var sync = await replicaClient.SynchronizeReplicaAsync(_server.Options.ServiceId, replica.ReplicaId);
+            Assert.True(sync.ServerGen >= 0);
+        }
+        finally
+        {
+            await replicaClient.UnRegisterReplicaAsync(_server.Options.ServiceId, replica.ReplicaId);
+        }
+
+        using var client = CreateMobileClient(preferGrpc: false);
+        var featureObjectId = await AddFeatureServerFeatureAsync(client, "offline-delete");
+        var ogcId = await CreateOgcFeatureAsync(client, "offline-delete");
+
+        var store = CreateStore();
+        await store.InitializeAsync();
+        await store.EnqueueAsync(CreateFeatureServerDeleteOperation(featureObjectId));
+        await store.EnqueueAsync(CreateOgcDeleteOperation(ogcId));
+
+        var engine = new OfflineSyncEngine(store, new HonuaApiOfflineOperationUploader(client));
+        await using var orchestrator = new BackgroundSyncOrchestrator(
+            engine,
+            new AlwaysOnlineConnectivity(),
+            new BackgroundSyncOrchestratorOptions { RunImmediately = false });
+
+        var result = await orchestrator.RunOnceIfOnlineAsync();
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Loaded);
+        Assert.Equal(2, result.Succeeded);
+        Assert.Equal(0, await store.CountPendingAsync());
+    }
+
+    [Fact]
+    public async Task LiveImage_MapAndScenePackageDownloaders_FetchServerAssets()
+    {
+        if (!_server.Enabled)
+        {
+            return;
+        }
+
+        Assert.NotNull(_server.Options.SceneAssetBaseUri);
+
+        var store = CreateStore();
+        using var http = CreateHttpClient();
+        var mapDownloader = new MapAreaDownloader(http, store);
+        var map = await mapDownloader.DownloadAsync(new MapAreaDownloadRequest
+        {
+            AreaId = "live-image-downtown",
+            Name = "Live Image Downtown",
+            BoundingBox = new BoundingBox(-158.1250, 21.2600, -157.7000, 21.5200),
+            MinZoom = 1,
+            MaxZoom = 1,
+            OutputDirectory = Path.Combine(_rootDirectory, "maps"),
+            Layers =
+            [
+                new MapLayerDownloadSource
+                {
+                    LayerKey = _server.Options.LayerId.ToString(CultureInfo.InvariantCulture),
+                    SourceUrl = _server.Uri($"/tiles/{_server.Options.LayerId}/1/0/0.mvt").ToString(),
+                    ContentType = "application/vnd.mapbox-vector-tile",
+                    Required = true,
+                },
+            ],
+        });
+        Assert.Equal(1, map.DownloadedLayerCount);
+        Assert.True(File.Exists(map.GeoPackagePath));
+
+        var manifest = await CreateLiveSceneManifestAsync(http, _server.Options.SceneAssetBaseUri!);
+        var sceneDownloader = new ScenePackageDownloader(http, store);
+        var scene = await sceneDownloader.DownloadAsync(new ScenePackageDownloadRequest
+        {
+            Manifest = manifest,
+            AssetBaseUri = _server.Options.SceneAssetBaseUri!,
+            OutputDirectory = Path.Combine(_rootDirectory, "scenes"),
+            UtcNow = Now,
+        });
+
+        Assert.Equal(manifest.Assets.Count, scene.DownloadedAssetCount);
+        Assert.Single(await store.ListMapAreasAsync());
+        Assert.Single(await store.ListScenePackagesAsync());
+    }
+
+    [Fact]
+    public async Task LiveImage_ScenesAndRouting_RoundTrip()
+    {
+        if (!_server.Enabled)
+        {
+            return;
+        }
+
+        using var client = CreateMobileClient(preferGrpc: false);
+        var scenes = await client.Scenes.ListScenesAsync(new HonuaSceneListRequest
+        {
+            Capabilities = [HonuaSceneCapabilities.ThreeDimensionalTiles],
+        });
+        Assert.Contains(scenes, scene => scene.Id == _server.Options.SceneId);
+
+        var sceneMetadata = await client.Scenes.GetSceneAsync(_server.Options.SceneId);
+        Assert.Equal(_server.Options.SceneId, sceneMetadata.Id);
+
+        var resolved = await client.Scenes.ResolveSceneAsync(_server.Options.SceneId);
+        Assert.Equal(_server.Options.SceneId, resolved.SceneId);
+
+        var directions = await client.Routing.GetDirectionsAsync(
+            RoutingLocation.FromLongitudeLatitude(-157.8583, 21.3069, "Start"),
+            RoutingLocation.FromLongitudeLatitude(-157.8037, 21.2810, "Finish"));
+        Assert.NotEmpty(directions.Routes);
+
+        var optimized = await client.Routing.OptimizeRouteAsync(
+            [
+                RoutingLocation.FromLongitudeLatitude(-157.86, 21.30, "A"),
+                RoutingLocation.FromLongitudeLatitude(-157.84, 21.31, "B"),
+                RoutingLocation.FromLongitudeLatitude(-157.82, 21.32, "C"),
+            ],
+            new RouteOptimizationOptions
+            {
+                PreserveFirstStop = true,
+                PreserveLastStop = false,
+            });
+        Assert.NotEmpty(optimized.Routes);
+
+        var serviceArea = await client.Routing.GetServiceAreaAsync(
+            RoutingLocation.FromLongitudeLatitude(-157.8583, 21.3069, "Depot"),
+            TimeSpan.FromMinutes(30));
+        Assert.NotNull(serviceArea);
+
+        var closest = await client.Routing.FindClosestFacilityAsync(
+            [RoutingLocation.FromLongitudeLatitude(-157.85, 21.30, "Incident")],
+            [RoutingLocation.FromLongitudeLatitude(-157.80, 21.28, "Facility A")]);
+        Assert.NotEmpty(closest.Routes);
+    }
+
+    [Fact]
+    public async Task LiveImage_AuthRefreshAndExceptionUploads_RoundTrip()
+    {
+        if (!_server.Enabled)
+        {
+            return;
+        }
+
+        using var authHttp = CreateHttpClient();
+        var authService = new FieldServices.AuthenticationService(authHttp);
+        Assert.True(await authService.ValidateConnectionAsync(_server.BaseUri.ToString(), _server.Options.ApiKey));
+
+        var store = new InMemoryAuthTokenStore();
+        await store.WriteAsync(new HonuaAuthToken(
+            HonuaAuthScheme.Bearer,
+            "expired-access-token",
+            "refresh-token",
+            DateTimeOffset.UtcNow.AddMinutes(-10)));
+        var provider = new RefreshingAuthTokenProvider(
+            store,
+            authHttp,
+            new RefreshingAuthTokenProviderOptions
+            {
+                RefreshEndpoint = _server.Uri(_server.Options.OAuthRefreshPath),
+                RefreshSkew = TimeSpan.FromMinutes(2),
+            });
+
+        var token = await provider.GetTokenAsync();
+        Assert.NotNull(token);
+        Assert.Equal(HonuaAuthScheme.Bearer, token.Scheme);
+
+        await UploadAppExceptionReportAsync();
+        await UploadMauiExceptionReportAsync();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_rootDirectory))
+        {
+            Directory.Delete(_rootDirectory, recursive: true);
+        }
+    }
+
+    private HttpClient CreateHttpClient()
+    {
+        var http = new HttpClient { BaseAddress = _server.BaseUri, Timeout = TimeSpan.FromSeconds(30) };
+        http.DefaultRequestHeaders.TryAddWithoutValidation("X-API-Key", _server.Options.ApiKey);
+        http.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _server.Options.BearerToken);
+        return http;
+    }
+
+    private HonuaMobileClient CreateMobileClient(bool preferGrpc, bool allowRestFallbackOnGrpcFailure = true)
+    {
+        return new HonuaMobileClient(
+            new HttpClient(),
+            new HonuaMobileClientOptions
+            {
+                BaseUri = _server.BaseUri,
+                GrpcEndpoint = _server.Options.GrpcEndpoint ?? _server.BaseUri,
+                ApiKey = _server.Options.ApiKey,
+                BearerToken = _server.Options.BearerToken,
+                AllowInsecureTransportForDevelopment = _server.BaseUri.Scheme == Uri.UriSchemeHttp,
+                PreferGrpcForFeatureQueries = preferGrpc,
+                PreferGrpcForFeatureEdits = preferGrpc,
+                AllowRestFallbackOnGrpcFailure = allowRestFallbackOnGrpcFailure,
+                RoutingServiceId = _server.Options.RoutingServiceId,
+            });
+    }
+
+    private GeoPackageSyncStore CreateStore()
+        => new(new GeoPackageSyncStoreOptions
+        {
+            DatabasePath = Path.Combine(_rootDirectory, $"sync-store-{Guid.NewGuid():N}.gpkg"),
+        });
+
+    private FeatureSource FeatureSource()
+        => new()
+        {
+            ServiceId = _server.Options.ServiceId,
+            LayerId = _server.Options.LayerId,
+        };
+
+    private async Task<long> AddFeatureServerFeatureAsync(HonuaMobileClient client, string suffix)
+    {
+        using var result = await client.ApplyEditsAsync(new ApplyEditsRequest
+        {
+            ServiceId = _server.Options.ServiceId,
+            LayerId = _server.Options.LayerId,
+            Adds = [CreateFeatureServerFeature(suffix)],
+            ForceWrite = true,
+        });
+
+        var objectId = AssertEditSucceeded(result, "addResults");
+        Assert.True(objectId > 0, result.RootElement.GetRawText());
+        return objectId;
+    }
+
+    private async Task DeleteFeatureServerFeatureAsync(HonuaMobileClient client, long objectId)
+    {
+        using var result = await client.ApplyEditsAsync(new ApplyEditsRequest
+        {
+            ServiceId = _server.Options.ServiceId,
+            LayerId = _server.Options.LayerId,
+            Deletes = [objectId],
+            ForceWrite = true,
+        });
+        AssertEditSucceeded(result, "deleteResults");
+    }
+
+    private FeatureServerFeature CreateFeatureServerFeature(string suffix)
+    {
+        return new FeatureServerFeature
+        {
+            Attributes = CreateFeatureAttributes(suffix),
+            Geometry = JsonSerializer.SerializeToElement(CreateFeatureServerGeometry(), JsonOptions),
+        };
+    }
+
+    private static Dictionary<string, JsonElement> CreateSdkAttributes(string suffix)
+        => CreateFeatureAttributes(suffix);
+
+    private static Dictionary<string, JsonElement> CreateFeatureAttributes(string suffix, long? objectId = null)
+    {
+        var attributes = new Dictionary<string, JsonElement>
+        {
+            ["globalid"] = JsonSerializer.SerializeToElement($"mobile-live-{suffix}-{Guid.NewGuid():N}", JsonOptions),
+            ["site_name"] = JsonSerializer.SerializeToElement($"Live Image {suffix}", JsonOptions),
+            ["status"] = JsonSerializer.SerializeToElement("open", JsonOptions),
+            ["priority"] = JsonSerializer.SerializeToElement("normal", JsonOptions),
+            ["assigned_to"] = JsonSerializer.SerializeToElement("mobile-live", JsonOptions),
+            ["inspection_date"] = JsonSerializer.SerializeToElement("2026-05-06T12:00:00Z", JsonOptions),
+            ["sync_version"] = JsonSerializer.SerializeToElement(1, JsonOptions),
+            ["offline_action"] = JsonSerializer.SerializeToElement("live-image-test", JsonOptions),
+            ["notes"] = JsonSerializer.SerializeToElement($"Created by honua-mobile live image test {suffix}", JsonOptions),
+        };
+
+        if (objectId is not null)
+        {
+            attributes["objectid"] = JsonSerializer.SerializeToElement(objectId.Value, JsonOptions);
+        }
+
+        return attributes;
+    }
+
+    private static object CreateFeatureServerGeometry()
+        => new
+        {
+            x = -158.0100,
+            y = 21.3100,
+            spatialReference = new { wkid = 4326 },
+        };
+
+    private static object CreateGeoJsonPoint()
+        => new
+        {
+            type = "Point",
+            coordinates = new[] { -158.0100, 21.3100 },
+        };
+
+    private static long AssertEditSucceeded(JsonDocument document, string resultProperty)
+    {
+        var result = document.RootElement.GetProperty(resultProperty)[0];
+        Assert.True(result.GetProperty("success").GetBoolean(), document.RootElement.GetRawText());
+
+        if (result.TryGetProperty("objectId", out var objectId) && objectId.TryGetInt64(out var id))
+        {
+            return id;
+        }
+
+        if (result.TryGetProperty("objectid", out var objectIdLower) && objectIdLower.TryGetInt64(out var lowerId))
+        {
+            return lowerId;
+        }
+
+        return 0;
+    }
+
+    private OgcFeature CreateOgcFeature(string id, string suffix)
+    {
+        return new OgcFeature
+        {
+            Id = JsonSerializer.SerializeToElement(id, JsonOptions),
+            Properties = CreateFeatureAttributes(suffix),
+            Geometry = JsonSerializer.SerializeToElement(CreateGeoJsonPoint(), JsonOptions),
+        };
+    }
+
+    private async Task<string> CreateOgcFeatureAsync(HonuaMobileClient client, string suffix)
+    {
+        var id = $"mobile-live-ogc-{Guid.NewGuid():N}";
+        using var created = await client.CreateOgcItemAsync(new OgcCreateItemRequest
+        {
+            CollectionId = _server.Options.OgcCollectionId,
+            Feature = CreateOgcFeature(id, suffix),
+        });
+
+        return ReadId(created.RootElement) ?? id;
+    }
+
+    private static string? ReadId(JsonElement element)
+    {
+        if (!element.TryGetProperty("id", out var id))
+        {
+            return null;
+        }
+
+        return id.ValueKind switch
+        {
+            JsonValueKind.String => id.GetString(),
+            JsonValueKind.Number => id.GetRawText(),
+            _ => null,
+        };
+    }
+
+    private OfflineEditOperation CreateFeatureServerDeleteOperation(long objectId)
+    {
+        return new OfflineEditOperation
+        {
+            OperationId = $"live-fs-delete-{Guid.NewGuid():N}",
+            LayerKey = $"{_server.Options.ServiceId}/{_server.Options.LayerId}",
+            TargetCollection = _server.Options.ServiceId,
+            OperationType = OfflineOperationType.Delete,
+            PayloadJson = JsonSerializer.Serialize(new OfflineOperationPayload
+            {
+                Protocol = "FeatureServer",
+                ServiceId = _server.Options.ServiceId,
+                LayerId = _server.Options.LayerId,
+                DeleteObjectIds = [objectId],
+            }, JsonOptions),
+        };
+    }
+
+    private OfflineEditOperation CreateOgcDeleteOperation(string featureId)
+    {
+        return new OfflineEditOperation
+        {
+            OperationId = $"live-ogc-delete-{Guid.NewGuid():N}",
+            LayerKey = _server.Options.OgcCollectionId,
+            TargetCollection = _server.Options.OgcCollectionId,
+            OperationType = OfflineOperationType.Delete,
+            PayloadJson = JsonSerializer.Serialize(new OfflineOperationPayload
+            {
+                Protocol = "ogc",
+                CollectionId = _server.Options.OgcCollectionId,
+                FeatureId = featureId,
+            }, JsonOptions),
+        };
+    }
+
+    private async Task<HonuaScenePackageManifest> CreateLiveSceneManifestAsync(HttpClient http, Uri assetBaseUri)
+    {
+        var metadata = await ReadAssetAsync(http, new Uri(assetBaseUri, "metadata/scene.json"));
+        var tileset = await ReadAssetAsync(http, new Uri(assetBaseUri, "tilesets/buildings/tileset.json"));
+
+        return new HonuaScenePackageManifest
+        {
+            SchemaVersion = HonuaScenePackageManifest.CurrentSchemaVersion,
+            PackageId = "live-image-scene-package",
+            SceneId = _server.Options.SceneId,
+            DisplayName = "Live Image Scene Package",
+            EditionGate = HonuaScenePackageEditionGates.Pro,
+            ServerRevision = "live-image",
+            CreatedAtUtc = Now.AddHours(-1),
+            StaleAfterUtc = Now.AddDays(1),
+            OfflineUseExpiresAtUtc = Now.AddDays(1),
+            AuthExpiresAtUtc = Now.AddHours(1),
+            Extent = new HonuaSceneBounds
+            {
+                MinLongitude = -158.1250,
+                MinLatitude = 21.2600,
+                MaxLongitude = -157.7000,
+                MaxLatitude = 21.5200,
+            },
+            Lod = new HonuaScenePackageLod
+            {
+                MinZoom = 12,
+                MaxZoom = 17,
+                MaxGeometricErrorMeters = 4,
+            },
+            ByteBudget = new HonuaScenePackageByteBudget
+            {
+                MaxPackageBytes = metadata.Length + tileset.Length + 1024,
+                DeclaredBytes = metadata.Length + tileset.Length,
+            },
+            Attribution = ["Honua"],
+            Assets =
+            [
+                CreateAsset("metadata", HonuaScenePackageAssetTypes.SceneMetadata, "metadata/scene.json", metadata),
+                CreateAsset("tileset", HonuaScenePackageAssetTypes.ThreeDimensionalTileset, "tilesets/buildings/tileset.json", tileset),
+            ],
+        };
+    }
+
+    private static async Task<byte[]> ReadAssetAsync(HttpClient http, Uri uri)
+    {
+        using var response = await http.GetAsync(uri);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsByteArrayAsync();
+    }
+
+    private static HonuaScenePackageAsset CreateAsset(string key, string type, string path, byte[] payload)
+        => new()
+        {
+            Key = key,
+            Type = type,
+            Role = "metadata",
+            Path = path,
+            ContentType = "application/octet-stream",
+            Bytes = payload.Length,
+            Sha256 = HonuaIntegrationServer.Sha256Hex(payload),
+            Required = true,
+        };
+
+    private async Task UploadAppExceptionReportAsync()
+    {
+        var auth = new FakeAuthenticationService(_server.BaseUri.ToString(), _server.Options.ApiKey);
+        var options = new AppDiagnostics.MobileExceptionReportingOptions
+        {
+            Mode = AppDiagnostics.MobileExceptionReportingMode.Server,
+            Endpoint = _server.Uri(_server.Options.ExceptionUploadPath),
+            PendingReportsDirectory = Path.Combine(_rootDirectory, "app-exceptions"),
+        };
+        var reporter = new AppDiagnostics.MobileExceptionReporter(CreateHttpClient(), auth, options);
+
+        await reporter.ReportAsync(
+            new InvalidOperationException("live app exception token=secret"),
+            "live-image-app",
+            new Dictionary<string, string?> { ["apiKey"] = "secret" });
+        await reporter.FlushPendingAsync();
+    }
+
+    private async Task UploadMauiExceptionReportAsync()
+    {
+        var options = new MobileExceptionReportingOptions
+        {
+            Mode = MobileExceptionReportingMode.ServerUpload,
+            QueueDirectory = Path.Combine(_rootDirectory, "maui-exceptions"),
+            UploadEndpoint = _server.Uri(_server.Options.ExceptionUploadPath),
+            UploadInitialBackoff = TimeSpan.Zero,
+            UploadMaxBackoff = TimeSpan.Zero,
+        };
+        var queue = new FileMobileExceptionReportQueue(options);
+        var reporter = new LocalMobileExceptionReporter(queue, options);
+        var uploader = new HttpMobileExceptionReportUploader(CreateHttpClient(), options);
+        var worker = new MobileExceptionReportUploadWorker(queue, uploader, options);
+
+        await reporter.ReportAsync(
+            new InvalidOperationException("live maui exception token=secret"),
+            new MobileExceptionReportContext { Source = "live-image-maui" });
+        await worker.FlushPendingAsync();
+
+        var pending = new List<QueuedMobileExceptionReport>();
+        await foreach (var report in queue.ReadPendingAsync())
+        {
+            pending.Add(report);
+        }
+
+        Assert.Empty(pending);
+    }
+
+    private sealed class AlwaysOnlineConnectivity : IConnectivityStateProvider
+    {
+        public bool IsOnline => true;
+    }
+
+    private sealed class FakeAuthenticationService : FieldServices.IAuthenticationService
+    {
+        public FakeAuthenticationService(string serverUrl, string apiKey)
+        {
+            ServerUrl = serverUrl;
+            ApiKey = apiKey;
+        }
+
+        public bool IsAuthenticated => true;
+
+        public string? CurrentUserId => "live-image";
+
+        public string? CurrentUserName => "Live Image";
+
+        public string? ApiKey { get; }
+
+        public string? ServerUrl { get; }
+
+        public event PropertyChangedEventHandler? PropertyChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public Task<FieldServices.AuthenticationResult> AuthenticateAsync(string serverUrl, string apiKey)
+            => Task.FromResult(FieldServices.AuthenticationResult.Success("live-image", "Live Image", apiKey));
+
+        public Task<FieldServices.AuthenticationResult> AuthenticateWithCredentialsAsync(
+            string serverUrl,
+            string username,
+            string password)
+            => Task.FromResult(FieldServices.AuthenticationResult.Failure("Credentials are not used in live image tests."));
+
+        public Task<bool> RefreshTokenAsync() => Task.FromResult(true);
+
+        public Task LogoutAsync() => Task.CompletedTask;
+
+        public Task<bool> ValidateConnectionAsync(string serverUrl, string? apiKey = null) => Task.FromResult(true);
+    }
+}


### PR DESCRIPTION
## Summary
- add an opt-in Testcontainers live Honua Server fixture for mobile server interaction tests
- cover FeatureServer REST/gRPC, SDK feature query/edit/paging, OGC CRUD/edit, attachments, replica/offline upload, maps, scenes, routing, auth refresh, and exception upload paths
- add opt-in live scene metadata coverage for @honua/embed and document the live-test environment variables

Related to honua-io/honua-server#895.

## Testing
- dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj
- npm test --prefix src/Honua.Embed
- npm run typecheck --prefix src/Honua.Embed
- git diff --check
- HONUA_MOBILE_LIVE_SERVER_TESTS=1 dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --filter LiveImage_HealthEndpoint_RespondsReady

## Platform Impact
- Test-only and documentation changes; no Android/iOS/Windows runtime behavior changes.

## Offline Impact
- Adds live coverage for offline replica, queued upload, GeoPackage-backed map downloads, and scene package downloads; no production sync behavior changes.

## Protocol Changes
- No protocol or generated gRPC contract changes. The live tests assert the existing gRPC feature query/edit client path.

## Live Fixture Note
- Full live interaction coverage requires a fixture seed matching the selected Honua Server image. The local honua-server#895 seed currently fails against honuaio/honua-server:latest because the image schema is missing services.max_record_count.