### PR TITLE
test: harden live image server integration contracts

### DIFF
--- a/apps/Honua.Mobile.FieldCollection/Services/IAuthenticationService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/IAuthenticationService.cs
@@ -46,7 +46,9 @@ public class AuthenticationService : IAuthenticationService
 
     private static readonly string[] AuthenticatedValidationPaths =
     {
-        "/api/scenes?f=json"
+        "/api/scenes?f=json",
+        "/rest/services?f=json",
+        "/health"
     };
 
     private readonly HttpClient _httpClient;

--- a/docs/guides/offline-sync.md
+++ b/docs/guides/offline-sync.md
@@ -217,6 +217,9 @@ adds opt-in live image coverage for the mobile server interaction surface. The
 tests are disabled unless `HONUA_MOBILE_LIVE_SERVER_TESTS=1` is set. When
 enabled without `HONUA_MOBILE_LIVE_SERVER_BASE_URL`, the fixture starts a
 PostGIS container plus a Honua Server container image through Testcontainers.
+The local image stack requests HTTP/1.1 plus HTTP/2 from the Honua container;
+images that do not expose native HTTP/2 keep the gRPC live test red until the
+server transport contract is settled.
 When `HONUA_MOBILE_LIVE_SERVER_BASE_URL` is set, the tests use that already
 running Honua environment instead.
 
@@ -239,9 +242,9 @@ validation, OAuth refresh, and both app-level and MAUI exception upload paths.
 | `HONUA_MOBILE_LIVE_SERVER_REPLICA_LAYER_IDS` | No | Comma-separated replica layer ids. Defaults to the editable layer plus `68920`. |
 | `HONUA_MOBILE_LIVE_SERVER_OGC_COLLECTION_ID` | No | OGC collection id. Defaults to the layer id. |
 | `HONUA_MOBILE_LIVE_SERVER_SCENE_ID` | No | Scene id used by scene metadata tests. Defaults to `downtown-honolulu`. |
-| `HONUA_MOBILE_LIVE_SERVER_SCENE_ASSET_BASE_URL` | No | Base URL that serves `metadata/scene.json` and `tilesets/buildings/tileset.json`. Defaults to `/scene-assets/pkg_downtown_honolulu_2026_04/` under the live base URL. |
+| `HONUA_MOBILE_LIVE_SERVER_SCENE_ASSET_BASE_URL` | No | Base URL that serves `tileset.json`. Defaults to `/scenes/{HONUA_MOBILE_LIVE_SERVER_SCENE_ID}/` under the live base URL. |
 | `HONUA_MOBILE_LIVE_SERVER_GRPC_URL` | No | Separate gRPC endpoint. Defaults to the base URL. |
-| `HONUA_MOBILE_LIVE_SERVER_API_KEY` | No | API key sent as `X-API-Key`. |
+| `HONUA_MOBILE_LIVE_SERVER_API_KEY` | No | API key sent as `X-API-Key`. Defaults to the Testcontainers admin password when the fixture starts the image. |
 | `HONUA_MOBILE_LIVE_SERVER_BEARER_TOKEN` | No | Bearer token sent on client requests. |
 | `HONUA_MOBILE_LIVE_SERVER_OAUTH_REFRESH_PATH` | No | OAuth refresh path. Defaults to `/oauth/token`. |
 | `HONUA_MOBILE_LIVE_SERVER_EXCEPTION_UPLOAD_PATH` | No | Mobile exception ingestion path. Defaults to `/api/mobile/exceptions`. |

--- a/src/Honua.Mobile.Offline/Sync/ReplicaSyncClient.cs
+++ b/src/Honua.Mobile.Offline/Sync/ReplicaSyncClient.cs
@@ -47,9 +47,8 @@ public sealed class ReplicaSyncClient : IReplicaSyncClient
         var root = doc.RootElement;
         ThrowIfError(root);
 
-        var replicaId = root.GetProperty("replicaID").GetString()
-            ?? throw new InvalidOperationException("Server did not return a replicaID.");
-        var serverGen = root.GetProperty("serverGen").GetInt64();
+        var replicaId = GetRequiredString(root, "replicaID", "replicaId", "replica_id");
+        var serverGen = GetCreateReplicaServerGen(root);
 
         return new CreateReplicaResult(replicaId, serverGen);
     }
@@ -74,7 +73,7 @@ public sealed class ReplicaSyncClient : IReplicaSyncClient
         var root = doc.RootElement;
         ThrowIfError(root);
 
-        var serverGen = root.GetProperty("serverGen").GetInt64();
+        var serverGen = GetRequiredInt64(root, "serverGen", "serverGeneration", "server_generation");
         var layerChanges = new List<LayerChangeSet>();
 
         if (root.TryGetProperty("layerChanges", out var layerChangesElement) && layerChangesElement.ValueKind == JsonValueKind.Array)
@@ -113,7 +112,7 @@ public sealed class ReplicaSyncClient : IReplicaSyncClient
         var root = doc.RootElement;
         ThrowIfError(root);
 
-        var serverGen = root.GetProperty("serverGen").GetInt64();
+        var serverGen = GetRequiredInt64(root, "serverGen", "serverGeneration", "server_generation");
 
         return new SynchronizeResult(replicaId, serverGen);
     }
@@ -189,5 +188,100 @@ public sealed class ReplicaSyncClient : IReplicaSyncClient
 
             throw new InvalidOperationException($"Replica sync error{(code.HasValue ? $" ({code.Value})" : "")}: {message}");
         }
+    }
+
+    private static string GetRequiredString(JsonElement element, params string[] propertyNames)
+    {
+        if (TryGetProperty(element, out var property, propertyNames) && property.ValueKind == JsonValueKind.String)
+        {
+            var value = property.GetString();
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        throw new InvalidOperationException($"Server did not return a required replica sync property: {string.Join(" or ", propertyNames)}.");
+    }
+
+    private static long GetRequiredInt64(JsonElement element, params string[] propertyNames)
+    {
+        if (TryGetInt64(element, out var value, propertyNames))
+        {
+            return value;
+        }
+
+        throw new InvalidOperationException($"Server did not return a required replica sync property: {string.Join(" or ", propertyNames)}.");
+    }
+
+    private static long GetCreateReplicaServerGen(JsonElement root)
+    {
+        if (TryGetInt64(root, out var serverGen, "serverGen", "serverGeneration", "server_generation"))
+        {
+            return serverGen;
+        }
+
+        if (TryGetProperty(root, out var layers, "layers") && layers.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var layer in layers.EnumerateArray())
+            {
+                if (layer.ValueKind == JsonValueKind.Object &&
+                    TryGetInt64(layer, out serverGen, "serverGen", "serverGeneration", "server_generation"))
+                {
+                    return serverGen;
+                }
+            }
+        }
+
+        throw new InvalidOperationException("Server did not return a required replica sync property: serverGen or layers[].serverGen.");
+    }
+
+    private static bool TryGetInt64(JsonElement element, out long value, params string[] propertyNames)
+    {
+        if (TryGetProperty(element, out var property, propertyNames))
+        {
+            if (property.ValueKind == JsonValueKind.Number && property.TryGetInt64(out value))
+            {
+                return true;
+            }
+
+            if (property.ValueKind == JsonValueKind.String &&
+                long.TryParse(property.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+            {
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static bool TryGetProperty(JsonElement element, out JsonElement property, params string[] propertyNames)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            property = default;
+            return false;
+        }
+
+        foreach (var name in propertyNames)
+        {
+            if (element.TryGetProperty(name, out property))
+            {
+                return true;
+            }
+        }
+
+        foreach (var candidate in element.EnumerateObject())
+        {
+            if (propertyNames.Any(name => string.Equals(name, candidate.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                property = candidate.Value;
+                return true;
+            }
+        }
+
+        property = default;
+        return false;
     }
 }

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -303,6 +305,10 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
         try
         {
             return await _featureServerClient.ListAttachmentsAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (HonuaFeatureServerException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return await ListAttachmentsRestCompatAsync(request, ct).ConfigureAwait(false);
         }
         catch (HonuaFeatureServerException ex)
         {
@@ -783,14 +789,334 @@ public sealed class HonuaMobileClient : IDisposable, IAsyncDisposable
             }
         }
 
-        try
+        using var raw = await ApplyFeatureServerSdkEditsRestAsync(request, ct).ConfigureAwait(false);
+        return ToFeatureServerFeatureEditResponse(raw.RootElement);
+    }
+
+    private async Task<JsonDocument> ApplyFeatureServerSdkEditsRestAsync(FeatureEditRequest request, CancellationToken ct)
+    {
+        var source = request.Source;
+        var serviceId = source.ServiceId
+            ?? throw new InvalidOperationException("FeatureServer feature edits require a service ID.");
+        var layerId = source.LayerId
+            ?? throw new InvalidOperationException("FeatureServer feature edits require a layer ID.");
+
+        var editRequest = new ApplyEditsRequest
         {
-            return await _featureServerClient.ApplyEditsAsync(request, ct).ConfigureAwait(false);
-        }
-        catch (HonuaFeatureServerException ex)
+            ServiceId = serviceId,
+            LayerId = layerId,
+            Adds = request.Adds.Count > 0
+                ? request.Adds.Select(SdkFeatureTransportMappings.ToFeatureServerFeature).ToArray()
+                : null,
+            Updates = request.Updates.Count > 0
+                ? request.Updates.Select(SdkFeatureTransportMappings.ToFeatureServerFeature).ToArray()
+                : null,
+            Deletes = SdkFeatureTransportMappings.ToFeatureServerDeleteObjectIds(request),
+            RollbackOnFailure = request.RollbackOnFailure,
+            ForceWrite = request.ForceWrite,
+        };
+
+        var path = $"/rest/services/{Uri.EscapeDataString(serviceId)}/FeatureServer/{layerId}/applyEdits";
+        return await SendJsonAsync(
+            HttpMethod.Post,
+            path,
+            query: null,
+            new FormUrlEncodedContent(SdkFeatureTransportMappings.ToFeatureServerEditFormParameters(editRequest)),
+            ct).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<FeatureAttachmentInfo>> ListAttachmentsRestCompatAsync(
+        FeatureAttachmentListRequest request,
+        CancellationToken ct)
+    {
+        var serviceId = request.Source.ServiceId
+            ?? throw new InvalidOperationException("FeatureServer attachments require a service ID.");
+        var layerId = request.Source.LayerId
+            ?? throw new InvalidOperationException("FeatureServer attachments require a layer ID.");
+        var path = $"/rest/services/{Uri.EscapeDataString(serviceId)}/FeatureServer/{layerId}/queryAttachments";
+
+        using var response = await SendJsonAsync(
+            HttpMethod.Get,
+            path,
+            new Dictionary<string, string?>
+            {
+                ["f"] = "json",
+                ["objectIds"] = request.ObjectId.ToString(CultureInfo.InvariantCulture),
+                ["returnUrl"] = "true",
+            },
+            content: null,
+            ct).ConfigureAwait(false);
+
+        return ToFeatureAttachmentInfos(response.RootElement, request.Source, request.ObjectId);
+    }
+
+    private static FeatureEditResponse ToFeatureServerFeatureEditResponse(JsonElement root)
+    {
+        var error = TryGetJsonProperty(root, out var errorElement, "error") && errorElement.ValueKind == JsonValueKind.Object
+            ? ToFeatureEditError(errorElement)
+            : null;
+        var addResults = ToFeatureEditResults(root, "addResults", "adds");
+        var updateResults = ToFeatureEditResults(root, "updateResults", "updates");
+        var deleteResults = ToFeatureEditResults(root, "deleteResults", "deletes");
+
+        if (error is null &&
+            addResults.Count == 0 &&
+            updateResults.Count == 0 &&
+            deleteResults.Count == 0)
         {
-            throw ToMobileApiException("FeatureServer", ex);
+            error = new FeatureEditError
+            {
+                Message = "FeatureServer applyEdits response is malformed: missing edit result arrays.",
+            };
         }
+
+        return new FeatureEditResponse
+        {
+            ProviderName = "geoservices-featureserver",
+            AddResults = addResults,
+            UpdateResults = updateResults,
+            DeleteResults = deleteResults,
+            Error = error,
+        };
+    }
+
+    private static IReadOnlyList<FeatureEditResult> ToFeatureEditResults(JsonElement root, params string[] propertyNames)
+    {
+        if (!TryGetJsonProperty(root, out var results, propertyNames))
+        {
+            return [];
+        }
+
+        if (results.ValueKind == JsonValueKind.Object)
+        {
+            return [ToFeatureEditResult(results)];
+        }
+
+        if (results.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return results.EnumerateArray()
+            .Where(result => result.ValueKind == JsonValueKind.Object)
+            .Select(ToFeatureEditResult)
+            .ToArray();
+    }
+
+    private static FeatureEditResult ToFeatureEditResult(JsonElement element)
+    {
+        var hasSuccess = TryGetBool(element, out var succeeded, "success", "succeeded");
+        var error = TryGetJsonProperty(element, out var errorElement, "error") && errorElement.ValueKind == JsonValueKind.Object
+            ? ToFeatureEditError(errorElement)
+            : null;
+
+        var hasId = TryGetString(element, out var id, "globalId", "globalid", "id");
+        var hasObjectId = TryGetInt64(element, out var objectId, "objectId", "objectid", "objectID", "oid");
+
+        return new FeatureEditResult
+        {
+            Id = hasId ? id : null,
+            ObjectId = hasObjectId ? objectId : null,
+            Succeeded = hasSuccess ? succeeded : error is null && (hasId || hasObjectId),
+            Error = error,
+        };
+    }
+
+    private static FeatureEditError ToFeatureEditError(JsonElement element)
+        => new()
+        {
+            Code = TryGetInt32(element, out var code, "code")
+                ? code
+                : null,
+            Message = TryGetString(element, out var message, "message", "description") && message is not null
+                ? message
+                : "Unknown FeatureServer edit error.",
+        };
+
+    private static IReadOnlyList<FeatureAttachmentInfo> ToFeatureAttachmentInfos(
+        JsonElement root,
+        FeatureSource source,
+        long parentObjectId)
+    {
+        var attachments = new List<FeatureAttachmentInfo>();
+        if (TryGetJsonProperty(root, out var groups, "attachmentGroups") && groups.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var group in groups.EnumerateArray())
+            {
+                if (group.ValueKind != JsonValueKind.Object)
+                {
+                    continue;
+                }
+
+                var groupParentObjectId = TryGetInt64(group, out var parsedParentObjectId, "parentObjectId", "objectId", "objectid")
+                    ? parsedParentObjectId
+                    : parentObjectId;
+                AddAttachmentInfos(attachments, group, source, groupParentObjectId);
+            }
+        }
+
+        AddAttachmentInfos(attachments, root, source, parentObjectId);
+        return attachments;
+    }
+
+    private static void AddAttachmentInfos(
+        List<FeatureAttachmentInfo> attachments,
+        JsonElement element,
+        FeatureSource source,
+        long parentObjectId)
+    {
+        if (!TryGetJsonProperty(element, out var infos, "attachmentInfos") || infos.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        foreach (var info in infos.EnumerateArray())
+        {
+            if (info.ValueKind == JsonValueKind.Object)
+            {
+                attachments.Add(ToFeatureAttachmentInfo(info, source, parentObjectId));
+            }
+        }
+    }
+
+    private static FeatureAttachmentInfo ToFeatureAttachmentInfo(JsonElement element, FeatureSource source, long parentObjectId)
+    {
+        var parsedParentObjectId = TryGetInt64(element, out var attachmentParentObjectId, "parentObjectId", "objectId", "objectid")
+            ? attachmentParentObjectId
+            : parentObjectId;
+        var url = TryGetString(element, out var rawUrl, "url") && !string.IsNullOrWhiteSpace(rawUrl)
+            ? new Uri(rawUrl, UriKind.RelativeOrAbsolute)
+            : null;
+
+        return new FeatureAttachmentInfo
+        {
+            Source = source,
+            ParentObjectId = parsedParentObjectId,
+            AttachmentId = TryGetInt64(element, out var attachmentId, "id", "attachmentId")
+                ? attachmentId
+                : 0,
+            GlobalId = TryGetString(element, out var globalId, "globalId", "globalid")
+                ? globalId
+                : null,
+            Name = TryGetString(element, out var name, "name")
+                ? name
+                : string.Empty,
+            ContentType = TryGetString(element, out var contentType, "contentType")
+                ? contentType
+                : "application/octet-stream",
+            Size = TryGetInt64(element, out var size, "size")
+                ? size
+                : 0,
+            Keywords = TryGetString(element, out var keywords, "keywords")
+                ? keywords
+                : null,
+            Url = url,
+        };
+    }
+
+    private static bool TryGetJsonProperty(JsonElement element, out JsonElement property, params string[] propertyNames)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            property = default;
+            return false;
+        }
+
+        foreach (var name in propertyNames)
+        {
+            if (element.TryGetProperty(name, out property))
+            {
+                return true;
+            }
+        }
+
+        foreach (var candidate in element.EnumerateObject())
+        {
+            if (propertyNames.Any(name => string.Equals(name, candidate.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                property = candidate.Value;
+                return true;
+            }
+        }
+
+        property = default;
+        return false;
+    }
+
+    private static bool TryGetString(JsonElement element, out string? value, params string[] propertyNames)
+    {
+        if (TryGetJsonProperty(element, out var property, propertyNames))
+        {
+            if (property.ValueKind == JsonValueKind.String)
+            {
+                value = property.GetString();
+                return !string.IsNullOrWhiteSpace(value);
+            }
+
+            if (property.ValueKind == JsonValueKind.Number)
+            {
+                value = property.GetRawText();
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static bool TryGetInt32(JsonElement element, out int value, params string[] propertyNames)
+    {
+        if (TryGetInt64(element, out var parsed, propertyNames) &&
+            parsed >= int.MinValue &&
+            parsed <= int.MaxValue)
+        {
+            value = (int)parsed;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static bool TryGetInt64(JsonElement element, out long value, params string[] propertyNames)
+    {
+        if (TryGetJsonProperty(element, out var property, propertyNames))
+        {
+            if (property.ValueKind == JsonValueKind.Number && property.TryGetInt64(out value))
+            {
+                return true;
+            }
+
+            if (property.ValueKind == JsonValueKind.String &&
+                long.TryParse(property.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+            {
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static bool TryGetBool(JsonElement element, out bool value, params string[] propertyNames)
+    {
+        if (TryGetJsonProperty(element, out var property, propertyNames))
+        {
+            if (property.ValueKind is JsonValueKind.True or JsonValueKind.False)
+            {
+                value = property.GetBoolean();
+                return true;
+            }
+
+            if (property.ValueKind == JsonValueKind.String &&
+                bool.TryParse(property.GetString(), out value))
+            {
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
     }
 
     private static bool IsDefaultJsonResponseFormat(string? responseFormat)

--- a/src/Honua.Mobile.Sdk/SdkFeatureTransportMappings.cs
+++ b/src/Honua.Mobile.Sdk/SdkFeatureTransportMappings.cs
@@ -49,7 +49,7 @@ internal static class SdkFeatureTransportMappings
         return new FeatureServerFeature
         {
             Attributes = feature.Attributes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone()),
-            Geometry = feature.Geometry.HasValue ? feature.Geometry.Value.Clone() : null,
+            Geometry = ToFeatureServerGeometry(feature.Geometry),
         };
     }
 
@@ -230,6 +230,35 @@ internal static class SdkFeatureTransportMappings
             features.ToArray(),
             HonuaMobileSdkTransportJsonContext.Default.FeatureServerFeatureArray);
 
+    private static JsonElement? ToFeatureServerGeometry(JsonElement? geometry)
+    {
+        if (!geometry.HasValue)
+        {
+            return null;
+        }
+
+        var value = geometry.Value;
+        if (value.ValueKind == JsonValueKind.Object &&
+            value.TryGetProperty("type", out var type) &&
+            type.ValueKind == JsonValueKind.String &&
+            string.Equals(type.GetString(), "Point", StringComparison.OrdinalIgnoreCase) &&
+            value.TryGetProperty("coordinates", out var coordinates) &&
+            coordinates.ValueKind == JsonValueKind.Array &&
+            coordinates.GetArrayLength() >= 2)
+        {
+            return JsonSerializer.SerializeToElement(
+                new FeatureServerPointGeometry
+                {
+                    X = coordinates[0].GetDouble(),
+                    Y = coordinates[1].GetDouble(),
+                    SpatialReference = new FeatureServerPointSpatialReference { Wkid = 4326 },
+                },
+                HonuaMobileSdkTransportJsonContext.Default.FeatureServerPointGeometry);
+        }
+
+        return value.Clone();
+    }
+
     private static string SerializeWithContext(object value)
     {
         try
@@ -301,10 +330,29 @@ internal sealed class OgcCollectionsEnvelope
     public IReadOnlyList<OgcCollection> Collections { get; init; } = [];
 }
 
+internal sealed class FeatureServerPointGeometry
+{
+    [JsonPropertyName("x")]
+    public double X { get; init; }
+
+    [JsonPropertyName("y")]
+    public double Y { get; init; }
+
+    [JsonPropertyName("spatialReference")]
+    public FeatureServerPointSpatialReference SpatialReference { get; init; } = new();
+}
+
+internal sealed class FeatureServerPointSpatialReference
+{
+    [JsonPropertyName("wkid")]
+    public int Wkid { get; init; }
+}
+
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(FeatureServerFeature[]))]
+[JsonSerializable(typeof(FeatureServerPointGeometry))]
 [JsonSerializable(typeof(FeatureServerQueryResponse))]
 [JsonSerializable(typeof(FeatureServerEditResponse))]
 [JsonSerializable(typeof(OgcCollectionsEnvelope))]

--- a/tests/Honua.Mobile.FieldCollection.Tests/AuthenticationServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/AuthenticationServiceTests.cs
@@ -25,6 +25,25 @@ public sealed class AuthenticationServiceTests
     }
 
     [Fact]
+    public async Task ValidateConnection_WithApiKey_FallsBackWhenSceneDiscoveryIsMissing()
+    {
+        var requestedPaths = new List<string>();
+        using var http = new HttpClient(new StubHttpMessageHandler(request =>
+        {
+            requestedPaths.Add(request.RequestUri!.PathAndQuery);
+            return request.RequestUri!.AbsolutePath == "/rest/services"
+                ? new HttpResponseMessage(HttpStatusCode.OK)
+                : new HttpResponseMessage(HttpStatusCode.NotFound);
+        }));
+        var service = new AuthenticationService(http);
+
+        var isValid = await service.ValidateConnectionAsync("https://api.honua.test", "api-key");
+
+        Assert.True(isValid);
+        Assert.Equal(["/api/scenes?f=json", "/rest/services?f=json"], requestedPaths);
+    }
+
+    [Fact]
     public async Task ValidateConnection_WithoutApiKey_AllowsPublicHealthEndpoint()
     {
         using var http = new HttpClient(new StubHttpMessageHandler(request =>

--- a/tests/Honua.Mobile.Offline.Tests/ReplicaSyncClientTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/ReplicaSyncClientTests.cs
@@ -56,6 +56,47 @@ public sealed class ReplicaSyncClientTests
     }
 
     [Fact]
+    public async Task CreateReplicaAsync_CamelCaseResponse_ReturnsReplicaIdAndServerGen()
+    {
+        var handler = new StubHttpMessageHandler((_, _) =>
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"replicaId":"replica-camel","serverGeneration":"42"}""", Encoding.UTF8, "application/json"),
+            });
+        });
+
+        var client = new ReplicaSyncClient(new HttpClient(handler) { BaseAddress = new Uri("https://api.honua.test") });
+
+        var result = await client.CreateReplicaAsync("assets", "test-replica");
+
+        Assert.Equal("replica-camel", result.ReplicaId);
+        Assert.Equal(42, result.ServerGen);
+    }
+
+    [Fact]
+    public async Task CreateReplicaAsync_PerLayerServerGenResponse_ReturnsReplicaIdAndServerGen()
+    {
+        var handler = new StubHttpMessageHandler((_, _) =>
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"replicaID":"replica-layer","layers":[{"id":68910,"serverGen":43}]}""",
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+        });
+
+        var client = new ReplicaSyncClient(new HttpClient(handler) { BaseAddress = new Uri("https://api.honua.test") });
+
+        var result = await client.CreateReplicaAsync("assets", "test-replica");
+
+        Assert.Equal("replica-layer", result.ReplicaId);
+        Assert.Equal(43, result.ServerGen);
+    }
+
+    [Fact]
     public async Task ExtractChangesAsync_Success_ParsesAddsUpdatesDeletes()
     {
         var responseJson = """

--- a/tests/Honua.Mobile.Sdk.Tests/HonuaMobileSdkFeatureClientTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/HonuaMobileSdkFeatureClientTests.cs
@@ -127,6 +127,62 @@ public sealed class HonuaMobileSdkFeatureClientTests
     }
 
     [Fact]
+    public async Task ApplyEditsAsync_FeatureServerRequest_AcceptsSparseLiveImageEditResponse()
+    {
+        string? capturedBody = null;
+        var handler = new StubHttpMessageHandler(async (request, ct) =>
+        {
+            capturedBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {
+                      "addResults": [{ "objectid": 99 }]
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"),
+            };
+        });
+
+        var adapter = CreateAdapter(handler);
+        var result = await adapter.ApplyEditsAsync(new FeatureEditRequest
+        {
+            Source = new FeatureSource { ServiceId = "assets", LayerId = 0 },
+            Adds =
+            [
+                new FeatureEditFeature
+                {
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["name"] = JsonSerializer.SerializeToElement("Live Image Edit")
+                    },
+                    Geometry = JsonSerializer.SerializeToElement(new
+                    {
+                        type = "Point",
+                        coordinates = new[] { -157.8, 21.3 },
+                    }),
+                }
+            ],
+        });
+
+        Assert.NotNull(capturedBody);
+        var form = ParseForm(capturedBody);
+        Assert.Contains("\"x\":-157.8", form["adds"]);
+        Assert.Contains("\"y\":21.3", form["adds"]);
+        Assert.DoesNotContain("\"type\":\"Point\"", form["adds"]);
+        Assert.Equal("geoservices-featureserver", result.ProviderName);
+        Assert.True(result.Succeeded);
+        Assert.Equal(99, result.AddResults[0].ObjectId);
+        Assert.Empty(result.UpdateResults);
+        Assert.Empty(result.DeleteResults);
+    }
+
+    [Fact]
     public async Task ApplyEditsAsync_OgcRequest_DeletesObjectIdsThroughSdkFeatureContract()
     {
         var capturedPaths = new List<string>();
@@ -310,6 +366,63 @@ public sealed class HonuaMobileSdkFeatureClientTests
         });
         Assert.True(deleteResult.Succeeded);
         Assert.Equal(7, deleteResult.AttachmentId);
+    }
+
+    [Fact]
+    public async Task ListAttachmentsAsync_FeatureServerRequest_FallsBackToQueryAttachments()
+    {
+        var requestedPaths = new List<string>();
+        var handler = new StubHttpMessageHandler((request, _) =>
+        {
+            requestedPaths.Add(request.RequestUri!.PathAndQuery);
+            if (request.RequestUri!.AbsolutePath == "/rest/services/assets/FeatureServer/0/queryAttachments")
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """
+                        {
+                          "attachmentGroups": [
+                            {
+                              "parentObjectId": 42,
+                              "attachmentInfos": [
+                                {
+                                  "id": 7,
+                                  "name": "photo.txt",
+                                  "contentType": "text/plain",
+                                  "size": 5,
+                                  "keywords": "field"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                        """,
+                        Encoding.UTF8,
+                        "application/json"),
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+            });
+        });
+
+        var adapter = CreateAdapter(handler);
+        var attachments = (IHonuaFeatureAttachmentClient)adapter;
+
+        var listed = await attachments.ListAttachmentsAsync(new FeatureAttachmentListRequest
+        {
+            Source = new FeatureSource { ServiceId = "assets", LayerId = 0 },
+            ObjectId = 42,
+        });
+
+        Assert.Contains(requestedPaths, path => path.Contains("/rest/services/assets/FeatureServer/0/queryAttachments", StringComparison.Ordinal));
+        var attachment = Assert.Single(listed);
+        Assert.Equal(42, attachment.ParentObjectId);
+        Assert.Equal(7, attachment.AttachmentId);
+        Assert.Equal("photo.txt", attachment.Name);
     }
 
     private static HonuaMobileSdkFeatureClient CreateAdapter(HttpMessageHandler handler)

--- a/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerFixture.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerFixture.cs
@@ -8,6 +8,8 @@ namespace Honua.Mobile.ServerIntegration.Tests;
 
 public sealed class LiveHonuaServerFixture : IAsyncLifetime
 {
+    public const string DefaultAdminPassword = "live-image-test-admin-password";
+
     private const string PostgresAlias = "postgres";
     private const string PostgresDatabase = "honua_dev";
     private const string PostgresUser = "honua_user";
@@ -80,7 +82,7 @@ public sealed class LiveHonuaServerFixture : IAsyncLifetime
         Options = Options with
         {
             SceneAssetBaseUri = Options.SceneAssetBaseUri
-                ?? Uri("/scene-assets/pkg_downtown_honolulu_2026_04/"),
+                ?? Uri($"/scenes/{Options.SceneId}/"),
         };
     }
 
@@ -107,8 +109,9 @@ public sealed class LiveHonuaServerFixture : IAsyncLifetime
             .WithNetwork(_network)
             .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
             .WithEnvironment("ASPNETCORE_URLS", $"http://+:{HonuaHttpPort.ToString(CultureInfo.InvariantCulture)}")
+            .WithEnvironment("Kestrel__EndpointDefaults__Protocols", "Http1AndHttp2")
             .WithEnvironment("ConnectionStrings__DefaultConnection", BuildPostgresConnectionString())
-            .WithEnvironment("HONUA_ADMIN_PASSWORD", "live-image-test-admin-password")
+            .WithEnvironment("HONUA_ADMIN_PASSWORD", DefaultAdminPassword)
             .WithEnvironment("Security__ConnectionEncryption__MasterKey", "mobile-live-image-test-master-key-32")
             .WithEnvironment("Security__ConnectionEncryption__Salt", "bW9iaWxlLWxpdmUtaW1hZ2Utc2FsdA==")
             .WithPortBinding(HonuaHttpPort, assignRandomHostPort: true)
@@ -272,7 +275,7 @@ public sealed record LiveHonuaServerOptions
 
     public Uri? GrpcEndpoint { get; init; }
 
-    public string ApiKey { get; init; } = "live-image-test-api-key";
+    public string ApiKey { get; init; } = LiveHonuaServerFixture.DefaultAdminPassword;
 
     public string BearerToken { get; init; } = "live-image-test-bearer-token";
 
@@ -303,7 +306,7 @@ public sealed record LiveHonuaServerOptions
             SceneId = ReadString("HONUA_MOBILE_LIVE_SERVER_SCENE_ID", "downtown-honolulu"),
             RoutingServiceId = ReadString("HONUA_MOBILE_LIVE_SERVER_ROUTING_SERVICE_ID", "Routing"),
             GrpcEndpoint = TryUri(Environment.GetEnvironmentVariable("HONUA_MOBILE_LIVE_SERVER_GRPC_URL")),
-            ApiKey = ReadString("HONUA_MOBILE_LIVE_SERVER_API_KEY", "live-image-test-api-key"),
+            ApiKey = ReadString("HONUA_MOBILE_LIVE_SERVER_API_KEY", LiveHonuaServerFixture.DefaultAdminPassword),
             BearerToken = ReadString("HONUA_MOBILE_LIVE_SERVER_BEARER_TOKEN", "live-image-test-bearer-token"),
             OAuthRefreshPath = ReadPath("HONUA_MOBILE_LIVE_SERVER_OAUTH_REFRESH_PATH", "/oauth/token"),
             ExceptionUploadPath = ReadPath("HONUA_MOBILE_LIVE_SERVER_EXCEPTION_UPLOAD_PATH", "/api/mobile/exceptions"),

--- a/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
@@ -796,8 +796,7 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
 
     private async Task<HonuaScenePackageManifest> CreateLiveSceneManifestAsync(HttpClient http, Uri assetBaseUri)
     {
-        var metadata = await ReadAssetAsync(http, new Uri(assetBaseUri, "metadata/scene.json"));
-        var tileset = await ReadAssetAsync(http, new Uri(assetBaseUri, "tilesets/buildings/tileset.json"));
+        var tileset = await ReadAssetAsync(http, new Uri(assetBaseUri, "tileset.json"));
 
         return new HonuaScenePackageManifest
         {
@@ -826,14 +825,13 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
             },
             ByteBudget = new HonuaScenePackageByteBudget
             {
-                MaxPackageBytes = metadata.Length + tileset.Length + 1024,
-                DeclaredBytes = metadata.Length + tileset.Length,
+                MaxPackageBytes = tileset.Length + 1024,
+                DeclaredBytes = tileset.Length,
             },
             Attribution = ["Honua"],
             Assets =
             [
-                CreateAsset("metadata", HonuaScenePackageAssetTypes.SceneMetadata, "metadata/scene.json", metadata),
-                CreateAsset("tileset", HonuaScenePackageAssetTypes.ThreeDimensionalTileset, "tilesets/buildings/tileset.json", tileset),
+                CreateAsset("tileset", HonuaScenePackageAssetTypes.ThreeDimensionalTileset, "tileset.json", tileset),
             ],
         };
     }


### PR DESCRIPTION
## Summary

- harden live Honua image fixture defaults for API key, HTTP protocol config, and server scene asset base paths
- make mobile FeatureServer SDK edit and attachment paths tolerant of live-image response/route shapes while still using SDK feature contracts
- make replica sync parsing tolerate `replicaId` casing and `layers[].serverGen` fallback from current server image
- add focused regression coverage for auth fallback, FeatureServer sparse edits, GeoJSON point transport, attachment query fallback, and replica response aliases

## Verification

Passed locally:

```bash
dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --logger "console;verbosity=minimal"
dotnet test tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj --logger "console;verbosity=minimal"
dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --logger "console;verbosity=minimal"
dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --logger "console;verbosity=minimal"
```

Live image suite against `honuaio/honua-server:latest` plus the merged server fixture seed now has 5/9 passing:

```bash
HONUA_MOBILE_LIVE_SERVER_TESTS=1 \
HONUA_MOBILE_LIVE_SERVER_FIXTURE_SQL=/home/makani/worktrees/honua-server/895-mobile-offline-fixture/tests/seed/mobile-offline-demo-v1.sql \
dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj \
  --filter "FullyQualifiedName~LiveHonuaServerInteractionTests" \
  --logger "console;verbosity=normal"
```

Passed live: health, FeatureServer REST/SDK, attachments, OGC CRUD, replica/offline queue.
Remaining server blockers are tracked in `honua-server`:

- honua-io/honua-server#923 public scene discovery and hosted scene fixture
- honua-io/honua-server#924 mobile auth refresh and exception ingestion endpoints
- honua-io/honua-server#925 native gRPC transport for Docker live image
- honua-io/honua-server#366 NAServer routing endpoints
- honua-io/honua-server#926 replica `createReplica.serverGen` parity

Closes part of #92.
