### PR TITLE
test: derive live server gRPC endpoint from image port

### DIFF
--- a/docs/guides/offline-sync.md
+++ b/docs/guides/offline-sync.md
@@ -217,9 +217,9 @@ adds opt-in live image coverage for the mobile server interaction surface. The
 tests are disabled unless `HONUA_MOBILE_LIVE_SERVER_TESTS=1` is set. When
 enabled without `HONUA_MOBILE_LIVE_SERVER_BASE_URL`, the fixture starts a
 PostGIS container plus a Honua Server container image through Testcontainers.
-The local image stack requests HTTP/1.1 plus HTTP/2 from the Honua container;
-images that do not expose native HTTP/2 keep the gRPC live test red until the
-server transport contract is settled.
+The local image stack publishes REST on the Honua container's port `8080` and
+native h2c gRPC on port `8081`; for Testcontainers-managed runs the fixture
+derives `GrpcEndpoint` from the mapped host port for container port `8081`.
 When `HONUA_MOBILE_LIVE_SERVER_BASE_URL` is set, the tests use that already
 running Honua environment instead.
 
@@ -243,7 +243,7 @@ validation, OAuth refresh, and both app-level and MAUI exception upload paths.
 | `HONUA_MOBILE_LIVE_SERVER_OGC_COLLECTION_ID` | No | OGC collection id. Defaults to the layer id. |
 | `HONUA_MOBILE_LIVE_SERVER_SCENE_ID` | No | Scene id used by scene metadata tests. Defaults to `downtown-honolulu`. |
 | `HONUA_MOBILE_LIVE_SERVER_SCENE_ASSET_BASE_URL` | No | Base URL that serves `tileset.json`. Defaults to `/scenes/{HONUA_MOBILE_LIVE_SERVER_SCENE_ID}/` under the live base URL. |
-| `HONUA_MOBILE_LIVE_SERVER_GRPC_URL` | No | Separate gRPC endpoint. Defaults to the base URL. |
+| `HONUA_MOBILE_LIVE_SERVER_GRPC_URL` | No | Separate gRPC endpoint. Overrides the Testcontainers-derived gRPC URL. For prestarted servers, omit it to keep the client default of using the base URL. |
 | `HONUA_MOBILE_LIVE_SERVER_API_KEY` | No | API key sent as `X-API-Key`. Defaults to the Testcontainers admin password when the fixture starts the image. |
 | `HONUA_MOBILE_LIVE_SERVER_BEARER_TOKEN` | No | Bearer token sent on client requests. |
 | `HONUA_MOBILE_LIVE_SERVER_OAUTH_REFRESH_PATH` | No | OAuth refresh path. Defaults to `/oauth/token`. |

--- a/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerFixture.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerFixture.cs
@@ -15,6 +15,7 @@ public sealed class LiveHonuaServerFixture : IAsyncLifetime
     private const string PostgresUser = "honua_user";
     private const string PostgresPassword = "honua_password";
     private const int HonuaHttpPort = 8080;
+    private const int HonuaGrpcPort = 8081;
 
     private INetwork? _network;
     private IContainer? _postgres;
@@ -108,13 +109,16 @@ public sealed class LiveHonuaServerFixture : IAsyncLifetime
         _honua = new ContainerBuilder(Options.Image)
             .WithNetwork(_network)
             .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
-            .WithEnvironment("ASPNETCORE_URLS", $"http://+:{HonuaHttpPort.ToString(CultureInfo.InvariantCulture)}")
-            .WithEnvironment("Kestrel__EndpointDefaults__Protocols", "Http1AndHttp2")
+            .WithEnvironment("Kestrel__Endpoints__Http__Url", $"http://+:{HonuaHttpPort.ToString(CultureInfo.InvariantCulture)}")
+            .WithEnvironment("Kestrel__Endpoints__Http__Protocols", "Http1")
+            .WithEnvironment("Kestrel__Endpoints__Grpc__Url", $"http://+:{HonuaGrpcPort.ToString(CultureInfo.InvariantCulture)}")
+            .WithEnvironment("Kestrel__Endpoints__Grpc__Protocols", "Http2")
             .WithEnvironment("ConnectionStrings__DefaultConnection", BuildPostgresConnectionString())
             .WithEnvironment("HONUA_ADMIN_PASSWORD", DefaultAdminPassword)
             .WithEnvironment("Security__ConnectionEncryption__MasterKey", "mobile-live-image-test-master-key-32")
             .WithEnvironment("Security__ConnectionEncryption__Salt", "bW9iaWxlLWxpdmUtaW1hZ2Utc2FsdA==")
             .WithPortBinding(HonuaHttpPort, assignRandomHostPort: true)
+            .WithPortBinding(HonuaGrpcPort, assignRandomHostPort: true)
             .WithWaitStrategy(Wait.ForUnixContainer()
                 .UntilHttpRequestIsSucceeded(request => request
                     .ForPort((ushort)HonuaHttpPort)
@@ -123,6 +127,8 @@ public sealed class LiveHonuaServerFixture : IAsyncLifetime
         await _honua.StartAsync();
 
         BaseUri = new Uri($"http://127.0.0.1:{_honua.GetMappedPublicPort(HonuaHttpPort).ToString(CultureInfo.InvariantCulture)}/");
+        Options = Options.WithTestcontainersGrpcEndpoint(
+            new Uri($"http://127.0.0.1:{_honua.GetMappedPublicPort(HonuaGrpcPort).ToString(CultureInfo.InvariantCulture)}/"));
         await ApplyFixtureSeedAsync();
     }
 
@@ -287,31 +293,47 @@ public sealed record LiveHonuaServerOptions
 
     public static LiveHonuaServerOptions FromEnvironment()
     {
-        var enabled = IsTruthy(Environment.GetEnvironmentVariable("HONUA_MOBILE_LIVE_SERVER_TESTS"));
-        var baseUri = TryUri(Environment.GetEnvironmentVariable("HONUA_MOBILE_LIVE_SERVER_BASE_URL"));
-        var layerId = ReadInt("HONUA_MOBILE_LIVE_SERVER_LAYER_ID", 68910);
+        return FromEnvironment(Environment.GetEnvironmentVariable);
+    }
+
+    internal static LiveHonuaServerOptions FromEnvironment(Func<string, string?> readVariable)
+    {
+        ArgumentNullException.ThrowIfNull(readVariable);
+
+        var enabled = IsTruthy(readVariable("HONUA_MOBILE_LIVE_SERVER_TESTS"));
+        var baseUri = TryUri(readVariable("HONUA_MOBILE_LIVE_SERVER_BASE_URL"));
+        var layerId = ReadInt(readVariable, "HONUA_MOBILE_LIVE_SERVER_LAYER_ID", 68910);
 
         return new LiveHonuaServerOptions
         {
             Enabled = enabled,
             BaseUri = baseUri,
-            Image = ReadString("HONUA_MOBILE_LIVE_SERVER_IMAGE", "honuaio/honua-server:latest"),
-            PostgresImage = ReadString("HONUA_MOBILE_LIVE_SERVER_POSTGRES_IMAGE", "postgis/postgis:17-3.5-alpine"),
-            FixtureSqlPath = EmptyToNull(Environment.GetEnvironmentVariable("HONUA_MOBILE_LIVE_SERVER_FIXTURE_SQL")),
-            ReadyPath = ReadPath("HONUA_MOBILE_LIVE_SERVER_READY_PATH", "/healthz/ready"),
-            ServiceId = ReadString("HONUA_MOBILE_LIVE_SERVER_SERVICE_ID", "mobile_offline_demo"),
+            Image = ReadString(readVariable, "HONUA_MOBILE_LIVE_SERVER_IMAGE", "honuaio/honua-server:latest"),
+            PostgresImage = ReadString(readVariable, "HONUA_MOBILE_LIVE_SERVER_POSTGRES_IMAGE", "postgis/postgis:17-3.5-alpine"),
+            FixtureSqlPath = EmptyToNull(readVariable("HONUA_MOBILE_LIVE_SERVER_FIXTURE_SQL")),
+            ReadyPath = ReadPath(readVariable, "HONUA_MOBILE_LIVE_SERVER_READY_PATH", "/healthz/ready"),
+            ServiceId = ReadString(readVariable, "HONUA_MOBILE_LIVE_SERVER_SERVICE_ID", "mobile_offline_demo"),
             LayerId = layerId,
-            ReplicaLayerIds = ReadIntList("HONUA_MOBILE_LIVE_SERVER_REPLICA_LAYER_IDS", [layerId, 68920]),
-            OgcCollectionId = ReadString("HONUA_MOBILE_LIVE_SERVER_OGC_COLLECTION_ID", layerId.ToString(CultureInfo.InvariantCulture)),
-            SceneId = ReadString("HONUA_MOBILE_LIVE_SERVER_SCENE_ID", "downtown-honolulu"),
-            RoutingServiceId = ReadString("HONUA_MOBILE_LIVE_SERVER_ROUTING_SERVICE_ID", "Routing"),
-            GrpcEndpoint = TryUri(Environment.GetEnvironmentVariable("HONUA_MOBILE_LIVE_SERVER_GRPC_URL")),
-            ApiKey = ReadString("HONUA_MOBILE_LIVE_SERVER_API_KEY", LiveHonuaServerFixture.DefaultAdminPassword),
-            BearerToken = ReadString("HONUA_MOBILE_LIVE_SERVER_BEARER_TOKEN", "live-image-test-bearer-token"),
-            OAuthRefreshPath = ReadPath("HONUA_MOBILE_LIVE_SERVER_OAUTH_REFRESH_PATH", "/oauth/token"),
-            ExceptionUploadPath = ReadPath("HONUA_MOBILE_LIVE_SERVER_EXCEPTION_UPLOAD_PATH", "/api/mobile/exceptions"),
-            SceneAssetBaseUri = TryUri(Environment.GetEnvironmentVariable("HONUA_MOBILE_LIVE_SERVER_SCENE_ASSET_BASE_URL")),
+            ReplicaLayerIds = ReadIntList(readVariable, "HONUA_MOBILE_LIVE_SERVER_REPLICA_LAYER_IDS", [layerId, 68920]),
+            OgcCollectionId = ReadString(readVariable, "HONUA_MOBILE_LIVE_SERVER_OGC_COLLECTION_ID", layerId.ToString(CultureInfo.InvariantCulture)),
+            SceneId = ReadString(readVariable, "HONUA_MOBILE_LIVE_SERVER_SCENE_ID", "downtown-honolulu"),
+            RoutingServiceId = ReadString(readVariable, "HONUA_MOBILE_LIVE_SERVER_ROUTING_SERVICE_ID", "Routing"),
+            GrpcEndpoint = TryUri(readVariable("HONUA_MOBILE_LIVE_SERVER_GRPC_URL")),
+            ApiKey = ReadString(readVariable, "HONUA_MOBILE_LIVE_SERVER_API_KEY", LiveHonuaServerFixture.DefaultAdminPassword),
+            BearerToken = ReadString(readVariable, "HONUA_MOBILE_LIVE_SERVER_BEARER_TOKEN", "live-image-test-bearer-token"),
+            OAuthRefreshPath = ReadPath(readVariable, "HONUA_MOBILE_LIVE_SERVER_OAUTH_REFRESH_PATH", "/oauth/token"),
+            ExceptionUploadPath = ReadPath(readVariable, "HONUA_MOBILE_LIVE_SERVER_EXCEPTION_UPLOAD_PATH", "/api/mobile/exceptions"),
+            SceneAssetBaseUri = TryUri(readVariable("HONUA_MOBILE_LIVE_SERVER_SCENE_ASSET_BASE_URL")),
         };
+    }
+
+    internal LiveHonuaServerOptions WithTestcontainersGrpcEndpoint(Uri grpcEndpoint)
+    {
+        ArgumentNullException.ThrowIfNull(grpcEndpoint);
+
+        return GrpcEndpoint is null
+            ? this with { GrpcEndpoint = grpcEndpoint }
+            : this;
     }
 
     private static bool IsTruthy(string? value)
@@ -338,23 +360,23 @@ public sealed record LiveHonuaServerOptions
         return uri;
     }
 
-    private static string ReadString(string name, string fallback)
-        => EmptyToNull(Environment.GetEnvironmentVariable(name)) ?? fallback;
+    private static string ReadString(Func<string, string?> readVariable, string name, string fallback)
+        => EmptyToNull(readVariable(name)) ?? fallback;
 
-    private static string ReadPath(string name, string fallback)
+    private static string ReadPath(Func<string, string?> readVariable, string name, string fallback)
     {
-        var value = ReadString(name, fallback);
+        var value = ReadString(readVariable, name, fallback);
         return value.StartsWith("/", StringComparison.Ordinal) ? value : "/" + value;
     }
 
-    private static int ReadInt(string name, int fallback)
-        => int.TryParse(Environment.GetEnvironmentVariable(name), NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+    private static int ReadInt(Func<string, string?> readVariable, string name, int fallback)
+        => int.TryParse(readVariable(name), NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
             ? value
             : fallback;
 
-    private static IReadOnlyList<int> ReadIntList(string name, IReadOnlyList<int> fallback)
+    private static IReadOnlyList<int> ReadIntList(Func<string, string?> readVariable, string name, IReadOnlyList<int> fallback)
     {
-        var value = Environment.GetEnvironmentVariable(name);
+        var value = readVariable(name);
         if (string.IsNullOrWhiteSpace(value))
         {
             return fallback;

--- a/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerFixtureOptionsTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerFixtureOptionsTests.cs
@@ -1,0 +1,60 @@
+namespace Honua.Mobile.ServerIntegration.Tests;
+
+public sealed class LiveHonuaServerFixtureOptionsTests
+{
+    [Fact]
+    public void FromEnvironment_uses_explicit_grpc_endpoint_override()
+    {
+        var options = LiveHonuaServerOptions.FromEnvironment(name => name switch
+        {
+            "HONUA_MOBILE_LIVE_SERVER_TESTS" => "1",
+            "HONUA_MOBILE_LIVE_SERVER_BASE_URL" => "http://127.0.0.1:18080",
+            "HONUA_MOBILE_LIVE_SERVER_GRPC_URL" => "http://127.0.0.1:18081",
+            _ => null,
+        });
+
+        Assert.True(options.Enabled);
+        Assert.Equal(new Uri("http://127.0.0.1:18080/"), options.BaseUri);
+        Assert.Equal(new Uri("http://127.0.0.1:18081/"), options.GrpcEndpoint);
+    }
+
+    [Fact]
+    public void FromEnvironment_with_prestarted_base_uri_and_no_grpc_override_leaves_grpc_endpoint_unset()
+    {
+        var options = LiveHonuaServerOptions.FromEnvironment(name => name switch
+        {
+            "HONUA_MOBILE_LIVE_SERVER_TESTS" => "1",
+            "HONUA_MOBILE_LIVE_SERVER_BASE_URL" => "http://127.0.0.1:18080",
+            _ => null,
+        });
+
+        Assert.True(options.Enabled);
+        Assert.Equal(new Uri("http://127.0.0.1:18080/"), options.BaseUri);
+        Assert.Null(options.GrpcEndpoint);
+    }
+
+    [Fact]
+    public void WithTestcontainersGrpcEndpoint_sets_derived_grpc_endpoint_when_no_override_exists()
+    {
+        var options = new LiveHonuaServerOptions();
+        var grpcEndpoint = new Uri("http://127.0.0.1:18081/");
+
+        var derived = options.WithTestcontainersGrpcEndpoint(grpcEndpoint);
+
+        Assert.Equal(grpcEndpoint, derived.GrpcEndpoint);
+    }
+
+    [Fact]
+    public void WithTestcontainersGrpcEndpoint_keeps_explicit_grpc_endpoint_override()
+    {
+        var explicitEndpoint = new Uri("http://127.0.0.1:19081/");
+        var options = new LiveHonuaServerOptions
+        {
+            GrpcEndpoint = explicitEndpoint,
+        };
+
+        var derived = options.WithTestcontainersGrpcEndpoint(new Uri("http://127.0.0.1:18081/"));
+
+        Assert.Equal(explicitEndpoint, derived.GrpcEndpoint);
+    }
+}


### PR DESCRIPTION
## Summary

- publish the Honua live-image container's REST endpoint on port `8080` and native h2c gRPC endpoint on port `8081`
- derive the Testcontainers-managed `GrpcEndpoint` from the mapped host port for container port `8081`
- preserve `HONUA_MOBILE_LIVE_SERVER_GRPC_URL` as an explicit override and keep prestarted-server behavior unchanged when only `HONUA_MOBILE_LIVE_SERVER_BASE_URL` is set
- document the live-image gRPC port behavior and add focused non-live option coverage

## Verification

Passed locally:

```bash
dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --filter "FullyQualifiedName~LiveHonuaServerFixtureOptionsTests" --logger "console;verbosity=minimal"
git diff --check
```

The full live-image suite still depends on the server backlog PRs landing and a final merged Honua Server image being available.

Related to #92.
