### PR TITLE
test: include live scene metadata asset

### DIFF
--- a/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
@@ -796,7 +796,9 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
 
     private async Task<HonuaScenePackageManifest> CreateLiveSceneManifestAsync(HttpClient http, Uri assetBaseUri)
     {
+        var metadata = await ReadAssetAsync(http, new Uri(assetBaseUri, "metadata/scene.json"));
         var tileset = await ReadAssetAsync(http, new Uri(assetBaseUri, "tileset.json"));
+        var declaredBytes = metadata.Length + tileset.Length;
 
         return new HonuaScenePackageManifest
         {
@@ -825,12 +827,13 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
             },
             ByteBudget = new HonuaScenePackageByteBudget
             {
-                MaxPackageBytes = tileset.Length + 1024,
-                DeclaredBytes = tileset.Length,
+                MaxPackageBytes = declaredBytes + 1024,
+                DeclaredBytes = declaredBytes,
             },
             Attribution = ["Honua"],
             Assets =
             [
+                CreateAsset("scene-metadata", HonuaScenePackageAssetTypes.SceneMetadata, "metadata/scene.json", metadata),
                 CreateAsset("tileset", HonuaScenePackageAssetTypes.ThreeDimensionalTileset, "tileset.json", tileset),
             ],
         };
@@ -850,7 +853,9 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
             Type = type,
             Role = "metadata",
             Path = path,
-            ContentType = "application/octet-stream",
+            ContentType = path.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
+                ? "application/json"
+                : "application/octet-stream",
             Bytes = payload.Length,
             Sha256 = HonuaIntegrationServer.Sha256Hex(payload),
             Required = true,


### PR DESCRIPTION
## Summary
- fetch live metadata/scene.json when building the scene package manifest
- include it as a required SceneMetadata asset alongside the existing tileset asset
- include both live assets in the declared and max byte budgets

## Offline Impact
- keeps the live-image scene package test aligned with the SDK scene package validator; no production offline storage behavior changes

## Testing
- dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --filter LiveHonuaServerFixtureOptionsTests
- HONUA_MOBILE_LIVE_SERVER_TESTS=1 HONUA_MOBILE_LIVE_SERVER_IMAGE=honua-server:mobile-live-candidate HONUA_MOBILE_LIVE_SERVER_FIXTURE_SQL=/home/makani/worktrees/honua-server/366-minimal-routing/tests/seed/mobile-offline-demo-v1.sql dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --filter FullyQualifiedName~LiveHonuaServerInteractionTests