### PR TITLE
sdk: add mobile auth refresh support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,11 @@ using Honua.Mobile.Offline.Sync;
 using Honua.Mobile.Sdk;
 
 builder.Services
-    .AddHonuaMobileAuth()
+    .AddHonuaMobilePlatformAuth()
     .AddHonuaMobileSdk(new HonuaMobileClientOptions
     {
         BaseUri = new Uri("https://your-honua-server.com"),
         GrpcEndpoint = new Uri("https://your-honua-server.com"),
-        ApiKey = "<your-api-key>",
         PreferGrpcForFeatureQueries = true,
     })
     .AddHonuaRouting()
@@ -54,6 +53,9 @@ builder.Services
     .AddHonuaMapAreaDownload()
     .AddHonuaBackgroundSync();
 ```
+
+After sign-in or bootstrap, store the API key or bearer token with `IAuthTokenProvider.StoreTokenAsync(...)`;
+the platform auth registration persists it in iOS Keychain or Android secure storage.
 
 ## Offline Sync
 

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -117,8 +117,7 @@ using Honua.Mobile.Maui.Auth;
 using Honua.Mobile.Sdk.Auth;
 
 builder.Services
-    .AddHonuaMobileAuth(
-        new MauiSecureAuthTokenStore(new PlatformMauiSecureStorage()),
+    .AddHonuaMobilePlatformAuth(
         new RefreshingAuthTokenProviderOptions
         {
             RefreshEndpoint = new Uri("https://api.example.com/auth/refresh"),
@@ -128,6 +127,9 @@ builder.Services
         BaseUri = new Uri("https://api.example.com"),
     });
 ```
+
+Store the initial API key or bearer token through `IAuthTokenProvider.StoreTokenAsync(...)` after sign-in
+or device bootstrap. Avoid keeping long-lived literals in `HonuaMobileClientOptions` outside local tests.
 
 `PlatformMauiSecureStorage` uses MAUI Essentials secure storage on platform targets: iOS Keychain on Apple platforms and encrypted Android storage backed by the Android Keystore provider. For unit tests, use `InMemoryAuthTokenStore` and a stub `HttpMessageHandler` to exercise refresh logic without a live server.
 

--- a/src/Honua.Mobile.Maui/Auth/MauiSecureAuthTokenStore.cs
+++ b/src/Honua.Mobile.Maui/Auth/MauiSecureAuthTokenStore.cs
@@ -65,6 +65,10 @@ public sealed class MauiSecureAuthTokenStore : IAuthTokenStore
                 ? null
                 : JsonSerializer.Deserialize(payload, HonuaMobileMauiAuthJsonContext.Default.HonuaAuthToken);
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             throw new HonuaMobileAuthException("Honua auth token secure-storage read failed.", ex);
@@ -81,6 +85,10 @@ public sealed class MauiSecureAuthTokenStore : IAuthTokenStore
             var payload = JsonSerializer.Serialize(token, HonuaMobileMauiAuthJsonContext.Default.HonuaAuthToken);
             await _storage.SetAsync(_storageKey, payload, ct).ConfigureAwait(false);
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             throw new HonuaMobileAuthException("Honua auth token secure-storage write failed.", ex);
@@ -93,6 +101,10 @@ public sealed class MauiSecureAuthTokenStore : IAuthTokenStore
         try
         {
             await _storage.RemoveAsync(_storageKey, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/Honua.Mobile.Maui/Auth/PlatformMauiSecureStorage.cs
+++ b/src/Honua.Mobile.Maui/Auth/PlatformMauiSecureStorage.cs
@@ -1,4 +1,3 @@
-#if IOS || ANDROID || MACCATALYST
 using Microsoft.Maui.Storage;
 
 namespace Honua.Mobile.Maui.Auth;
@@ -25,4 +24,3 @@ public sealed class PlatformMauiSecureStorage : IMauiSecureStorage
         return ValueTask.CompletedTask;
     }
 }
-#endif

--- a/src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
+++ b/src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Honua.Sdk.Offline.Abstractions" Version="0.1.8-alpha.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Maui.Essentials" Version="10.0.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -77,13 +77,47 @@ public static class HonuaMobileServiceCollectionExtensions
 
         if (tokenStore is null)
         {
-            services.AddSingleton<IAuthTokenStore, InMemoryAuthTokenStore>();
+            services.TryAddSingleton<IAuthTokenStore, InMemoryAuthTokenStore>();
         }
         else
         {
             services.AddSingleton<IAuthTokenStore>(tokenStore);
         }
 
+        return services.AddHonuaMobileAuthProvider(options);
+    }
+
+    /// <summary>
+    /// Registers mobile auth using MAUI secure storage. iOS and Mac Catalyst use Keychain, while Android uses
+    /// encrypted storage backed by the Android Keystore provider.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="options">Optional token refresh options.</param>
+    /// <param name="storageKey">Optional secure-storage key. Defaults to the Honua SDK key.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaMobilePlatformAuth(
+        this IServiceCollection services,
+        RefreshingAuthTokenProviderOptions? options = null,
+        string? storageKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<IMauiSecureStorage, PlatformMauiSecureStorage>();
+        services.TryAddSingleton<IAuthTokenStore>(sp =>
+        {
+            var secureStorage = sp.GetRequiredService<IMauiSecureStorage>();
+            return storageKey is null
+                ? new MauiSecureAuthTokenStore(secureStorage)
+                : new MauiSecureAuthTokenStore(secureStorage, storageKey);
+        });
+
+        return services.AddHonuaMobileAuthProvider(options);
+    }
+
+    private static IServiceCollection AddHonuaMobileAuthProvider(
+        this IServiceCollection services,
+        RefreshingAuthTokenProviderOptions? options)
+    {
         services.AddSingleton(options ?? new RefreshingAuthTokenProviderOptions());
         services.AddHttpClient("HonuaMobileAuth");
         services.AddSingleton<IAuthTokenProvider>(sp =>

--- a/src/Honua.Mobile.Sdk/Auth/HonuaAuthProblemDetails.cs
+++ b/src/Honua.Mobile.Sdk/Auth/HonuaAuthProblemDetails.cs
@@ -1,0 +1,81 @@
+using System.Net;
+using System.Text.Json;
+
+namespace Honua.Mobile.Sdk.Auth;
+
+internal static class HonuaAuthProblemDetails
+{
+    private const int MaxProblemTextLength = 512;
+
+    public static HonuaMobileAuthException CreateRefreshException(
+        HttpStatusCode statusCode,
+        string? reasonPhrase,
+        string? responseBody)
+    {
+        var problem = TryReadProblemSummary(responseBody);
+        var statusText = string.IsNullOrWhiteSpace(reasonPhrase)
+            ? $"status {(int)statusCode}"
+            : $"status {(int)statusCode} {reasonPhrase}";
+        var message = problem is null
+            ? $"Honua auth token refresh failed with {statusText}."
+            : $"Honua auth token refresh failed with {statusText}: {problem}";
+
+        return new HonuaMobileAuthException(message, statusCode);
+    }
+
+    private static string? TryReadProblemSummary(string? responseBody)
+    {
+        if (string.IsNullOrWhiteSpace(responseBody))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(responseBody);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            var title = ReadString(root, "title");
+            var detail = ReadString(root, "detail");
+
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                return TrimProblemText(detail);
+            }
+
+            if (string.IsNullOrWhiteSpace(detail) ||
+                string.Equals(title, detail, StringComparison.OrdinalIgnoreCase))
+            {
+                return TrimProblemText(title);
+            }
+
+            return TrimProblemText($"{title}: {detail}");
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? ReadString(JsonElement payload, string name)
+        => payload.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static string? TrimProblemText(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        return trimmed.Length <= MaxProblemTextLength
+            ? trimmed
+            : string.Concat(trimmed.AsSpan(0, MaxProblemTextLength), "...");
+    }
+}

--- a/src/Honua.Mobile.Sdk/Auth/HonuaMobileAuthException.cs
+++ b/src/Honua.Mobile.Sdk/Auth/HonuaMobileAuthException.cs
@@ -1,3 +1,5 @@
+using System.Net;
+
 namespace Honua.Mobile.Sdk.Auth;
 
 /// <summary>
@@ -15,6 +17,17 @@ public sealed class HonuaMobileAuthException : Exception
     }
 
     /// <summary>
+    /// Initializes a new <see cref="HonuaMobileAuthException"/> for a failed server auth interaction.
+    /// </summary>
+    /// <param name="message">Redacted error message safe for SDK consumers.</param>
+    /// <param name="statusCode">HTTP status code returned by the auth endpoint.</param>
+    public HonuaMobileAuthException(string message, HttpStatusCode statusCode)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+
+    /// <summary>
     /// Initializes a new <see cref="HonuaMobileAuthException"/>.
     /// </summary>
     /// <param name="message">Redacted error message safe for SDK consumers.</param>
@@ -23,4 +36,9 @@ public sealed class HonuaMobileAuthException : Exception
         : base(message, innerException)
     {
     }
+
+    /// <summary>
+    /// HTTP status code returned by the auth endpoint, when the failure came from a server response.
+    /// </summary>
+    public HttpStatusCode? StatusCode { get; }
 }

--- a/src/Honua.Mobile.Sdk/Auth/RefreshingAuthTokenProvider.cs
+++ b/src/Honua.Mobile.Sdk/Auth/RefreshingAuthTokenProvider.cs
@@ -88,12 +88,16 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
     public async ValueTask<HonuaAuthToken?> RefreshTokenAsync(CancellationToken ct = default)
     {
         using var activity = MobileAuthTelemetry.ActivitySource.StartActivity("honua.mobile.auth.refresh", ActivityKind.Client);
-        activity?.SetTag("auth.scheme", "bearer");
 
         try
         {
             var current = await _store.ReadAsync(ct).ConfigureAwait(false);
-            if (current is null || string.IsNullOrWhiteSpace(current.RefreshToken) || _options.RefreshEndpoint is null)
+            activity?.SetTag("auth.scheme", current?.Scheme.ToString().ToLowerInvariant() ?? "none");
+
+            if (current is null ||
+                current.Scheme != HonuaAuthScheme.Bearer ||
+                string.IsNullOrWhiteSpace(current.RefreshToken) ||
+                _options.RefreshEndpoint is null)
             {
                 MobileAuthTelemetry.RecordTokenRefresh("skipped");
                 activity?.SetTag("auth.refresh.result", "skipped");
@@ -107,9 +111,8 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
 
             if (!response.IsSuccessStatusCode)
             {
-                MobileAuthTelemetry.RecordTokenRefresh("failure");
-                activity?.SetStatus(ActivityStatusCode.Error);
-                throw new HonuaMobileAuthException("Honua auth token refresh failed.");
+                var raw = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                throw HonuaAuthProblemDetails.CreateRefreshException(response.StatusCode, response.ReasonPhrase, raw);
             }
 
             await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
@@ -117,7 +120,7 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
                 stream,
                 HonuaMobileAuthJsonContext.Default.JsonElement,
                 ct).ConfigureAwait(false);
-            var refreshed = ParseRefreshResponse(payload, current);
+            var refreshed = ParseRefreshResponse(payload, current, _options.TimeProvider.GetUtcNow());
             await _store.WriteAsync(refreshed, ct).ConfigureAwait(false);
 
             MobileAuthTelemetry.RecordTokenRefresh("success");
@@ -126,6 +129,9 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
         }
         catch (HonuaMobileAuthException)
         {
+            MobileAuthTelemetry.RecordTokenRefresh("failure");
+            activity?.SetTag("auth.refresh.result", "failure");
+            activity?.SetStatus(ActivityStatusCode.Error);
             throw;
         }
         catch (OperationCanceledException)
@@ -176,7 +182,10 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
         }
     }
 
-    private static HonuaAuthToken ParseRefreshResponse(JsonElement payload, HonuaAuthToken current)
+    private static HonuaAuthToken ParseRefreshResponse(
+        JsonElement payload,
+        HonuaAuthToken current,
+        DateTimeOffset nowUtc)
     {
         var accessToken = ReadString(payload, "accessToken", "access_token")
             ?? throw new HonuaMobileAuthException("Honua auth token refresh returned no access token.");
@@ -186,7 +195,7 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
             string.Equals(tokenType, "apiKey", StringComparison.OrdinalIgnoreCase)
                 ? HonuaAuthScheme.ApiKey
                 : HonuaAuthScheme.Bearer;
-        var expiresAtUtc = ReadExpiresAt(payload);
+        var expiresAtUtc = ReadExpiresAt(payload, nowUtc);
 
         return new HonuaAuthToken(scheme, accessToken, refreshToken, expiresAtUtc);
     }
@@ -197,14 +206,15 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
         {
             if (payload.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String)
             {
-                return value.GetString();
+                var text = value.GetString();
+                return string.IsNullOrWhiteSpace(text) ? null : text;
             }
         }
 
         return null;
     }
 
-    private static DateTimeOffset? ReadExpiresAt(JsonElement payload)
+    private static DateTimeOffset? ReadExpiresAt(JsonElement payload, DateTimeOffset nowUtc)
     {
         var expiresAt = ReadString(payload, "expiresAtUtc", "expires_at_utc", "expiresAt", "expires_at");
         if (DateTimeOffset.TryParse(expiresAt, out var parsed))
@@ -216,7 +226,7 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
         {
             if (expiresIn.TryGetInt64(out var seconds))
             {
-                return DateTimeOffset.UtcNow.AddSeconds(seconds);
+                return nowUtc.AddSeconds(seconds);
             }
         }
 

--- a/tests/Honua.Mobile.Maui.Tests/MauiAuthRegistrationTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/MauiAuthRegistrationTests.cs
@@ -47,6 +47,32 @@ public sealed class MauiAuthRegistrationTests
         Assert.Equal("refresh-token", token.RefreshToken);
     }
 
+    [Fact]
+    public async Task AddHonuaMobilePlatformAuth_RegistersSecureStorageBackedStore()
+    {
+        using var provider = new ServiceCollection()
+            .AddSingleton<IMauiSecureStorage, FakeSecureStorage>()
+            .AddHonuaMobilePlatformAuth()
+            .BuildServiceProvider();
+
+        var store = Assert.IsType<MauiSecureAuthTokenStore>(provider.GetRequiredService<IAuthTokenStore>());
+        await store.WriteAsync(new HonuaAuthToken(HonuaAuthScheme.ApiKey, "provider-api-key"));
+
+        var token = await provider.GetRequiredService<IAuthTokenProvider>().GetTokenAsync();
+
+        Assert.NotNull(token);
+        Assert.Equal(HonuaAuthScheme.ApiKey, token.Scheme);
+        Assert.Equal("provider-api-key", token.AccessToken);
+    }
+
+    [Fact]
+    public async Task MauiSecureAuthTokenStore_WhenStorageCancels_PreservesCancellation()
+    {
+        var store = new MauiSecureAuthTokenStore(new CancelingSecureStorage());
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await store.ReadAsync());
+    }
+
     private sealed class FakeSecureStorage : IMauiSecureStorage
     {
         private string? _value;
@@ -65,5 +91,17 @@ public sealed class MauiAuthRegistrationTests
             _value = null;
             return ValueTask.CompletedTask;
         }
+    }
+
+    private sealed class CancelingSecureStorage : IMauiSecureStorage
+    {
+        public ValueTask<string?> GetAsync(string key, CancellationToken ct = default)
+            => throw new OperationCanceledException();
+
+        public ValueTask SetAsync(string key, string value, CancellationToken ct = default)
+            => throw new OperationCanceledException();
+
+        public ValueTask RemoveAsync(string key, CancellationToken ct = default)
+            => throw new OperationCanceledException();
     }
 }

--- a/tests/Honua.Mobile.Sdk.Tests/AuthTokenProviderTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/AuthTokenProviderTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Net;
 using System.Text;
 using Honua.Mobile.Sdk;
@@ -163,6 +165,176 @@ public sealed class AuthTokenProviderTests
     }
 
     [Fact]
+    public async Task GetTokenAsync_WithExpiresIn_UsesConfiguredClockForRefreshedExpiration()
+    {
+        var now = new DateTimeOffset(2026, 5, 6, 12, 0, 0, TimeSpan.Zero);
+        var store = new InMemoryAuthTokenStore();
+        await store.WriteAsync(new HonuaAuthToken(
+            HonuaAuthScheme.Bearer,
+            "expired-token",
+            "refresh-token",
+            now.AddMinutes(-5)));
+
+        var provider = new RefreshingAuthTokenProvider(
+            store,
+            new HttpClient(new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {
+                        "access_token": "fresh-token",
+                        "refresh_token": "next-refresh-token",
+                        "expires_in": 120
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"),
+            })),
+            new RefreshingAuthTokenProviderOptions
+            {
+                RefreshEndpoint = new Uri("https://auth.honua.test/token/refresh"),
+                TimeProvider = new FixedTimeProvider(now),
+            });
+
+        var token = await provider.GetTokenAsync();
+
+        Assert.NotNull(token);
+        Assert.Equal(now.AddSeconds(120), token.ExpiresAtUtc);
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_WithApiKeyToken_SkipsRefreshEndpoint()
+    {
+        var refreshCalls = 0;
+        var store = new InMemoryAuthTokenStore();
+        await store.WriteAsync(new HonuaAuthToken(HonuaAuthScheme.ApiKey, "provider-api-key"));
+        var provider = new RefreshingAuthTokenProvider(
+            store,
+            new HttpClient(new StubHttpMessageHandler(_ =>
+            {
+                refreshCalls++;
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            })),
+            new RefreshingAuthTokenProviderOptions
+            {
+                RefreshEndpoint = new Uri("https://auth.honua.test/token/refresh"),
+            });
+
+        var token = await provider.RefreshTokenAsync();
+
+        Assert.NotNull(token);
+        Assert.Equal(HonuaAuthScheme.ApiKey, token.Scheme);
+        Assert.Equal("provider-api-key", token.AccessToken);
+        Assert.Equal(0, refreshCalls);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_WhenRefreshReturnsProblemDetails_ThrowsMappedAuthException()
+    {
+        var now = new DateTimeOffset(2026, 5, 6, 12, 0, 0, TimeSpan.Zero);
+        var store = new InMemoryAuthTokenStore();
+        await store.WriteAsync(new HonuaAuthToken(
+            HonuaAuthScheme.Bearer,
+            "expired-token",
+            "refresh-token",
+            now.AddMinutes(-5)));
+        var provider = new RefreshingAuthTokenProvider(
+            store,
+            new HttpClient(new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent(
+                    """
+                    {
+                        "type": "https://honua.test/problems/auth/expired-refresh-token",
+                        "title": "Refresh token expired",
+                        "detail": "Sign in again before syncing."
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/problem+json"),
+            })),
+            new RefreshingAuthTokenProviderOptions
+            {
+                RefreshEndpoint = new Uri("https://auth.honua.test/token/refresh"),
+                TimeProvider = new FixedTimeProvider(now),
+            });
+
+        var exception = await Assert.ThrowsAsync<HonuaMobileAuthException>(async () => await provider.GetTokenAsync());
+
+        Assert.Equal(HttpStatusCode.Unauthorized, exception.StatusCode);
+        Assert.Contains("Refresh token expired", exception.Message);
+        Assert.Contains("Sign in again before syncing.", exception.Message);
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_EmitsActivityAndRefreshCounterResult()
+    {
+        var now = new DateTimeOffset(2026, 5, 6, 12, 0, 0, TimeSpan.Zero);
+        var measurements = new List<string>();
+        using var meterListener = new MeterListener();
+        meterListener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Meter.Name == MobileAuthTelemetry.MeterName &&
+                instrument.Name == "mobile_auth_token_refreshes_total")
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
+        {
+            var result = tags.ToArray().FirstOrDefault(tag => tag.Key == "result").Value?.ToString();
+            if (measurement == 1 && result is not null)
+            {
+                measurements.Add(result);
+            }
+        });
+        meterListener.Start();
+
+        var activities = new List<Activity>();
+        using var activityListener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == MobileAuthTelemetry.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activities.Add,
+        };
+        ActivitySource.AddActivityListener(activityListener);
+
+        var store = new InMemoryAuthTokenStore();
+        await store.WriteAsync(new HonuaAuthToken(
+            HonuaAuthScheme.Bearer,
+            "expired-token",
+            "refresh-token",
+            now.AddMinutes(-5)));
+        var provider = new RefreshingAuthTokenProvider(
+            store,
+            new HttpClient(new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {
+                        "accessToken": "fresh-token",
+                        "refreshToken": "next-refresh-token",
+                        "expiresIn": 120
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"),
+            })),
+            new RefreshingAuthTokenProviderOptions
+            {
+                RefreshEndpoint = new Uri("https://auth.honua.test/token/refresh"),
+                TimeProvider = new FixedTimeProvider(now),
+            });
+
+        await provider.RefreshTokenAsync();
+
+        Assert.Contains("success", measurements);
+        Assert.Contains(activities, activity =>
+            activity.OperationName == "honua.mobile.auth.refresh" &&
+            string.Equals(activity.GetTagItem("auth.refresh.result")?.ToString(), "success", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task GetTokenAsync_WhenCanceled_ThrowsOperationCanceledException()
     {
         using var cts = new CancellationTokenSource();
@@ -206,5 +378,17 @@ public sealed class AuthTokenProviderTests
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             => Task.FromResult(_handler(request));
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+
+        public FixedTimeProvider(DateTimeOffset now)
+        {
+            _now = now;
+        }
+
+        public override DateTimeOffset GetUtcNow() => _now;
     }
 }


### PR DESCRIPTION
## Summary
- Add sanitized auth problem mapping and status-code context for refresh failures.
- Register MAUI platform secure-storage auth backed by Keychain on Apple platforms and Android Keystore-backed secure storage.
- Keep API-key tokens from hitting bearer refresh paths and cover refresh telemetry/clock behavior.

## Platform Impact
- Adds MAUI DI registration for platform secure storage without adding biometric prompts or app-level UI flows.
- iOS and Mac Catalyst continue through Keychain-backed `SecureStorage`; Android continues through Keystore-backed encrypted secure storage.

## Tests
- [x] git diff --cached --check
- [x] dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --configuration Release
- [x] dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --configuration Release

Fixes honua-io/honua-server#829