### PR TITLE
sdk: add mobile sync conflict policies

### DIFF
--- a/docs/guides/offline-sync.md
+++ b/docs/guides/offline-sync.md
@@ -510,72 +510,100 @@ public async Task UploadOnlyAsync()
 
 ## Conflict Resolution
 
-### Conflict Strategies
-
-Handle data conflicts when multiple users edit the same features:
+`OfflineSyncEngine` defaults to `ManualReview` so conflicting edits are not
+silently overwritten. Apps can set a global v1 strategy and override it per
+layer and operation type:
 
 ```csharp
-public enum ConflictResolution
+var sync = new OfflineSyncEngine(
+    store,
+    uploader,
+    new OfflineSyncEngineOptions
+    {
+        BatchSize = 100,
+        ConflictStrategy = SyncConflictStrategy.ManualReview,
+        ConflictPolicyRules =
+        [
+            new SyncConflictPolicyRule
+            {
+                LayerKey = "critical-assets",
+                OperationType = OfflineOperationType.Update,
+                Strategy = SyncConflictStrategy.ClientWins,
+            },
+            new SyncConflictPolicyRule
+            {
+                LayerKey = "reference-boundaries",
+                Strategy = SyncConflictStrategy.ServerWins,
+            },
+        ],
+    });
+```
+
+The mobile-owned v1 strategies are:
+
+```csharp
+public enum SyncConflictStrategy
 {
-    ServerWins,       // Server data takes precedence
-    ClientWins,       // Local data takes precedence
-    MergeAttributes,  // Merge non-conflicting attributes
-    UserDecides      // Prompt user to resolve
+    ClientWins,   // retry with forceWrite=true
+    ServerWins,   // drop the local operation and accept the server version
+    ManualReview, // mark failed for user/operator resolution
 }
 ```
 
-### Custom Conflict Resolution
+Rules with both `LayerKey` and `OperationType` are more specific than rules for
+only one dimension. If no rule matches, `ConflictStrategy` is used.
 
-Implement custom conflict resolution logic:
+## Pending Queue And Connectivity
+
+`GeoPackageSyncStore` persists the local edit queue in the device GeoPackage, so
+pending operations survive process restart. A sync cycle claims pending rows
+with an in-progress lease, releases claims on cancellation, deletes succeeded
+operations, and leaves retryable failures in the queue for the next run.
+
+`BackgroundSyncOrchestrator` gates upload/download cycles through
+`IConnectivityStateProvider`. When the provider reports offline,
+`RunOnceIfOnlineAsync` returns without claiming queue rows. When connectivity is
+restored, the next manual or scheduled cycle resumes from the persisted pending
+queue.
 
 ```csharp
-public class CustomConflictResolver : IConflictResolver
+await using var orchestrator = new BackgroundSyncOrchestrator(
+    sync,
+    connectivityStateProvider,
+    new BackgroundSyncOrchestratorOptions
+    {
+        SyncInterval = TimeSpan.FromMinutes(5),
+    });
+
+await orchestrator.StartAsync();
+```
+
+## Sync Problems And Telemetry
+
+Sync upload failures are mapped through `MobileSyncProblemHelper` before they are
+stored in queue state or returned in `SyncRunResult.Failures`. Raw provider
+exception names such as gRPC or SQLite exception types are kept as inner
+diagnostic details, not user-facing sync failure reasons.
+
+The mobile sync layer emits:
+
+- ActivitySource: `Honua.Mobile.Sync`
+- Counter: `mobile_sync_runs_total{result}`
+- Counter: `mobile_sync_conflicts_total{strategy}`
+- Gauge: `mobile_pending_operations`
+
+Apps can subscribe with standard .NET diagnostics:
+
+```csharp
+using var listener = new MeterListener();
+listener.InstrumentPublished = (instrument, meterListener) =>
 {
-    public async Task<Feature> ResolveConflictAsync(
-        Feature localFeature,
-        Feature serverFeature,
-        ConflictContext context)
+    if (instrument.Meter.Name == MobileSyncTelemetry.MeterName)
     {
-        // Custom resolution logic
-        if (context.ConflictType == ConflictType.AttributeChange)
-        {
-            return await MergeAttributesAsync(localFeature, serverFeature);
-        }
-        else if (context.ConflictType == ConflictType.GeometryChange)
-        {
-            // Use most recent geometry
-            var newerFeature = localFeature.LastModified > serverFeature.LastModified
-                ? localFeature
-                : serverFeature;
-            return newerFeature;
-        }
-
-        return serverFeature; // Default to server
+        meterListener.EnableMeasurementEvents(instrument);
     }
-
-    private async Task<Feature> MergeAttributesAsync(Feature local, Feature server)
-    {
-        var merged = new Feature
-        {
-            Id = local.Id,
-            Geometry = local.Geometry, // Keep local geometry
-            Attributes = new Dictionary<string, object>()
-        };
-
-        // Merge attributes with local taking precedence
-        foreach (var attr in server.Attributes)
-        {
-            merged.Attributes[attr.Key] = attr.Value;
-        }
-
-        foreach (var attr in local.Attributes)
-        {
-            merged.Attributes[attr.Key] = attr.Value; // Local overwrites server
-        }
-
-        return merged;
-    }
-}
+};
+listener.Start();
 ```
 
 ## Storage Management

--- a/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
+++ b/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
@@ -74,15 +74,19 @@ public sealed class HonuaApiOfflineOperationUploader : IOfflineOperationUploader
         }
         catch (HttpRequestException ex)
         {
-            return new UploadResult { Outcome = UploadOutcome.RetryableFailure, Message = ex.Message };
+            return MobileSyncProblemHelper.ToUploadResult(ex);
         }
-        catch (TaskCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             throw;
         }
         catch (TaskCanceledException ex)
         {
-            return new UploadResult { Outcome = UploadOutcome.RetryableFailure, Message = ex.Message };
+            return MobileSyncProblemHelper.ToUploadResult(ex);
+        }
+        catch (Exception ex)
+        {
+            return MobileSyncProblemHelper.ToUploadResult(ex);
         }
     }
 
@@ -230,36 +234,10 @@ public sealed class HonuaApiOfflineOperationUploader : IOfflineOperationUploader
     }
 
     private static UploadResult FromStatusCode(HttpStatusCode statusCode, string message)
-    {
-        if (statusCode is HttpStatusCode.Conflict or HttpStatusCode.PreconditionFailed)
-        {
-            return new UploadResult { Outcome = UploadOutcome.Conflict, Message = message };
-        }
-
-        if (statusCode == HttpStatusCode.RequestTimeout ||
-            (int)statusCode == 429 ||
-            (int)statusCode >= 500)
-        {
-            return new UploadResult { Outcome = UploadOutcome.RetryableFailure, Message = message };
-        }
-
-        return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = message };
-    }
+        => MobileSyncProblemHelper.ToUploadResult(MobileSyncProblemHelper.FromStatusCode(statusCode, message));
 
     private static UploadResult FromErrorCode(int? code, string? message)
-    {
-        if (code is 409 or 412)
-        {
-            return new UploadResult { Outcome = UploadOutcome.Conflict, Message = message ?? "Conflict" };
-        }
-
-        if (code is 408 or 429 || (code.HasValue && code.Value >= 500))
-        {
-            return new UploadResult { Outcome = UploadOutcome.RetryableFailure, Message = message ?? "Retryable error" };
-        }
-
-        return new UploadResult { Outcome = UploadOutcome.FatalFailure, Message = message ?? "Fatal error" };
-    }
+        => MobileSyncProblemHelper.ToUploadResult(MobileSyncProblemHelper.FromErrorCode(code, message));
 
     private static bool TryReadError(JsonElement element, out int? code, out string? message)
     {

--- a/src/Honua.Mobile.Offline/Sync/MobileSyncProblem.cs
+++ b/src/Honua.Mobile.Offline/Sync/MobileSyncProblem.cs
@@ -1,0 +1,210 @@
+using System.Net;
+using Honua.Mobile.Offline.GeoPackage;
+using Honua.Mobile.Sdk;
+
+namespace Honua.Mobile.Offline.Sync;
+
+/// <summary>
+/// Sanitized sync failure category safe to surface in mobile sync results.
+/// </summary>
+public enum MobileSyncProblemCategory
+{
+    /// <summary>Network, gRPC, HTTP, timeout, or reachability problem.</summary>
+    Transport,
+    /// <summary>Server-side version conflict.</summary>
+    Conflict,
+    /// <summary>Local offline storage problem.</summary>
+    LocalStorage,
+    /// <summary>Malformed queued payload or unsupported operation.</summary>
+    InvalidOperation,
+    /// <summary>Unclassified failure.</summary>
+    Unknown,
+}
+
+/// <summary>
+/// Sanitized sync problem information used for queue state, result failures, and telemetry.
+/// </summary>
+/// <param name="Category">Failure category.</param>
+/// <param name="Message">Safe user-facing message.</param>
+/// <param name="Retryable">Whether the failed operation can be retried.</param>
+public sealed record MobileSyncProblem(MobileSyncProblemCategory Category, string Message, bool Retryable);
+
+/// <summary>
+/// Exception raised when sync cannot continue, with provider-specific exception details redacted from the public message.
+/// </summary>
+public sealed class MobileSyncException : Exception
+{
+    /// <summary>
+    /// Initializes a new <see cref="MobileSyncException"/>.
+    /// </summary>
+    /// <param name="problem">Sanitized problem details.</param>
+    /// <param name="innerException">Original exception retained for diagnostics.</param>
+    public MobileSyncException(MobileSyncProblem problem, Exception innerException)
+        : base(problem.Message, innerException)
+    {
+        Problem = problem;
+    }
+
+    /// <summary>
+    /// Sanitized sync problem details.
+    /// </summary>
+    public MobileSyncProblem Problem { get; }
+}
+
+/// <summary>
+/// Shared mapper from provider-specific exceptions to sanitized mobile sync problems.
+/// </summary>
+public static class MobileSyncProblemHelper
+{
+    private const string TransportRetryMessage = "Sync transport is unavailable; the operation will retry.";
+    private const string TransportTimeoutMessage = "Sync transport timed out; the operation will retry.";
+    private const string LocalStorageMessage = "Local offline sync storage is unavailable.";
+    private const string UnknownRetryMessage = "Sync operation failed; the operation will retry.";
+
+    /// <summary>
+    /// Maps an exception to a sanitized sync problem.
+    /// </summary>
+    /// <param name="exception">Exception to classify.</param>
+    /// <returns>Sanitized problem details.</returns>
+    public static MobileSyncProblem FromException(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        if (exception is MobileSyncException syncException)
+        {
+            return syncException.Problem;
+        }
+
+        if (exception is GeoPackageStorageException || IsSqliteException(exception))
+        {
+            return new MobileSyncProblem(MobileSyncProblemCategory.LocalStorage, LocalStorageMessage, Retryable: true);
+        }
+
+        if (exception is HonuaMobileApiException apiException)
+        {
+            return FromStatusCode(apiException.StatusCode, apiException.Message);
+        }
+
+        if (exception is HttpRequestException)
+        {
+            return new MobileSyncProblem(MobileSyncProblemCategory.Transport, TransportRetryMessage, Retryable: true);
+        }
+
+        if (exception is TaskCanceledException)
+        {
+            return new MobileSyncProblem(MobileSyncProblemCategory.Transport, TransportTimeoutMessage, Retryable: true);
+        }
+
+        if (IsGrpcException(exception))
+        {
+            return new MobileSyncProblem(MobileSyncProblemCategory.Transport, TransportRetryMessage, Retryable: true);
+        }
+
+        return new MobileSyncProblem(MobileSyncProblemCategory.Unknown, UnknownRetryMessage, Retryable: true);
+    }
+
+    /// <summary>
+    /// Maps an exception to an upload result without exposing provider-specific exception names.
+    /// </summary>
+    /// <param name="exception">Exception to classify.</param>
+    /// <returns>Upload result matching the sanitized problem.</returns>
+    public static UploadResult ToUploadResult(Exception exception)
+    {
+        var problem = FromException(exception);
+        return ToUploadResult(problem);
+    }
+
+    /// <summary>
+    /// Maps a sanitized problem to an upload result.
+    /// </summary>
+    /// <param name="problem">Sanitized problem.</param>
+    /// <returns>Upload result matching the sanitized problem.</returns>
+    public static UploadResult ToUploadResult(MobileSyncProblem problem)
+    {
+        ArgumentNullException.ThrowIfNull(problem);
+
+        return new UploadResult
+        {
+            Outcome = problem.Category == MobileSyncProblemCategory.Conflict
+                ? UploadOutcome.Conflict
+                : problem.Retryable
+                    ? UploadOutcome.RetryableFailure
+                    : UploadOutcome.FatalFailure,
+            Message = problem.Message,
+        };
+    }
+
+    /// <summary>
+    /// Maps a server edit error code to a sync problem.
+    /// </summary>
+    /// <param name="code">Provider edit error code.</param>
+    /// <param name="message">Optional provider message.</param>
+    /// <returns>Sanitized problem details.</returns>
+    public static MobileSyncProblem FromErrorCode(int? code, string? message)
+    {
+        if (code is 409 or 412)
+        {
+            return new MobileSyncProblem(MobileSyncProblemCategory.Conflict, message ?? "Conflict", Retryable: false);
+        }
+
+        if (code is 408 or 429 || (code.HasValue && code.Value >= 500))
+        {
+            return new MobileSyncProblem(
+                MobileSyncProblemCategory.Transport,
+                message ?? TransportRetryMessage,
+                Retryable: true);
+        }
+
+        return new MobileSyncProblem(
+            MobileSyncProblemCategory.InvalidOperation,
+            message ?? "Fatal error",
+            Retryable: false);
+    }
+
+    /// <summary>
+    /// Maps an HTTP status code to a sync problem.
+    /// </summary>
+    /// <param name="statusCode">HTTP status code.</param>
+    /// <param name="message">Optional server message.</param>
+    /// <returns>Sanitized problem details.</returns>
+    public static MobileSyncProblem FromStatusCode(HttpStatusCode statusCode, string? message)
+    {
+        if (statusCode is HttpStatusCode.Conflict or HttpStatusCode.PreconditionFailed)
+        {
+            return new MobileSyncProblem(MobileSyncProblemCategory.Conflict, message ?? "Conflict", Retryable: false);
+        }
+
+        if (statusCode == HttpStatusCode.RequestTimeout ||
+            (int)statusCode == 429 ||
+            (int)statusCode >= 500)
+        {
+            return new MobileSyncProblem(
+                MobileSyncProblemCategory.Transport,
+                string.IsNullOrWhiteSpace(message) ? TransportRetryMessage : message,
+                Retryable: true);
+        }
+
+        return new MobileSyncProblem(
+            MobileSyncProblemCategory.InvalidOperation,
+            string.IsNullOrWhiteSpace(message) ? "Sync request was rejected." : message,
+            Retryable: false);
+    }
+
+    private static bool IsGrpcException(Exception exception)
+    {
+        var typeName = exception.GetType().FullName;
+        return ContainsOrdinalIgnoreCase(typeName, "Grpc") ||
+               ContainsOrdinalIgnoreCase(exception.Message, "RpcException") ||
+               ContainsOrdinalIgnoreCase(exception.Message, "StatusCode=");
+    }
+
+    private static bool IsSqliteException(Exception exception)
+    {
+        var typeName = exception.GetType().FullName;
+        return ContainsOrdinalIgnoreCase(typeName, "Sqlite") ||
+               ContainsOrdinalIgnoreCase(exception.Message, "SQLite Error");
+    }
+
+    private static bool ContainsOrdinalIgnoreCase(string? value, string token)
+        => value is not null && value.Contains(token, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Honua.Mobile.Offline/Sync/MobileSyncTelemetry.cs
+++ b/src/Honua.Mobile.Offline/Sync/MobileSyncTelemetry.cs
@@ -1,0 +1,63 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Honua.Mobile.Offline.Sync;
+
+/// <summary>
+/// Telemetry sources emitted by the Honua mobile sync layer.
+/// </summary>
+public static class MobileSyncTelemetry
+{
+    /// <summary>
+    /// Activity source name for mobile sync operations.
+    /// </summary>
+    public const string ActivitySourceName = "Honua.Mobile.Sync";
+
+    /// <summary>
+    /// Meter name for mobile sync metrics.
+    /// </summary>
+    public const string MeterName = "Honua.Mobile.Sync";
+
+    /// <summary>
+    /// Activity source for offline sync runs.
+    /// </summary>
+    public static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+
+    private static readonly Meter Meter = new(MeterName);
+    private static readonly Counter<long> SyncRuns = Meter.CreateCounter<long>(
+        "mobile_sync_runs_total",
+        description: "Number of mobile sync runs by result.");
+    private static readonly Counter<long> SyncConflicts = Meter.CreateCounter<long>(
+        "mobile_sync_conflicts_total",
+        description: "Number of mobile sync conflicts by applied strategy.");
+    private static long _pendingOperations;
+
+    static MobileSyncTelemetry()
+    {
+        Meter.CreateObservableGauge(
+            "mobile_pending_operations",
+            () => Volatile.Read(ref _pendingOperations),
+            description: "Current count of pending or retryable mobile sync operations.");
+    }
+
+    /// <summary>
+    /// Records a completed sync run.
+    /// </summary>
+    /// <param name="result">Run result label.</param>
+    public static void RecordRun(string result)
+        => SyncRuns.Add(1, new KeyValuePair<string, object?>("result", result));
+
+    /// <summary>
+    /// Records a conflict handled by the specified strategy.
+    /// </summary>
+    /// <param name="strategy">Conflict strategy label.</param>
+    public static void RecordConflict(SyncConflictStrategy strategy)
+        => SyncConflicts.Add(1, new KeyValuePair<string, object?>("strategy", strategy.ToString()));
+
+    /// <summary>
+    /// Updates the pending operation gauge.
+    /// </summary>
+    /// <param name="pendingOperations">Current pending/retryable operation count.</param>
+    public static void RecordPendingOperations(long pendingOperations)
+        => Volatile.Write(ref _pendingOperations, Math.Max(0, pendingOperations));
+}

--- a/src/Honua.Mobile.Offline/Sync/OfflineSyncEngine.cs
+++ b/src/Honua.Mobile.Offline/Sync/OfflineSyncEngine.cs
@@ -144,7 +144,7 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
         var selected = _options.ConflictStrategy;
         var selectedSpecificity = -1;
 
-        foreach (var rule in _options.ConflictPolicyRules)
+        foreach (var rule in _options.ConflictPolicyRules ?? Array.Empty<SyncConflictPolicyRule>())
         {
             if (!rule.Matches(operation) || rule.Specificity <= selectedSpecificity)
             {

--- a/src/Honua.Mobile.Offline/Sync/OfflineSyncEngine.cs
+++ b/src/Honua.Mobile.Offline/Sync/OfflineSyncEngine.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Honua.Mobile.Offline.GeoPackage;
 
 namespace Honua.Mobile.Offline.Sync;
@@ -29,80 +30,142 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
     /// <inheritdoc />
     public async Task<SyncRunResult> SyncAsync(CancellationToken ct = default)
     {
-        await _store.InitializeAsync(ct).ConfigureAwait(false);
-        var pending = await _store.GetPendingAsync(_options.BatchSize, ct).ConfigureAwait(false);
-
-        var failures = new List<SyncFailure>();
-        var success = 0;
-
-        for (var index = 0; index < pending.Count; index++)
+        using var activity = MobileSyncTelemetry.ActivitySource.StartActivity("honua.mobile.sync.run", ActivityKind.Internal);
+        try
         {
-            var operation = pending[index];
+            await _store.InitializeAsync(ct).ConfigureAwait(false);
+            await RecordPendingGaugeAsync(ct).ConfigureAwait(false);
+            var pending = await _store.GetPendingAsync(_options.BatchSize, ct).ConfigureAwait(false);
+            activity?.SetTag("honua.mobile.sync.loaded", pending.Count);
 
-            try
+            var failures = new List<SyncFailure>();
+            var success = 0;
+
+            for (var index = 0; index < pending.Count; index++)
             {
-                ct.ThrowIfCancellationRequested();
+                var operation = pending[index];
 
-                if (operation.AttemptCount >= _options.MaxAttempts)
+                try
                 {
-                    await _store.MarkFailedAsync(operation.OperationId, "max attempts reached", retryable: false, ct).ConfigureAwait(false);
-                    failures.Add(new SyncFailure(operation.OperationId, "max attempts reached"));
-                    continue;
-                }
+                    ct.ThrowIfCancellationRequested();
 
-                var uploadResult = await _uploader.UploadAsync(operation, forceWrite: false, ct).ConfigureAwait(false);
-                if (uploadResult.Outcome == UploadOutcome.Success)
-                {
-                    await _store.MarkSucceededAsync(operation.OperationId, ct).ConfigureAwait(false);
-                    success++;
-                    continue;
-                }
-
-                if (uploadResult.Outcome == UploadOutcome.Conflict)
-                {
-                    var conflictResolved = await HandleConflictAsync(operation, ct).ConfigureAwait(false);
-                    if (conflictResolved.Resolved)
+                    if (operation.AttemptCount >= _options.MaxAttempts)
                     {
+                        await _store.MarkFailedAsync(operation.OperationId, "max attempts reached", retryable: false, ct).ConfigureAwait(false);
+                        failures.Add(new SyncFailure(operation.OperationId, "max attempts reached"));
+                        continue;
+                    }
+
+                    var uploadResult = await UploadSafelyAsync(operation, forceWrite: false, ct).ConfigureAwait(false);
+                    if (uploadResult.Outcome == UploadOutcome.Success)
+                    {
+                        await _store.MarkSucceededAsync(operation.OperationId, ct).ConfigureAwait(false);
                         success++;
                         continue;
                     }
 
-                    if (conflictResolved.FailureHandled)
+                    if (uploadResult.Outcome == UploadOutcome.Conflict)
                     {
-                        failures.Add(new SyncFailure(operation.OperationId, conflictResolved.FailureReason ?? "Conflict resolution failed."));
-                        continue;
+                        var strategy = ResolveConflictStrategy(operation);
+                        var conflictResolved = await HandleConflictAsync(operation, strategy, ct).ConfigureAwait(false);
+                        if (conflictResolved.Resolved)
+                        {
+                            success++;
+                            continue;
+                        }
+
+                        if (conflictResolved.FailureHandled)
+                        {
+                            failures.Add(new SyncFailure(operation.OperationId, conflictResolved.FailureReason ?? "Conflict resolution failed."));
+                            continue;
+                        }
                     }
+
+                    var retryable = uploadResult.Outcome == UploadOutcome.RetryableFailure;
+                    var reason = uploadResult.Message ?? uploadResult.Outcome.ToString();
+                    await _store.MarkFailedAsync(operation.OperationId, reason, retryable, ct).ConfigureAwait(false);
+                    failures.Add(new SyncFailure(operation.OperationId, reason));
                 }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    await ReleaseClaimedOperationsBestEffortAsync(pending, index).ConfigureAwait(false);
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    await ReleaseClaimedOperationsBestEffortAsync(pending, index).ConfigureAwait(false);
+                    throw new MobileSyncException(MobileSyncProblemHelper.FromException(ex), ex);
+                }
+            }
 
-                var retryable = uploadResult.Outcome == UploadOutcome.RetryableFailure;
-                var reason = uploadResult.Message ?? uploadResult.Outcome.ToString();
-                await _store.MarkFailedAsync(operation.OperationId, reason, retryable, ct).ConfigureAwait(false);
-                failures.Add(new SyncFailure(operation.OperationId, reason));
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            var result = new SyncRunResult
             {
-                await ReleaseClaimedOperationsAsync(pending, index).ConfigureAwait(false);
-                throw;
-            }
-            catch
-            {
-                await ReleaseClaimedOperationsAsync(pending, index).ConfigureAwait(false);
-                throw;
-            }
+                Loaded = pending.Count,
+                Succeeded = success,
+                Failed = failures.Count,
+                Failures = failures,
+            };
+
+            activity?.SetTag("honua.mobile.sync.succeeded", result.Succeeded);
+            activity?.SetTag("honua.mobile.sync.failed", result.Failed);
+            var resultLabel = result.Failed == 0 ? "succeeded" : result.Succeeded == 0 ? "failed" : "partial_failure";
+            MobileSyncTelemetry.RecordRun(resultLabel);
+            activity?.SetStatus(result.Failed == 0 ? ActivityStatusCode.Ok : ActivityStatusCode.Error);
+            await RecordPendingGaugeAsync(CancellationToken.None).ConfigureAwait(false);
+
+            return result;
         }
-
-        return new SyncRunResult
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            Loaded = pending.Count,
-            Succeeded = success,
-            Failed = failures.Count,
-            Failures = failures,
-        };
+            MobileSyncTelemetry.RecordRun("cancelled");
+            activity?.SetStatus(ActivityStatusCode.Error, "cancelled");
+            await RecordPendingGaugeAsync(CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
+        catch (MobileSyncException ex)
+        {
+            MobileSyncTelemetry.RecordRun("exception");
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Problem.Message);
+            await RecordPendingGaugeAsync(CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            var problem = MobileSyncProblemHelper.FromException(ex);
+            MobileSyncTelemetry.RecordRun("exception");
+            activity?.SetStatus(ActivityStatusCode.Error, problem.Message);
+            await RecordPendingGaugeAsync(CancellationToken.None).ConfigureAwait(false);
+            throw new MobileSyncException(problem, ex);
+        }
     }
 
-    private async Task<ConflictResolutionState> HandleConflictAsync(OfflineEditOperation operation, CancellationToken ct)
+    private SyncConflictStrategy ResolveConflictStrategy(OfflineEditOperation operation)
     {
-        switch (_options.ConflictStrategy)
+        var selected = _options.ConflictStrategy;
+        var selectedSpecificity = -1;
+
+        foreach (var rule in _options.ConflictPolicyRules)
+        {
+            if (!rule.Matches(operation) || rule.Specificity <= selectedSpecificity)
+            {
+                continue;
+            }
+
+            selected = rule.Strategy;
+            selectedSpecificity = rule.Specificity;
+        }
+
+        return selected;
+    }
+
+    private async Task<ConflictResolutionState> HandleConflictAsync(
+        OfflineEditOperation operation,
+        SyncConflictStrategy strategy,
+        CancellationToken ct)
+    {
+        MobileSyncTelemetry.RecordConflict(strategy);
+
+        switch (strategy)
         {
             case SyncConflictStrategy.ServerWins:
                 await _store.MarkSucceededAsync(operation.OperationId, ct).ConfigureAwait(false);
@@ -110,7 +173,7 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
 
             case SyncConflictStrategy.ClientWins:
                 {
-                    var forced = await _uploader.UploadAsync(operation, forceWrite: true, ct).ConfigureAwait(false);
+                    var forced = await UploadSafelyAsync(operation, forceWrite: true, ct).ConfigureAwait(false);
                     if (forced.Outcome == UploadOutcome.Success)
                     {
                         await _store.MarkSucceededAsync(operation.OperationId, ct).ConfigureAwait(false);
@@ -130,16 +193,51 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
         }
     }
 
+    private async Task<UploadResult> UploadSafelyAsync(OfflineEditOperation operation, bool forceWrite, CancellationToken ct)
+    {
+        try
+        {
+            return await _uploader.UploadAsync(operation, forceWrite, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return MobileSyncProblemHelper.ToUploadResult(ex);
+        }
+    }
+
     private readonly record struct ConflictResolutionState(bool Resolved, bool FailureHandled, string? FailureReason)
     {
         public static readonly ConflictResolutionState ResolvedState = new(true, false, null);
     }
 
-    private async Task ReleaseClaimedOperationsAsync(IReadOnlyList<OfflineEditOperation> pending, int startIndex)
+    private async Task ReleaseClaimedOperationsBestEffortAsync(IReadOnlyList<OfflineEditOperation> pending, int startIndex)
     {
-        for (var i = startIndex; i < pending.Count; i++)
+        try
         {
-            await _store.MarkPendingAsync(pending[i].OperationId, CancellationToken.None).ConfigureAwait(false);
+            for (var i = startIndex; i < pending.Count; i++)
+            {
+                await _store.MarkPendingAsync(pending[i].OperationId, CancellationToken.None).ConfigureAwait(false);
+            }
+        }
+        catch
+        {
+            // Preserve the original sync failure/cancellation surface.
+        }
+    }
+
+    private async Task RecordPendingGaugeAsync(CancellationToken ct)
+    {
+        try
+        {
+            MobileSyncTelemetry.RecordPendingOperations(await _store.CountPendingAsync(ct).ConfigureAwait(false));
+        }
+        catch
+        {
+            // Telemetry must not change sync behavior.
         }
     }
 }

--- a/src/Honua.Mobile.Offline/Sync/SyncContracts.cs
+++ b/src/Honua.Mobile.Offline/Sync/SyncContracts.cs
@@ -104,6 +104,43 @@ public sealed class OfflineSyncEngineOptions
     /// Strategy for resolving version conflicts. Defaults to <see cref="SyncConflictStrategy.ManualReview"/>.
     /// </summary>
     public SyncConflictStrategy ConflictStrategy { get; init; } = SyncConflictStrategy.ManualReview;
+
+    /// <summary>
+    /// Optional conflict policy overrides. The most specific matching rule is used before
+    /// falling back to <see cref="ConflictStrategy"/>.
+    /// </summary>
+    public IReadOnlyList<SyncConflictPolicyRule> ConflictPolicyRules { get; init; } = [];
+}
+
+/// <summary>
+/// Per-layer and/or per-operation conflict policy override for <see cref="OfflineSyncEngine"/>.
+/// </summary>
+public sealed class SyncConflictPolicyRule
+{
+    /// <summary>
+    /// Exact layer key to match. When <see langword="null"/>, the rule applies to any layer.
+    /// </summary>
+    public string? LayerKey { get; init; }
+
+    /// <summary>
+    /// Operation type to match. When <see langword="null"/>, the rule applies to any operation type.
+    /// </summary>
+    public OfflineOperationType? OperationType { get; init; }
+
+    /// <summary>
+    /// Strategy to use for matching operations.
+    /// </summary>
+    public SyncConflictStrategy Strategy { get; init; } = SyncConflictStrategy.ManualReview;
+
+    internal bool Matches(OfflineEditOperation operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        return (LayerKey is null || string.Equals(LayerKey, operation.LayerKey, StringComparison.Ordinal)) &&
+               (OperationType is null || OperationType == operation.OperationType);
+    }
+
+    internal int Specificity => (LayerKey is null ? 0 : 1) + (OperationType is null ? 0 : 1);
 }
 
 /// <summary>

--- a/tests/Honua.Mobile.Offline.Tests/BackgroundSyncOrchestratorTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/BackgroundSyncOrchestratorTests.cs
@@ -1,3 +1,4 @@
+using Honua.Mobile.Offline.GeoPackage;
 using Honua.Mobile.Offline.Sync;
 
 namespace Honua.Mobile.Offline.Tests;
@@ -60,6 +61,70 @@ public sealed class BackgroundSyncOrchestratorTests
         Assert.True(runner.SuccessCount >= 1);
     }
 
+    [Fact]
+    public async Task RunOnceIfOnlineAsync_OutageDuringHundredFeatureBatch_PreservesQueueUntilReconnect()
+    {
+        var databasePath = Path.Combine(Path.GetTempPath(), $"honua-mobile-outage-{Guid.NewGuid():N}.gpkg");
+
+        try
+        {
+            var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions { DatabasePath = databasePath });
+            await store.InitializeAsync();
+
+            for (var index = 0; index < 100; index++)
+            {
+                await store.EnqueueAsync(new OfflineEditOperation
+                {
+                    OperationId = $"outage-op-{index:000}",
+                    LayerKey = "assets",
+                    TargetCollection = "assets",
+                    OperationType = OfflineOperationType.Update,
+                    PayloadJson = $$"""{"id":{{index}}}""",
+                    Priority = 1,
+                    CreatedAtUtc = DateTimeOffset.UtcNow.AddSeconds(index),
+                });
+            }
+
+            var connectivity = new ToggleConnectivityProvider { IsOnline = false };
+            var offlineStore = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions { DatabasePath = databasePath });
+            var offlineEngine = new OfflineSyncEngine(
+                offlineStore,
+                new AlwaysSuccessUploader(),
+                new OfflineSyncEngineOptions { BatchSize = 100 });
+            await using (var offlineOrchestrator = new BackgroundSyncOrchestrator(offlineEngine, connectivity))
+            {
+                var offlineResult = await offlineOrchestrator.RunOnceIfOnlineAsync();
+                Assert.Null(offlineResult);
+            }
+
+            var restartedStore = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions { DatabasePath = databasePath });
+            await restartedStore.InitializeAsync();
+            Assert.Equal(100, await restartedStore.CountPendingAsync());
+
+            connectivity.IsOnline = true;
+            var resumedEngine = new OfflineSyncEngine(
+                restartedStore,
+                new AlwaysSuccessUploader(),
+                new OfflineSyncEngineOptions { BatchSize = 100 });
+            await using var resumedOrchestrator = new BackgroundSyncOrchestrator(resumedEngine, connectivity);
+
+            var resumedResult = await resumedOrchestrator.RunOnceIfOnlineAsync();
+
+            Assert.NotNull(resumedResult);
+            Assert.Equal(100, resumedResult.Loaded);
+            Assert.Equal(100, resumedResult.Succeeded);
+            Assert.Equal(0, resumedResult.Failed);
+            Assert.Equal(0, await restartedStore.CountPendingAsync());
+        }
+        finally
+        {
+            if (File.Exists(databasePath))
+            {
+                File.Delete(databasePath);
+            }
+        }
+    }
+
     private sealed class FakeSyncRunner : IOfflineSyncRunner
     {
         private int _callCount;
@@ -82,6 +147,12 @@ public sealed class BackgroundSyncOrchestratorTests
                 Failed = 0,
             });
         }
+    }
+
+    private sealed class AlwaysSuccessUploader : IOfflineOperationUploader
+    {
+        public Task<UploadResult> UploadAsync(OfflineEditOperation operation, bool forceWrite, CancellationToken ct = default)
+            => Task.FromResult(new UploadResult { Outcome = UploadOutcome.Success });
     }
 
     private sealed class ToggleConnectivityProvider : IConnectivityStateProvider

--- a/tests/Honua.Mobile.Offline.Tests/GeoPackageSyncStoreTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/GeoPackageSyncStoreTests.cs
@@ -145,6 +145,32 @@ public sealed class GeoPackageSyncStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task PendingOperations_PersistAcrossStoreRestart()
+    {
+        var firstStore = CreateStore();
+        await firstStore.InitializeAsync();
+
+        await firstStore.EnqueueAsync(new OfflineEditOperation
+        {
+            OperationId = "restart-op",
+            LayerKey = "assets",
+            TargetCollection = "assets",
+            OperationType = OfflineOperationType.Update,
+            PayloadJson = "{}",
+            Priority = 1,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+        });
+
+        var restartedStore = CreateStore();
+        await restartedStore.InitializeAsync();
+        var pending = await restartedStore.GetPendingAsync(10);
+
+        Assert.Single(pending);
+        Assert.Equal("restart-op", pending[0].OperationId);
+        Assert.Equal(OfflineOperationType.Update, pending[0].OperationType);
+    }
+
+    [Fact]
     public async Task MapAreas_CanBeUpsertedAndListed()
     {
         var store = CreateStore();

--- a/tests/Honua.Mobile.Offline.Tests/OfflineSyncEngineTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/OfflineSyncEngineTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.Metrics;
 using Honua.Mobile.Offline.GeoPackage;
 using Honua.Mobile.Offline.Sync;
 using Microsoft.Data.Sqlite;
@@ -79,6 +80,54 @@ public sealed class OfflineSyncEngineTests : IDisposable
     }
 
     [Fact]
+    public async Task SyncAsync_ConflictPolicyRules_HandleConflictsAcrossThreeLayers()
+    {
+        var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions { DatabasePath = _databasePath });
+        await store.InitializeAsync();
+
+        await store.EnqueueAsync(CreateOperation("critical-update", "critical", OfflineOperationType.Update));
+        await store.EnqueueAsync(CreateOperation("reference-delete", "reference", OfflineOperationType.Delete));
+        await store.EnqueueAsync(CreateOperation("assets-add", "assets", OfflineOperationType.Add));
+
+        var uploader = new AlwaysConflictRecordingUploader();
+        var engine = new OfflineSyncEngine(
+            store,
+            uploader,
+            new OfflineSyncEngineOptions
+            {
+                BatchSize = 10,
+                ConflictStrategy = SyncConflictStrategy.ManualReview,
+                ConflictPolicyRules =
+                [
+                    new SyncConflictPolicyRule
+                    {
+                        LayerKey = "critical",
+                        OperationType = OfflineOperationType.Update,
+                        Strategy = SyncConflictStrategy.ClientWins,
+                    },
+                    new SyncConflictPolicyRule
+                    {
+                        LayerKey = "reference",
+                        Strategy = SyncConflictStrategy.ServerWins,
+                    },
+                ],
+            });
+
+        var result = await engine.SyncAsync();
+        var manualState = await ReadOperationStateAsync("assets-add");
+
+        Assert.Equal(3, result.Loaded);
+        Assert.Equal(2, result.Succeeded);
+        Assert.Equal(1, result.Failed);
+        Assert.Null(await ReadOperationStateAsync("critical-update"));
+        Assert.Null(await ReadOperationStateAsync("reference-delete"));
+        Assert.NotNull(manualState);
+        Assert.Equal("failed", manualState!.Value.Status);
+        Assert.Contains(uploader.Calls, call => call.OperationId == "critical-update" && call.ForceWrite);
+        Assert.DoesNotContain(uploader.Calls, call => call.OperationId == "reference-delete" && call.ForceWrite);
+    }
+
+    [Fact]
     public async Task SyncAsync_WhenCanceled_RequeuesClaimedOperationsWithoutIncrementingAttempts()
     {
         var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions { DatabasePath = _databasePath });
@@ -111,7 +160,7 @@ public sealed class OfflineSyncEngineTests : IDisposable
     }
 
     [Fact]
-    public async Task SyncAsync_WhenUploaderThrows_RequeuesClaimedOperations()
+    public async Task SyncAsync_WhenUploaderThrows_MapsProblemAndKeepsOperationsRetryable()
     {
         var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions { DatabasePath = _databasePath });
         await store.InitializeAsync();
@@ -138,12 +187,65 @@ public sealed class OfflineSyncEngineTests : IDisposable
 
         var engine = new OfflineSyncEngine(store, new ThrowingUploader());
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => engine.SyncAsync());
+        var result = await engine.SyncAsync();
 
         var pending = await store.GetPendingAsync(10);
+        Assert.Equal(2, result.Loaded);
+        Assert.Equal(0, result.Succeeded);
+        Assert.Equal(2, result.Failed);
+        Assert.All(result.Failures, failure =>
+        {
+            Assert.DoesNotContain("Grpc", failure.Reason, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Sqlite", failure.Reason, StringComparison.OrdinalIgnoreCase);
+        });
         Assert.Equal(2, pending.Count);
         Assert.Contains(pending, operation => operation.OperationId == "throw-op-1");
         Assert.Contains(pending, operation => operation.OperationId == "throw-op-2");
+    }
+
+    [Fact]
+    public async Task SyncAsync_EmitsSyncTelemetryCountersAndPendingGauge()
+    {
+        var measurements = new List<MetricMeasurement>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == MobileSyncTelemetry.MeterName)
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+        {
+            measurements.Add(new MetricMeasurement(instrument.Name, measurement, tags.ToArray()));
+        });
+        listener.Start();
+
+        var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions { DatabasePath = _databasePath });
+        await store.InitializeAsync();
+        await store.EnqueueAsync(new OfflineEditOperation
+        {
+            OperationId = "telemetry-op",
+            LayerKey = "assets",
+            TargetCollection = "assets",
+            OperationType = OfflineOperationType.Update,
+            PayloadJson = "{}",
+            Priority = 1,
+        });
+
+        var engine = new OfflineSyncEngine(store, new AlwaysSuccessUploader());
+
+        var result = await engine.SyncAsync();
+        listener.RecordObservableInstruments();
+
+        Assert.Equal(1, result.Succeeded);
+        Assert.Contains(measurements, measurement =>
+            measurement.Name == "mobile_sync_runs_total" &&
+            measurement.Value == 1 &&
+            measurement.HasTag("result", "succeeded"));
+        Assert.Contains(measurements, measurement =>
+            measurement.Name == "mobile_pending_operations" &&
+            measurement.Value == 0);
     }
 
     public void Dispose()
@@ -177,6 +279,25 @@ public sealed class OfflineSyncEngineTests : IDisposable
             => Task.FromResult(new UploadResult { Outcome = UploadOutcome.Conflict, Message = "conflict" });
     }
 
+    private sealed class AlwaysConflictRecordingUploader : IOfflineOperationUploader
+    {
+        public List<(string OperationId, bool ForceWrite)> Calls { get; } = [];
+
+        public Task<UploadResult> UploadAsync(OfflineEditOperation operation, bool forceWrite, CancellationToken ct = default)
+        {
+            Calls.Add((operation.OperationId, forceWrite));
+            return Task.FromResult(forceWrite
+                ? new UploadResult { Outcome = UploadOutcome.Success }
+                : new UploadResult { Outcome = UploadOutcome.Conflict, Message = "conflict" });
+        }
+    }
+
+    private sealed class AlwaysSuccessUploader : IOfflineOperationUploader
+    {
+        public Task<UploadResult> UploadAsync(OfflineEditOperation operation, bool forceWrite, CancellationToken ct = default)
+            => Task.FromResult(new UploadResult { Outcome = UploadOutcome.Success });
+    }
+
     private sealed class BlockingUploader : IOfflineOperationUploader
     {
         public TaskCompletionSource<bool> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -192,7 +313,32 @@ public sealed class OfflineSyncEngineTests : IDisposable
     private sealed class ThrowingUploader : IOfflineOperationUploader
     {
         public Task<UploadResult> UploadAsync(OfflineEditOperation operation, bool forceWrite, CancellationToken ct = default)
-            => throw new InvalidOperationException("unexpected uploader fault");
+            => throw new InvalidOperationException("Grpc.Core.RpcException: Status(StatusCode=\"Unavailable\")");
+    }
+
+    private static OfflineEditOperation CreateOperation(
+        string operationId,
+        string layerKey,
+        OfflineOperationType operationType)
+        => new()
+        {
+            OperationId = operationId,
+            LayerKey = layerKey,
+            TargetCollection = layerKey,
+            OperationType = operationType,
+            PayloadJson = "{}",
+            Priority = 1,
+        };
+
+    private sealed record MetricMeasurement(
+        string Name,
+        long Value,
+        KeyValuePair<string, object?>[] Tags)
+    {
+        public bool HasTag(string name, string value)
+            => Tags.Any(tag =>
+                tag.Key == name &&
+                string.Equals(tag.Value as string, value, StringComparison.Ordinal));
     }
 
     private async Task<(int AttemptCount, string Status)?> ReadOperationStateAsync(string operationId)

--- a/tests/Honua.Mobile.Offline.Tests/OfflineSyncEngineTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/OfflineSyncEngineTests.cs
@@ -128,6 +128,29 @@ public sealed class OfflineSyncEngineTests : IDisposable
     }
 
     [Fact]
+    public async Task SyncAsync_NullConflictPolicyRules_UsesDefaultConflictStrategy()
+    {
+        var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions { DatabasePath = _databasePath });
+        await store.InitializeAsync();
+        await store.EnqueueAsync(CreateOperation("server-wins-op", "assets", OfflineOperationType.Update));
+
+        var engine = new OfflineSyncEngine(
+            store,
+            new AlwaysConflictUploader(),
+            new OfflineSyncEngineOptions
+            {
+                ConflictStrategy = SyncConflictStrategy.ServerWins,
+                ConflictPolicyRules = null!,
+            });
+
+        var result = await engine.SyncAsync();
+
+        Assert.Equal(1, result.Succeeded);
+        Assert.Equal(0, result.Failed);
+        Assert.Null(await ReadOperationStateAsync("server-wins-op"));
+    }
+
+    [Fact]
     public async Task SyncAsync_WhenCanceled_RequeuesClaimedOperationsWithoutIncrementingAttempts()
     {
         var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions { DatabasePath = _databasePath });


### PR DESCRIPTION
## Summary
- Add per-layer/per-operation sync conflict policy rules over the v1 manual/client/server strategies.
- Map transport, storage, gRPC-like, and request failures into sanitized sync problems before queue/result exposure.
- Add sync telemetry counters/gauge plus restart/reconnect and three-layer conflict strategy coverage.

## Sync Impact
- Offline queues remain durable across process restart and connectivity recovery, with retryable provider failures kept in the pending queue.
- Conflict behavior can now be selected globally, per layer, or per operation type while preserving manual review as the default.

## Protocol Changes
- None. This consumes existing uploader and queue contracts and does not alter server protocol shape.

## Tests
- [x] git diff --cached --check
- [x] dotnet test tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj --configuration Release

Fixes honua-io/honua-server#831