### PR TITLE
docs: document mobile SDK scaffolding gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Verify branch protection
+        if: ${{ github.event_name == 'push' && vars.HONUA_VERIFY_BRANCH_PROTECTION == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.HONUA_BRANCH_PROTECTION_READ_TOKEN }}
+        run: bash scripts/verify-branch-protection.sh "${GITHUB_REF_NAME}"
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:

--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ The smoke test project can also run an optional live Honua query when
 `HONUA_MOBILE_SMOKE_LAYER_ID`, and optionally `HONUA_MOBILE_SMOKE_API_KEY` are
 set.
 
+Release workflow, branch-protection, package metadata, Dependabot, Trivy, and
+platform smoke guardrails for honua-server #826 are documented in
+[Repo Scaffolding Gates](docs/guides/repo-scaffolding-gates.md).
+
 ## Status
 
 Production-ready foundation for offline sync, forms, and gRPC transport.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -23,6 +23,7 @@ In-depth guides for building with the Honua Mobile SDK.
 | [Plugin Client Extension Hosts](plugin-client-extension-hosts.md) | MAUI and web host/runtime plugin boundaries, SDK/server dependencies, and intentionally deferred contract work |
 | [Plugin and Host Extension Boundary](plugin-extension-api.md) | Web embed extension APIs and the SDK/mobile ownership split for plugin work |
 | [Protected 3D Scene Auth](protected-3d-scene-auth.md) | Signed URL, proxy, header, CORS, cache, and revocation policy for protected scene assets |
+| [Repo Scaffolding Gates](repo-scaffolding-gates.md) | Issue #826 release workflow, package metadata, branch protection, Dependabot, Trivy, and platform smoke verification commands |
 | [Scene Controls](scene-controls.md) | `<honua-scene-*>` control surfaces, `HonuaSceneMetadata` schema, and typed scene events |
 | [Security](security.md) | Authentication, transport security, and secure storage best practices |
 | [Troubleshooting](troubleshooting.md) | Common issues and solutions for development and production |

--- a/docs/guides/repo-scaffolding-gates.md
+++ b/docs/guides/repo-scaffolding-gates.md
@@ -69,7 +69,7 @@ dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --con
 
 ```bash
 dotnet workload install maui
-dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj --configuration Release --framework net10.0-ios /p:RuntimeIdentifier=ios-arm64 /p:PublishTrimmed=true /p:TrimMode=full /p:PublishAot=true /p:PublishAotUsingRuntimePack=true /p:EnableCodeSigning=false /p:ArchiveOnBuild=false /p:TreatWarningsAsErrors=true /p:WarningsNotAsErrors=IL2104%3BIL3053
+dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj --configuration Release --framework net10.0-ios /p:RuntimeIdentifier=ios-arm64 /p:PublishTrimmed=true /p:TrimMode=full /p:PublishAot=true /p:PublishAotUsingRuntimePack=true /p:EnableCodeSigning=false /p:ArchiveOnBuild=false /p:TreatWarningsAsErrors=true '/p:WarningsNotAsErrors=IL2104;IL3053'
 dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --configuration Release
 ```
 

--- a/docs/guides/repo-scaffolding-gates.md
+++ b/docs/guides/repo-scaffolding-gates.md
@@ -1,0 +1,96 @@
+# Repo Scaffolding Gates
+
+This runbook covers the repository scaffolding checks for honua-server #826.
+It is intentionally limited to mobile-owned CI, package metadata, release
+documentation, and smoke-test commands. It does not introduce server API
+clients or duplicate SDK-owned contracts.
+
+## Automated Gate
+
+Run the focused guardrail tests before changing release workflow, package,
+license, or dependency automation files:
+
+```bash
+dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --filter RepoScaffolding
+```
+
+These tests verify:
+
+- `publish-dotnet-mobile.yml` publishes only from signed
+  `mobile-dotnet-v*` release tags and keeps manual runs dry-run only.
+- Android API 33 emulator smoke, Android trim smoke, iOS 17+ simulator smoke,
+  iOS trim smoke, and iOS AOT smoke remain wired in CI.
+- `Honua.Mobile.Sdk`, `Honua.Mobile.Field`, `Honua.Mobile.Offline`, and
+  `Honua.Mobile.Maui` keep Apache-2.0 NuGet metadata and package README
+  inclusion.
+- Dependabot covers NuGet, npm, and GitHub Actions, while CI uploads Trivy
+  SARIF for high and critical findings.
+- README keeps the honua-server #811 roadmap link.
+
+## Branch Protection
+
+Branch protection is a live GitHub repository setting, so it cannot be fully
+validated from a checkout without GitHub credentials. The repository's current
+default branch is `main`; pass `trunk` if the default branch is renamed.
+Release owners can run:
+
+```bash
+GH_TOKEN=<token-with-branch-protection-read> bash scripts/verify-branch-protection.sh main
+```
+
+On GitHub Actions, the CI workflow passes the pushed branch name with
+`GITHUB_REPOSITORY` already set. The token must be allowed to read branch
+protection for the repository. The script fails unless the target branch
+requires approving reviews, requires status checks, and has force pushes
+disabled.
+
+CI runs this check only when `HONUA_VERIFY_BRANCH_PROTECTION=true` is configured
+as a repository variable and `HONUA_BRANCH_PROTECTION_READ_TOKEN` is available
+as a repository secret. Leave the variable unset until the release-owner or repo
+admin token is ready.
+
+## Platform CI Smoke Commands
+
+The full Android emulator and iOS simulator/AOT checks require hosted runners
+with Android SDK, Xcode, and MAUI workloads. Use the repo-native CI workflow for
+the complete gate:
+
+```bash
+gh workflow run ci.yml
+```
+
+Local equivalents for maintainers with platform tooling installed:
+
+```bash
+dotnet workload install maui-android
+dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj --configuration Release --framework net10.0-android /p:PublishTrimmed=true /p:TrimMode=full /p:TreatWarningsAsErrors=true /p:WarningsNotAsErrors=IL2104 /p:AndroidPackageFormat=apk
+dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --configuration Release
+```
+
+```bash
+dotnet workload install maui
+dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj --configuration Release --framework net10.0-ios /p:RuntimeIdentifier=ios-arm64 /p:PublishTrimmed=true /p:TrimMode=full /p:PublishAot=true /p:PublishAotUsingRuntimePack=true /p:EnableCodeSigning=false /p:ArchiveOnBuild=false /p:TreatWarningsAsErrors=true /p:WarningsNotAsErrors=IL2104%3BIL3053
+dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --configuration Release
+```
+
+Optional live Honua smoke queries must use the existing live-image or configured
+server harness. Set these variables only for live server coverage:
+
+```bash
+HONUA_MOBILE_SMOKE_BASE_URL=https://<honua-server>
+HONUA_MOBILE_SMOKE_SERVICE_ID=<service-id>
+HONUA_MOBILE_SMOKE_LAYER_ID=<layer-id>
+HONUA_MOBILE_SMOKE_API_KEY=<optional-api-key>
+dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --filter LiveFeatureQuery
+```
+
+## Package Publish Dry Run
+
+Manual validation can build and pack the four NuGet packages without publish:
+
+```bash
+gh workflow run publish-dotnet-mobile.yml -f version=0.1.0-alpha.1 -f dry_run=true
+```
+
+Publishing remains blocked for manual runs. Actual package publish happens only
+when a signed `mobile-dotnet-v*` release tag is pushed.

--- a/scripts/verify-branch-protection.sh
+++ b/scripts/verify-branch-protection.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+branch="${1:-${GITHUB_REF_NAME:-}}"
+repo="${GITHUB_REPOSITORY:-}"
+
+if [[ -z "${repo}" ]]; then
+  remote_url="$(git config --get remote.origin.url || true)"
+  if [[ "${remote_url}" =~ github.com[:/]([^/]+/[^/.]+)(\.git)?$ ]]; then
+    repo="${BASH_REMATCH[1]}"
+  fi
+fi
+
+if [[ -z "${repo}" ]]; then
+  echo "Could not determine GitHub repository. Set GITHUB_REPOSITORY=owner/repo." >&2
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI is required. Install gh and authenticate with a token that can read branch protection." >&2
+  exit 2
+fi
+
+if [[ -z "${GH_TOKEN:-${GITHUB_TOKEN:-}}" ]]; then
+  echo "Set GH_TOKEN or GITHUB_TOKEN with permission to read branch protection for ${repo}." >&2
+  exit 2
+fi
+
+if [[ -z "${branch}" ]]; then
+  branch="$(gh repo view "${repo}" --json defaultBranchRef --jq '.defaultBranchRef.name')"
+fi
+
+protection_path="repos/${repo}/branches/${branch}/protection"
+
+required_reviews="$(gh api "${protection_path}" --jq '.required_pull_request_reviews.required_approving_review_count // 0')"
+required_status_checks_present="$(gh api "${protection_path}" --jq '(.required_status_checks != null)')"
+required_status_check_count="$(gh api "${protection_path}" --jq '((.required_status_checks.contexts // []) + ((.required_status_checks.checks // []) | map(.context))) | length')"
+force_pushes_enabled="$(gh api "${protection_path}" --jq '.allow_force_pushes.enabled // false')"
+
+if (( required_reviews < 1 )); then
+  echo "Branch ${branch} in ${repo} must require at least one approving review." >&2
+  exit 1
+fi
+
+if [[ "${required_status_checks_present}" != "true" || "${required_status_check_count}" == "0" ]]; then
+  echo "Branch ${branch} in ${repo} must require status checks." >&2
+  exit 1
+fi
+
+if [[ "${force_pushes_enabled}" == "true" ]]; then
+  echo "Branch ${branch} in ${repo} must disable force pushes." >&2
+  exit 1
+fi
+
+echo "Branch protection OK for ${repo}:${branch}"
+echo "Required approving reviews: ${required_reviews}"
+echo "Required status checks: ${required_status_check_count}"
+echo "Force pushes enabled: ${force_pushes_enabled}"

--- a/tests/Honua.Mobile.Smoke.Tests/RepoScaffoldingGateTests.cs
+++ b/tests/Honua.Mobile.Smoke.Tests/RepoScaffoldingGateTests.cs
@@ -1,0 +1,185 @@
+using System.Xml.Linq;
+
+namespace Honua.Mobile.Smoke.Tests;
+
+public sealed class RepoScaffoldingGateTests
+{
+    private static readonly string[] MobilePackageProjects =
+    [
+        "src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj",
+        "src/Honua.Mobile.Field/Honua.Mobile.Field.csproj",
+        "src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj",
+        "src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj",
+    ];
+
+    [Fact]
+    public void PublishWorkflow_IsLimitedToSignedMobilePackageReleaseTags()
+    {
+        var root = FindRepositoryRoot();
+        var workflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "publish-dotnet-mobile.yml"));
+
+        Assert.Contains("- \"mobile-dotnet-v*\"", workflow);
+        Assert.Contains("git verify-tag \"${GITHUB_REF_NAME}\"", workflow);
+        Assert.Contains("Block manual publishing outside signed releases", workflow);
+        Assert.Contains("github.event.inputs.dry_run != 'true'", workflow);
+        Assert.Contains("Mobile .NET packages publish only from signed mobile-dotnet-v* release tags", workflow);
+        Assert.Contains("if: ${{ github.event_name == 'push' }}", workflow);
+        Assert.Contains("dotnet nuget push nupkgs/*.nupkg", workflow);
+
+        foreach (var projectPath in MobilePackageProjects)
+        {
+            Assert.Contains(projectPath, workflow);
+        }
+    }
+
+    [Fact]
+    public void CiWorkflow_DefinesMobilePlatformSmokeMatrix()
+    {
+        var root = FindRepositoryRoot();
+        var workflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "ci.yml"));
+
+        Assert.Contains("MAUI Android Build & Trim Smoke", workflow);
+        Assert.Contains("dotnet workload install maui-android", workflow);
+        Assert.Contains("--framework net10.0-android", workflow);
+        Assert.Contains("Android trim smoke", workflow);
+        Assert.Contains("/p:PublishTrimmed=true", workflow);
+        Assert.Contains("/p:TrimMode=full", workflow);
+        Assert.Contains("api-level: 33", workflow);
+        Assert.Contains("reactivecircus/android-emulator-runner@v2", workflow);
+
+        Assert.Contains("MAUI iOS Build & AOT Smoke", workflow);
+        Assert.Contains("Verify iOS 17+ simulator runtime", workflow);
+        Assert.Contains("iOS (1[7-9]|2[0-9])", workflow);
+        Assert.Contains("--framework net10.0-ios", workflow);
+        Assert.Contains("iOS trim and NativeAOT smoke", workflow);
+        Assert.Contains("/p:PublishAot=true", workflow);
+        Assert.Contains("/p:PublishAotUsingRuntimePack=true", workflow);
+
+        Assert.Contains("HONUA_MOBILE_SMOKE_BASE_URL", workflow);
+        Assert.Contains("HONUA_MOBILE_SMOKE_SERVICE_ID", workflow);
+        Assert.Contains("HONUA_MOBILE_SMOKE_LAYER_ID", workflow);
+    }
+
+    [Fact]
+    public void SecurityAndDependencyAutomation_CoverDependabotAndTrivy()
+    {
+        var root = FindRepositoryRoot();
+        var dependabot = File.ReadAllText(Path.Combine(root, ".github", "dependabot.yml"));
+        var ci = File.ReadAllText(Path.Combine(root, ".github", "workflows", "ci.yml"));
+
+        Assert.Contains("package-ecosystem: \"nuget\"", dependabot);
+        Assert.Contains("registries:", dependabot);
+        Assert.Contains("github-honua", dependabot);
+        Assert.Contains("package-ecosystem: \"npm\"", dependabot);
+        Assert.Contains("directory: \"/src/Honua.Embed\"", dependabot);
+        Assert.Contains("package-ecosystem: \"github-actions\"", dependabot);
+        Assert.Contains("groups:", dependabot);
+
+        Assert.Contains("aquasecurity/trivy-action@", ci);
+        Assert.Contains("scan-type: fs", ci);
+        Assert.Contains("format: sarif", ci);
+        Assert.Contains("severity: CRITICAL,HIGH", ci);
+        Assert.Contains("ignore-unfixed: true", ci);
+        Assert.Contains("github/codeql-action/upload-sarif@", ci);
+    }
+
+    [Fact]
+    public void ReadmeAndDocs_LinkServerRoadmapAndScaffoldingRunbook()
+    {
+        var root = FindRepositoryRoot();
+        var readme = File.ReadAllText(Path.Combine(root, "README.md"));
+        var guideIndex = File.ReadAllText(Path.Combine(root, "docs", "guides", "README.md"));
+        var runbook = File.ReadAllText(Path.Combine(root, "docs", "guides", "repo-scaffolding-gates.md"));
+
+        Assert.Contains("https://github.com/honua-io/honua-server/issues/811", readme);
+        Assert.Contains("mobile SDK roadmap", readme);
+        Assert.Contains("[Repo Scaffolding Gates](repo-scaffolding-gates.md)", guideIndex);
+        Assert.Contains("honua-server #826", runbook);
+        Assert.Contains("dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --filter RepoScaffolding", runbook);
+        Assert.Contains("bash scripts/verify-branch-protection.sh main", runbook);
+    }
+
+    [Fact]
+    public void LicenseAndNugetPackageMetadata_AreReleaseReady()
+    {
+        var root = FindRepositoryRoot();
+        var license = File.ReadAllText(Path.Combine(root, "LICENSE"));
+
+        Assert.Contains("Apache License", license);
+        Assert.Contains("Version 2.0, January 2004", license);
+
+        foreach (var projectPath in MobilePackageProjects)
+        {
+            var document = XDocument.Load(Path.Combine(root, projectPath));
+
+            Assert.Equal(Path.GetFileNameWithoutExtension(projectPath), GetProperty(document, "PackageId"));
+            Assert.Equal("Honua", GetProperty(document, "Authors"));
+            Assert.Equal("Apache-2.0", GetProperty(document, "PackageLicenseExpression"));
+            Assert.Equal("README.md", GetProperty(document, "PackageReadmeFile"));
+            Assert.Equal("https://github.com/honua-io/honua-mobile", GetProperty(document, "PackageProjectUrl"));
+            Assert.Equal("https://github.com/honua-io/honua-mobile", GetProperty(document, "RepositoryUrl"));
+            Assert.Equal("git", GetProperty(document, "RepositoryType"));
+
+            var description = GetProperty(document, "Description");
+            Assert.False(string.IsNullOrWhiteSpace(description));
+
+            var tags = GetProperty(document, "PackageTags");
+            Assert.Contains("honua", tags);
+            Assert.Contains("mobile", tags);
+
+            var readme = document
+                .Descendants("None")
+                .SingleOrDefault(element =>
+                    string.Equals(element.Attribute("Include")?.Value, @"..\..\README.md", StringComparison.Ordinal));
+            Assert.NotNull(readme);
+            Assert.Equal("true", readme.Attribute("Pack")?.Value);
+            Assert.Equal(@"\", readme.Attribute("PackagePath")?.Value);
+        }
+    }
+
+    [Fact]
+    public void BranchProtectionVerification_IsDocumentedAndRunnable()
+    {
+        var root = FindRepositoryRoot();
+        var script = File.ReadAllText(Path.Combine(root, "scripts", "verify-branch-protection.sh"));
+        var ci = File.ReadAllText(Path.Combine(root, ".github", "workflows", "ci.yml"));
+        var checklist = File.ReadAllText(Path.Combine(root, "quality", "release-checklist.md"));
+
+        Assert.Contains("required_pull_request_reviews", script);
+        Assert.Contains("required_status_checks", script);
+        Assert.Contains("allow_force_pushes", script);
+        Assert.Contains("gh api", script);
+        Assert.Contains("HONUA_VERIFY_BRANCH_PROTECTION", ci);
+        Assert.Contains("HONUA_BRANCH_PROTECTION_READ_TOKEN", ci);
+        Assert.Contains("bash scripts/verify-branch-protection.sh \"${GITHUB_REF_NAME}\"", ci);
+        Assert.Contains("branch protection confirmed", checklist);
+    }
+
+    private static string GetProperty(XDocument document, string propertyName)
+    {
+        return document
+            .Descendants(propertyName)
+            .Select(element => element.Value)
+            .FirstOrDefault() ?? string.Empty;
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            var agentsPath = Path.Combine(directory.FullName, "AGENTS.md");
+            var docsPath = Path.Combine(directory.FullName, "docs");
+
+            if (File.Exists(agentsPath) && Directory.Exists(docsPath))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root from test output directory.");
+    }
+}


### PR DESCRIPTION
## Summary

- Add a repo-scaffolding gates runbook for release workflow, package metadata, dependency/security automation, branch protection, and platform smoke validation.
- Add focused smoke tests that guard the mobile NuGet publish workflow, MAUI CI matrix, package metadata, Dependabot/Trivy wiring, and roadmap links.
- Add a branch-protection verification script and wire it into CI behind the `HONUA_VERIFY_BRANCH_PROTECTION` repository variable.

## Platform Testing

This PR does not add new mobile runtime behavior. It documents and guards the existing Android/iOS MAUI CI smoke gates for honua-server #826.

## Testing

- `dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --filter RepoScaffolding`
- `bash -n scripts/verify-branch-protection.sh`
- `git diff --check`
- `GH_TOKEN="$(gh auth token)" bash scripts/verify-branch-protection.sh main` currently reports that `main` has 0 required approving reviews.

## Blocker

The live branch-protection check cannot pass until repository settings require at least one approving review on `main`. Current protection has required status checks and force-push disabled.

Related to honua-io/honua-server#826
