### PR TITLE
test: add iOS and Android MAUI platform smoke gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
             CHANGED_FILES=$(git diff --name-only ${{ github.event.before }}..${{ github.sha }})
           fi
 
-          SRC_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^(src/|apps/|proto/|quality/)' || true)
+          SRC_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^(src/|apps/|proto/|quality/|scripts/|\.github/workflows/|tests/Honua.Mobile.PlatformSmoke/)' || true)
           TEST_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^tests/' || true)
 
           if [ -n "$SRC_CHANGED" ]; then
@@ -320,7 +320,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
           ls -l /dev/kvm
 
-      - name: Android API 33 emulator smoke
+      - name: Android API 33 platform smoke
         uses: reactivecircus/android-emulator-runner@v2
         env:
           HONUA_MOBILE_SMOKE_BASE_URL: ${{ vars.HONUA_MOBILE_SMOKE_BASE_URL }}
@@ -336,7 +336,7 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -no-metrics
           script: |
             adb shell getprop ro.build.version.sdk
-            dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --configuration Release --logger "console;verbosity=minimal"
+            scripts/run-android-platform-smoke.sh
 
   maui-ios:
     name: MAUI iOS Build & AOT Smoke
@@ -433,16 +433,15 @@ jobs:
             /p:TreatWarningsAsErrors=true \
             /p:WarningsNotAsErrors=IL2104%3BIL3053
 
-      - name: iOS live query smoke
+      - name: iOS simulator platform smoke
+        if: steps.ios_tools.outputs.actool_available == 'true'
         env:
           HONUA_MOBILE_SMOKE_BASE_URL: ${{ vars.HONUA_MOBILE_SMOKE_BASE_URL }}
           HONUA_MOBILE_SMOKE_SERVICE_ID: ${{ vars.HONUA_MOBILE_SMOKE_SERVICE_ID }}
           HONUA_MOBILE_SMOKE_LAYER_ID: ${{ vars.HONUA_MOBILE_SMOKE_LAYER_ID }}
           HONUA_MOBILE_SMOKE_API_KEY: ${{ secrets.HONUA_MOBILE_SMOKE_API_KEY }}
         run: |
-          dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj \
-            --configuration Release \
-            --logger "console;verbosity=minimal"
+          scripts/run-ios-platform-smoke.sh
 
   maui-windows:
     name: MAUI Windows Build

--- a/Honua.Mobile.sln
+++ b/Honua.Mobile.sln
@@ -29,6 +29,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Mobile.FieldCollectio
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Mobile.ServerIntegration.Tests", "tests\Honua.Mobile.ServerIntegration.Tests\Honua.Mobile.ServerIntegration.Tests.csproj", "{E4932418-1C59-49D0-981E-1A06FC657649}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Mobile.PlatformSmoke", "tests\Honua.Mobile.PlatformSmoke\Honua.Mobile.PlatformSmoke.csproj", "{0F322272-A4E5-43B4-909B-40A936F3CFDE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -171,6 +173,18 @@ Global
 		{E4932418-1C59-49D0-981E-1A06FC657649}.Release|x64.Build.0 = Release|Any CPU
 		{E4932418-1C59-49D0-981E-1A06FC657649}.Release|x86.ActiveCfg = Release|Any CPU
 		{E4932418-1C59-49D0-981E-1A06FC657649}.Release|x86.Build.0 = Release|Any CPU
+		{0F322272-A4E5-43B4-909B-40A936F3CFDE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F322272-A4E5-43B4-909B-40A936F3CFDE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F322272-A4E5-43B4-909B-40A936F3CFDE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0F322272-A4E5-43B4-909B-40A936F3CFDE}.Debug|x64.Build.0 = Debug|Any CPU
+		{0F322272-A4E5-43B4-909B-40A936F3CFDE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0F322272-A4E5-43B4-909B-40A936F3CFDE}.Debug|x86.Build.0 = Debug|Any CPU
+		{0F322272-A4E5-43B4-909B-40A936F3CFDE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F322272-A4E5-43B4-909B-40A936F3CFDE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F322272-A4E5-43B4-909B-40A936F3CFDE}.Release|x64.ActiveCfg = Release|Any CPU
+		{0F322272-A4E5-43B4-909B-40A936F3CFDE}.Release|x64.Build.0 = Release|Any CPU
+		{0F322272-A4E5-43B4-909B-40A936F3CFDE}.Release|x86.ActiveCfg = Release|Any CPU
+		{0F322272-A4E5-43B4-909B-40A936F3CFDE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -187,5 +201,6 @@ Global
 		{2DEE74CC-D0FB-458C-8980-1A9E54FADE0B} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{8F30E9F6-4C66-49FC-9020-0706E5708782} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{E4932418-1C59-49D0-981E-1A06FC657649} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{0F322272-A4E5-43B4-909B-40A936F3CFDE} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/docs/guides/mobile-devops-builds.md
+++ b/docs/guides/mobile-devops-builds.md
@@ -72,6 +72,59 @@ Workflows stamp the app with MSBuild properties:
 | `HonuaMobileBuildRunAttempt` | Retry attempt for the run, when available. |
 | `HonuaMobileApiBaseUrl` | Optional embedded service endpoint metadata. Leave blank when testers enter the server URL manually. |
 
+## PR Platform Smoke
+
+The PR CI MAUI Android and iOS jobs include a device-hosted live query smoke for
+honua-server #827 and #828. The smoke app lives at
+`tests/Honua.Mobile.PlatformSmoke/Honua.Mobile.PlatformSmoke.csproj`, installs
+onto the active emulator or simulator, and queries through the existing
+`HonuaMobileSdkFeatureClient` as `IHonuaFeatureQueryClient`. It does not add a
+new server API client or duplicate SDK feature contracts.
+
+Required GitHub repository variables:
+
+- `HONUA_MOBILE_SMOKE_BASE_URL`: public Honua server base URL.
+- `HONUA_MOBILE_SMOKE_SERVICE_ID`: public feature service ID.
+- `HONUA_MOBILE_SMOKE_LAYER_ID`: public feature layer ID.
+
+Optional GitHub Actions secret:
+
+- `HONUA_MOBILE_SMOKE_API_KEY`: API key when the selected smoke layer is not
+  anonymous.
+
+The app writes `honua-mobile-platform-smoke-result.json` in its mobile app data
+sandbox. CI fails if the app does not produce the marker, the query fails, or
+the live feature query takes one second or longer.
+
+Exact Android command, after an emulator is booted and `adb` is available:
+
+```bash
+HONUA_MOBILE_SMOKE_BASE_URL="https://example.honua.server/" \
+HONUA_MOBILE_SMOKE_SERVICE_ID="mobile_offline_demo" \
+HONUA_MOBILE_SMOKE_LAYER_ID="68910" \
+scripts/run-android-platform-smoke.sh
+```
+
+Exact iOS command, on macOS after the iOS MAUI workload and Xcode are selected:
+
+```bash
+HONUA_MOBILE_SMOKE_BASE_URL="https://example.honua.server/" \
+HONUA_MOBILE_SMOKE_SERVICE_ID="mobile_offline_demo" \
+HONUA_MOBILE_SMOKE_LAYER_ID="68910" \
+scripts/run-ios-platform-smoke.sh
+```
+
+Set `HONUA_MOBILE_SMOKE_API_KEY` in the shell for either command if the layer
+requires it. Set `IOS_SIMULATOR_UDID` to force a specific booted simulator; when
+unset, the iOS script uses a booted simulator or creates an available iPhone
+simulator. Set `RUNTIME_IDENTIFIER=iossimulator-arm64` on Apple Silicon runners
+when the selected .NET iOS workload and simulator require it.
+
+The broader live Honua server integration suite remains in
+`tests/Honua.Mobile.ServerIntegration.Tests` and is enabled with
+`HONUA_MOBILE_LIVE_SERVER_TESTS=true`. Use that Testcontainers-backed harness
+for server interaction coverage beyond the one-query emulator/simulator smoke.
+
 ## Version Numbers
 
 Debug phone artifacts use the workflow run number as Android

--- a/scripts/run-android-platform-smoke.sh
+++ b/scripts/run-android-platform-smoke.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_PATH="${ROOT_DIR}/tests/Honua.Mobile.PlatformSmoke/Honua.Mobile.PlatformSmoke.csproj"
+PROJECT_DIR="$(dirname "${PROJECT_PATH}")"
+PACKAGE_ID="${HONUA_MOBILE_PLATFORM_SMOKE_PACKAGE_ID:-io.honua.mobile.platformsmoke}"
+CONFIGURATION="${CONFIGURATION:-Debug}"
+TARGET_FRAMEWORK="net10.0-android"
+CONFIG_FILE="honua-mobile-platform-smoke-config.json"
+RESULT_FILE="honua-mobile-platform-smoke-result.json"
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "::error::${name} is required for Android platform smoke."
+    exit 1
+  fi
+}
+
+require_env HONUA_MOBILE_SMOKE_BASE_URL
+require_env HONUA_MOBILE_SMOKE_SERVICE_ID
+require_env HONUA_MOBILE_SMOKE_LAYER_ID
+
+adb wait-for-device
+until [[ "$(adb shell getprop sys.boot_completed | tr -d '\r')" == "1" ]]; do
+  sleep 1
+done
+
+dotnet build "${PROJECT_PATH}" \
+  --configuration "${CONFIGURATION}" \
+  --framework "${TARGET_FRAMEWORK}" \
+  /p:TreatWarningsAsErrors=true
+
+apk_path="$(find "${PROJECT_DIR}/bin/${CONFIGURATION}/${TARGET_FRAMEWORK}" -type f \( -name "*Signed.apk" -o -name "*.apk" \) | head -n 1)"
+if [[ -z "${apk_path}" ]]; then
+  echo "::error::Android platform smoke APK was not produced."
+  exit 1
+fi
+
+adb install -r "${apk_path}" >/dev/null
+
+config_json="$(python3 - <<'PY'
+import json
+import os
+
+payload = {
+    "baseUrl": os.environ["HONUA_MOBILE_SMOKE_BASE_URL"],
+    "serviceId": os.environ["HONUA_MOBILE_SMOKE_SERVICE_ID"],
+    "layerId": int(os.environ["HONUA_MOBILE_SMOKE_LAYER_ID"]),
+}
+api_key = os.environ.get("HONUA_MOBILE_SMOKE_API_KEY")
+if api_key:
+    payload["apiKey"] = api_key
+print(json.dumps(payload, separators=(",", ":")))
+PY
+)"
+
+tmp_config="$(mktemp)"
+trap 'rm -f "${tmp_config}"' EXIT
+printf '%s' "${config_json}" > "${tmp_config}"
+
+adb push "${tmp_config}" "/data/local/tmp/${CONFIG_FILE}" >/dev/null
+adb shell chmod 644 "/data/local/tmp/${CONFIG_FILE}" >/dev/null
+adb shell run-as "${PACKAGE_ID}" sh -c "mkdir -p files && cp /data/local/tmp/${CONFIG_FILE} files/${CONFIG_FILE} && rm -f files/${RESULT_FILE}"
+
+adb logcat -c || true
+adb shell am force-stop "${PACKAGE_ID}" >/dev/null 2>&1 || true
+adb shell monkey -p "${PACKAGE_ID}" -c android.intent.category.LAUNCHER 1 >/dev/null
+
+result_json=""
+deadline=$((SECONDS + 45))
+while (( SECONDS < deadline )); do
+  result_json="$(adb shell run-as "${PACKAGE_ID}" cat "files/${RESULT_FILE}" 2>/dev/null | tr -d '\r' || true)"
+  if [[ -n "${result_json}" ]]; then
+    break
+  fi
+
+  sleep 1
+done
+
+if [[ -z "${result_json}" ]]; then
+  echo "::error::Android platform smoke did not write ${RESULT_FILE} before timeout."
+  adb logcat -d -v time | grep -F "Honua" | tail -n 120 || true
+  exit 1
+fi
+
+printf '%s\n' "${result_json}" | python3 -m json.tool
+if ! printf '%s' "${result_json}" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("success") is True else 1)'; then
+  echo "::error::Android platform smoke failed."
+  exit 1
+fi
+
+elapsed_ms="$(printf '%s' "${result_json}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("elapsedMilliseconds"))')"
+echo "Android platform smoke completed in ${elapsed_ms} ms."

--- a/scripts/run-android-platform-smoke.sh
+++ b/scripts/run-android-platform-smoke.sh
@@ -18,6 +18,17 @@ require_env() {
   fi
 }
 
+has_live_smoke_config() {
+  [[ -n "${HONUA_MOBILE_SMOKE_BASE_URL:-}" ]] &&
+    [[ -n "${HONUA_MOBILE_SMOKE_SERVICE_ID:-}" ]] &&
+    [[ -n "${HONUA_MOBILE_SMOKE_LAYER_ID:-}" ]]
+}
+
+if ! has_live_smoke_config; then
+  echo "::notice::Skipping Android live Honua platform smoke because HONUA_MOBILE_SMOKE_BASE_URL, HONUA_MOBILE_SMOKE_SERVICE_ID, or HONUA_MOBILE_SMOKE_LAYER_ID is not configured."
+  exit 0
+fi
+
 require_env HONUA_MOBILE_SMOKE_BASE_URL
 require_env HONUA_MOBILE_SMOKE_SERVICE_ID
 require_env HONUA_MOBILE_SMOKE_LAYER_ID

--- a/scripts/run-ios-platform-smoke.sh
+++ b/scripts/run-ios-platform-smoke.sh
@@ -19,6 +19,17 @@ require_env() {
   fi
 }
 
+has_live_smoke_config() {
+  [[ -n "${HONUA_MOBILE_SMOKE_BASE_URL:-}" ]] &&
+    [[ -n "${HONUA_MOBILE_SMOKE_SERVICE_ID:-}" ]] &&
+    [[ -n "${HONUA_MOBILE_SMOKE_LAYER_ID:-}" ]]
+}
+
+if ! has_live_smoke_config; then
+  echo "::notice::Skipping iOS live Honua platform smoke because HONUA_MOBILE_SMOKE_BASE_URL, HONUA_MOBILE_SMOKE_SERVICE_ID, or HONUA_MOBILE_SMOKE_LAYER_ID is not configured."
+  exit 0
+fi
+
 require_env HONUA_MOBILE_SMOKE_BASE_URL
 require_env HONUA_MOBILE_SMOKE_SERVICE_ID
 require_env HONUA_MOBILE_SMOKE_LAYER_ID

--- a/scripts/run-ios-platform-smoke.sh
+++ b/scripts/run-ios-platform-smoke.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_PATH="${ROOT_DIR}/tests/Honua.Mobile.PlatformSmoke/Honua.Mobile.PlatformSmoke.csproj"
+PROJECT_DIR="$(dirname "${PROJECT_PATH}")"
+BUNDLE_ID="${HONUA_MOBILE_PLATFORM_SMOKE_BUNDLE_ID:-io.honua.mobile.platformsmoke}"
+CONFIGURATION="${CONFIGURATION:-Debug}"
+TARGET_FRAMEWORK="net10.0-ios"
+RUNTIME_IDENTIFIER="${RUNTIME_IDENTIFIER:-iossimulator-x64}"
+CONFIG_FILE="honua-mobile-platform-smoke-config.json"
+RESULT_FILE="honua-mobile-platform-smoke-result.json"
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "::error::${name} is required for iOS platform smoke."
+    exit 1
+  fi
+}
+
+require_env HONUA_MOBILE_SMOKE_BASE_URL
+require_env HONUA_MOBILE_SMOKE_SERVICE_ID
+require_env HONUA_MOBILE_SMOKE_LAYER_ID
+
+resolve_simulator_udid() {
+  if [[ -n "${IOS_SIMULATOR_UDID:-}" ]]; then
+    printf '%s\n' "${IOS_SIMULATOR_UDID}"
+    return
+  fi
+
+  local booted_udid
+  booted_udid="$(xcrun simctl list -j devices booted | python3 -c '
+import json
+import sys
+
+devices = json.load(sys.stdin).get("devices", {})
+for runtime_devices in devices.values():
+    for device in runtime_devices:
+        if device.get("state") == "Booted":
+            print(device["udid"])
+            raise SystemExit
+')"
+
+  if [[ -n "${booted_udid}" ]]; then
+    printf '%s\n' "${booted_udid}"
+    return
+  fi
+
+  local runtime_id
+  runtime_id="$(xcrun simctl list -j runtimes available | python3 -c '
+import json
+import sys
+
+runtimes = [
+    runtime for runtime in json.load(sys.stdin).get("runtimes", [])
+    if runtime.get("isAvailable")
+    and (runtime.get("platform") == "iOS" or ".iOS-" in runtime.get("identifier", ""))
+]
+if not runtimes:
+    raise SystemExit("No available iOS simulator runtime found.")
+runtimes.sort(key=lambda runtime: runtime.get("version", ""), reverse=True)
+print(runtimes[0]["identifier"])
+')"
+
+  local device_type
+  device_type="$(xcrun simctl list -j devicetypes | python3 -c '
+import json
+import sys
+
+device_types = json.load(sys.stdin).get("devicetypes", [])
+preferred = ("iPhone 16", "iPhone 15", "iPhone 14", "iPhone 13")
+for name in preferred:
+    for device_type in device_types:
+        if device_type.get("name") == name:
+            print(device_type["identifier"])
+            raise SystemExit
+for device_type in device_types:
+    if device_type.get("name", "").startswith("iPhone"):
+        print(device_type["identifier"])
+        raise SystemExit
+raise SystemExit("No iPhone simulator device type found.")
+')"
+
+  xcrun simctl create "Honua Platform Smoke" "${device_type}" "${runtime_id}"
+}
+
+simulator_udid="$(resolve_simulator_udid)"
+xcrun simctl boot "${simulator_udid}" >/dev/null 2>&1 || true
+xcrun simctl bootstatus "${simulator_udid}" -b
+
+dotnet build "${PROJECT_PATH}" \
+  --configuration "${CONFIGURATION}" \
+  --framework "${TARGET_FRAMEWORK}" \
+  /p:RuntimeIdentifier="${RUNTIME_IDENTIFIER}" \
+  /p:_DeviceName=":v2:udid=${simulator_udid}" \
+  /p:TreatWarningsAsErrors=true
+
+app_path="$(find "${PROJECT_DIR}/bin/${CONFIGURATION}/${TARGET_FRAMEWORK}/${RUNTIME_IDENTIFIER}" -maxdepth 1 -type d -name "*.app" | head -n 1)"
+if [[ -z "${app_path}" ]]; then
+  echo "::error::iOS platform smoke app bundle was not produced."
+  exit 1
+fi
+
+xcrun simctl uninstall "${simulator_udid}" "${BUNDLE_ID}" >/dev/null 2>&1 || true
+xcrun simctl install "${simulator_udid}" "${app_path}"
+
+data_container="$(xcrun simctl get_app_container "${simulator_udid}" "${BUNDLE_ID}" data)"
+documents_dir="${data_container}/Documents"
+mkdir -p "${documents_dir}"
+
+config_json="$(python3 - <<'PY'
+import json
+import os
+
+payload = {
+    "baseUrl": os.environ["HONUA_MOBILE_SMOKE_BASE_URL"],
+    "serviceId": os.environ["HONUA_MOBILE_SMOKE_SERVICE_ID"],
+    "layerId": int(os.environ["HONUA_MOBILE_SMOKE_LAYER_ID"]),
+}
+api_key = os.environ.get("HONUA_MOBILE_SMOKE_API_KEY")
+if api_key:
+    payload["apiKey"] = api_key
+print(json.dumps(payload, separators=(",", ":")))
+PY
+)"
+
+printf '%s' "${config_json}" > "${documents_dir}/${CONFIG_FILE}"
+rm -f "${documents_dir}/${RESULT_FILE}"
+
+xcrun simctl launch --terminate-running-process "${simulator_udid}" "${BUNDLE_ID}" >/dev/null
+
+result_json=""
+deadline=$((SECONDS + 45))
+while (( SECONDS < deadline )); do
+  if [[ -f "${documents_dir}/${RESULT_FILE}" ]]; then
+    result_json="$(cat "${documents_dir}/${RESULT_FILE}")"
+    break
+  fi
+
+  sleep 1
+done
+
+if [[ -z "${result_json}" ]]; then
+  echo "::error::iOS platform smoke did not write ${RESULT_FILE} before timeout."
+  xcrun simctl spawn "${simulator_udid}" log show --last 2m --style compact --predicate 'eventMessage CONTAINS "Honua"' || true
+  exit 1
+fi
+
+printf '%s\n' "${result_json}" | python3 -m json.tool
+if ! printf '%s' "${result_json}" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("success") is True else 1)'; then
+  echo "::error::iOS platform smoke failed."
+  exit 1
+fi
+
+elapsed_ms="$(printf '%s' "${result_json}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("elapsedMilliseconds"))')"
+echo "iOS platform smoke completed in ${elapsed_ms} ms."

--- a/scripts/run-ios-platform-smoke.sh
+++ b/scripts/run-ios-platform-smoke.sh
@@ -35,7 +35,9 @@ import json
 import sys
 
 devices = json.load(sys.stdin).get("devices", {})
-for runtime_devices in devices.values():
+for runtime_id, runtime_devices in devices.items():
+    if ".iOS-" not in runtime_id and "SimRuntime.iOS" not in runtime_id:
+        continue
     for device in runtime_devices:
         if device.get("state") == "Booted":
             print(device["udid"])

--- a/tests/Honua.Mobile.PlatformSmoke/App.cs
+++ b/tests/Honua.Mobile.PlatformSmoke/App.cs
@@ -1,0 +1,60 @@
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls;
+
+namespace Honua.Mobile.PlatformSmoke;
+
+public sealed class App : Application
+{
+    private readonly PlatformSmokeRunner _runner;
+    private Label? _statusLabel;
+
+    public App(PlatformSmokeRunner runner)
+    {
+        _runner = runner;
+    }
+
+    protected override Window CreateWindow(IActivationState? activationState)
+    {
+        _statusLabel = new Label
+        {
+            Text = "Running Honua platform smoke...",
+            FontSize = 16,
+            HorizontalOptions = LayoutOptions.Center,
+            HorizontalTextAlignment = TextAlignment.Center,
+            VerticalOptions = LayoutOptions.Center,
+        };
+
+        var page = new ContentPage
+        {
+            Content = new Grid
+            {
+                Padding = 24,
+                Children = { _statusLabel },
+            },
+        };
+
+        _ = RunSmokeAsync();
+        return new Window(page);
+    }
+
+    private async Task RunSmokeAsync()
+    {
+        var result = await _runner.RunAsync().ConfigureAwait(false);
+
+        await MainThread.InvokeOnMainThreadAsync(() =>
+        {
+            if (_statusLabel is not null)
+            {
+                _statusLabel.Text = result.Success
+                    ? $"Honua platform smoke passed in {result.ElapsedMilliseconds} ms."
+                    : $"Honua platform smoke failed: {result.ErrorMessage}";
+            }
+        });
+
+        if (!result.Success)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(250)).ConfigureAwait(false);
+            Environment.Exit(1);
+        }
+    }
+}

--- a/tests/Honua.Mobile.PlatformSmoke/Honua.Mobile.PlatformSmoke.csproj
+++ b/tests/Honua.Mobile.PlatformSmoke/Honua.Mobile.PlatformSmoke.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net10.0-ios</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Honua.Mobile.PlatformSmoke</RootNamespace>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <ApplicationTitle>Honua Platform Smoke</ApplicationTitle>
+    <ApplicationId>io.honua.mobile.platformsmoke</ApplicationId>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <ApplicationVersion>1</ApplicationVersion>
+
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">23.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <MauiIcon Include="Resources/AppIcon/appicon.svg" ForegroundFile="Resources/AppIcon/appiconfg.svg" Color="#0F766E" />
+    <MauiSplashScreen Include="Resources/Splash/splash.svg" Color="#0F766E" BaseSize="128,128" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Honua.Mobile.Sdk\Honua.Mobile.Sdk.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\..\build\Honua.Mobile.BuildMetadata.props" />
+
+</Project>

--- a/tests/Honua.Mobile.PlatformSmoke/MauiProgram.cs
+++ b/tests/Honua.Mobile.PlatformSmoke/MauiProgram.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Mobile.PlatformSmoke;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiApp<App>()
+            .Services.AddSingleton<PlatformSmokeRunner>();
+
+        builder.Logging.AddDebug();
+
+        return builder.Build();
+    }
+}

--- a/tests/Honua.Mobile.PlatformSmoke/PlatformSmokeConfiguration.cs
+++ b/tests/Honua.Mobile.PlatformSmoke/PlatformSmokeConfiguration.cs
@@ -1,0 +1,152 @@
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.Maui.Storage;
+
+namespace Honua.Mobile.PlatformSmoke;
+
+internal sealed record PlatformSmokeConfiguration(
+    Uri BaseUri,
+    string ServiceId,
+    int LayerId,
+    string? ApiKey,
+    string ResultDirectory)
+{
+    public static string DefaultResultDirectory
+        => FirstWritableDirectory() ?? Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+
+    public static PlatformSmokeConfiguration Load()
+    {
+        var fileConfig = ReadFileConfiguration();
+
+        var baseUrl = ReadRequired("HONUA_MOBILE_SMOKE_BASE_URL", "baseUrl", fileConfig);
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var baseUri))
+        {
+            throw new InvalidOperationException("HONUA_MOBILE_SMOKE_BASE_URL/baseUrl must be an absolute URI.");
+        }
+
+        var serviceId = ReadRequired("HONUA_MOBILE_SMOKE_SERVICE_ID", "serviceId", fileConfig);
+        var layerIdValue = ReadRequired("HONUA_MOBILE_SMOKE_LAYER_ID", "layerId", fileConfig);
+        if (!int.TryParse(layerIdValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var layerId))
+        {
+            throw new InvalidOperationException("HONUA_MOBILE_SMOKE_LAYER_ID/layerId must be an integer.");
+        }
+
+        return new PlatformSmokeConfiguration(
+            EnsureDirectoryUri(baseUri),
+            serviceId,
+            layerId,
+            ReadOptional("HONUA_MOBILE_SMOKE_API_KEY", "apiKey", fileConfig),
+            fileConfig?.Directory ?? DefaultResultDirectory);
+    }
+
+    private static FileConfiguration? ReadFileConfiguration()
+    {
+        foreach (var directory in CandidateDirectories())
+        {
+            var path = Path.Combine(directory, PlatformSmokeRunner.ConfigFileName);
+            if (!File.Exists(path))
+            {
+                continue;
+            }
+
+            using var document = JsonDocument.Parse(File.ReadAllText(path));
+            var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            foreach (var property in document.RootElement.EnumerateObject())
+            {
+                values[property.Name] = property.Value.ValueKind switch
+                {
+                    JsonValueKind.Number => property.Value.GetRawText(),
+                    JsonValueKind.String => property.Value.GetString(),
+                    JsonValueKind.True => bool.TrueString,
+                    JsonValueKind.False => bool.FalseString,
+                    _ => null,
+                };
+            }
+
+            return new FileConfiguration(directory, values);
+        }
+
+        return null;
+    }
+
+    private static string ReadRequired(string environmentName, string jsonName, FileConfiguration? fileConfiguration)
+    {
+        return ReadOptional(environmentName, jsonName, fileConfiguration)
+            ?? throw new InvalidOperationException(
+                $"Missing required platform smoke setting {environmentName} or {jsonName} in {PlatformSmokeRunner.ConfigFileName}.");
+    }
+
+    private static string? ReadOptional(string environmentName, string jsonName, FileConfiguration? fileConfiguration)
+    {
+        var environmentValue = Environment.GetEnvironmentVariable(environmentName);
+        if (!string.IsNullOrWhiteSpace(environmentValue))
+        {
+            return environmentValue.Trim();
+        }
+
+        if (fileConfiguration is not null &&
+            fileConfiguration.Values.TryGetValue(jsonName, out var fileValue) &&
+            !string.IsNullOrWhiteSpace(fileValue))
+        {
+            return fileValue.Trim();
+        }
+
+        return null;
+    }
+
+    private static Uri EnsureDirectoryUri(Uri uri)
+    {
+        if (string.IsNullOrEmpty(uri.Query) && string.IsNullOrEmpty(uri.Fragment) && !uri.AbsolutePath.EndsWith('/'))
+        {
+            return new Uri(uri.AbsoluteUri + "/");
+        }
+
+        return uri;
+    }
+
+    private static IEnumerable<string> CandidateDirectories()
+    {
+        foreach (var directory in new[]
+        {
+            Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+            SafeAppDataDirectory(),
+        })
+        {
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                yield return directory;
+            }
+        }
+    }
+
+    private static string? FirstWritableDirectory()
+    {
+        foreach (var directory in CandidateDirectories())
+        {
+            try
+            {
+                Directory.CreateDirectory(directory);
+                return directory;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+            }
+        }
+
+        return null;
+    }
+
+    private static string? SafeAppDataDirectory()
+    {
+        try
+        {
+            return FileSystem.AppDataDirectory;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or NotImplementedException)
+        {
+            return null;
+        }
+    }
+
+    private sealed record FileConfiguration(string Directory, IReadOnlyDictionary<string, string?> Values);
+}

--- a/tests/Honua.Mobile.PlatformSmoke/PlatformSmokeResult.cs
+++ b/tests/Honua.Mobile.PlatformSmoke/PlatformSmokeResult.cs
@@ -1,0 +1,50 @@
+namespace Honua.Mobile.PlatformSmoke;
+
+internal sealed record PlatformSmokeResult
+{
+    public required bool Success { get; init; }
+
+    public required DateTimeOffset CompletedAt { get; init; }
+
+    public required string Platform { get; init; }
+
+    public required long ElapsedMilliseconds { get; init; }
+
+    public int? FeatureCount { get; init; }
+
+    public string? ProviderName { get; init; }
+
+    public string? ErrorMessage { get; init; }
+
+    public string? ErrorType { get; init; }
+
+    public static PlatformSmokeResult Passed(
+        string platform,
+        long elapsedMilliseconds,
+        int featureCount,
+        string providerName)
+        => new()
+        {
+            Success = true,
+            CompletedAt = DateTimeOffset.UtcNow,
+            Platform = platform,
+            ElapsedMilliseconds = elapsedMilliseconds,
+            FeatureCount = featureCount,
+            ProviderName = providerName,
+        };
+
+    public static PlatformSmokeResult Failed(
+        string platform,
+        long elapsedMilliseconds,
+        string errorMessage,
+        string errorType)
+        => new()
+        {
+            Success = false,
+            CompletedAt = DateTimeOffset.UtcNow,
+            Platform = platform,
+            ElapsedMilliseconds = elapsedMilliseconds,
+            ErrorMessage = errorMessage,
+            ErrorType = errorType,
+        };
+}

--- a/tests/Honua.Mobile.PlatformSmoke/PlatformSmokeRunner.cs
+++ b/tests/Honua.Mobile.PlatformSmoke/PlatformSmokeRunner.cs
@@ -1,0 +1,109 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Honua.Mobile.Sdk;
+using Honua.Mobile.Sdk.Features;
+using Honua.Sdk.Abstractions.Features;
+using Microsoft.Maui.Devices;
+
+namespace Honua.Mobile.PlatformSmoke;
+
+internal sealed class PlatformSmokeRunner
+{
+    public const string ConfigFileName = "honua-mobile-platform-smoke-config.json";
+    public const string ResultFileName = "honua-mobile-platform-smoke-result.json";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+
+    public async Task<PlatformSmokeResult> RunAsync()
+    {
+        PlatformSmokeConfiguration? configuration = null;
+
+        try
+        {
+            configuration = PlatformSmokeConfiguration.Load();
+            var result = await QueryFeatureLayerAsync(configuration).ConfigureAwait(false);
+            await WriteResultAsync(result, configuration.ResultDirectory).ConfigureAwait(false);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            var result = PlatformSmokeResult.Failed(
+                platform: DeviceInfo.Platform.ToString(),
+                elapsedMilliseconds: 0,
+                errorMessage: ex.Message,
+                errorType: ex.GetType().FullName ?? ex.GetType().Name);
+
+            await WriteResultAsync(result, configuration?.ResultDirectory ?? PlatformSmokeConfiguration.DefaultResultDirectory)
+                .ConfigureAwait(false);
+            return result;
+        }
+    }
+
+    private static async Task<PlatformSmokeResult> QueryFeatureLayerAsync(PlatformSmokeConfiguration configuration)
+    {
+        using var http = new HttpClient();
+        using var client = new HonuaMobileClient(http, new HonuaMobileClientOptions
+        {
+            BaseUri = configuration.BaseUri,
+            ApiKey = configuration.ApiKey,
+            PreferGrpcForFeatureQueries = false,
+            PreferGrpcForFeatureEdits = false,
+            Timeout = TimeSpan.FromSeconds(5),
+        });
+
+        IHonuaFeatureQueryClient featureClient = new HonuaMobileSdkFeatureClient(client);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+
+        var stopwatch = Stopwatch.StartNew();
+        FeatureQueryResult query;
+        try
+        {
+            query = await featureClient.QueryAsync(new FeatureQueryRequest
+            {
+                Source = new FeatureSource
+                {
+                    ServiceId = configuration.ServiceId,
+                    LayerId = configuration.LayerId,
+                },
+                Limit = 1,
+            }, timeout.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+        {
+            stopwatch.Stop();
+            return PlatformSmokeResult.Failed(
+                platform: DeviceInfo.Platform.ToString(),
+                elapsedMilliseconds: stopwatch.ElapsedMilliseconds,
+                errorMessage: $"Live feature query exceeded the 1 second smoke budget: {stopwatch.Elapsed}.",
+                errorType: "SmokeBudgetExceeded");
+        }
+
+        stopwatch.Stop();
+
+        if (stopwatch.Elapsed >= TimeSpan.FromSeconds(1))
+        {
+            return PlatformSmokeResult.Failed(
+                platform: DeviceInfo.Platform.ToString(),
+                elapsedMilliseconds: stopwatch.ElapsedMilliseconds,
+                errorMessage: $"Live feature query exceeded the 1 second smoke budget: {stopwatch.Elapsed}.",
+                errorType: "SmokeBudgetExceeded");
+        }
+
+        return PlatformSmokeResult.Passed(
+            platform: DeviceInfo.Platform.ToString(),
+            elapsedMilliseconds: stopwatch.ElapsedMilliseconds,
+            featureCount: query.Features.Count,
+            providerName: featureClient.ProviderName);
+    }
+
+    private static async Task WriteResultAsync(PlatformSmokeResult result, string directory)
+    {
+        Directory.CreateDirectory(directory);
+        var resultPath = Path.Combine(directory, ResultFileName);
+        var json = JsonSerializer.Serialize(result, JsonOptions);
+        await File.WriteAllTextAsync(resultPath, json).ConfigureAwait(false);
+    }
+}

--- a/tests/Honua.Mobile.PlatformSmoke/Platforms/Android/AndroidManifest.xml
+++ b/tests/Honua.Mobile.PlatformSmoke/Platforms/Android/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.INTERNET" />
+  <application android:label="Honua Platform Smoke" android:usesCleartextTraffic="true" />
+</manifest>

--- a/tests/Honua.Mobile.PlatformSmoke/Platforms/Android/MainActivity.cs
+++ b/tests/Honua.Mobile.PlatformSmoke/Platforms/Android/MainActivity.cs
@@ -1,0 +1,17 @@
+using Android.App;
+using Android.Content.PM;
+
+namespace Honua.Mobile.PlatformSmoke;
+
+[Activity(
+    Theme = "@style/Maui.SplashTheme",
+    MainLauncher = true,
+    ConfigurationChanges = ConfigChanges.ScreenSize
+        | ConfigChanges.Orientation
+        | ConfigChanges.UiMode
+        | ConfigChanges.ScreenLayout
+        | ConfigChanges.SmallestScreenSize
+        | ConfigChanges.Density)]
+public sealed class MainActivity : MauiAppCompatActivity
+{
+}

--- a/tests/Honua.Mobile.PlatformSmoke/Platforms/Android/MainApplication.cs
+++ b/tests/Honua.Mobile.PlatformSmoke/Platforms/Android/MainApplication.cs
@@ -1,0 +1,16 @@
+using Android.App;
+using Android.Runtime;
+
+namespace Honua.Mobile.PlatformSmoke;
+
+[Application]
+public sealed class MainApplication : MauiApplication
+{
+    public MainApplication(IntPtr handle, JniHandleOwnership ownership)
+        : base(handle, ownership)
+    {
+    }
+
+    protected override MauiApp CreateMauiApp()
+        => MauiProgram.CreateMauiApp();
+}

--- a/tests/Honua.Mobile.PlatformSmoke/Platforms/iOS/AppDelegate.cs
+++ b/tests/Honua.Mobile.PlatformSmoke/Platforms/iOS/AppDelegate.cs
@@ -1,0 +1,10 @@
+using Foundation;
+
+namespace Honua.Mobile.PlatformSmoke;
+
+[Register("AppDelegate")]
+public sealed class AppDelegate : MauiUIApplicationDelegate
+{
+    protected override MauiApp CreateMauiApp()
+        => MauiProgram.CreateMauiApp();
+}

--- a/tests/Honua.Mobile.PlatformSmoke/Platforms/iOS/Info.plist
+++ b/tests/Honua.Mobile.PlatformSmoke/Platforms/iOS/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>LSRequiresIPhoneOS</key>
+  <true/>
+  <key>UIDeviceFamily</key>
+  <array>
+    <integer>1</integer>
+    <integer>2</integer>
+  </array>
+  <key>UISupportedInterfaceOrientations</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+  </array>
+  <key>UISupportedInterfaceOrientations~ipad</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <string>UIInterfaceOrientationPortraitUpsideDown</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+  </array>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
+</dict>
+</plist>

--- a/tests/Honua.Mobile.PlatformSmoke/Platforms/iOS/Program.cs
+++ b/tests/Honua.Mobile.PlatformSmoke/Platforms/iOS/Program.cs
@@ -1,0 +1,12 @@
+using ObjCRuntime;
+using UIKit;
+
+namespace Honua.Mobile.PlatformSmoke;
+
+public static class Program
+{
+    private static void Main(string[] args)
+    {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/tests/Honua.Mobile.PlatformSmoke/Resources/AppIcon/appicon.svg
+++ b/tests/Honua.Mobile.PlatformSmoke/Resources/AppIcon/appicon.svg
@@ -1,0 +1,5 @@
+<svg width="456" height="456" viewBox="0 0 456 456" xmlns="http://www.w3.org/2000/svg">
+  <rect width="456" height="456" fill="#0F766E"/>
+  <path d="M86 275L228 84l142 191H86z" fill="#F8FAFC"/>
+  <path d="M116 312h224v58H116z" fill="#14B8A6"/>
+</svg>

--- a/tests/Honua.Mobile.PlatformSmoke/Resources/AppIcon/appiconfg.svg
+++ b/tests/Honua.Mobile.PlatformSmoke/Resources/AppIcon/appiconfg.svg
@@ -1,0 +1,4 @@
+<svg width="456" height="456" viewBox="0 0 456 456" xmlns="http://www.w3.org/2000/svg">
+  <path d="M86 275L228 84l142 191H86z" fill="#F8FAFC"/>
+  <path d="M116 312h224v58H116z" fill="#14B8A6"/>
+</svg>

--- a/tests/Honua.Mobile.PlatformSmoke/Resources/Splash/splash.svg
+++ b/tests/Honua.Mobile.PlatformSmoke/Resources/Splash/splash.svg
@@ -1,0 +1,5 @@
+<svg width="456" height="456" viewBox="0 0 456 456" xmlns="http://www.w3.org/2000/svg">
+  <rect width="456" height="456" fill="#0F766E"/>
+  <path d="M96 282L228 104l132 178H96z" fill="#F8FAFC"/>
+  <path d="M130 318h196v46H130z" fill="#14B8A6"/>
+</svg>

--- a/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
@@ -18,6 +18,7 @@ using Honua.Sdk.Abstractions.Routing;
 using Honua.Sdk.Abstractions.Scenes;
 using Honua.Sdk.GeoServices.FeatureServer.Models;
 using Honua.Sdk.OgcFeatures.Models;
+using SdkFeatureClient = Honua.Mobile.Sdk.Features.HonuaMobileSdkFeatureClient;
 
 namespace Honua.Mobile.ServerIntegration.Tests;
 
@@ -158,6 +159,28 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
                 await DeleteFeatureServerFeatureAsync(client, sdkObjectId.Value);
             }
         }
+    }
+
+    [Fact]
+    public async Task LiveImage_MobileSdkFeatureClientAdapter_QuerySmoke()
+    {
+        if (!_server.Enabled)
+        {
+            return;
+        }
+
+        using var client = CreateMobileClient(preferGrpc: false);
+        IHonuaFeatureQueryClient featureClient = new SdkFeatureClient(client);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var result = await featureClient.QueryAsync(new FeatureQueryRequest
+        {
+            Source = FeatureSource(),
+            Limit = 1,
+        }, timeout.Token);
+
+        Assert.Equal("honua-mobile", featureClient.ProviderName);
+        Assert.NotNull(result.Features);
     }
 
     [Fact]

--- a/tests/Honua.Mobile.Smoke.Tests/PlatformSmokeScriptTests.cs
+++ b/tests/Honua.Mobile.Smoke.Tests/PlatformSmokeScriptTests.cs
@@ -1,0 +1,101 @@
+using System.Diagnostics;
+
+namespace Honua.Mobile.Smoke.Tests;
+
+public sealed class PlatformSmokeScriptTests
+{
+    [Theory]
+    [InlineData("run-android-platform-smoke.sh", "Skipping Android live Honua platform smoke")]
+    [InlineData("run-ios-platform-smoke.sh", "Skipping iOS live Honua platform smoke")]
+    public void PlatformSmokeScript_SkipsWhenLiveHonuaConfigIsMissing(string scriptName, string expectedMessage)
+    {
+        if (!IsBashAvailable())
+        {
+            return;
+        }
+
+        var root = FindRepositoryRoot();
+        var result = RunScript(root, scriptName);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains(expectedMessage, result.Output);
+    }
+
+    private static ScriptResult RunScript(string root, string scriptName)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "bash",
+            WorkingDirectory = root,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        startInfo.ArgumentList.Add(Path.Combine(root, "scripts", scriptName));
+        startInfo.Environment.Remove("HONUA_MOBILE_SMOKE_BASE_URL");
+        startInfo.Environment.Remove("HONUA_MOBILE_SMOKE_SERVICE_ID");
+        startInfo.Environment.Remove("HONUA_MOBILE_SMOKE_LAYER_ID");
+        startInfo.Environment.Remove("HONUA_MOBILE_SMOKE_API_KEY");
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Failed to start {scriptName}.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        return new ScriptResult(process.ExitCode, stdout + stderr);
+    }
+
+    private static bool IsBashAvailable()
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "bash",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            startInfo.ArgumentList.Add("--version");
+
+            using var process = Process.Start(startInfo);
+            if (process is null)
+            {
+                return false;
+            }
+
+            if (!process.WaitForExit(2000))
+            {
+                process.Kill(entireProcessTree: true);
+                return false;
+            }
+
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            var agentsPath = Path.Combine(directory.FullName, "AGENTS.md");
+            var docsPath = Path.Combine(directory.FullName, "docs");
+
+            if (File.Exists(agentsPath) && Directory.Exists(docsPath))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root from test output directory.");
+    }
+
+    private sealed record ScriptResult(int ExitCode, string Output);
+}


### PR DESCRIPTION
## Summary

- Add a MAUI platform-smoke app that queries a configured public feature layer through the existing `HonuaMobileSdkFeatureClient` / `IHonuaFeatureQueryClient` surface.
- Wire Android API 33 emulator and iOS simulator smoke scripts into the existing MAUI CI jobs.
- Document required smoke variables/secrets and add live-image adapter coverage for the mobile SDK feature client.

## Combined Scope

This intentionally combines honua-server #827 and #828. The iOS and Android acceptance criteria share the same live-query harness, result marker contract, repository variables/secrets, CI change detection, and DevOps documentation. Splitting the work would duplicate the app and scripts without creating a cleaner review boundary; `/home/makani/worktrees/honua-mobile-828` has no independent diff.

## Platform Testing

Android platform smoke is wired to the API 33 emulator job and iOS platform smoke is wired to the macOS simulator job. Both scripts install the same MAUI smoke app, inject the configured live layer settings, and fail when the result marker reports failure or the query exceeds one second.

## Testing

- `dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --filter LiveImage_MobileSdkFeatureClientAdapter_QuerySmoke`
- `bash -n scripts/run-android-platform-smoke.sh scripts/run-ios-platform-smoke.sh`
- `git diff --check`
- Attempted `dotnet build tests/Honua.Mobile.PlatformSmoke/Honua.Mobile.PlatformSmoke.csproj --configuration Debug --framework net10.0-android /p:TreatWarningsAsErrors=true`; local build is blocked by missing Android SDK path (`XA5300`).
- iOS simulator/AOT smoke was not run locally because this workspace is on Linux.

Fixes honua-io/honua-server#827
Fixes honua-io/honua-server#828
