### PR TITLE
docs(embed): document display adapter page appends

### DIFF
--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -197,6 +197,10 @@ display.setFeatureQueryResults([assetPage, workOrderPage], (_page, index) => ({
   source: index === 0 ? assetSource : workOrderSource,
 }));
 
+display.appendFeatureQueryResult(assetPage2, {
+  source: assetSource,
+});
+
 const assets = display.getFeatureCollection('honua-assets');
 display.removeLayer('honua-work-orders');
 display.clearFeatureLayers();
@@ -204,7 +208,9 @@ display.clearFeatureLayers();
 
 `clearFeatureLayers()` only removes layers created by feature query and stream
 helpers. Host-owned deck.gl layers passed to the adapter constructor remain in
-place.
+place. When appending pages, pass the SDK source descriptor whenever the host is
+loading more than one source; the adapter resolves the incoming result source
+before falling back to its single cached feature layer.
 
 Streaming feature feeds can use the same renderer-neutral source descriptor and
 apply upsert/delete events into the adapter's GeoJSON layer state:

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -51,6 +51,7 @@ display.fitToSource(sourceDescriptor, { padding: 32 });
 The adapter keeps MapLibre responsible for the base map and camera while deck.gl
 owns Honua feature overlays. Use `setView(...)` for imperative center/zoom or
 bounds changes, `setFeatureQueryResults(...)` for query batches,
+`appendFeatureQueryResult(...)` for paged query results from the same source,
 `getFeatureCollection(...)` for cached GeoJSON, and `removeLayer(...)` or
 `clearFeatureLayers()` when a host screen changes active sources.
 


### PR DESCRIPTION
## Summary
- document appendFeatureQueryResult for paged MapLibre/deck.gl display adapter flows
- clarify that multi-source append callers should pass the SDK source descriptor so incoming sources are resolved before cached layer fallback

## Validation
- npm test -- tests/display-adapter.test.ts
- npm run typecheck

## Context
The MapLibre/deck.gl adapter implementation and focused append-source test are already on main from #127. This PR adds the remaining usage docs for the closure slice.

Closes #50