### PR TITLE
feat(embed): package iframe fallback shell

### DIFF
--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -128,7 +128,8 @@ from the query string, and forwards `honua-map-ready`,
 `honua-map-config-change`, `honua-map-search`, and `honua-map-identify` to the
 embedding window with `{ source: 'honua-map-iframe', version: 1, type, detail }`.
 Set `parentOrigin` to constrain forwarded messages to the host application
-origin.
+origin. If a `parent-origin` query value is malformed, the iframe disables
+parent event forwarding instead of falling back to `*`.
 
 ## Integration Events
 

--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -99,7 +99,9 @@ applyHonuaMapOptions(document.querySelector('honua-map'), {
 
 For hosts that cannot use web components, generate an iframe fallback with the
 same option shape. Map options are serialized into the iframe URL query string,
-and `apiKey` is omitted unless `includeCredentials: true` is set.
+and `apiKey` is omitted unless `includeCredentials: true` is set. The npm/CDN
+build packages the fallback shell at `dist/embed/map.html`; the default snippet
+URL assumes that file is hosted as `https://cdn.honua.dev/embed/map.html`.
 
 ```js
 import { createHonuaMapIframeSnippet } from '@honua-io/embed/snippets';
@@ -114,11 +116,19 @@ const snippet = createHonuaMapIframeSnippet({
   label: 'City asset map',
 }, {
   iframeUrl: 'https://cdn.honua.dev/embed/map.html',
+  parentOrigin: 'https://portal.example.com',
   iframe: {
     title: 'City asset map',
   },
 });
 ```
+
+The fallback shell imports `../iframe.js`, creates a full-frame `<honua-map>`
+from the query string, and forwards `honua-map-ready`,
+`honua-map-config-change`, `honua-map-search`, and `honua-map-identify` to the
+embedding window with `{ source: 'honua-map-iframe', version: 1, type, detail }`.
+Set `parentOrigin` to constrain forwarded messages to the host application
+origin.
 
 ## Integration Events
 
@@ -273,9 +283,10 @@ original error.
 
 `<honua-map>` provides the declarative, white-label web component shell, Shadow
 DOM encapsulation, theme hooks, generated snippets, host extension controls,
-accessible controls, search events, and identify events. Production map
-rendering should use the MapLibre/deck.gl adapter above until the custom element
-owns a full renderer lifecycle. Follow-on work can add feature loading,
-analytics, binary deck.gl attribute batches, and framework-specific wrappers.
+accessible controls, iframe fallback packaging, search events, and identify
+events. Production map rendering should use the MapLibre/deck.gl adapter above
+until the custom element owns a full renderer lifecycle. Follow-on work can add
+feature loading, analytics, binary deck.gl attribute batches, admin embed-builder
+screens, and framework-specific wrappers.
 
 For 3D Tiles and CesiumJS-based scenes, use the [`<honua-scene>` guide](3d-scene-embed.md).

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -256,7 +256,9 @@ entrypoint.
 
 For hosts that cannot load custom elements, use `createHonuaMapIframeSnippet`.
 Map options are encoded into the iframe URL query string, with `apiKey` omitted
-unless `includeCredentials: true` is passed.
+unless `includeCredentials: true` is passed. The package build includes the
+static fallback shell at `dist/embed/map.html`; CDN deployments can serve that
+file as `https://cdn.honua.dev/embed/map.html`.
 
 ```ts
 import { createHonuaMapIframeSnippet } from '@honua-io/embed/snippets';
@@ -269,11 +271,19 @@ const snippet = createHonuaMapIframeSnippet({
   label: 'City asset map',
 }, {
   iframeUrl: 'https://cdn.honua.dev/embed/map.html',
+  parentOrigin: 'https://portal.example.com',
   iframe: {
     title: 'City asset map',
   },
 });
 ```
+
+The iframe shell imports `../iframe.js`, hydrates a full-frame `<honua-map>`
+from the query string, and forwards `honua-map-ready`,
+`honua-map-config-change`, `honua-map-search`, and `honua-map-identify` to the
+parent window with `{ source: 'honua-map-iframe', version: 1, type, detail }`.
+Set `parentOrigin` when generating snippets so forwarded messages are scoped to
+the embedding application origin.
 
 Use `applyHonuaMapOptions(element, options)` to apply the same options shape to
 an existing map element at runtime.

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -284,7 +284,8 @@ from the query string, and forwards `honua-map-ready`,
 `honua-map-config-change`, `honua-map-search`, and `honua-map-identify` to the
 parent window with `{ source: 'honua-map-iframe', version: 1, type, detail }`.
 Set `parentOrigin` when generating snippets so forwarded messages are scoped to
-the embedding application origin.
+the embedding application origin. If a `parent-origin` query value is malformed,
+the iframe disables parent event forwarding instead of falling back to `*`.
 
 Use `applyHonuaMapOptions(element, options)` to apply the same options shape to
 an existing map element at runtime.

--- a/src/Honua.Embed/package.json
+++ b/src/Honua.Embed/package.json
@@ -22,6 +22,10 @@
     "./snippets": {
       "types": "./dist/snippets.d.ts",
       "import": "./dist/snippets.js"
+    },
+    "./iframe": {
+      "types": "./dist/iframe.d.ts",
+      "import": "./dist/iframe.js"
     }
   },
   "files": [

--- a/src/Honua.Embed/public/embed/map.html
+++ b/src/Honua.Embed/public/embed/map.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Embedded map</title>
+    <style>
+      html,
+      body,
+      #honua-map-frame-root {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+      }
+
+      body {
+        overflow: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="honua-map-frame-root"></div>
+    <script type="module">
+      import { hydrateHonuaMapIframe } from '../iframe.js';
+
+      hydrateHonuaMapIframe();
+    </script>
+  </body>
+</html>

--- a/src/Honua.Embed/scripts/copy-cesium-assets.mjs
+++ b/src/Honua.Embed/scripts/copy-cesium-assets.mjs
@@ -1,10 +1,17 @@
-import { cpSync, mkdirSync, rmSync } from 'node:fs';
+import { copyFileSync, cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const cesiumRoot = join(packageRoot, 'node_modules', 'cesium', 'Build', 'Cesium');
+const distRoot = join(packageRoot, 'dist');
 const targetRoot = join(packageRoot, 'dist', 'cesium');
+
+const indexEntry = join(distRoot, 'index.js');
+const cdnEntry = join(distRoot, 'embed.js');
+if (existsSync(indexEntry)) {
+  copyFileSync(indexEntry, cdnEntry);
+}
 
 rmSync(targetRoot, { recursive: true, force: true });
 mkdirSync(targetRoot, { recursive: true });

--- a/src/Honua.Embed/src/iframe.ts
+++ b/src/Honua.Embed/src/iframe.ts
@@ -1,0 +1,268 @@
+import { defineHonuaMapElement, type HonuaMapElement } from './map';
+import {
+  applyHonuaMapOptions,
+  type HonuaMapEmbedOptions,
+  type HonuaMapThemeOptions,
+} from './snippets';
+
+export interface HonuaMapIframeConfig {
+  options: HonuaMapEmbedOptions;
+  parentOrigin: string;
+}
+
+export interface HonuaMapIframeMessage {
+  source: 'honua-map-iframe';
+  version: 1;
+  type: string;
+  detail: unknown;
+}
+
+export interface HonuaMapIframeMessageTarget {
+  postMessage(message: HonuaMapIframeMessage, targetOrigin: string): void;
+}
+
+export interface HonuaMapIframeHydrateOptions {
+  window?: Window;
+  element?: HonuaMapElement | null;
+  parent?: HonuaMapIframeMessageTarget | null;
+  targetOrigin?: string | null;
+}
+
+export interface HonuaMapIframeRuntime {
+  element: HonuaMapElement;
+  config: HonuaMapIframeConfig;
+  disconnect(): void;
+}
+
+const FORWARDED_EVENTS = [
+  'honua-map-ready',
+  'honua-map-config-change',
+  'honua-map-search',
+  'honua-map-identify',
+] as const;
+
+const THEME_PARAMETERS: Array<[keyof HonuaMapThemeOptions, string]> = [
+  ['accent', '--honua-map-accent'],
+  ['background', '--honua-map-background'],
+  ['foreground', '--honua-map-foreground'],
+  ['muted', '--honua-map-muted'],
+  ['surface', '--honua-map-surface'],
+  ['border', '--honua-map-border'],
+  ['fontFamily', '--honua-map-font-family'],
+  ['controlSize', '--honua-map-control-size'],
+];
+
+export function parseHonuaMapIframeConfig(
+  input: URL | URLSearchParams | string | null | undefined = defaultLocation(),
+): HonuaMapIframeConfig {
+  const params = searchParamsFrom(input);
+  const style = parseThemeOptions(params);
+  const options: HonuaMapEmbedOptions = {
+    serviceUrl: param(params, 'service-url'),
+    layerIds: parseList(param(params, 'layer-ids')),
+    apiKey: param(params, 'api-key'),
+    center: parseCoordinate(param(params, 'center')),
+    zoom: parseNumber(param(params, 'zoom')),
+    bounds: parseBounds(param(params, 'bbox')),
+    basemap: param(params, 'basemap'),
+    interactive: parseBoolean(params, 'interactive'),
+    search: parseBoolean(params, 'search'),
+    identify: parseBoolean(params, 'identify'),
+    attribution: param(params, 'attribution'),
+    theme: parseTheme(param(params, 'theme')),
+    label: param(params, 'label'),
+    style: Object.keys(style).length > 0 ? style : undefined,
+  };
+
+  return {
+    options,
+    parentOrigin: parseParentOrigin(param(params, 'parent-origin')),
+  };
+}
+
+export function hydrateHonuaMapIframe(
+  options: HonuaMapIframeHydrateOptions = {},
+): HonuaMapIframeRuntime {
+  const targetWindow = options.window ?? window;
+  const document = targetWindow.document;
+  defineHonuaMapElement();
+
+  const config = parseHonuaMapIframeConfig(targetWindow.location.href);
+  const element = options.element
+    ?? document.querySelector<HonuaMapElement>('honua-map')
+    ?? document.createElement('honua-map') as HonuaMapElement;
+
+  applyHonuaMapOptions(element, config.options);
+  applyFrameSizing(element);
+
+  const parent = options.parent === undefined ? targetWindow.parent : options.parent;
+  const targetOrigin = options.targetOrigin?.trim() || config.parentOrigin;
+  const disconnect = parent && parent !== targetWindow
+    ? bridgeMapEvents(element, parent, targetOrigin)
+    : () => {};
+
+  if (!element.isConnected) {
+    const mount = document.getElementById('honua-map-frame-root')
+      ?? document.body
+      ?? document.documentElement;
+    mount.append(element);
+  }
+
+  return { element, config, disconnect };
+}
+
+function bridgeMapEvents(
+  element: HonuaMapElement,
+  parent: HonuaMapIframeMessageTarget,
+  targetOrigin: string,
+): () => void {
+  const listeners = FORWARDED_EVENTS.map((type) => {
+    const listener: EventListener = (event) => {
+      parent.postMessage({
+        source: 'honua-map-iframe',
+        version: 1,
+        type,
+        detail: 'detail' in event ? event.detail : undefined,
+      }, targetOrigin);
+    };
+
+    element.addEventListener(type, listener);
+    return () => element.removeEventListener(type, listener);
+  });
+
+  return () => {
+    for (const remove of listeners) {
+      remove();
+    }
+  };
+}
+
+function applyFrameSizing(element: HTMLElement): void {
+  element.style.display = 'block';
+  element.style.width = '100%';
+  element.style.height = '100%';
+  element.style.minHeight = '100vh';
+}
+
+function searchParamsFrom(
+  input: URL | URLSearchParams | string | null | undefined,
+): URLSearchParams {
+  if (input instanceof URLSearchParams) {
+    return new URLSearchParams(input);
+  }
+
+  if (input instanceof URL) {
+    return new URLSearchParams(input.searchParams);
+  }
+
+  const value = input ?? 'https://cdn.honua.dev/embed/map.html';
+  return new URL(value, 'https://cdn.honua.dev').searchParams;
+}
+
+function defaultLocation(): string {
+  if (typeof location === 'undefined') {
+    return 'https://cdn.honua.dev/embed/map.html';
+  }
+
+  return location.href;
+}
+
+function param(params: URLSearchParams, name: string): string | undefined {
+  const value = params.get(name)?.trim();
+  return value ? value : undefined;
+}
+
+function parseList(value: string | undefined): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const items = value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return items.length > 0 ? items : undefined;
+}
+
+function parseCoordinate(value: string | undefined): HonuaMapEmbedOptions['center'] {
+  const [latitude, longitude] = parseNumberList(value, 2);
+  if (latitude === undefined || longitude === undefined) {
+    return undefined;
+  }
+
+  return { latitude, longitude };
+}
+
+function parseBounds(value: string | undefined): HonuaMapEmbedOptions['bounds'] {
+  const [minLongitude, minLatitude, maxLongitude, maxLatitude] = parseNumberList(value, 4);
+  if (
+    minLongitude === undefined
+    || minLatitude === undefined
+    || maxLongitude === undefined
+    || maxLatitude === undefined
+  ) {
+    return undefined;
+  }
+
+  return { minLongitude, minLatitude, maxLongitude, maxLatitude };
+}
+
+function parseNumberList(value: string | undefined, expectedLength: number): number[] {
+  const values = parseList(value);
+  if (values?.length !== expectedLength) {
+    return [];
+  }
+
+  const parsed = values.map(Number);
+  return parsed.every(Number.isFinite) ? parsed : [];
+}
+
+function parseNumber(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseBoolean(params: URLSearchParams, name: string): boolean | undefined {
+  if (!params.has(name)) {
+    return undefined;
+  }
+
+  const value = params.get(name)?.trim() ?? '';
+  if (value === '') {
+    return true;
+  }
+
+  return !['false', '0', 'no'].includes(value.toLowerCase());
+}
+
+function parseTheme(value: string | undefined): HonuaMapEmbedOptions['theme'] {
+  return value === 'dark' || value === 'light' ? value : undefined;
+}
+
+function parseThemeOptions(params: URLSearchParams): HonuaMapThemeOptions {
+  const style: HonuaMapThemeOptions = {};
+  for (const [key, parameter] of THEME_PARAMETERS) {
+    const value = param(params, parameter);
+    if (value !== undefined) {
+      style[key] = value;
+    }
+  }
+
+  return style;
+}
+
+function parseParentOrigin(value: string | undefined): string {
+  if (value === undefined || value === '*') {
+    return '*';
+  }
+
+  try {
+    return new URL(value).origin;
+  } catch {
+    return '*';
+  }
+}

--- a/src/Honua.Embed/src/iframe.ts
+++ b/src/Honua.Embed/src/iframe.ts
@@ -7,7 +7,7 @@ import {
 
 export interface HonuaMapIframeConfig {
   options: HonuaMapEmbedOptions;
-  parentOrigin: string;
+  parentOrigin: string | null;
 }
 
 export interface HonuaMapIframeMessage {
@@ -97,7 +97,7 @@ export function hydrateHonuaMapIframe(
 
   const parent = options.parent === undefined ? targetWindow.parent : options.parent;
   const targetOrigin = options.targetOrigin?.trim() || config.parentOrigin;
-  const disconnect = parent && parent !== targetWindow
+  const disconnect = parent && parent !== targetWindow && targetOrigin
     ? bridgeMapEvents(element, parent, targetOrigin)
     : () => {};
 
@@ -255,7 +255,7 @@ function parseThemeOptions(params: URLSearchParams): HonuaMapThemeOptions {
   return style;
 }
 
-function parseParentOrigin(value: string | undefined): string {
+function parseParentOrigin(value: string | undefined): string | null {
   if (value === undefined || value === '*') {
     return '*';
   }
@@ -263,6 +263,6 @@ function parseParentOrigin(value: string | undefined): string {
   try {
     return new URL(value).origin;
   } catch {
-    return '*';
+    return null;
   }
 }

--- a/src/Honua.Embed/src/snippets.ts
+++ b/src/Honua.Embed/src/snippets.ts
@@ -69,6 +69,7 @@ export interface HonuaMapIframeAttributes {
 export interface HonuaMapIframeSnippetOptions {
   iframeUrl?: string;
   includeCredentials?: boolean;
+  parentOrigin?: string | null;
   iframe?: HonuaMapIframeAttributes;
   indent?: string;
 }
@@ -174,7 +175,10 @@ export function createHonuaMapIframeSnippet(
   snippetOptions: HonuaMapIframeSnippetOptions = {},
 ): string {
   const iframeUrl = snippetOptions.iframeUrl ?? 'https://cdn.honua.dev/embed/map.html';
-  const src = createIframeSrc(iframeUrl, options, snippetOptions.includeCredentials ?? false);
+  const src = createIframeSrc(iframeUrl, options, {
+    includeCredentials: snippetOptions.includeCredentials ?? false,
+    parentOrigin: snippetOptions.parentOrigin,
+  });
   const attributes = iframeAttributes(src, snippetOptions.iframe);
   const indent = snippetOptions.indent ?? '  ';
   const lines = attributes.map(([name, value]) => (
@@ -246,11 +250,19 @@ function createElementMarkup(
 function createIframeSrc(
   iframeUrl: string,
   options: HonuaMapEmbedOptions,
-  includeCredentials: boolean,
+  config: {
+    includeCredentials: boolean;
+    parentOrigin?: string | null;
+  },
 ): string {
   const url = new URL(iframeUrl, 'https://cdn.honua.dev');
-  for (const [name, value] of mapQueryParameters(options, includeCredentials)) {
+  for (const [name, value] of mapQueryParameters(options, config.includeCredentials)) {
     url.searchParams.set(name, value);
+  }
+
+  const parentOrigin = config.parentOrigin?.trim();
+  if (parentOrigin) {
+    url.searchParams.set('parent-origin', parentOrigin);
   }
 
   if (isAbsoluteUrl(iframeUrl)) {

--- a/src/Honua.Embed/tests/honua-iframe.test.ts
+++ b/src/Honua.Embed/tests/honua-iframe.test.ts
@@ -61,6 +61,9 @@ describe('honua map iframe fallback', () => {
     const flagConfig = parseHonuaMapIframeConfig(new URLSearchParams('search&interactive=false'));
     expect(flagConfig.options.search).toBe(true);
     expect(flagConfig.options.interactive).toBe(false);
+
+    const invalidOriginConfig = parseHonuaMapIframeConfig(new URLSearchParams('parent-origin=portal.example.test'));
+    expect(invalidOriginConfig.parentOrigin).toBeNull();
   });
 
   it('hydrates a full-frame map element from the current URL', () => {
@@ -117,5 +120,22 @@ describe('honua map iframe fallback', () => {
     }));
 
     expect(parent.postMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not forward events when parent-origin is invalid', () => {
+    const url = new URL('/embed/map.html', window.location.href);
+    url.searchParams.set('parent-origin', 'portal.example.test');
+    window.history.replaceState(null, '', url);
+    const parent = {
+      postMessage: vi.fn<(message: HonuaMapIframeMessage, targetOrigin: string) => void>(),
+    };
+
+    const runtime = hydrateHonuaMapIframe({ parent });
+    runtime.element.dispatchEvent(new CustomEvent('honua-map-search', {
+      detail: { query: 'hydrants' },
+    }));
+
+    expect(runtime.config.parentOrigin).toBeNull();
+    expect(parent.postMessage).not.toHaveBeenCalled();
   });
 });

--- a/src/Honua.Embed/tests/honua-iframe.test.ts
+++ b/src/Honua.Embed/tests/honua-iframe.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  hydrateHonuaMapIframe,
+  parseHonuaMapIframeConfig,
+  type HonuaMapIframeMessage,
+} from '../src/iframe';
+
+describe('honua map iframe fallback', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    window.history.replaceState(null, '', '/embed/map.html');
+  });
+
+  it('parses map options and parent origin from iframe query parameters', () => {
+    const url = new URL('/embed/map.html', window.location.href);
+    url.searchParams.set('service-url', 'https://services.example.test/FeatureServer');
+    url.searchParams.set('layer-ids', 'assets, work-orders');
+    url.searchParams.set('api-key', 'public-browser-key');
+    url.searchParams.set('center', '21.3069,-157.8583');
+    url.searchParams.set('zoom', '12');
+    url.searchParams.set('bbox', '-158.3,21.2,-157.6,21.6');
+    url.searchParams.set('basemap', 'dark');
+    url.searchParams.set('interactive', 'true');
+    url.searchParams.set('search', 'true');
+    url.searchParams.set('identify', 'true');
+    url.searchParams.set('attribution', 'City GIS');
+    url.searchParams.set('theme', 'dark');
+    url.searchParams.set('label', 'City asset map');
+    url.searchParams.set('--honua-map-accent', '#0f766e');
+    url.searchParams.set('--honua-map-font-family', 'Aptos, sans-serif');
+    url.searchParams.set('parent-origin', 'https://portal.example.test/admin');
+
+    const config = parseHonuaMapIframeConfig(url);
+
+    expect(config.parentOrigin).toBe('https://portal.example.test');
+    expect(config.options).toMatchObject({
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      layerIds: ['assets', 'work-orders'],
+      apiKey: 'public-browser-key',
+      center: { latitude: 21.3069, longitude: -157.8583 },
+      zoom: 12,
+      bounds: {
+        minLongitude: -158.3,
+        minLatitude: 21.2,
+        maxLongitude: -157.6,
+        maxLatitude: 21.6,
+      },
+      basemap: 'dark',
+      interactive: true,
+      search: true,
+      identify: true,
+      attribution: 'City GIS',
+      theme: 'dark',
+      label: 'City asset map',
+      style: {
+        accent: '#0f766e',
+        fontFamily: 'Aptos, sans-serif',
+      },
+    });
+
+    const flagConfig = parseHonuaMapIframeConfig(new URLSearchParams('search&interactive=false'));
+    expect(flagConfig.options.search).toBe(true);
+    expect(flagConfig.options.interactive).toBe(false);
+  });
+
+  it('hydrates a full-frame map element from the current URL', () => {
+    const mount = document.createElement('div');
+    mount.id = 'honua-map-frame-root';
+    document.body.append(mount);
+    const url = new URL('/embed/map.html', window.location.href);
+    url.searchParams.set('service-url', 'https://services.example.test/FeatureServer');
+    url.searchParams.set('layer-ids', 'assets');
+    url.searchParams.set('search', 'true');
+    url.searchParams.set('--honua-map-accent', '#0f766e');
+    window.history.replaceState(null, '', url);
+
+    const runtime = hydrateHonuaMapIframe({ parent: null });
+
+    expect(mount.querySelector('honua-map')).toBe(runtime.element);
+    expect(runtime.element.getAttribute('service-url')).toBe('https://services.example.test/FeatureServer');
+    expect(runtime.element.getAttribute('layer-ids')).toBe('assets');
+    expect(runtime.element.hasAttribute('search')).toBe(true);
+    expect(runtime.element.style.getPropertyValue('--honua-map-accent')).toBe('#0f766e');
+    expect(runtime.element.style.height).toBe('100%');
+  });
+
+  it('forwards map events to the parent frame with the scoped target origin', () => {
+    const url = new URL('/embed/map.html', window.location.href);
+    url.searchParams.set('label', 'City asset map');
+    url.searchParams.set('parent-origin', 'https://portal.example.test');
+    window.history.replaceState(null, '', url);
+    const parent = {
+      postMessage: vi.fn<(message: HonuaMapIframeMessage, targetOrigin: string) => void>(),
+    };
+
+    const runtime = hydrateHonuaMapIframe({ parent });
+    runtime.element.dispatchEvent(new CustomEvent('honua-map-search', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        query: 'hydrants',
+      },
+    }));
+
+    expect(parent.postMessage).toHaveBeenLastCalledWith({
+      source: 'honua-map-iframe',
+      version: 1,
+      type: 'honua-map-search',
+      detail: {
+        query: 'hydrants',
+      },
+    }, 'https://portal.example.test');
+
+    runtime.disconnect();
+    runtime.element.dispatchEvent(new CustomEvent('honua-map-identify', {
+      detail: { x: 12, y: 34 },
+    }));
+
+    expect(parent.postMessage).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/Honua.Embed/tests/honua-snippets.test.ts
+++ b/src/Honua.Embed/tests/honua-snippets.test.ts
@@ -208,6 +208,7 @@ describe('honua map snippets', () => {
       },
     }, {
       iframeUrl: 'https://embed.example.test/map.html?tenant=city',
+      parentOrigin: 'https://portal.example.test/admin/embed',
     });
 
     const src = readIframe(snippet).getAttribute('src');
@@ -215,6 +216,7 @@ describe('honua map snippets', () => {
 
     expect(url.origin).toBe('https://embed.example.test');
     expect(url.searchParams.get('tenant')).toBe('city');
+    expect(url.searchParams.get('parent-origin')).toBe('https://portal.example.test/admin/embed');
     expect(url.searchParams.get('service-url')).toBe('https://services.example.test/FeatureServer');
     expect(url.searchParams.get('layer-ids')).toBe('assets,work-orders');
     expect(url.searchParams.get('center')).toBe('21.3069,-157.8583');

--- a/src/Honua.Embed/vite.config.ts
+++ b/src/Honua.Embed/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     lib: {
       entry: {
         index: resolve(__dirname, 'src/index.ts'),
+        iframe: resolve(__dirname, 'src/iframe.ts'),
         snippets: resolve(__dirname, 'src/snippets.ts'),
       },
       formats: ['es'],


### PR DESCRIPTION
## Summary
- add a packaged iframe fallback runtime that hydrates <honua-map> from query parameters and forwards map events to the parent frame
- include the static dist/embed/map.html shell and dist/embed.js CDN alias in the embed package build
- document the iframe fallback, parentOrigin scoping, and package artifacts

Refs #10

## Tests
- npm run typecheck
- npm test
- npm run build
- node -e "const {spawnSync}=require('node:child_process'); const r=spawnSync('npm',['pack','--dry-run','--json'],{encoding:'utf8'}); if (r.status !== 0) { process.stderr.write(r.stderr); process.exit(r.status ?? 1); } const files=JSON.parse(r.stdout)[0].files.map(f=>f.path); for (const path of ['dist/embed.js','dist/embed/map.html','dist/iframe.js','dist/iframe.d.ts']) console.log(path + ': ' + files.includes(path));"