### PR TITLE
test: validate mobile .NET SDK release train

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+  <PropertyGroup>
+    <HonuaSdkDotNetTrainVersion>0.1.16-alpha.1</HonuaSdkDotNetTrainVersion>
+    <HonuaSdkDotNetTrainTag>dotnet-sdk-v$(HonuaSdkDotNetTrainVersion)</HonuaSdkDotNetTrainTag>
+    <HonuaSdkDotNetTrainRepository>honua-io/honua-sdk-dotnet</HonuaSdkDotNetTrainRepository>
+    <HonuaSdkDotNetTrainReleaseUrl>https://github.com/honua-io/honua-sdk-dotnet/releases/tag/$(HonuaSdkDotNetTrainTag)</HonuaSdkDotNetTrainReleaseUrl>
+    <HonuaSdkDotNetTrainReleaseCommit>f31cfeb6c21af896b96194688a393638461f3d8a</HonuaSdkDotNetTrainReleaseCommit>
+    <HonuaSdkDotNetTrainReleasePublishedAt>2026-05-07T08:52:04Z</HonuaSdkDotNetTrainReleasePublishedAt>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,10 @@
 <Project>
   <PropertyGroup>
-    <HonuaSdkDotNetTrainVersion>0.1.16-alpha.1</HonuaSdkDotNetTrainVersion>
+    <HonuaSdkDotNetTrainVersion>0.1.15-alpha.1</HonuaSdkDotNetTrainVersion>
     <HonuaSdkDotNetTrainTag>dotnet-sdk-v$(HonuaSdkDotNetTrainVersion)</HonuaSdkDotNetTrainTag>
     <HonuaSdkDotNetTrainRepository>honua-io/honua-sdk-dotnet</HonuaSdkDotNetTrainRepository>
     <HonuaSdkDotNetTrainReleaseUrl>https://github.com/honua-io/honua-sdk-dotnet/releases/tag/$(HonuaSdkDotNetTrainTag)</HonuaSdkDotNetTrainReleaseUrl>
-    <HonuaSdkDotNetTrainReleaseCommit>f31cfeb6c21af896b96194688a393638461f3d8a</HonuaSdkDotNetTrainReleaseCommit>
-    <HonuaSdkDotNetTrainReleasePublishedAt>2026-05-07T08:52:04Z</HonuaSdkDotNetTrainReleasePublishedAt>
+    <HonuaSdkDotNetTrainReleaseCommit>9d264e358099dc20a30b9247013b61d1fba0b0a9</HonuaSdkDotNetTrainReleaseCommit>
+    <HonuaSdkDotNetTrainReleasePublishedAt>2026-04-30T23:32:50Z</HonuaSdkDotNetTrainReleasePublishedAt>
   </PropertyGroup>
 </Project>

--- a/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
+++ b/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
@@ -11,39 +11,39 @@
     },
     "sdkBaseline": {
       "repository": "honua-io/honua-sdk-dotnet",
-      "ref": "trunk after dotnet-sdk-v0.1.8-alpha.1",
+      "ref": "dotnet-sdk-v0.1.16-alpha.1",
       "packages": [
         {
           "packageId": "Honua.Sdk.Abstractions",
-          "version": "0.1.8-alpha.1"
+          "version": "0.1.16-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.Offline.Abstractions",
-          "version": "0.1.8-alpha.1"
+          "version": "0.1.16-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.Offline",
-          "version": "0.1.8-alpha.1"
+          "version": "0.1.16-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.Grpc",
-          "version": "0.1.8-alpha.1"
+          "version": "0.1.16-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.GeoServices",
-          "version": "0.1.8-alpha.1"
+          "version": "0.1.16-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.Scenes",
-          "version": "0.1.8-alpha.1"
+          "version": "0.1.16-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.OgcFeatures",
-          "version": "0.1.8-alpha.1"
+          "version": "0.1.16-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.Field",
-          "version": "0.1.8-alpha.1"
+          "version": "0.1.16-alpha.1"
         }
       ]
     }

--- a/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
+++ b/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
@@ -11,39 +11,39 @@
     },
     "sdkBaseline": {
       "repository": "honua-io/honua-sdk-dotnet",
-      "ref": "dotnet-sdk-v0.1.16-alpha.1",
+      "ref": "dotnet-sdk-v0.1.15-alpha.1",
       "packages": [
         {
           "packageId": "Honua.Sdk.Abstractions",
-          "version": "0.1.16-alpha.1"
+          "version": "0.1.15-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.Offline.Abstractions",
-          "version": "0.1.16-alpha.1"
+          "version": "0.1.15-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.Offline",
-          "version": "0.1.16-alpha.1"
+          "version": "0.1.15-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.Grpc",
-          "version": "0.1.16-alpha.1"
+          "version": "0.1.15-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.GeoServices",
-          "version": "0.1.16-alpha.1"
+          "version": "0.1.15-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.Scenes",
-          "version": "0.1.16-alpha.1"
+          "version": "0.1.15-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.OgcFeatures",
-          "version": "0.1.16-alpha.1"
+          "version": "0.1.15-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.Field",
-          "version": "0.1.16-alpha.1"
+          "version": "0.1.15-alpha.1"
         }
       ]
     }

--- a/docs/guides/mobile-contract-harmonization.md
+++ b/docs/guides/mobile-contract-harmonization.md
@@ -12,7 +12,7 @@ the same ownership map without referencing mobile assemblies.
 
 | Mobile baseline | Shared SDK baseline | Status |
 |-----------------|---------------------|--------|
-| `honua-mobile` source packages from `main` after #68 plus scene, field, and feature adapter work | `Honua.Sdk.*` `0.1.16-alpha.1` | Fixture-level compatibility for shared feature, attachment, source, edit, routing, scene, field, and offline contracts |
+| `honua-mobile` source packages from `main` after #68 plus scene, field, and feature adapter work | `Honua.Sdk.*` `0.1.15-alpha.1` | Fixture-level compatibility for shared feature, attachment, source, edit, routing, scene, field, and offline contracts |
 
 `honua-mobile` does not currently publish versioned NuGet packages. Until it
 does, compatibility is stated as source-baseline compatibility against the
@@ -93,9 +93,9 @@ published shared SDK package versions above. When mobile packages gain
   client from `Honua.Sdk.*`; mobile keeps only
   location-provider helpers.
 - #55 consumes SDK scene metadata and package manifest contracts from
-  `Honua.Sdk.*` `0.1.16-alpha.1`; mobile keeps downloader, GeoPackage catalog,
+  `Honua.Sdk.*` `0.1.15-alpha.1`; mobile keeps downloader, GeoPackage catalog,
   display, and renderer lifecycle code.
-- #56 consumes SDK field contracts from `Honua.Sdk.Field` `0.1.16-alpha.1`;
+- #56 consumes SDK field contracts from `Honua.Sdk.Field` `0.1.15-alpha.1`;
   mobile keeps field rendering/capture UX, local media paths, GPS acquisition,
   DI, and offline adapter integration.
 - Once a mobile package version exists, add it to the compatibility table and

--- a/docs/guides/mobile-contract-harmonization.md
+++ b/docs/guides/mobile-contract-harmonization.md
@@ -12,7 +12,7 @@ the same ownership map without referencing mobile assemblies.
 
 | Mobile baseline | Shared SDK baseline | Status |
 |-----------------|---------------------|--------|
-| `honua-mobile` source packages from `main` after #68 plus scene, field, and feature adapter work | `Honua.Sdk.*` `0.1.8-alpha.1` | Fixture-level compatibility for shared feature, attachment, source, edit, routing, scene, field, and offline contracts |
+| `honua-mobile` source packages from `main` after #68 plus scene, field, and feature adapter work | `Honua.Sdk.*` `0.1.16-alpha.1` | Fixture-level compatibility for shared feature, attachment, source, edit, routing, scene, field, and offline contracts |
 
 `honua-mobile` does not currently publish versioned NuGet packages. Until it
 does, compatibility is stated as source-baseline compatibility against the
@@ -93,9 +93,9 @@ published shared SDK package versions above. When mobile packages gain
   client from `Honua.Sdk.*`; mobile keeps only
   location-provider helpers.
 - #55 consumes SDK scene metadata and package manifest contracts from
-  `Honua.Sdk.*` `0.1.8-alpha.1`; mobile keeps downloader, GeoPackage catalog,
+  `Honua.Sdk.*` `0.1.16-alpha.1`; mobile keeps downloader, GeoPackage catalog,
   display, and renderer lifecycle code.
-- #56 consumes SDK field contracts from `Honua.Sdk.Field` `0.1.8-alpha.1`;
+- #56 consumes SDK field contracts from `Honua.Sdk.Field` `0.1.16-alpha.1`;
   mobile keeps field rendering/capture UX, local media paths, GPS acquisition,
   DI, and offline adapter integration.
 - Once a mobile package version exists, add it to the compatibility table and

--- a/docs/guides/mobile-devops-release-handoff.md
+++ b/docs/guides/mobile-devops-release-handoff.md
@@ -95,6 +95,7 @@ Collect evidence before promotion, not after testers find a problem.
 
 | Stage | Minimum Evidence |
 | --- | --- |
+| .NET SDK train | `HonuaSdkDotNetTrainVersion`, SDK release tag and commit, mobile commit SHA, contract/integration test run URL, release evidence JSON, and the `mobile-dotnet-sdk-train` manifest lane update or approved waiver. |
 | Direct APK | Artifact name, metadata JSON, install notes, selected non-production API base URL, commit SHA, tester notes, and smoke result. |
 | Android internal | Workflow run URL, signed artifact name, SHA-256 digest, Play channel, version name, version code, package name, protected environment approval, and tester link or track. |
 | TestFlight | Workflow run URL, IPA artifact, App Store Connect build number, bundle ID, protected environment approval, TestFlight processing status, and tester group. |

--- a/quality/release-checklist.md
+++ b/quality/release-checklist.md
@@ -9,6 +9,9 @@ comment, etc.) in the Notes column.
 ## CI and Automated Gates
 
 - [ ] All CI gates pass (build, test, gRPC validation, security)
+- [ ] .NET SDK train evidence is current: `Directory.Build.props`
+      `HonuaSdkDotNetTrainVersion` matches the published `honua-sdk-dotnet`
+      train and `quality/release-evidence/` names the release manifest lane
 - [ ] Performance budgets within thresholds (`quality/performance-budget.json`)
 - [ ] Smoke tests pass (`tests/Honua.Mobile.Smoke.Tests`)
 - [ ] MAUI Android API 33 emulator smoke and trim publish pass; direct
@@ -27,6 +30,9 @@ comment, etc.) in the Notes column.
 
 - [ ] CHANGELOG updated with user-facing changes
 - [ ] Version number bumped in `Directory.Build.props` / `.csproj` files
+- [ ] The `mobile-dotnet-sdk-train` release lane in
+      `honua-server/release/honua-2026-05-preview.json` has the mobile commit
+      SHA, SDK train, run URL, and waiver state
 - [ ] Migration notes documented for breaking API changes (if any)
 - [ ] NuGet package metadata reviewed (description, tags, license)
 - [ ] NuGet publish release tag is signed and matches `mobile-dotnet-v*`

--- a/quality/release-evidence/honua-2026-05-preview-mobile-dotnet-sdk-train.json
+++ b/quality/release-evidence/honua-2026-05-preview-mobile-dotnet-sdk-train.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://honua.io/schemas/mobile-dotnet-sdk-train-release-evidence.v1.json",
+  "schemaVersion": 1,
+  "releaseId": "honua-2026-05-preview",
+  "repositoryLaneId": "mobile-dotnet-sdk-train",
+  "owningRepo": "honua-io/honua-mobile",
+  "issue": {
+    "repo": "honua-io/honua-mobile",
+    "number": 133,
+    "url": "https://github.com/honua-io/honua-mobile/issues/133"
+  },
+  "parentReleaseGate": {
+    "repo": "honua-io/honua-server",
+    "number": 876,
+    "url": "https://github.com/honua-io/honua-server/issues/876"
+  },
+  "serverReleaseManifest": {
+    "repo": "honua-io/honua-server",
+    "path": "release/honua-2026-05-preview.json",
+    "laneId": "mobile-dotnet-sdk-train"
+  },
+  "sdkTrain": {
+    "repository": "honua-io/honua-sdk-dotnet",
+    "packageVersion": "0.1.16-alpha.1",
+    "releaseTag": "dotnet-sdk-v0.1.16-alpha.1",
+    "releaseUrl": "https://github.com/honua-io/honua-sdk-dotnet/releases/tag/dotnet-sdk-v0.1.16-alpha.1",
+    "releaseCommit": "f31cfeb6c21af896b96194688a393638461f3d8a",
+    "releasePublishedAt": "2026-05-07T08:52:04Z"
+  },
+  "mobileValidation": {
+    "packageReferenceProperty": "HonuaSdkDotNetTrainVersion",
+    "packageReferenceVersionExpression": "$(HonuaSdkDotNetTrainVersion)",
+    "sourceBoundary": "Published Honua.Sdk.* NuGet packages only; no copied SDK source or long-lived honua-sdk-dotnet ProjectReference links.",
+    "requiredChecks": [
+      "dotnet restore tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj",
+      "dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --configuration Release",
+      "dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --configuration Release"
+    ],
+    "liveServerChecks": {
+      "mode": "optional-release-candidate-image",
+      "enableVariable": "HONUA_MOBILE_LIVE_SERVER_TESTS",
+      "imageVariable": "HONUA_MOBILE_LIVE_SERVER_IMAGE",
+      "baseUrlVariable": "HONUA_MOBILE_LIVE_SERVER_BASE_URL"
+    }
+  },
+  "manifestEvidenceRequirements": [
+    "resolved mobile commit SHA",
+    "CI or local run URL/log for the required checks",
+    "SDK train package version, release tag, and release commit",
+    "waiver record if the validation cannot pass before the Preview release"
+  ],
+  "waiver": null
+}

--- a/quality/release-evidence/honua-2026-05-preview-mobile-dotnet-sdk-train.json
+++ b/quality/release-evidence/honua-2026-05-preview-mobile-dotnet-sdk-train.json
@@ -21,11 +21,18 @@
   },
   "sdkTrain": {
     "repository": "honua-io/honua-sdk-dotnet",
-    "packageVersion": "0.1.16-alpha.1",
+    "packageVersion": "0.1.15-alpha.1",
+    "releaseTag": "dotnet-sdk-v0.1.15-alpha.1",
+    "releaseUrl": "https://github.com/honua-io/honua-sdk-dotnet/releases/tag/dotnet-sdk-v0.1.15-alpha.1",
+    "releaseCommit": "9d264e358099dc20a30b9247013b61d1fba0b0a9",
+    "releasePublishedAt": "2026-04-30T23:32:50Z"
+  },
+  "observedUnconsumedRelease": {
     "releaseTag": "dotnet-sdk-v0.1.16-alpha.1",
     "releaseUrl": "https://github.com/honua-io/honua-sdk-dotnet/releases/tag/dotnet-sdk-v0.1.16-alpha.1",
     "releaseCommit": "f31cfeb6c21af896b96194688a393638461f3d8a",
-    "releasePublishedAt": "2026-05-07T08:52:04Z"
+    "releasePublishedAt": "2026-05-07T08:52:04Z",
+    "reason": "GitHub Packages did not expose Honua.Sdk.* 0.1.16-alpha.1 during PR CI restore; the feed reported 0.1.15-alpha.1 as the nearest published package train."
   },
   "mobileValidation": {
     "packageReferenceProperty": "HonuaSdkDotNetTrainVersion",

--- a/src/Honua.Mobile.Field/Honua.Mobile.Field.csproj
+++ b/src/Honua.Mobile.Field/Honua.Mobile.Field.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-    <PackageReference Include="Honua.Sdk.Field" Version="0.1.8-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Field" Version="$(HonuaSdkDotNetTrainVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
+++ b/src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
@@ -7,10 +7,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Honua.Sdk.Abstractions" Version="0.1.8-alpha.1" />
-    <PackageReference Include="Honua.Sdk.Field" Version="0.1.8-alpha.1" />
-    <PackageReference Include="Honua.Sdk.Offline" Version="0.1.8-alpha.1" />
-    <PackageReference Include="Honua.Sdk.Offline.Abstractions" Version="0.1.8-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Abstractions" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.Field" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.Offline" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.Offline.Abstractions" Version="$(HonuaSdkDotNetTrainVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageReference Include="Microsoft.Maui.Essentials" Version="10.0.0" />

--- a/src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj
+++ b/src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj
@@ -6,9 +6,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Honua.Sdk.Abstractions" Version="0.1.8-alpha.1" />
-    <PackageReference Include="Honua.Sdk.Offline" Version="0.1.8-alpha.1" />
-    <PackageReference Include="Honua.Sdk.Offline.Abstractions" Version="0.1.8-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Abstractions" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.Offline" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.Offline.Abstractions" Version="$(HonuaSdkDotNetTrainVersion)" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
   </ItemGroup>

--- a/src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj
+++ b/src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj
@@ -22,11 +22,11 @@
 
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-    <PackageReference Include="Honua.Sdk.Abstractions" Version="0.1.8-alpha.1" />
-    <PackageReference Include="Honua.Sdk.GeoServices" Version="0.1.8-alpha.1" />
-    <PackageReference Include="Honua.Sdk.Grpc" Version="0.1.8-alpha.1" />
-    <PackageReference Include="Honua.Sdk.OgcFeatures" Version="0.1.8-alpha.1" />
-    <PackageReference Include="Honua.Sdk.Scenes" Version="0.1.8-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Abstractions" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.GeoServices" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.Grpc" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.OgcFeatures" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.Scenes" Version="$(HonuaSdkDotNetTrainVersion)" />
   </ItemGroup>
 
 </Project>

--- a/tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj
+++ b/tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj
@@ -9,11 +9,11 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Honua.Sdk.Abstractions" Version="0.1.8-alpha.1" />
-    <PackageReference Include="Honua.Sdk.GeoServices" Version="0.1.8-alpha.1" />
-    <PackageReference Include="Honua.Sdk.Grpc" Version="0.1.8-alpha.1" />
-    <PackageReference Include="Honua.Sdk.OgcFeatures" Version="0.1.8-alpha.1" />
-    <PackageReference Include="Honua.Sdk.Scenes" Version="0.1.8-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Abstractions" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.GeoServices" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.Grpc" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.OgcFeatures" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.Scenes" Version="$(HonuaSdkDotNetTrainVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/tests/Honua.Mobile.Sdk.Tests/MobileContractHarmonizationFixtureTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/MobileContractHarmonizationFixtureTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Xml.Linq;
 
 namespace Honua.Mobile.Sdk.Tests;
 
@@ -151,7 +152,8 @@ public sealed class MobileContractHarmonizationFixtureTests
 
         var abstractionsPackage = fixture.Compatibility.SdkBaseline.Packages.Single(package => package.PackageId == "Honua.Sdk.Abstractions");
         Assert.Equal("Honua.Sdk.Abstractions", abstractionsPackage.PackageId);
-        Assert.Equal("0.1.8-alpha.1", abstractionsPackage.Version);
+        var sdkTrainVersion = LoadSdkTrainVersion();
+        Assert.Equal(sdkTrainVersion, abstractionsPackage.Version);
 
         Assert.Contains(fixture.Compatibility.SdkBaseline.Packages, package => package.PackageId == "Honua.Sdk.Offline.Abstractions");
         Assert.Contains(fixture.Compatibility.SdkBaseline.Packages, package => package.PackageId == "Honua.Sdk.Offline");
@@ -160,7 +162,7 @@ public sealed class MobileContractHarmonizationFixtureTests
         Assert.Contains(fixture.Compatibility.SdkBaseline.Packages, package => package.PackageId == "Honua.Sdk.Scenes");
         Assert.Contains(fixture.Compatibility.SdkBaseline.Packages, package => package.PackageId == "Honua.Sdk.OgcFeatures");
         Assert.Contains(fixture.Compatibility.SdkBaseline.Packages, package => package.PackageId == "Honua.Sdk.Field");
-        Assert.All(fixture.Compatibility.SdkBaseline.Packages, package => Assert.Equal("0.1.8-alpha.1", package.Version));
+        Assert.All(fixture.Compatibility.SdkBaseline.Packages, package => Assert.Equal(sdkTrainVersion, package.Version));
     }
 
     private static ContractFixture LoadFixture()
@@ -192,6 +194,13 @@ public sealed class MobileContractHarmonizationFixtureTests
         }
 
         throw new DirectoryNotFoundException("Could not locate Honua.Mobile.sln from the test output directory.");
+    }
+
+    private static string LoadSdkTrainVersion()
+    {
+        var path = Path.Combine(FindRepositoryRoot(), "Directory.Build.props");
+        var document = XDocument.Load(path);
+        return document.Descendants("HonuaSdkDotNetTrainVersion").Single().Value;
     }
 
     private sealed record ContractFixture

--- a/tests/Honua.Mobile.Sdk.Tests/SdkTrainReleaseEvidenceTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/SdkTrainReleaseEvidenceTests.cs
@@ -5,7 +5,7 @@ namespace Honua.Mobile.Sdk.Tests;
 
 public sealed class SdkTrainReleaseEvidenceTests
 {
-    private const string ExpectedSdkTrainVersion = "0.1.16-alpha.1";
+    private const string ExpectedSdkTrainVersion = "0.1.15-alpha.1";
     private const string SdkTrainVersionExpression = "$(HonuaSdkDotNetTrainVersion)";
     private const string EvidencePath = "quality/release-evidence/honua-2026-05-preview-mobile-dotnet-sdk-train.json";
 
@@ -21,9 +21,9 @@ public sealed class SdkTrainReleaseEvidenceTests
             "https://github.com/honua-io/honua-sdk-dotnet/releases/tag/$(HonuaSdkDotNetTrainTag)",
             ReadProperty(props, "HonuaSdkDotNetTrainReleaseUrl"));
         Assert.Equal(
-            "f31cfeb6c21af896b96194688a393638461f3d8a",
+            "9d264e358099dc20a30b9247013b61d1fba0b0a9",
             ReadProperty(props, "HonuaSdkDotNetTrainReleaseCommit"));
-        Assert.Equal("2026-05-07T08:52:04Z", ReadProperty(props, "HonuaSdkDotNetTrainReleasePublishedAt"));
+        Assert.Equal("2026-04-30T23:32:50Z", ReadProperty(props, "HonuaSdkDotNetTrainReleasePublishedAt"));
     }
 
     [Fact]

--- a/tests/Honua.Mobile.Sdk.Tests/SdkTrainReleaseEvidenceTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/SdkTrainReleaseEvidenceTests.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using System.Xml.Linq;
+
+namespace Honua.Mobile.Sdk.Tests;
+
+public sealed class SdkTrainReleaseEvidenceTests
+{
+    private const string ExpectedSdkTrainVersion = "0.1.16-alpha.1";
+    private const string SdkTrainVersionExpression = "$(HonuaSdkDotNetTrainVersion)";
+    private const string EvidencePath = "quality/release-evidence/honua-2026-05-preview-mobile-dotnet-sdk-train.json";
+
+    [Fact]
+    public void DirectoryBuildProps_Declares202605PreviewSdkTrain()
+    {
+        var props = LoadBuildProps();
+
+        Assert.Equal(ExpectedSdkTrainVersion, ReadProperty(props, "HonuaSdkDotNetTrainVersion"));
+        Assert.Equal("dotnet-sdk-v$(HonuaSdkDotNetTrainVersion)", ReadProperty(props, "HonuaSdkDotNetTrainTag"));
+        Assert.Equal("honua-io/honua-sdk-dotnet", ReadProperty(props, "HonuaSdkDotNetTrainRepository"));
+        Assert.Equal(
+            "https://github.com/honua-io/honua-sdk-dotnet/releases/tag/$(HonuaSdkDotNetTrainTag)",
+            ReadProperty(props, "HonuaSdkDotNetTrainReleaseUrl"));
+        Assert.Equal(
+            "f31cfeb6c21af896b96194688a393638461f3d8a",
+            ReadProperty(props, "HonuaSdkDotNetTrainReleaseCommit"));
+        Assert.Equal("2026-05-07T08:52:04Z", ReadProperty(props, "HonuaSdkDotNetTrainReleasePublishedAt"));
+    }
+
+    [Fact]
+    public void HonuaSdkPackageReferences_UseCentralReleaseTrainProperty()
+    {
+        var violations = ProjectFiles()
+            .SelectMany(project => XDocument.Load(project)
+                .Descendants("PackageReference")
+                .Select(reference => new
+                {
+                    Project = Relative(project),
+                    Include = reference.Attribute("Include")?.Value,
+                    Version = reference.Attribute("Version")?.Value,
+                }))
+            .Where(reference => reference.Include?.StartsWith("Honua.Sdk.", StringComparison.Ordinal) == true)
+            .Where(reference => reference.Version != SdkTrainVersionExpression)
+            .Select(reference => $"{reference.Project}: {reference.Include} uses {reference.Version ?? "<missing>"}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Empty(violations);
+    }
+
+    [Fact]
+    public void MobileProjects_DoNotReferenceHonuaSdkDotNetSourceProjects()
+    {
+        var violations = ProjectFiles()
+            .SelectMany(project => XDocument.Load(project)
+                .Descendants("ProjectReference")
+                .Select(reference => new
+                {
+                    Project = Relative(project),
+                    Include = reference.Attribute("Include")?.Value,
+                }))
+            .Where(reference => IsHonuaSdkDotNetProjectReference(reference.Include))
+            .Select(reference => $"{reference.Project}: {reference.Include}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Empty(violations);
+    }
+
+    [Fact]
+    public void ReleaseEvidenceDocument_MatchesCentralSdkTrain()
+    {
+        var props = LoadBuildProps();
+        using var evidence = JsonDocument.Parse(File.ReadAllText(Path.Combine(FindRepositoryRoot(), EvidencePath)));
+        var root = evidence.RootElement;
+        var sdkTrain = root.GetProperty("sdkTrain");
+        var mobileValidation = root.GetProperty("mobileValidation");
+
+        Assert.Equal("honua-2026-05-preview", root.GetProperty("releaseId").GetString());
+        Assert.Equal("mobile-dotnet-sdk-train", root.GetProperty("repositoryLaneId").GetString());
+        Assert.Equal(ReadProperty(props, "HonuaSdkDotNetTrainRepository"), sdkTrain.GetProperty("repository").GetString());
+        Assert.Equal(ReadProperty(props, "HonuaSdkDotNetTrainVersion"), sdkTrain.GetProperty("packageVersion").GetString());
+        Assert.Equal($"dotnet-sdk-v{ExpectedSdkTrainVersion}", sdkTrain.GetProperty("releaseTag").GetString());
+        Assert.Equal(ReadProperty(props, "HonuaSdkDotNetTrainReleaseCommit"), sdkTrain.GetProperty("releaseCommit").GetString());
+        Assert.Equal(
+            ReadProperty(props, "HonuaSdkDotNetTrainReleasePublishedAt"),
+            sdkTrain.GetProperty("releasePublishedAt").GetString());
+        Assert.Equal("HonuaSdkDotNetTrainVersion", mobileValidation.GetProperty("packageReferenceProperty").GetString());
+        Assert.Equal(SdkTrainVersionExpression, mobileValidation.GetProperty("packageReferenceVersionExpression").GetString());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("waiver").ValueKind);
+    }
+
+    private static XDocument LoadBuildProps()
+        => XDocument.Load(Path.Combine(FindRepositoryRoot(), "Directory.Build.props"));
+
+    private static string ReadProperty(XDocument document, string name)
+        => document.Descendants(name).Single().Value;
+
+    private static IEnumerable<string> ProjectFiles()
+        => Directory.EnumerateFiles(FindRepositoryRoot(), "*.csproj", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+
+    private static bool IsHonuaSdkDotNetProjectReference(string? include)
+    {
+        if (string.IsNullOrWhiteSpace(include))
+        {
+            return false;
+        }
+
+        return include.Contains("honua-sdk-dotnet", StringComparison.OrdinalIgnoreCase) ||
+            include.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries)
+                .Any(part => part.StartsWith("Honua.Sdk.", StringComparison.Ordinal));
+    }
+
+    private static string Relative(string path)
+        => Path.GetRelativePath(FindRepositoryRoot(), path).Replace(Path.DirectorySeparatorChar, '/');
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Honua.Mobile.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate Honua.Mobile.sln from the test output directory.");
+    }
+}

--- a/tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj
@@ -13,10 +13,10 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Honua.Sdk.Abstractions" Version="0.1.8-alpha.1" />
-    <PackageReference Include="Honua.Sdk.GeoServices" Version="0.1.8-alpha.1" />
-    <PackageReference Include="Honua.Sdk.OgcFeatures" Version="0.1.8-alpha.1" />
-    <PackageReference Include="Honua.Sdk.Scenes" Version="0.1.8-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Abstractions" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.GeoServices" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.OgcFeatures" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.Scenes" Version="$(HonuaSdkDotNetTrainVersion)" />
     <PackageReference Include="Microsoft.Maui.Essentials" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Testcontainers" Version="4.11.0" />


### PR DESCRIPTION
Related to #133

## Summary
- Move all `Honua.Sdk.*` package references onto a single `HonuaSdkDotNetTrainVersion` property set to the current published package train, `0.1.15-alpha.1`.
- Add release evidence metadata for `honua-2026-05-preview` / `mobile-dotnet-sdk-train`, including the SDK package train, release tag, release commit, manifest lane requirements, and the observed unpublished `0.1.16-alpha.1` release tag.
- Add tests that fail if mobile drifts from the central SDK train, uses a non-published SDK package reference expression, or adds a `honua-sdk-dotnet` source `ProjectReference`.

## Testing
- `git diff --check`
- `jq empty quality/release-evidence/honua-2026-05-preview-mobile-dotnet-sdk-train.json contracts/fixtures/mobile-sdk-contract-harmonization.v1.json`
- `rg --pcre2 -n '<PackageReference Include="Honua\\.Sdk\\.[^"]+" Version="(?!\\$\\(HonuaSdkDotNetTrainVersion\\))' -g '*.csproj'` returned no matches.
- `rg -n '<ProjectReference Include=.*(honua-sdk-dotnet|Honua\\.Sdk\\.)' -g '*.csproj'` returned no matches.
- Local `dotnet restore tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj` is blocked by GitHub Packages `403 Forbidden` because the local `gh` token does not have `read:packages`; CI has `packages: read` and is the package restore evidence source.

## Platform Impact
No platform-specific Android, iOS, Windows, or MAUI runtime behavior changes. This only changes shared package version resolution and release evidence validation.

## Offline Impact
The offline package references now resolve through the same `HonuaSdkDotNetTrainVersion` as the rest of mobile. No GeoPackage schema, sync queue, or runtime storage behavior changes.

## API Changes
No gRPC/proto or mobile public API changes. This validates consumption of the published .NET SDK train.

## Breaking Changes
None.

## Release Evidence
- Consumed SDK package train: `honua-io/honua-sdk-dotnet` `dotnet-sdk-v0.1.15-alpha.1`
- Consumed SDK release commit: `9d264e358099dc20a30b9247013b61d1fba0b0a9`
- Consumed SDK release published at: `2026-04-30T23:32:50Z`
- Observed but not consumed: `dotnet-sdk-v0.1.16-alpha.1`; PR CI restore reported `0.1.15-alpha.1` as the nearest published `Honua.Sdk.*` package train.
- Evidence file: `quality/release-evidence/honua-2026-05-preview-mobile-dotnet-sdk-train.json`
- After CI completes, the `mobile-dotnet-sdk-train` lane in `honua-server/release/honua-2026-05-preview.json` should record this PR commit SHA, the successful run URL, SDK train metadata, and `waiver: null` or record the `0.1.16-alpha.1` package-publish gap as the remaining SDK-side blocker.
