### PR TITLE
docs: validate iOS store prereqs

### DIFF
--- a/docs/guides/mobile-store-prereqs.md
+++ b/docs/guides/mobile-store-prereqs.md
@@ -141,6 +141,9 @@ environments.
       may submit or promote iOS builds.
 - [ ] Record certificate and provisioning profile expiration dates in the
       release calendar with rotation reminders.
+- [ ] Run `scripts/validate-ios-store-prereqs.sh` before importing signing
+      assets or enabling TestFlight uploads, then attach the output to the
+      release evidence.
 
 ### iOS Secrets
 
@@ -234,3 +237,19 @@ App Store Connect API key exposure:
 
 Review store access, GitHub environment reviewers, and all store automation
 secrets before each production release and after any owner change.
+
+## Repository Validation
+
+Run this check after changing app identifiers, TestFlight workflow inputs, or
+iOS signing secret names:
+
+```bash
+scripts/validate-ios-store-prereqs.sh
+```
+
+The script validates that the documented iOS bundle IDs match the MAUI
+`ApplicationId` values, that the TestFlight workflow maps each app target to the
+same bundle ID and provisioning profile secret, and that required iOS signing
+and App Store Connect secret names stay documented. It does not read or verify
+secret values, certificate files, provisioning profile contents, App Store
+Connect app records, or Apple Developer account state.

--- a/docs/guides/mobile-testflight-builds.md
+++ b/docs/guides/mobile-testflight-builds.md
@@ -31,6 +31,12 @@ the expected bundle ID in the table. After importing the selected profile, it
 also verifies that the decoded profile team and application identifier match the
 same expected bundle ID.
 
+Maintainers can run `scripts/validate-ios-store-prereqs.sh` before a signing
+asset rotation or workflow change to verify that this table, the MAUI project
+identifiers, and the workflow secret mapping still agree. The script checks
+names and repository configuration only; it never reads Apple credentials or
+GitHub secret values.
+
 Store these secrets in the protected environment, not as repository-wide
 secrets:
 

--- a/quality/release-checklist.md
+++ b/quality/release-checklist.md
@@ -32,6 +32,8 @@ comment, etc.) in the Notes column.
 - [ ] NuGet publish release tag is signed and matches `mobile-dotnet-v*`
 - [ ] Mobile store prerequisites reviewed for app-store builds
       (`docs/guides/mobile-store-prereqs.md`)
+- [ ] iOS store prerequisite mapping validation passes
+      (`scripts/validate-ios-store-prereqs.sh`)
 - [ ] `trunk` branch protection confirmed: required reviews, required status
       checks, and force-push disabled
 

--- a/scripts/test-validate-ios-store-prereqs.sh
+++ b/scripts/test-validate-ios-store-prereqs.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+scripts/validate-ios-store-prereqs.sh >/dev/null
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+swapped_workflow="${temp_dir}/ios-testflight-swapped.yml"
+failure_output="${temp_dir}/validation-output.txt"
+
+awk '
+  /^[[:space:]]*field-collection\)/ {
+    block = "field-collection"
+  }
+
+  /^[[:space:]]*mobile-app\)/ {
+    block = "mobile-app"
+  }
+
+  block == "field-collection" {
+    gsub("apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj", "apps/Honua.Mobile.App/Honua.Mobile.App.csproj")
+    gsub("io.honua.mobile.fieldcollection", "io.honua.mobile.app")
+    gsub("IOS_FIELD_COLLECTION_PROVISIONING_PROFILE_MOBILEPROVISION_BASE64", "IOS_APP_PROVISIONING_PROFILE_MOBILEPROVISION_BASE64")
+  }
+
+  block == "mobile-app" {
+    gsub("apps/Honua.Mobile.App/Honua.Mobile.App.csproj", "apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj")
+    gsub("io.honua.mobile.app", "io.honua.mobile.fieldcollection")
+    gsub("IOS_APP_PROVISIONING_PROFILE_MOBILEPROVISION_BASE64", "IOS_FIELD_COLLECTION_PROVISIONING_PROFILE_MOBILEPROVISION_BASE64")
+  }
+
+  {
+    print
+  }
+
+  block != "" && /^[[:space:]]*;;[[:space:]]*$/ {
+    block = ""
+  }
+' .github/workflows/ios-testflight.yml > "${swapped_workflow}"
+
+if IOS_TESTFLIGHT_WORKFLOW_PATH="${swapped_workflow}" scripts/validate-ios-store-prereqs.sh >"${failure_output}" 2>&1; then
+  echo "Expected swapped iOS TestFlight workflow mapping to fail validation." >&2
+  exit 1
+fi
+
+grep -Fq "${swapped_workflow} field-collection mapping does not bind Honua Field Collection project path" "${failure_output}"
+grep -Fq "${swapped_workflow} mobile-app mapping does not bind Honua Mobile App project path" "${failure_output}"
+
+printf 'Validated iOS store prerequisite smoke tests.\n'

--- a/scripts/validate-ios-store-prereqs.sh
+++ b/scripts/validate-ios-store-prereqs.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+failures=()
+
+require_file() {
+  local path="$1"
+  if [[ ! -f "${path}" ]]; then
+    failures+=("Missing required file: ${path}")
+  fi
+}
+
+require_contains() {
+  local path="$1"
+  local expected="$2"
+  local label="$3"
+
+  if ! grep -Fq "${expected}" "${path}"; then
+    failures+=("${path} does not document ${label}: ${expected}")
+  fi
+}
+
+application_id_for_project() {
+  local project_path="$1"
+  local application_id=""
+
+  if command -v dotnet >/dev/null 2>&1; then
+    application_id="$(dotnet msbuild "${project_path}" \
+      -nologo \
+      -getProperty:ApplicationId \
+      -p:TargetFramework=net10.0-ios 2>/dev/null \
+      | tr -d '\r' \
+      | sed -n '/./p' \
+      | tail -n 1 || true)"
+  fi
+
+  if [[ -z "${application_id}" ]]; then
+    application_id="$(sed -n 's:.*<ApplicationId>\([^<]*\)</ApplicationId>.*:\1:p' "${project_path}" \
+      | head -n 1 \
+      | tr -d '[:space:]')"
+  fi
+
+  printf '%s' "${application_id}"
+}
+
+store_prereqs_doc="docs/guides/mobile-store-prereqs.md"
+testflight_doc="docs/guides/mobile-testflight-builds.md"
+testflight_workflow=".github/workflows/ios-testflight.yml"
+release_checklist="quality/release-checklist.md"
+
+for path in \
+  "${store_prereqs_doc}" \
+  "${testflight_doc}" \
+  "${testflight_workflow}" \
+  "${release_checklist}"
+do
+  require_file "${path}"
+done
+
+target_rows=(
+  "mobile-app|Honua Mobile App|apps/Honua.Mobile.App/Honua.Mobile.App.csproj|io.honua.mobile.app|IOS_APP_PROVISIONING_PROFILE_MOBILEPROVISION_BASE64"
+  "field-collection|Honua Field Collection|apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj|io.honua.mobile.fieldcollection|IOS_FIELD_COLLECTION_PROVISIONING_PROFILE_MOBILEPROVISION_BASE64"
+)
+
+for row in "${target_rows[@]}"; do
+  IFS='|' read -r app_target app_name project_path bundle_id profile_secret <<< "${row}"
+
+  require_file "${project_path}"
+
+  actual_application_id="$(application_id_for_project "${project_path}")"
+  if [[ "${actual_application_id}" != "${bundle_id}" ]]; then
+    failures+=("${project_path} ApplicationId is '${actual_application_id:-<empty>}', expected '${bundle_id}' for ${app_target}.")
+  fi
+
+  require_contains "${store_prereqs_doc}" "${project_path}" "${app_name} project path"
+  require_contains "${store_prereqs_doc}" "${bundle_id}" "${app_name} iOS bundle ID"
+  require_contains "${testflight_doc}" "${project_path}" "${app_name} TestFlight project path"
+  require_contains "${testflight_doc}" "${bundle_id}" "${app_name} TestFlight bundle ID"
+  require_contains "${testflight_doc}" "${profile_secret}" "${app_name} provisioning profile secret"
+  require_contains "${testflight_workflow}" "${project_path}" "${app_name} workflow project path"
+  require_contains "${testflight_workflow}" "${bundle_id}" "${app_name} workflow bundle ID"
+  require_contains "${testflight_workflow}" "${profile_secret}" "${app_name} workflow provisioning profile secret"
+done
+
+required_ios_secret_names=(
+  APPLE_TEAM_ID
+  APP_STORE_CONNECT_ISSUER_ID
+  APP_STORE_CONNECT_KEY_ID
+  APP_STORE_CONNECT_API_KEY_P8
+  IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64
+  IOS_DISTRIBUTION_CERTIFICATE_PASSWORD
+  IOS_APP_PROVISIONING_PROFILE_MOBILEPROVISION_BASE64
+  IOS_FIELD_COLLECTION_PROVISIONING_PROFILE_MOBILEPROVISION_BASE64
+)
+
+for secret_name in "${required_ios_secret_names[@]}"; do
+  require_contains "${store_prereqs_doc}" "${secret_name}" "iOS secret ${secret_name}"
+  require_contains "${testflight_doc}" "${secret_name}" "TestFlight secret ${secret_name}"
+  require_contains "${testflight_workflow}" "${secret_name}" "workflow secret ${secret_name}"
+done
+
+if grep -Rqs "<key>CFBundleIdentifier</key>" \
+  apps/Honua.Mobile.App/Platforms/iOS \
+  apps/Honua.Mobile.FieldCollection/Platforms/iOS
+then
+  failures+=("iOS Info.plist files declare CFBundleIdentifier; update docs and workflow mapping if the MAUI ApplicationId is no longer authoritative.")
+fi
+
+if [[ ${#failures[@]} -gt 0 ]]; then
+  printf 'iOS store prerequisite validation failed:\n' >&2
+  printf ' - %s\n' "${failures[@]}" >&2
+  exit 1
+fi
+
+printf 'Validated iOS store prerequisite docs and workflow mapping for %s targets.\n' "${#target_rows[@]}"

--- a/scripts/validate-ios-store-prereqs.sh
+++ b/scripts/validate-ios-store-prereqs.sh
@@ -23,6 +23,60 @@ require_contains() {
   fi
 }
 
+workflow_case_block() {
+  local path="$1"
+  local app_target="$2"
+
+  awk -v app_target="${app_target}" '
+    $0 ~ "^[[:space:]]*" app_target "\\)" {
+      in_block = 1
+    }
+
+    in_block {
+      print
+      if ($0 ~ "^[[:space:]]*;;[[:space:]]*$") {
+        exit
+      }
+    }
+  ' "${path}"
+}
+
+require_workflow_target_mapping() {
+  local path="$1"
+  local app_target="$2"
+  local app_name="$3"
+  local project_path="$4"
+  local bundle_id="$5"
+  local profile_secret="$6"
+  local block
+
+  if [[ ! -f "${path}" ]]; then
+    return
+  fi
+
+  if ! block="$(workflow_case_block "${path}" "${app_target}")"; then
+    failures+=("${path} could not be read while validating workflow app_target mapping block for ${app_target}.")
+    return
+  fi
+
+  if [[ -z "${block}" ]]; then
+    failures+=("${path} does not define workflow app_target mapping block for ${app_target}.")
+    return
+  fi
+
+  if ! grep -Fq "${project_path}" <<< "${block}"; then
+    failures+=("${path} ${app_target} mapping does not bind ${app_name} project path: ${project_path}")
+  fi
+
+  if ! grep -Fq "${bundle_id}" <<< "${block}"; then
+    failures+=("${path} ${app_target} mapping does not bind ${app_name} bundle ID: ${bundle_id}")
+  fi
+
+  if ! grep -Fq "${profile_secret}" <<< "${block}"; then
+    failures+=("${path} ${app_target} mapping does not bind ${app_name} provisioning profile secret: ${profile_secret}")
+  fi
+}
+
 application_id_for_project() {
   local project_path="$1"
   local application_id=""
@@ -48,7 +102,7 @@ application_id_for_project() {
 
 store_prereqs_doc="docs/guides/mobile-store-prereqs.md"
 testflight_doc="docs/guides/mobile-testflight-builds.md"
-testflight_workflow=".github/workflows/ios-testflight.yml"
+testflight_workflow="${IOS_TESTFLIGHT_WORKFLOW_PATH:-.github/workflows/ios-testflight.yml}"
 release_checklist="quality/release-checklist.md"
 
 for path in \
@@ -80,9 +134,7 @@ for row in "${target_rows[@]}"; do
   require_contains "${testflight_doc}" "${project_path}" "${app_name} TestFlight project path"
   require_contains "${testflight_doc}" "${bundle_id}" "${app_name} TestFlight bundle ID"
   require_contains "${testflight_doc}" "${profile_secret}" "${app_name} provisioning profile secret"
-  require_contains "${testflight_workflow}" "${project_path}" "${app_name} workflow project path"
-  require_contains "${testflight_workflow}" "${bundle_id}" "${app_name} workflow bundle ID"
-  require_contains "${testflight_workflow}" "${profile_secret}" "${app_name} workflow provisioning profile secret"
+  require_workflow_target_mapping "${testflight_workflow}" "${app_target}" "${app_name}" "${project_path}" "${bundle_id}" "${profile_secret}"
 done
 
 required_ios_secret_names=(


### PR DESCRIPTION
## Summary
- Add a repository-local iOS store prerequisite validation script for #87
- Document when to run the validation before signing asset imports and TestFlight uploads
- Add the check to the release checklist evidence gates

## Validation
- scripts/validate-ios-store-prereqs.sh
- bash -n scripts/validate-ios-store-prereqs.sh
- git diff --check HEAD~1..HEAD

## Notes
- This does not add secrets or verify Apple Developer/App Store Connect account state. Those remain external setup blockers for #87.
- I attempted to add a PR workflow hook, but push was rejected because the available token lacks GitHub workflow scope for .github/workflows changes, so this PR keeps the mergeable docs/script slice.