### PR TITLE
test: cover mobile plugin host boundaries

### DIFF
--- a/docs/guides/plugin-client-extension-hosts.md
+++ b/docs/guides/plugin-client-extension-hosts.md
@@ -30,6 +30,11 @@ registration.
 - `AddHonuaMapPluginHost` and `AddHonuaMapPlugin<TPlugin>` DI helpers in a
   separate plugin-host registration extension file.
 
+Use these APIs as host adapter contracts. A mobile plugin package should expose
+registration glue, UI surfaces, and native renderer adapters; portable
+manifests, permissions, validators, workflow hooks, geometry, and service
+clients still come from versioned SDK packages when those contracts exist.
+
 Example:
 
 ```csharp
@@ -86,6 +91,20 @@ load.
 This is runtime failure isolation, not a process sandbox. Code signing,
 enterprise trust, permission enforcement, and package provenance require the SDK
 and server work linked above.
+
+### Mobile Adapter Checklist
+
+Keep mobile plugin slices mergeable by checking these boundaries before adding a
+new extension package:
+
+| Adapter concern | Mobile-owned shape |
+| --- | --- |
+| Registration | `IServiceCollection` extension methods that call `AddHonuaMapPluginHost` and register plugin implementations. |
+| UI mounting | `HonuaMapPluginUiExtension` entries for host-owned panels, dialogs, forms, or workflow screens. |
+| Toolbar commands | `HonuaMapPluginToolbarButton` entries that resolve mobile services from `HonuaMapPluginCommandContext.Services`. |
+| Feature rendering | `HonuaMapPluginFeatureRenderer` entries that point at native renderer adapter types. |
+| SDK dependency | Reference a published `Honua.Sdk.*` package and link the SDK issue when portable contracts are required. |
+| Server dependency | Link the `honua-server` dependency issue when plugin behavior requires server endpoints or hooks. |
 
 ## Web Host Boundary
 

--- a/tests/Honua.Mobile.Maui.Tests/HonuaMapPluginHostTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaMapPluginHostTests.cs
@@ -80,6 +80,30 @@ public sealed class HonuaMapPluginHostTests
     }
 
     [Fact]
+    public async Task ActivateAsync_TreatsDuplicatePluginIdAsActivationFailure()
+    {
+        using var provider = new ServiceCollection()
+            .AddHonuaMapPlugin(new ToolbarOnlyPlugin("shared", "first-action", priority: 1))
+            .AddHonuaMapPlugin(new ToolbarOnlyPlugin("shared", "second-action", priority: 2))
+            .AddHonuaMapPlugin(new ToolbarOnlyPlugin("later", "later-action", priority: 3))
+            .BuildServiceProvider();
+
+        var report = await provider.GetRequiredService<HonuaMapPluginHost>().ActivateAsync();
+
+        Assert.Equal(["shared", "later"], report.ActivatedPlugins.Select(plugin => plugin.Id));
+
+        var failure = Assert.Single(report.Failures);
+        Assert.Equal("shared", failure.PluginId);
+        Assert.Contains("already registered", failure.Message, StringComparison.Ordinal);
+        Assert.IsType<InvalidOperationException>(failure.Exception);
+
+        Assert.Equal(["first-action", "later-action"], report.Contributions.ToolbarButtons
+            .Select(item => item.Contribution.Id));
+        Assert.DoesNotContain(report.Contributions.ToolbarButtons, item =>
+            item.Contribution.Id == "second-action");
+    }
+
+    [Fact]
     public async Task AddHonuaMapPlugin_RegistersPluginTypeAndHost()
     {
         using var provider = new ServiceCollection()


### PR DESCRIPTION
## Summary
- Document the MAUI plugin host adapter checklist for issue #16 boundaries.
- Add a focused MAUI plugin host test proving duplicate plugin IDs fail only the duplicate activation while preserving earlier and later healthy contributions.

## Checks
- `dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --filter FullyQualifiedName~HonuaMapPluginHostTests --logger "console;verbosity=normal"`
- `git diff --check`

Closes a small slice of #16.