### PR TITLE
test: add cloud readback gate for offline workflow

### DIFF
--- a/docs/guides/disconnected-field-workflow-harness.md
+++ b/docs/guides/disconnected-field-workflow-harness.md
@@ -47,6 +47,7 @@ for acceptance edits:
 | `HONUA_MOBILE_CLOUD_LAYER_IDS` | No | Comma-separated FeatureServer layer ids. Defaults to `0`; the first layer is the editable source. |
 | `HONUA_MOBILE_CLOUD_API_KEY` | No | API key sent as `X-API-Key` when the fixture uses API key auth. |
 | `HONUA_MOBILE_CLOUD_BEARER_TOKEN` | No | Bearer token when the fixture uses token auth. |
+| `HONUA_MOBILE_CLOUD_VERIFY_READBACK` | No | Defaults to `true`. Set to `0`, `false`, or `no` only for bring-up runs where the fixture can accept edits but cannot yet answer readback queries. |
 | `HONUA_MOBILE_ACCEPTANCE_PACKAGE_ID` | No | Package id recorded in queued operation payloads and evidence. Defaults to `pkg_acceptance_field_workflow`. |
 | `HONUA_MOBILE_ACCEPTANCE_RUN_ID` | No | Stable run id used in operation metadata and artifact file names. Defaults to a UTC timestamped cloud run id. |
 | `HONUA_MOBILE_ACCEPTANCE_EVIDENCE_DIR` | No | Directory for evidence artifacts. Defaults to a temp directory for cloud runs. |
@@ -62,6 +63,15 @@ The fixture must support the FeatureServer replica endpoints used by
 | `/rest/services/{serviceId}/FeatureServer/extractChanges` | Download deterministic pre-edit features into the GeoPackage cache. |
 | `/rest/services/{serviceId}/FeatureServer/synchronizeReplica` | Advance the download cursor after extraction. |
 | `/rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits` | Reconcile create, update, and delete operations after reconnect. |
+| `/rest/services/{serviceId}/FeatureServer/{layerId}/query` | Read back run-tagged create/update records and deterministic delete-target state. |
+
+When readback verification is enabled, the fixture must expose:
+
+- a seeded feature with `objectid = 3` so the delete operation can prove
+  pre-sync presence and post-sync removal;
+- a writable `honua_acceptance_run` field on the editable layer;
+- a writable `status` field that preserves `created-offline` and
+  `inspection-complete` after reconnect sync.
 
 If the fixture supports attachment or media readback, capture it as additional
 manual evidence. The current automated harness records attachment/media metadata
@@ -110,7 +120,7 @@ Required evidence fields:
 | `plannedOperations` | Operation kind, target id, syncability, and metadata for each planned edit or media item. |
 | `cursorState` | Replica and server generation cursors after verification. |
 | `phases` | Per-phase status, timings, details, and failure category when applicable. |
-| `finalState` | Pre-reconnect pending count, final pending count, local feature count, and verification notes. |
+| `finalState` | Pre-reconnect pending count, final pending count, local feature count, readback counts, delete-target state, and verification notes. |
 | `failureCategories` | Structured category definitions for troubleshooting. |
 
 Keep the JSON evidence with any cloud run logs, server fixture seed identifiers,

--- a/docs/guides/offline-sync.md
+++ b/docs/guides/offline-sync.md
@@ -169,6 +169,7 @@ The loopback test runs by default against the in-process integration server. The
 | `HONUA_MOBILE_CLOUD_LAYER_IDS` | No | Comma-separated FeatureServer layer IDs. Defaults to `0`. |
 | `HONUA_MOBILE_CLOUD_API_KEY` | No | API key sent as `X-API-Key`. |
 | `HONUA_MOBILE_CLOUD_BEARER_TOKEN` | No | Bearer token for authenticated staging fixtures. |
+| `HONUA_MOBILE_CLOUD_VERIFY_READBACK` | No | Defaults to `true`. Set to `0` only for fixture bring-up runs that cannot yet answer FeatureServer readback queries. |
 | `HONUA_MOBILE_ACCEPTANCE_EVIDENCE_DIR` | No | Directory for evidence JSON artifacts. Defaults to a temp evidence directory for cloud runs. |
 | `HONUA_MOBILE_ACCEPTANCE_RUN_ID` | No | Stable run id used in artifact names and operation metadata. |
 | `HONUA_MOBILE_ACCEPTANCE_PACKAGE_ID` | No | Offline package id recorded in evidence. Defaults to `pkg_acceptance_field_workflow`. |
@@ -200,17 +201,24 @@ Evidence artifacts are written as `<run-id>.evidence.json` and use schema
   "finalState": {
     "localFeatureCount": 1,
     "pendingOperationCount": 0,
+    "runTaggedFeatureCountBeforeReconnect": 0,
+    "deleteTargetPresentBeforeReconnect": true,
+    "runTaggedFeatureCount": 2,
+    "deleteTargetPresent": false,
     "localVerification": "downloaded features retained and sync queue drained",
-    "cloudVerification": "fixture-specific verification result"
+    "cloudVerification": "cloud readback found run-tagged create/update edits and confirmed deterministic delete target removal"
   }
 }
 ```
 
-Until honua-server#895 is available, the cloud test intentionally does not
-assume server-side readback endpoints beyond the replica and `applyEdits`
-contract. The loopback harness verifies request-level behavior locally; the
-cloud harness records the fixture assumption in the queued operation metadata
-and evidence artifact.
+The cloud harness now expects the honua-server#895 fixture path to support
+server-side readback on the editable FeatureServer layer. Before reconnect it
+asserts that no records carry the current `HONUA_MOBILE_ACCEPTANCE_RUN_ID` and
+that the deterministic delete target, `objectid = 3`, exists. After reconnect it
+asserts that run-tagged create/update records are visible with
+`created-offline` and `inspection-complete` statuses and that `objectid = 3` is
+no longer returned. The loopback harness continues to verify request-level
+behavior locally for ordinary CI runs.
 
 ## Live Honua Image Server Interaction Tests
 

--- a/docs/guides/sdk-backed-offline-field-ops-demo-harness.md
+++ b/docs/guides/sdk-backed-offline-field-ops-demo-harness.md
@@ -3,9 +3,10 @@
 This page documents the first repeatable slice for issue
 [honua-mobile#92](https://github.com/honua-io/honua-mobile/issues/92).
 It proves the preferred mobile registration path and evidence shape for the
-offline field operations demo. It does not close the full epic: cloud fixture
-seeding, end-to-end push/pull verification, attachment upload, and in-app
-conflict review still require follow-up work.
+offline field operations demo. The cloud/staging end-to-end path is covered by
+the disconnected field workflow harness in
+`tests/Honua.Mobile.ServerIntegration.Tests/DisconnectedFieldWorkflowAcceptanceTests.cs`,
+which verifies readback once the honua-server#895 fixture is configured.
 
 ## Scope
 
@@ -78,13 +79,23 @@ Required fields:
 | `syncState` | Persisted SDK sync phase, token, and pulled feature count. |
 | `conflictReview` | Manual-review mode and deterministic conflict scenario label. |
 
-## Remaining Work
+## Cloud Acceptance Handoff
 
-- Run the existing disconnected workflow harness against the seeded cloud
-  fixture once `honua-io/honua-server#895` is available.
-- Move reconnect push/pull verification from the mobile-owned sync engine path
-  to the SDK-backed runner when the fixture can safely accept deterministic
-  edits.
-- Surface the conflict-review operation in the field collection app UX.
-- Extend evidence with package size, metadata cache status, retry failures, and
-  attachment/media upload results.
+For issue #92 closure, run both harnesses:
+
+```bash
+dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --filter FullyQualifiedName~SdkBackedOfflineFieldOperationsDemoHarnessTests
+
+HONUA_MOBILE_CLOUD_ACCEPTANCE=1 \
+HONUA_MOBILE_CLOUD_BASE_URL=https://staging-api.honua.io \
+HONUA_MOBILE_CLOUD_SERVICE_ID=mobile_offline_demo \
+HONUA_MOBILE_CLOUD_LAYER_IDS=68910 \
+HONUA_MOBILE_ACCEPTANCE_EVIDENCE_DIR=/tmp/honua-mobile-acceptance-evidence \
+dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --filter "Category=CloudAcceptance"
+```
+
+The cloud run expects the fixture to preserve `honua_acceptance_run` and
+`status` fields on create/update and to seed `objectid = 3` as the deterministic
+delete target. If a fixture is still being brought up, set
+`HONUA_MOBILE_CLOUD_VERIFY_READBACK=0` to collect upload evidence without
+claiming final readback acceptance.

--- a/tests/Honua.Mobile.ServerIntegration.Tests/DisconnectedFieldWorkflowAcceptanceTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/DisconnectedFieldWorkflowAcceptanceTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Honua.Mobile.Offline.GeoPackage;
 using Honua.Mobile.Offline.Sync;
 using Honua.Mobile.Sdk;
+using Honua.Mobile.Sdk.Models;
 
 namespace Honua.Mobile.ServerIntegration.Tests;
 
@@ -19,6 +20,7 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
     private const string FailureCategoryEditQueue = "edit-queue";
     private const string FailureCategoryTransport = "transport";
     private const string FailureCategoryConflict = "conflict";
+    private const long DeleteTargetObjectId = 3;
     private static readonly DateTimeOffset FixedOperationTime = new(2026, 5, 4, 10, 0, 0, TimeSpan.Zero);
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
     {
@@ -139,17 +141,43 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
             config,
             createReplicaClient: () => CreateReplicaClient(config),
             createUploader: () => CreateUploader(config),
-            verifyPreSyncCloudStateAsync: evidence =>
+            verifyPreSyncCloudStateAsync: async evidence =>
             {
+                if (!config.VerifyCloudReadback)
+                {
+                    evidence.FinalState.PreSyncCloudVerification =
+                        "cloud readback verification disabled by HONUA_MOBILE_CLOUD_VERIFY_READBACK=0";
+                    return;
+                }
+
+                var preSync = await QueryCloudReadbackAsync(config);
+                evidence.FinalState.RunTaggedFeatureCountBeforeReconnect = preSync.RunTaggedFeatureCount;
+                evidence.FinalState.DeleteTargetPresentBeforeReconnect = preSync.DeleteTargetPresent;
                 evidence.FinalState.PreSyncCloudVerification =
-                    "cloud fixture pre-sync verification requires fixture query inputs from honua-server#895";
-                return Task.CompletedTask;
+                    "cloud fixture has no run-tagged edits before reconnect and includes the deterministic delete target";
+
+                Assert.Equal(0, preSync.RunTaggedFeatureCount);
+                Assert.True(preSync.DeleteTargetPresent);
             },
-            verifyPostSyncCloudStateAsync: evidence =>
+            verifyPostSyncCloudStateAsync: async evidence =>
             {
+                if (!config.VerifyCloudReadback)
+                {
+                    evidence.FinalState.CloudVerification =
+                        "cloud readback verification disabled by HONUA_MOBILE_CLOUD_VERIFY_READBACK=0";
+                    return;
+                }
+
+                var postSync = await QueryCloudReadbackAsync(config);
+                evidence.FinalState.RunTaggedFeatureCount = postSync.RunTaggedFeatureCount;
+                evidence.FinalState.DeleteTargetPresent = postSync.DeleteTargetPresent;
                 evidence.FinalState.CloudVerification =
-                    "cloud fixture verification delegated to honua-server#895; request-level verification is not available from this process";
-                return Task.CompletedTask;
+                    "cloud readback found run-tagged create/update edits and confirmed deterministic delete target removal";
+
+                Assert.True(postSync.RunTaggedFeatureCount >= 2, $"Expected at least two run-tagged create/update records, got {postSync.RunTaggedFeatureCount}.");
+                Assert.Contains("created-offline", postSync.Statuses);
+                Assert.Contains("inspection-complete", postSync.Statuses);
+                Assert.False(postSync.DeleteTargetPresent);
             });
 
         Assert.Equal("passed", result.Evidence.Status);
@@ -207,6 +235,32 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
         Assert.Equal(
             FailureCategoryLocalCache,
             ClassifyFailure(new GeoPackageStorageException("GeoPackage feature cache write failed."), "offline-edit"));
+    }
+
+    [Fact]
+    public void CloudReadbackParser_ExtractsRunTaggedStatusesAndDeleteTargetPresence()
+    {
+        using var runTaggedFeatures = JsonDocument.Parse("""
+            {
+              "features": [
+                { "attributes": { "objectid": 9001, "status": "created-offline", "honua_acceptance_run": "run-1" } },
+                { "attributes": { "objectid": 1, "status": "inspection-complete", "honua_acceptance_run": "run-1" } }
+              ]
+            }
+            """);
+        using var deleteTarget = JsonDocument.Parse("""
+            {
+              "features": [
+                { "attributes": { "objectid": 3, "status": "seeded" } }
+              ]
+            }
+            """);
+
+        var readback = CloudReadback.FromQueryResponses(runTaggedFeatures, deleteTarget);
+
+        Assert.Equal(2, readback.RunTaggedFeatureCount);
+        Assert.Equal(["created-offline", "inspection-complete"], readback.Statuses);
+        Assert.True(readback.DeleteTargetPresent);
     }
 
     public void Dispose()
@@ -638,7 +692,7 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
                 OfflineOperationType.Delete,
                 layerId,
                 priority: 3,
-                deleteObjectIds: [3]);
+                deleteObjectIds: [DeleteTargetObjectId]);
 
             return new AcceptanceWorkflowPlan
             {
@@ -781,6 +835,8 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
 
         public string? BearerToken { get; init; }
 
+        public bool VerifyCloudReadback { get; init; } = true;
+
         public static AcceptanceHarnessConfiguration Loopback(Uri baseUri, string artifactDirectory)
             => new()
             {
@@ -822,6 +878,7 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
                 ArtifactDirectory = artifactDirectory,
                 ApiKey = Environment.GetEnvironmentVariable("HONUA_MOBILE_CLOUD_API_KEY"),
                 BearerToken = Environment.GetEnvironmentVariable("HONUA_MOBILE_CLOUD_BEARER_TOKEN"),
+                VerifyCloudReadback = ReadBoolean(Environment.GetEnvironmentVariable("HONUA_MOBILE_CLOUD_VERIFY_READBACK"), defaultValue: true),
             };
         }
 
@@ -841,6 +898,30 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
             }
 
             return layerIds;
+        }
+
+        private static bool ReadBoolean(string? value, bool defaultValue)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return defaultValue;
+            }
+
+            if (string.Equals(value, "1", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (string.Equals(value, "0", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "false", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "no", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            throw new InvalidOperationException("HONUA_MOBILE_CLOUD_VERIFY_READBACK must be 1, true, yes, 0, false, or no.");
         }
     }
 
@@ -970,10 +1051,100 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
 
         public int PendingOperationCount { get; set; }
 
+        public int RunTaggedFeatureCountBeforeReconnect { get; set; }
+
+        public bool DeleteTargetPresentBeforeReconnect { get; set; }
+
+        public int RunTaggedFeatureCount { get; set; }
+
+        public bool DeleteTargetPresent { get; set; }
+
         public string? LocalVerification { get; set; }
 
         public string? PreSyncCloudVerification { get; set; }
 
         public string? CloudVerification { get; set; }
+    }
+
+    private static async Task<CloudReadback> QueryCloudReadbackAsync(AcceptanceHarnessConfiguration config)
+    {
+        using var client = CreateReadbackClient(config);
+        var layerId = config.LayerIds[0];
+        var escapedRunId = config.RunId.Replace("'", "''", StringComparison.Ordinal);
+
+        using var runTagged = await client.QueryFeaturesAsync(new QueryFeaturesRequest
+        {
+            ServiceId = config.ServiceId,
+            LayerId = layerId,
+            Where = $"honua_acceptance_run = '{escapedRunId}'",
+            OutFields = ["objectid", "status", "honua_acceptance_run"],
+            ReturnGeometry = false,
+            ResultRecordCount = 10,
+        });
+        using var deleteTarget = await client.QueryFeaturesAsync(new QueryFeaturesRequest
+        {
+            ServiceId = config.ServiceId,
+            LayerId = layerId,
+            ObjectIds = [DeleteTargetObjectId],
+            OutFields = ["objectid", "status"],
+            ReturnGeometry = false,
+            ResultRecordCount = 1,
+        });
+
+        return CloudReadback.FromQueryResponses(runTagged, deleteTarget);
+    }
+
+    private static HonuaMobileClient CreateReadbackClient(AcceptanceHarnessConfiguration config)
+    {
+        return new HonuaMobileClient(
+            new HttpClient(),
+            new HonuaMobileClientOptions
+            {
+                BaseUri = config.BaseUri,
+                ApiKey = config.ApiKey,
+                BearerToken = config.BearerToken,
+                AllowInsecureTransportForDevelopment = config.BaseUri.Scheme == Uri.UriSchemeHttp,
+                PreferGrpcForFeatureQueries = false,
+                PreferGrpcForFeatureEdits = false,
+            });
+    }
+
+    private sealed record CloudReadback(
+        int RunTaggedFeatureCount,
+        IReadOnlyList<string> Statuses,
+        bool DeleteTargetPresent)
+    {
+        public static CloudReadback FromQueryResponses(JsonDocument runTaggedFeatures, JsonDocument deleteTarget)
+            => new(
+                CountFeatures(runTaggedFeatures.RootElement),
+                ReadFeatureStatuses(runTaggedFeatures.RootElement),
+                CountFeatures(deleteTarget.RootElement) > 0);
+
+        private static int CountFeatures(JsonElement root)
+            => root.TryGetProperty("features", out var features) && features.ValueKind == JsonValueKind.Array
+                ? features.GetArrayLength()
+                : 0;
+
+        private static string[] ReadFeatureStatuses(JsonElement root)
+        {
+            if (!root.TryGetProperty("features", out var features) || features.ValueKind != JsonValueKind.Array)
+            {
+                return [];
+            }
+
+            var statuses = new List<string>();
+            foreach (var feature in features.EnumerateArray())
+            {
+                if (feature.TryGetProperty("attributes", out var attributes) &&
+                    attributes.TryGetProperty("status", out var status) &&
+                    status.ValueKind == JsonValueKind.String &&
+                    !string.IsNullOrWhiteSpace(status.GetString()))
+                {
+                    statuses.Add(status.GetString()!);
+                }
+            }
+
+            return statuses.ToArray();
+        }
     }
 }


### PR DESCRIPTION
## Summary

Related to #92.

This turns the disconnected field workflow cloud harness into an actual live fixture readback gate instead of only recording fixture assumptions. The cloud path now verifies pre-sync state, pushes create/update/delete operations, reads the FeatureServer layer back after reconnect, and records the observed run-tagged records plus deterministic delete-target state in evidence JSON.

## Changes

- Add FeatureServer readback queries for the current acceptance run and deterministic `objectid = 3` delete target.
- Assert pre-sync cloud state has no run-tagged edits and still contains the delete target.
- Assert post-sync cloud state exposes the expected `created-offline` and `inspection-complete` statuses and removes the delete target.
- Document the readback fixture requirements and `HONUA_MOBILE_CLOUD_VERIFY_READBACK` escape hatch for fixture bring-up runs.

## Offline Impact

The existing disconnected workflow harness now proves the cloud fixture state before and after reconnect. Ordinary loopback coverage remains local, while cloud acceptance runs require readback support unless `HONUA_MOBILE_CLOUD_VERIFY_READBACK=0` is set for fixture bring-up only.

## Validation

- `git diff --check`
- GitHub CI passed: Build & Format Check, Test Suite, Quality Gates, Security Scan, gRPC Protocol Validation, and PR Validation.
- Local `dotnet build tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --no-restore --verbosity minimal` is blocked in this workspace by GitHub Packages returning 403 for `Honua.Sdk.GeoServices 0.1.15-alpha.1`; the active local token does not include `read:packages`.
