### PR TITLE
mobile: report handled sync failures

### DIFF
--- a/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
+++ b/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
@@ -62,7 +62,12 @@ public static class MauiProgram
             var authService = provider.GetRequiredService<IAuthenticationService>();
             var connectivityService = provider.GetRequiredService<IConnectivityService>();
             var logger = provider.GetRequiredService<ILogger<GeoPackageSyncService>>();
-            return databaseService.GetSyncService(authService, connectivityService, logger: logger);
+            var exceptionReporter = provider.GetRequiredService<IMobileExceptionReporter>();
+            return databaseService.GetSyncService(
+                authService,
+                connectivityService,
+                logger: logger,
+                exceptionReporter: exceptionReporter);
         });
 
         // Core services

--- a/apps/Honua.Mobile.FieldCollection/Services/Storage/DatabaseService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Storage/DatabaseService.cs
@@ -1,5 +1,6 @@
 using Honua.Mobile.FieldCollection.Services.Storage;
 using Honua.Mobile.FieldCollection.Services.Sync;
+using Honua.Mobile.Maui.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Honua.Mobile.FieldCollection.Services.Storage;
@@ -79,7 +80,8 @@ public class DatabaseService : IDisposable
         IConnectivityService connectivityService,
         IFieldCollectionChangeUploader? changeUploader = null,
         IFieldCollectionChangePuller? changePuller = null,
-        ILogger<GeoPackageSyncService>? logger = null)
+        ILogger<GeoPackageSyncService>? logger = null,
+        IMobileExceptionReporter? exceptionReporter = null)
     {
         lock (_serviceLock)
         {
@@ -92,7 +94,8 @@ public class DatabaseService : IDisposable
                     connectivityService,
                     changeUploader,
                     changePuller,
-                    logger);
+                    logger,
+                    exceptionReporter);
             }
 
             return _syncService;

--- a/apps/Honua.Mobile.FieldCollection/Services/Sync/GeoPackageSyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Sync/GeoPackageSyncService.cs
@@ -286,6 +286,17 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         }
         catch (Exception ex)
         {
+            if (ex is OperationCanceledException)
+            {
+                Status = SyncStatus.Cancelled;
+                return new SyncResult
+                {
+                    IsSuccess = false,
+                    ErrorMessage = "Pull was cancelled",
+                    CompletedAt = DateTime.UtcNow
+                };
+            }
+
             _logger?.LogError(ex, "Field collection pull failed");
             await ReportSyncFailureAsync(ex, "sync.pull", sessionId, session);
             return new SyncResult
@@ -385,6 +396,17 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         }
         catch (Exception ex)
         {
+            if (ex is OperationCanceledException)
+            {
+                Status = SyncStatus.Cancelled;
+                return new SyncResult
+                {
+                    IsSuccess = false,
+                    ErrorMessage = "Push was cancelled",
+                    CompletedAt = DateTime.UtcNow
+                };
+            }
+
             _logger?.LogError(ex, "Field collection push failed");
             await ReportSyncFailureAsync(ex, "sync.push", sessionId, session);
             return new SyncResult

--- a/apps/Honua.Mobile.FieldCollection/Services/Sync/GeoPackageSyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Sync/GeoPackageSyncService.cs
@@ -284,19 +284,18 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
                 ChangesPulled = session.ChangesPulled
             };
         }
+        catch (OperationCanceledException)
+        {
+            Status = SyncStatus.Cancelled;
+            return new SyncResult
+            {
+                IsSuccess = false,
+                ErrorMessage = "Pull was cancelled",
+                CompletedAt = DateTime.UtcNow
+            };
+        }
         catch (Exception ex)
         {
-            if (ex is OperationCanceledException)
-            {
-                Status = SyncStatus.Cancelled;
-                return new SyncResult
-                {
-                    IsSuccess = false,
-                    ErrorMessage = "Pull was cancelled",
-                    CompletedAt = DateTime.UtcNow
-                };
-            }
-
             _logger?.LogError(ex, "Field collection pull failed");
             await ReportSyncFailureAsync(ex, "sync.pull", sessionId, session);
             return new SyncResult
@@ -394,19 +393,18 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
                 ChangesPushed = session.ChangesPushed
             };
         }
+        catch (OperationCanceledException)
+        {
+            Status = SyncStatus.Cancelled;
+            return new SyncResult
+            {
+                IsSuccess = false,
+                ErrorMessage = "Push was cancelled",
+                CompletedAt = DateTime.UtcNow
+            };
+        }
         catch (Exception ex)
         {
-            if (ex is OperationCanceledException)
-            {
-                Status = SyncStatus.Cancelled;
-                return new SyncResult
-                {
-                    IsSuccess = false,
-                    ErrorMessage = "Push was cancelled",
-                    CompletedAt = DateTime.UtcNow
-                };
-            }
-
             _logger?.LogError(ex, "Field collection push failed");
             await ReportSyncFailureAsync(ex, "sync.push", sessionId, session);
             return new SyncResult

--- a/apps/Honua.Mobile.FieldCollection/Services/Sync/GeoPackageSyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Sync/GeoPackageSyncService.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services.Storage;
 using Honua.Mobile.FieldCollection.Services.Diagnostics;
+using Honua.Mobile.Maui.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using StorageChangeOperation = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeOperation;
@@ -48,6 +49,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
     private readonly IConnectivityService _connectivityService;
     private readonly IFieldCollectionChangeUploader _changeUploader;
     private readonly IFieldCollectionChangePuller _changePuller;
+    private readonly IMobileExceptionReporter _exceptionReporter;
     private readonly ILogger<GeoPackageSyncService>? _logger;
     private readonly SemaphoreSlim _syncLock = new(1, 1);
     private readonly CancellationTokenSource _pendingChangesCancellation = new();
@@ -79,13 +81,15 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         IConnectivityService connectivityService,
         IFieldCollectionChangeUploader? changeUploader = null,
         IFieldCollectionChangePuller? changePuller = null,
-        ILogger<GeoPackageSyncService>? logger = null)
+        ILogger<GeoPackageSyncService>? logger = null,
+        IMobileExceptionReporter? exceptionReporter = null)
     {
         _storage = storage;
         _authService = authService;
         _connectivityService = connectivityService;
         _changeUploader = changeUploader ?? new UnconfiguredFieldCollectionChangeUploader();
         _changePuller = changePuller ?? new UnconfiguredFieldCollectionChangePuller();
+        _exceptionReporter = exceptionReporter ?? new NoOpMobileExceptionReporter();
         _logger = logger;
 
         // Update pending changes count periodically
@@ -218,6 +222,8 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
                     await CompleteSyncSessionAsync(session, StorageSyncSessionStatus.Failed, ex.Message);
                 }
 
+                await ReportSyncFailureAsync(ex, "sync.full", sessionId, session);
+
                 return new SyncResult
                 {
                     IsSuccess = false,
@@ -255,11 +261,13 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         }
 
         await _syncLock.WaitAsync();
+        string? sessionId = null;
+        StorageSyncSession? session = null;
         try
         {
             _syncCancellation = new CancellationTokenSource();
-            var sessionId = Guid.NewGuid().ToString();
-            var session = await CreateSyncSessionAsync(sessionId, includeRemoteGeneration: true);
+            sessionId = Guid.NewGuid().ToString();
+            session = await CreateSyncSessionAsync(sessionId, includeRemoteGeneration: true);
 
             IsSyncing = true;
             Status = SyncStatus.PullingChanges;
@@ -279,6 +287,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         catch (Exception ex)
         {
             _logger?.LogError(ex, "Field collection pull failed");
+            await ReportSyncFailureAsync(ex, "sync.pull", sessionId, session);
             return new SyncResult
             {
                 IsSuccess = false,
@@ -342,6 +351,8 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         }
 
         await _syncLock.WaitAsync();
+        string? sessionId = null;
+        StorageSyncSession? session = null;
         try
         {
             var pendingChanges = await _storage.GetPendingChangesAsync();
@@ -356,8 +367,8 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
             }
 
             _syncCancellation = new CancellationTokenSource();
-            var sessionId = Guid.NewGuid().ToString();
-            var session = await CreateSyncSessionAsync(sessionId, includeRemoteGeneration: false);
+            sessionId = Guid.NewGuid().ToString();
+            session = await CreateSyncSessionAsync(sessionId, includeRemoteGeneration: false);
 
             IsSyncing = true;
             Status = SyncStatus.PushingChanges;
@@ -375,6 +386,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         catch (Exception ex)
         {
             _logger?.LogError(ex, "Field collection push failed");
+            await ReportSyncFailureAsync(ex, "sync.push", sessionId, session);
             return new SyncResult
             {
                 IsSuccess = false,
@@ -529,6 +541,45 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
             "{ConflictCount} sync conflict(s) require manual review",
             session.ConflictsDetected);
         return Task.CompletedTask;
+    }
+
+    private async Task ReportSyncFailureAsync(
+        Exception exception,
+        string operation,
+        string? sessionId,
+        StorageSyncSession? session)
+    {
+        var properties = new Dictionary<string, object?>
+        {
+            ["status"] = Status.ToString(),
+            ["pendingChangesCount"] = PendingChangesCount,
+        };
+
+        if (session is not null)
+        {
+            properties["sessionStatus"] = session.Status.ToString();
+            properties["changesPulled"] = session.ChangesPulled;
+            properties["changesPushed"] = session.ChangesPushed;
+            properties["conflictsDetected"] = session.ConflictsDetected;
+        }
+
+        try
+        {
+            await _exceptionReporter.ReportAsync(
+                exception,
+                new MobileExceptionReportContext
+                {
+                    Source = "FieldCollection.Sync",
+                    Operation = operation,
+                    CorrelationId = sessionId,
+                    Severity = MobileExceptionSeverity.Error,
+                    Properties = properties,
+                });
+        }
+        catch (Exception reportException)
+        {
+            _logger?.LogWarning(reportException, "Failed to report field collection sync exception");
+        }
     }
 
     private async Task<bool> ApplyServerChangeAsync(ServerChange serverChange, StorageSyncSession session)

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -59,6 +59,26 @@ public sealed class GeoPackageSyncServiceTests
     }
 
     [Fact]
+    public async Task PushChangesAsync_WhenCanceled_DoesNotReportSyncException()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.StoreFeatureAsync(CreateFeature("asset-1", version: 1));
+        var reporter = new RecordingExceptionReporter();
+        using var sync = CreateSyncService(
+            storage,
+            uploader: new CancelingUploader(),
+            exceptionReporter: reporter);
+
+        var result = await sync.PushChangesAsync();
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Push was cancelled", result.ErrorMessage);
+        Assert.Empty(reporter.Reports);
+    }
+
+    [Fact]
     public async Task PushChangesAsync_WhenUploaderReturnsTrue_MarksChangeSynced()
     {
         var databasePath = CreateDatabasePath();
@@ -125,6 +145,25 @@ public sealed class GeoPackageSyncServiceTests
         Assert.Equal("Active", context.Properties["sessionStatus"]);
         Assert.Equal(0, context.Properties["changesPulled"]);
         Assert.Equal(0, context.Properties["conflictsDetected"]);
+    }
+
+    [Fact]
+    public async Task PullChangesAsync_WhenCanceled_DoesNotReportSyncException()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var reporter = new RecordingExceptionReporter();
+        using var sync = CreateSyncService(
+            storage,
+            puller: new CancelingPuller(),
+            exceptionReporter: reporter);
+
+        var result = await sync.PullChangesAsync();
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Pull was cancelled", result.ErrorMessage);
+        Assert.Empty(reporter.Reports);
     }
 
     [Fact]
@@ -343,6 +382,16 @@ public sealed class GeoPackageSyncServiceTests
         }
     }
 
+    private sealed class CancelingUploader : IFieldCollectionChangeUploader
+    {
+        public Task<bool> UploadChangeAsync(
+            StorageChangeRecord change,
+            CancellationToken cancellationToken = default)
+        {
+            throw new OperationCanceledException("Push canceled.");
+        }
+    }
+
     private sealed class FixedPuller : IFieldCollectionChangePuller
     {
         private readonly IReadOnlyList<ServerChange> _changes;
@@ -357,6 +406,26 @@ public sealed class GeoPackageSyncServiceTests
             CancellationToken cancellationToken = default)
         {
             return Task.FromResult(_changes);
+        }
+
+        public Task<long> GetLatestServerGenerationAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(1L);
+        }
+
+        public Task<long> GetLastSyncedGenerationAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(0L);
+        }
+    }
+
+    private sealed class CancelingPuller : IFieldCollectionChangePuller
+    {
+        public Task<IReadOnlyList<ServerChange>> GetChangesAsync(
+            long sinceGeneration,
+            CancellationToken cancellationToken = default)
+        {
+            throw new OperationCanceledException("Pull canceled.");
         }
 
         public Task<long> GetLatestServerGenerationAsync(CancellationToken cancellationToken = default)

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -3,6 +3,7 @@ using Honua.Mobile.FieldCollection.Services;
 using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using Honua.Mobile.FieldCollection.Services.Sync;
 using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Mobile.Maui.Diagnostics;
 using StorageChangeRecord = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeRecord;
 using StorageChangeOperation = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeOperation;
 using StorageConflictRecord = Honua.Mobile.FieldCollection.Services.Storage.Models.ConflictRecord;
@@ -31,6 +32,30 @@ public sealed class GeoPackageSyncServiceTests
         Assert.False(result.IsSuccess);
         Assert.Contains("failed to upload", result.ErrorMessage);
         Assert.Single(await storage.GetPendingChangesAsync());
+    }
+
+    [Fact]
+    public async Task PushChangesAsync_WhenHandledFailureOccurs_ReportsSyncExceptionContext()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.StoreFeatureAsync(CreateFeature("asset-1", version: 1));
+        var reporter = new RecordingExceptionReporter();
+        using var sync = CreateSyncService(
+            storage,
+            uploader: new FixedResultUploader(false),
+            exceptionReporter: reporter);
+
+        var result = await sync.PushChangesAsync();
+
+        Assert.False(result.IsSuccess);
+        var report = Assert.Single(reporter.Reports);
+        var context = AssertSyncReportContext(report, "sync.push");
+        Assert.Equal("PushingChanges", context.Properties["status"]);
+        Assert.Equal("Active", context.Properties["sessionStatus"]);
+        Assert.Equal(0, context.Properties["changesPushed"]);
+        Assert.Equal(0, context.Properties["conflictsDetected"]);
     }
 
     [Fact]
@@ -69,6 +94,68 @@ public sealed class GeoPackageSyncServiceTests
 
         Assert.False(result.IsSuccess);
         Assert.Equal(0, result.ChangesPulled);
+    }
+
+    [Fact]
+    public async Task PullChangesAsync_WhenHandledFailureOccurs_ReportsSyncExceptionContext()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var serverChange = new ServerChange
+        {
+            FeatureId = "asset-1",
+            LayerId = 1,
+            Operation = StorageChangeOperation.Update,
+            Version = 1,
+            Feature = CreateFeature("asset-1", version: 1, geometry: new UnsupportedGeometry())
+        };
+        var reporter = new RecordingExceptionReporter();
+        using var sync = CreateSyncService(
+            storage,
+            puller: new FixedPuller([serverChange]),
+            exceptionReporter: reporter);
+
+        var result = await sync.PullChangesAsync();
+
+        Assert.False(result.IsSuccess);
+        var report = Assert.Single(reporter.Reports);
+        var context = AssertSyncReportContext(report, "sync.pull");
+        Assert.Equal("PullingChanges", context.Properties["status"]);
+        Assert.Equal("Active", context.Properties["sessionStatus"]);
+        Assert.Equal(0, context.Properties["changesPulled"]);
+        Assert.Equal(0, context.Properties["conflictsDetected"]);
+    }
+
+    [Fact]
+    public async Task SyncAsync_WhenHandledFailureOccurs_ReportsFullSyncExceptionContext()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var serverChange = new ServerChange
+        {
+            FeatureId = "asset-1",
+            LayerId = 1,
+            Operation = StorageChangeOperation.Update,
+            Version = 1,
+            Feature = CreateFeature("asset-1", version: 1, geometry: new UnsupportedGeometry())
+        };
+        var reporter = new RecordingExceptionReporter();
+        using var sync = CreateSyncService(
+            storage,
+            puller: new FixedPuller([serverChange]),
+            exceptionReporter: reporter);
+
+        var result = await sync.SyncAsync();
+
+        Assert.False(result.IsSuccess);
+        var report = Assert.Single(reporter.Reports);
+        var context = AssertSyncReportContext(report, "sync.full");
+        Assert.Equal("Error", context.Properties["status"]);
+        Assert.Equal("Failed", context.Properties["sessionStatus"]);
+        Assert.Equal(0, context.Properties["changesPulled"]);
+        Assert.Equal(0, context.Properties["changesPushed"]);
     }
 
     [Fact]
@@ -189,14 +276,29 @@ public sealed class GeoPackageSyncServiceTests
     private static GeoPackageSyncService CreateSyncService(
         GeoPackageStorageService storage,
         IFieldCollectionChangeUploader? uploader = null,
-        IFieldCollectionChangePuller? puller = null)
+        IFieldCollectionChangePuller? puller = null,
+        IMobileExceptionReporter? exceptionReporter = null)
     {
         return new GeoPackageSyncService(
             storage,
             new TestAuthenticationService(),
             new TestConnectivityService(),
             uploader ?? new FixedResultUploader(true),
-            puller ?? new FixedPuller([]));
+            puller ?? new FixedPuller([]),
+            exceptionReporter: exceptionReporter);
+    }
+
+    private static MobileExceptionReportContext AssertSyncReportContext(
+        ReportedException report,
+        string expectedOperation)
+    {
+        var context = Assert.IsType<MobileExceptionReportContext>(report.Context);
+        Assert.Equal("FieldCollection.Sync", context.Source);
+        Assert.Equal(expectedOperation, context.Operation);
+        Assert.Equal(MobileExceptionSeverity.Error, context.Severity);
+        Assert.False(string.IsNullOrWhiteSpace(context.CorrelationId));
+        Assert.True(context.Properties.ContainsKey("pendingChangesCount"));
+        return context;
     }
 
     private static Feature CreateFeature(
@@ -267,6 +369,22 @@ public sealed class GeoPackageSyncServiceTests
             return Task.FromResult(0L);
         }
     }
+
+    private sealed class RecordingExceptionReporter : IMobileExceptionReporter
+    {
+        public List<ReportedException> Reports { get; } = [];
+
+        public Task ReportAsync(
+            Exception exception,
+            MobileExceptionReportContext? context = null,
+            CancellationToken cancellationToken = default)
+        {
+            Reports.Add(new ReportedException(exception, context));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record ReportedException(Exception Exception, MobileExceptionReportContext? Context);
 
     private sealed class UnsupportedGeometry : Geometry
     {


### PR DESCRIPTION
## Summary
- Wire `IMobileExceptionReporter` into the FieldCollection GeoPackage sync service through MAUI DI.
- Report handled `SyncAsync`, `PullChangesAsync`, and `PushChangesAsync` failures with a sanitized mobile-only context: source, operation, correlation id, status, and aggregate counts.
- Add focused tests covering full, pull, and push handled-failure reporting without changing existing `SyncResult` behavior.

## Issue
Refs #91

## Validation
- `git diff --check`
- Blocked: `dotnet restore tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj` fails locally because this environment cannot authenticate to GitHub Packages for private `Honua.Sdk.*` packages (`403 Forbidden` / `NU1101`). CI should validate with repo package credentials.