### PR TITLE
mobile: gate exception reporting consent

### DIFF
--- a/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/FieldCollectionExceptionReporting.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/FieldCollectionExceptionReporting.cs
@@ -8,9 +8,11 @@ namespace Honua.Mobile.FieldCollection.Services.Diagnostics;
 
 public static class FieldCollectionExceptionReporting
 {
-    private const string ModePreferenceKey = "honua_exception_reporting_mode";
-    private const string EndpointPreferenceKey = "honua_exception_reporting_endpoint";
-    private const string QueuePathPreferenceKey = "honua_exception_reporting_queue_path";
+    internal const string ModePreferenceKey = "honua_exception_reporting_mode";
+    internal const string EndpointPreferenceKey = "honua_exception_reporting_endpoint";
+    internal const string QueuePathPreferenceKey = "honua_exception_reporting_queue_path";
+    internal const string TesterConsentPreferenceKey = "honua_exception_reporting_tester_consent";
+    internal const string EnvironmentEnabledPreferenceKey = "honua_exception_reporting_environment_enabled";
 
     public static MobileExceptionReportingOptions FromPreferences(MobileBuildConfiguration buildConfiguration)
     {
@@ -24,7 +26,9 @@ public static class FieldCollectionExceptionReporting
             SafeAppId(),
             SafePlatform(),
             SafeOsVersion(),
-            SafeDeviceClass());
+            SafeDeviceClass(),
+            Preferences.Default.Get(TesterConsentPreferenceKey, false),
+            Preferences.Default.Get(EnvironmentEnabledPreferenceKey, true));
     }
 
     internal static MobileExceptionReportingOptions CreateOptions(
@@ -35,13 +39,19 @@ public static class FieldCollectionExceptionReporting
         string? appId,
         string? platform,
         string? osVersion,
-        string? deviceClass)
+        string? deviceClass,
+        bool hasTesterConsent = true,
+        bool environmentAllowsReporting = true)
     {
         ArgumentNullException.ThrowIfNull(buildConfiguration);
+        var requestedMode = ParseMode(modeValue);
+        var mode = hasTesterConsent && environmentAllowsReporting
+            ? requestedMode
+            : MobileExceptionReportingMode.Disabled;
 
         return new MobileExceptionReportingOptions
         {
-            Mode = ParseMode(modeValue),
+            Mode = mode,
             UploadEndpoint = Uri.TryCreate(endpointValue, UriKind.Absolute, out var endpoint) ? endpoint : null,
             QueueDirectory = string.IsNullOrWhiteSpace(queueDirectory) ? null : queueDirectory,
             Metadata = new MobileExceptionReportMetadata

--- a/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/FieldCollectionExceptionReporting.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/FieldCollectionExceptionReporting.cs
@@ -14,6 +14,11 @@ public static class FieldCollectionExceptionReporting
     internal const string TesterConsentPreferenceKey = "honua_exception_reporting_tester_consent";
     internal const string EnvironmentEnabledPreferenceKey = "honua_exception_reporting_environment_enabled";
 
+    internal readonly record struct PreferenceUpdate(
+        bool ShouldWriteModeAndConsent,
+        bool TesterConsent,
+        MobileExceptionReportingMode Mode);
+
     public static MobileExceptionReportingOptions FromPreferences(MobileBuildConfiguration buildConfiguration)
     {
         ArgumentNullException.ThrowIfNull(buildConfiguration);
@@ -29,6 +34,25 @@ public static class FieldCollectionExceptionReporting
             SafeDeviceClass(),
             Preferences.Default.Get(TesterConsentPreferenceKey, false),
             Preferences.Default.Get(EnvironmentEnabledPreferenceKey, true));
+    }
+
+    internal static PreferenceUpdate CreatePreferenceUpdate(
+        bool enableExceptionReporting,
+        bool environmentAllowsReporting,
+        string? endpointValue)
+    {
+        if (!environmentAllowsReporting)
+        {
+            return new PreferenceUpdate(false, false, MobileExceptionReportingMode.Disabled);
+        }
+
+        var mode = enableExceptionReporting
+            ? string.IsNullOrWhiteSpace(endpointValue)
+                ? MobileExceptionReportingMode.LocalOnly
+                : MobileExceptionReportingMode.ServerUpload
+            : MobileExceptionReportingMode.Disabled;
+
+        return new PreferenceUpdate(true, enableExceptionReporting, mode);
     }
 
     internal static MobileExceptionReportingOptions CreateOptions(

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/SettingsViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/SettingsViewModel.cs
@@ -231,19 +231,20 @@ public partial class SettingsViewModel : BaseViewModel
     private void SaveExceptionReportingPreferences()
     {
         var endpoint = (ExceptionReportingEndpoint ?? string.Empty).Trim();
-        var shouldEnable = EnableExceptionReporting && CanEnableExceptionReporting;
-        var mode = shouldEnable
-            ? string.IsNullOrWhiteSpace(endpoint)
-                ? MobileExceptionReportingMode.LocalOnly
-                : MobileExceptionReportingMode.ServerUpload
-            : MobileExceptionReportingMode.Disabled;
+        var preferenceUpdate = FieldCollectionExceptionReporting.CreatePreferenceUpdate(
+            EnableExceptionReporting,
+            CanEnableExceptionReporting,
+            endpoint);
 
-        Preferences.Default.Set(
-            FieldCollectionExceptionReporting.TesterConsentPreferenceKey,
-            shouldEnable);
-        Preferences.Default.Set(
-            FieldCollectionExceptionReporting.ModePreferenceKey,
-            mode.ToString());
+        if (preferenceUpdate.ShouldWriteModeAndConsent)
+        {
+            Preferences.Default.Set(
+                FieldCollectionExceptionReporting.TesterConsentPreferenceKey,
+                preferenceUpdate.TesterConsent);
+            Preferences.Default.Set(
+                FieldCollectionExceptionReporting.ModePreferenceKey,
+                preferenceUpdate.Mode.ToString());
+        }
 
         if (string.IsNullOrWhiteSpace(endpoint))
         {

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/SettingsViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/SettingsViewModel.cs
@@ -2,6 +2,8 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Honua.Mobile.FieldCollection.Services;
 using Honua.Mobile.FieldCollection.Services.Configuration;
+using Honua.Mobile.FieldCollection.Services.Diagnostics;
+using Honua.Mobile.Maui.Diagnostics;
 using Microsoft.Maui.Storage;
 using FieldDeviceInfo = Honua.Mobile.FieldCollection.Models.DeviceInfo;
 
@@ -45,6 +47,18 @@ public partial class SettingsViewModel : BaseViewModel
 
     [ObservableProperty]
     private bool enableDeveloperMode = false;
+
+    [ObservableProperty]
+    private bool enableExceptionReporting;
+
+    [ObservableProperty]
+    private bool canEnableExceptionReporting = true;
+
+    [ObservableProperty]
+    private string exceptionReportingEndpoint = string.Empty;
+
+    [ObservableProperty]
+    private string exceptionReportingStatus = "Disabled";
 
     [ObservableProperty]
     private int syncIntervalMinutes = 15;
@@ -148,6 +162,16 @@ public partial class SettingsViewModel : BaseViewModel
             EnableBackgroundSync = await _settingsService.GetSettingAsync("background_sync", true);
             EnablePushNotifications = await _settingsService.GetSettingAsync("push_notifications", true);
             EnableDeveloperMode = await _settingsService.GetSettingAsync("developer_mode", false);
+            CanEnableExceptionReporting = Preferences.Default.Get(
+                FieldCollectionExceptionReporting.EnvironmentEnabledPreferenceKey,
+                true);
+            EnableExceptionReporting = CanEnableExceptionReporting &&
+                Preferences.Default.Get(FieldCollectionExceptionReporting.TesterConsentPreferenceKey, false) &&
+                ReadExceptionReportingMode() != MobileExceptionReportingMode.Disabled;
+            ExceptionReportingEndpoint = Preferences.Default.Get(
+                FieldCollectionExceptionReporting.EndpointPreferenceKey,
+                string.Empty);
+            UpdateExceptionReportingStatus();
             SyncIntervalMinutes = await _settingsService.GetSettingAsync("sync_interval_minutes", 15);
             MaxOfflineStorageMb = await _settingsService.GetSettingAsync("max_offline_storage_mb", 500);
         });
@@ -162,11 +186,94 @@ public partial class SettingsViewModel : BaseViewModel
             await _settingsService.SetSettingAsync("background_sync", EnableBackgroundSync);
             await _settingsService.SetSettingAsync("push_notifications", EnablePushNotifications);
             await _settingsService.SetSettingAsync("developer_mode", EnableDeveloperMode);
+            SaveExceptionReportingPreferences();
             await _settingsService.SetSettingAsync("sync_interval_minutes", SyncIntervalMinutes);
             await _settingsService.SetSettingAsync("max_offline_storage_mb", MaxOfflineStorageMb);
 
-            await ShowMessage("Settings Saved", "Your settings have been saved successfully.");
+            await ShowMessage(
+                "Settings Saved",
+                "Your settings have been saved. Exception reporting changes take effect after app restart.");
         });
+    }
+
+    partial void OnEnableExceptionReportingChanged(bool value)
+    {
+        UpdateExceptionReportingStatus();
+    }
+
+    partial void OnCanEnableExceptionReportingChanged(bool value)
+    {
+        if (!value)
+        {
+            EnableExceptionReporting = false;
+        }
+
+        UpdateExceptionReportingStatus();
+    }
+
+    partial void OnExceptionReportingEndpointChanged(string value)
+    {
+        UpdateExceptionReportingStatus();
+    }
+
+    private MobileExceptionReportingMode ReadExceptionReportingMode()
+    {
+        var value = Preferences.Default.Get(
+            FieldCollectionExceptionReporting.ModePreferenceKey,
+            MobileExceptionReportingMode.Disabled.ToString());
+        return string.Equals(value, "Server", StringComparison.OrdinalIgnoreCase)
+            ? MobileExceptionReportingMode.ServerUpload
+            : Enum.TryParse<MobileExceptionReportingMode>(value, ignoreCase: true, out var mode)
+                ? mode
+                : MobileExceptionReportingMode.Disabled;
+    }
+
+    private void SaveExceptionReportingPreferences()
+    {
+        var endpoint = (ExceptionReportingEndpoint ?? string.Empty).Trim();
+        var shouldEnable = EnableExceptionReporting && CanEnableExceptionReporting;
+        var mode = shouldEnable
+            ? string.IsNullOrWhiteSpace(endpoint)
+                ? MobileExceptionReportingMode.LocalOnly
+                : MobileExceptionReportingMode.ServerUpload
+            : MobileExceptionReportingMode.Disabled;
+
+        Preferences.Default.Set(
+            FieldCollectionExceptionReporting.TesterConsentPreferenceKey,
+            shouldEnable);
+        Preferences.Default.Set(
+            FieldCollectionExceptionReporting.ModePreferenceKey,
+            mode.ToString());
+
+        if (string.IsNullOrWhiteSpace(endpoint))
+        {
+            Preferences.Default.Remove(FieldCollectionExceptionReporting.EndpointPreferenceKey);
+        }
+        else
+        {
+            Preferences.Default.Set(FieldCollectionExceptionReporting.EndpointPreferenceKey, endpoint);
+        }
+
+        UpdateExceptionReportingStatus();
+    }
+
+    private void UpdateExceptionReportingStatus()
+    {
+        if (!CanEnableExceptionReporting)
+        {
+            ExceptionReportingStatus = "Disabled by environment";
+            return;
+        }
+
+        if (!EnableExceptionReporting)
+        {
+            ExceptionReportingStatus = "Disabled";
+            return;
+        }
+
+        ExceptionReportingStatus = string.IsNullOrWhiteSpace(ExceptionReportingEndpoint)
+            ? "Local queue only"
+            : "Uploads after local queue";
     }
 
     [RelayCommand]

--- a/apps/Honua.Mobile.FieldCollection/Views/SettingsPage.xaml
+++ b/apps/Honua.Mobile.FieldCollection/Views/SettingsPage.xaml
@@ -90,6 +90,29 @@
                                     VerticalOptions="Center" />
                         </Grid>
 
+                        <!-- Exception Reporting -->
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                            <StackLayout Grid.Column="0">
+                                <Label Text="Exception Reporting" FontSize="16" />
+                                <Label Text="{Binding ExceptionReportingStatus}"
+                                       FontSize="12" TextColor="{StaticResource Gray600}" />
+                            </StackLayout>
+                            <Switch Grid.Column="1"
+                                    IsToggled="{Binding EnableExceptionReporting}"
+                                    IsEnabled="{Binding CanEnableExceptionReporting}"
+                                    VerticalOptions="Center" />
+                        </Grid>
+
+                        <StackLayout>
+                            <Label Text="Exception Upload Endpoint" FontSize="16" />
+                            <Entry Text="{Binding ExceptionReportingEndpoint}"
+                                   Placeholder="Local queue only"
+                                   Keyboard="Url"
+                                   IsEnabled="{Binding EnableExceptionReporting}" />
+                            <Label Text="Leave blank to store sanitized reports locally until an approved ingestion endpoint is configured."
+                                   FontSize="12" TextColor="{StaticResource Gray600}" />
+                        </StackLayout>
+
                         <!-- Sync Interval -->
                         <StackLayout>
                             <Label Text="⏱️ Sync Interval" FontSize="16" />

--- a/docs/guides/mobile-exception-reporting.md
+++ b/docs/guides/mobile-exception-reporting.md
@@ -106,12 +106,22 @@ exception-report DTO or hardcoded server client. Tenant routing and ingestion
 schema versioning should be added through the uploader boundary once the server
 endpoint contract exists.
 
-The FieldCollection app maps the legacy `honua_exception_reporting_mode=Server`
-preference to `ServerUpload`, stamps build/device metadata from the mobile build
+The FieldCollection app keeps exception reporting off until both tester consent
+and the environment kill switch allow it. The Settings screen writes
+`honua_exception_reporting_tester_consent` and `honua_exception_reporting_mode`
+after the tester opts in. Environments can force reporting off by setting
+`honua_exception_reporting_environment_enabled=false`; that override wins even
+when a tester has opted in. Settings changes are read during app startup, so a
+restart is required before reporter registration changes take effect.
+
+When enabled without an upload endpoint, FieldCollection uses `LocalOnly` mode
+and stores sanitized reports in the local queue. When
+`honua_exception_reporting_endpoint` is configured, it uses `ServerUpload`. The
+app also maps the legacy `honua_exception_reporting_mode=Server` preference to
+`ServerUpload`, stamps build/device metadata from the mobile build
 configuration, and attaches its API key only when the configured upload endpoint
-shares the authenticated server origin. It still requires the explicit
-`honua_exception_reporting_endpoint` preference; mobile does not assume a server
-route before the ingestion contract is defined.
+shares the authenticated server origin. Mobile does not assume a server route
+before the ingestion contract is defined.
 
 Do not flush from a blocking UI path or synchronously during app startup. Start
 flush work from lifecycle/background scheduling code and allow it to stop on

--- a/tests/Honua.Mobile.FieldCollection.Tests/MobileExceptionReporterTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/MobileExceptionReporterTests.cs
@@ -113,6 +113,43 @@ public sealed class MobileExceptionReporterTests
     }
 
     [Fact]
+    public void CreatePreferenceUpdate_UsesLocalOnlyWhenConsentAllowsReportingWithoutEndpoint()
+    {
+        var update = FieldCollectionExceptionReporting.CreatePreferenceUpdate(
+            enableExceptionReporting: true,
+            environmentAllowsReporting: true,
+            endpointValue: string.Empty);
+
+        Assert.True(update.ShouldWriteModeAndConsent);
+        Assert.True(update.TesterConsent);
+        Assert.Equal(MobileExceptionReportingMode.LocalOnly, update.Mode);
+    }
+
+    [Fact]
+    public void CreatePreferenceUpdate_UsesServerUploadWhenEndpointIsConfigured()
+    {
+        var update = FieldCollectionExceptionReporting.CreatePreferenceUpdate(
+            enableExceptionReporting: true,
+            environmentAllowsReporting: true,
+            endpointValue: "https://api.honua.test/mobile/exception-reports");
+
+        Assert.True(update.ShouldWriteModeAndConsent);
+        Assert.True(update.TesterConsent);
+        Assert.Equal(MobileExceptionReportingMode.ServerUpload, update.Mode);
+    }
+
+    [Fact]
+    public void CreatePreferenceUpdate_PreservesConsentWhenEnvironmentKillSwitchIsOff()
+    {
+        var update = FieldCollectionExceptionReporting.CreatePreferenceUpdate(
+            enableExceptionReporting: false,
+            environmentAllowsReporting: false,
+            endpointValue: "https://api.honua.test/mobile/exception-reports");
+
+        Assert.False(update.ShouldWriteModeAndConsent);
+    }
+
+    [Fact]
     public void AuthHeaderCustomizer_DoesNotForwardApiKeyToCrossOriginEndpoint()
     {
         using var request = new HttpRequestMessage(HttpMethod.Post, "https://collector.example.test/mobile/exceptions");

--- a/tests/Honua.Mobile.FieldCollection.Tests/MobileExceptionReporterTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/MobileExceptionReporterTests.cs
@@ -57,6 +57,62 @@ public sealed class MobileExceptionReporterTests
     }
 
     [Fact]
+    public void CreateOptions_UsesLocalOnlyWhenConsentAllowsReportingWithoutEndpoint()
+    {
+        var options = FieldCollectionExceptionReporting.CreateOptions(
+            "LocalOnly",
+            string.Empty,
+            string.Empty,
+            CreateBuildConfiguration(),
+            "io.honua.mobile.fieldcollection",
+            "Android",
+            "15",
+            "Phone",
+            hasTesterConsent: true,
+            environmentAllowsReporting: true);
+
+        Assert.Equal(MobileExceptionReportingMode.LocalOnly, options.Mode);
+        Assert.Null(options.UploadEndpoint);
+    }
+
+    [Fact]
+    public void CreateOptions_DisablesReportingWhenTesterConsentIsMissing()
+    {
+        var options = FieldCollectionExceptionReporting.CreateOptions(
+            "ServerUpload",
+            "https://api.honua.test/mobile/exception-reports",
+            string.Empty,
+            CreateBuildConfiguration(),
+            "io.honua.mobile.fieldcollection",
+            "Android",
+            "15",
+            "Phone",
+            hasTesterConsent: false,
+            environmentAllowsReporting: true);
+
+        Assert.Equal(MobileExceptionReportingMode.Disabled, options.Mode);
+        Assert.Equal(new Uri("https://api.honua.test/mobile/exception-reports"), options.UploadEndpoint);
+    }
+
+    [Fact]
+    public void CreateOptions_DisablesReportingWhenEnvironmentKillSwitchIsOff()
+    {
+        var options = FieldCollectionExceptionReporting.CreateOptions(
+            "LocalOnly",
+            string.Empty,
+            string.Empty,
+            CreateBuildConfiguration(),
+            "io.honua.mobile.fieldcollection",
+            "Android",
+            "15",
+            "Phone",
+            hasTesterConsent: true,
+            environmentAllowsReporting: false);
+
+        Assert.Equal(MobileExceptionReportingMode.Disabled, options.Mode);
+    }
+
+    [Fact]
     public void AuthHeaderCustomizer_DoesNotForwardApiKeyToCrossOriginEndpoint()
     {
         using var request = new HttpRequestMessage(HttpMethod.Post, "https://collector.example.test/mobile/exceptions");


### PR DESCRIPTION
## Summary
- Add FieldCollection tester consent and environment kill-switch gates before exception reporting can register as local/server upload.
- Surface opt-in controls on Settings, including local-queue-only vs upload-endpoint mode and restart messaging.
- Extend #91 docs/tests for consent, kill-switch, and local-only enablement.

## Issue
Refs #91

## Validation
- `git diff --check`
- Blocked locally: `dotnet restore tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj` fails in this environment because GitHub Packages denies private `Honua.Sdk.*` package reads (`403 Forbidden`). CI should validate with repo package credentials.