### PR TITLE
docs: add android store prereq release gate

### DIFF
--- a/quality/release-checklist.md
+++ b/quality/release-checklist.md
@@ -38,6 +38,8 @@ comment, etc.) in the Notes column.
 - [ ] NuGet publish release tag is signed and matches `mobile-dotnet-v*`
 - [ ] Mobile store prerequisites reviewed for app-store builds
       (`docs/guides/mobile-store-prereqs.md`)
+- [ ] Android store prerequisite mapping validation passes
+      (`scripts/validate-android-store-prereqs.sh`)
 - [ ] iOS store prerequisite mapping validation passes
       (`scripts/validate-ios-store-prereqs.sh`)
 - [ ] `trunk` branch protection confirmed: required reviews, required status


### PR DESCRIPTION
## Summary
- Add the Android store prerequisite validator to the release checklist beside the existing iOS validator gate.
- Keeps #82/#85 release evidence aligned with the Android manifest/docs/workflow validation script.

## Issues
Refs #82
Refs #85

## Validation
- `scripts/validate-android-store-prereqs.sh`
- `scripts/validate-ios-store-prereqs.sh`
- `git diff --check`

## Note
The remaining #85 acceptance items are external Play Console app records, protected GitHub environment secret values, and tester access confirmation.