### PR TITLE
feat: add iframe message listener helper

### DIFF
--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -131,6 +131,24 @@ Set `parentOrigin` to constrain forwarded messages to the host application
 origin. If a `parent-origin` query value is malformed, the iframe disables
 parent event forwarding instead of falling back to `*`.
 
+Browser hosts can consume those forwarded events through the typed iframe helper.
+The `origin` filter is the iframe shell origin, while `parentOrigin` in the
+generated snippet is the embedding application origin used by `postMessage`.
+
+```js
+import { addHonuaMapIframeMessageListener } from '@honua-io/embed/iframe';
+
+const iframe = document.querySelector('#asset-map-frame');
+const disconnect = addHonuaMapIframeMessageListener((message) => {
+  if (message.type === 'honua-map-identify') {
+    console.log(message.detail);
+  }
+}, {
+  origin: 'https://cdn.honua.dev',
+  source: iframe.contentWindow,
+});
+```
+
 ## Integration Events
 
 ```js

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -287,6 +287,23 @@ Set `parentOrigin` when generating snippets so forwarded messages are scoped to
 the embedding application origin. If a `parent-origin` query value is malformed,
 the iframe disables parent event forwarding instead of falling back to `*`.
 
+Hosts can validate and subscribe to forwarded iframe events from the browser
+entrypoint. The `origin` filter is the iframe shell origin.
+
+```js
+import { addHonuaMapIframeMessageListener } from '@honua-io/embed/iframe';
+
+const iframe = document.querySelector('#asset-map-frame');
+const disconnect = addHonuaMapIframeMessageListener((message) => {
+  if (message.type === 'honua-map-search') {
+    console.log(message.detail);
+  }
+}, {
+  origin: 'https://cdn.honua.dev',
+  source: iframe.contentWindow,
+});
+```
+
 Use `applyHonuaMapOptions(element, options)` to apply the same options shape to
 an existing map element at runtime.
 

--- a/src/Honua.Embed/src/iframe.ts
+++ b/src/Honua.Embed/src/iframe.ts
@@ -13,12 +13,23 @@ export interface HonuaMapIframeConfig {
 export interface HonuaMapIframeMessage {
   source: 'honua-map-iframe';
   version: 1;
-  type: string;
+  type: HonuaMapIframeEventType;
   detail: unknown;
 }
 
+export type HonuaMapIframeMessageListener = (
+  message: HonuaMapIframeMessage,
+  event: MessageEvent<HonuaMapIframeMessage>,
+) => void;
+
 export interface HonuaMapIframeMessageTarget {
   postMessage(message: HonuaMapIframeMessage, targetOrigin: string): void;
+}
+
+export interface HonuaMapIframeMessageListenerOptions {
+  window?: Window;
+  origin?: string | readonly string[] | null;
+  source?: MessageEventSource | null;
 }
 
 export interface HonuaMapIframeHydrateOptions {
@@ -40,6 +51,10 @@ const FORWARDED_EVENTS = [
   'honua-map-search',
   'honua-map-identify',
 ] as const;
+
+export type HonuaMapIframeEventType = (typeof FORWARDED_EVENTS)[number];
+
+const FORWARDED_EVENT_SET = new Set<string>(FORWARDED_EVENTS);
 
 const THEME_PARAMETERS: Array<[keyof HonuaMapThemeOptions, string]> = [
   ['accent', '--honua-map-accent'],
@@ -111,6 +126,45 @@ export function hydrateHonuaMapIframe(
   return { element, config, disconnect };
 }
 
+export function isHonuaMapIframeMessage(value: unknown): value is HonuaMapIframeMessage {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<HonuaMapIframeMessage>;
+  return candidate.source === 'honua-map-iframe'
+    && candidate.version === 1
+    && typeof candidate.type === 'string'
+    && FORWARDED_EVENT_SET.has(candidate.type);
+}
+
+export function addHonuaMapIframeMessageListener(
+  listener: HonuaMapIframeMessageListener,
+  options: HonuaMapIframeMessageListenerOptions = {},
+): () => void {
+  const targetWindow = options.window ?? defaultWindow();
+  const expectedOrigins = normalizeExpectedOrigins(options.origin);
+  const expectedSource = options.source;
+  const messageListener = (event: MessageEvent) => {
+    if (expectedSource !== undefined && event.source !== expectedSource) {
+      return;
+    }
+
+    if (!originMatches(event.origin, expectedOrigins)) {
+      return;
+    }
+
+    if (!isHonuaMapIframeMessage(event.data)) {
+      return;
+    }
+
+    listener(event.data, event as MessageEvent<HonuaMapIframeMessage>);
+  };
+
+  targetWindow.addEventListener('message', messageListener);
+  return () => targetWindow.removeEventListener('message', messageListener);
+}
+
 function bridgeMapEvents(
   element: HonuaMapElement,
   parent: HonuaMapIframeMessageTarget,
@@ -135,6 +189,39 @@ function bridgeMapEvents(
       remove();
     }
   };
+}
+
+function defaultWindow(): Window {
+  if (typeof window === 'undefined') {
+    throw new Error('Honua map iframe message listeners require a browser Window.');
+  }
+
+  return window;
+}
+
+function normalizeExpectedOrigins(origin: string | readonly string[] | null | undefined): Set<string> | null {
+  if (origin === undefined || origin === null) {
+    return null;
+  }
+
+  const values = Array.isArray(origin) ? origin : [origin];
+  const normalized = new Set<string>();
+  for (const value of values) {
+    const parsed = parseParentOrigin(value);
+    if (parsed) {
+      normalized.add(parsed);
+    }
+  }
+
+  return normalized;
+}
+
+function originMatches(origin: string, expectedOrigins: Set<string> | null): boolean {
+  if (expectedOrigins === null || expectedOrigins.has('*')) {
+    return true;
+  }
+
+  return expectedOrigins.has(origin);
 }
 
 function applyFrameSizing(element: HTMLElement): void {

--- a/src/Honua.Embed/tests/honua-iframe.test.ts
+++ b/src/Honua.Embed/tests/honua-iframe.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  addHonuaMapIframeMessageListener,
   hydrateHonuaMapIframe,
+  isHonuaMapIframeMessage,
   parseHonuaMapIframeConfig,
   type HonuaMapIframeMessage,
 } from '../src/iframe';
@@ -137,5 +139,74 @@ describe('honua map iframe fallback', () => {
 
     expect(runtime.config.parentOrigin).toBeNull();
     expect(parent.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('identifies iframe fallback messages by source, version, and forwarded event type', () => {
+    expect(isHonuaMapIframeMessage({
+      source: 'honua-map-iframe',
+      version: 1,
+      type: 'honua-map-search',
+      detail: { query: 'hydrants' },
+    })).toBe(true);
+
+    expect(isHonuaMapIframeMessage({
+      source: 'other-frame',
+      version: 1,
+      type: 'honua-map-search',
+      detail: {},
+    })).toBe(false);
+
+    expect(isHonuaMapIframeMessage({
+      source: 'honua-map-iframe',
+      version: 1,
+      type: 'unscoped-event',
+      detail: {},
+    })).toBe(false);
+  });
+
+  it('subscribes to iframe fallback messages with origin and source filtering', () => {
+    const sourceFrame = document.createElement('iframe');
+    document.body.append(sourceFrame);
+    const source = sourceFrame.contentWindow;
+    const listener = vi.fn<(message: HonuaMapIframeMessage, event: MessageEvent) => void>();
+    const message: HonuaMapIframeMessage = {
+      source: 'honua-map-iframe',
+      version: 1,
+      type: 'honua-map-identify',
+      detail: { x: 12, y: 34 },
+    };
+    const disconnect = addHonuaMapIframeMessageListener(listener, {
+      origin: 'https://portal.example.test/admin/embed',
+      source,
+    });
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data: message,
+      origin: 'https://other.example.test',
+      source,
+    }));
+    window.dispatchEvent(new MessageEvent('message', {
+      data: message,
+      origin: 'https://portal.example.test',
+      source: window,
+    }));
+    window.dispatchEvent(new MessageEvent('message', {
+      data: message,
+      origin: 'https://portal.example.test',
+      source,
+    }));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0]?.[0]).toBe(message);
+    expect(listener.mock.calls[0]?.[1].origin).toBe('https://portal.example.test');
+
+    disconnect();
+    window.dispatchEvent(new MessageEvent('message', {
+      data: message,
+      origin: 'https://portal.example.test',
+      source,
+    }));
+
+    expect(listener).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- Add typed host-side validation and subscription helpers for forwarded Honua iframe fallback messages.
- Filter iframe messages by allowed origin and source window, with cleanup support.
- Document consuming forwarded iframe events from browser hosts.

## Issue
Refs #10

## Validation
- `npm test -- --run tests/honua-iframe.test.ts tests/honua-snippets.test.ts`
- `npm run typecheck`
- `git diff --check`

## Remaining #10 Scope
CDN publishing, admin/embed builder UI, framework wrapper packages, and server-backed analytics/API-key/rate/CORS controls remain separate larger slices.