### PR TITLE
feat: add embed framework snippet helpers

### DIFF
--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -149,6 +149,44 @@ const disconnect = addHonuaMapIframeMessageListener((message) => {
 });
 ```
 
+Framework teams can generate typed starter components around the same
+`<honua-map>` custom element or iframe fallback. `@honua-io/embed` does not
+depend on React, Vue, or Angular; these helpers only return code strings and
+reuse the same option serializers and credential omission defaults as the base
+snippet helpers.
+
+```js
+import {
+  createHonuaMapAngularSnippet,
+  createHonuaMapReactIframeSnippet,
+  createHonuaMapVueSnippet,
+} from '@honua-io/embed/snippets';
+
+const vueComponent = createHonuaMapVueSnippet({
+  serviceUrl: 'https://services.honua.example/FeatureServer',
+  layerIds: ['assets'],
+  identify: true,
+  label: 'City asset map',
+});
+
+const reactIframeComponent = createHonuaMapReactIframeSnippet({
+  search: true,
+  label: 'City asset map',
+}, {
+  componentName: 'CityAssetMapFrame',
+  iframeUrl: 'https://cdn.honua.dev/embed/map.html',
+  parentOrigin: 'https://portal.example.com',
+});
+
+const angularComponent = createHonuaMapAngularSnippet({
+  basemap: 'streets',
+  search: true,
+}, {
+  componentName: 'CityAssetMapComponent',
+  selector: 'city-asset-map',
+});
+```
+
 ## Integration Events
 
 ```js

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -304,6 +304,40 @@ const disconnect = addHonuaMapIframeMessageListener((message) => {
 });
 ```
 
+Framework hosts can generate starter components without taking a React, Vue, or
+Angular dependency from this package. These helpers reuse the same map options,
+HTML escaping, iframe query serialization, and default credential omission as
+the plain snippet helpers.
+
+```ts
+import {
+  createHonuaMapAngularIframeSnippet,
+  createHonuaMapReactSnippet,
+  createHonuaMapVueSnippet,
+} from '@honua-io/embed/snippets';
+
+const reactComponent = createHonuaMapReactSnippet({
+  serviceUrl: 'https://services.honua.example/FeatureServer',
+  layerIds: ['assets'],
+  search: true,
+  label: 'City asset map',
+}, {
+  componentName: 'CityAssetMap',
+});
+
+const vueComponent = createHonuaMapVueSnippet({
+  basemap: 'satellite',
+  identify: true,
+});
+
+const angularIframeComponent = createHonuaMapAngularIframeSnippet({
+  search: true,
+}, {
+  iframeUrl: 'https://cdn.honua.dev/embed/map.html',
+  parentOrigin: 'https://portal.example.com',
+});
+```
+
 Use `applyHonuaMapOptions(element, options)` to apply the same options shape to
 an existing map element at runtime.
 

--- a/src/Honua.Embed/src/snippets.ts
+++ b/src/Honua.Embed/src/snippets.ts
@@ -74,6 +74,30 @@ export interface HonuaMapIframeSnippetOptions {
   indent?: string;
 }
 
+export interface HonuaMapReactSnippetOptions extends HonuaMapSnippetOptions {
+  componentName?: string;
+}
+
+export interface HonuaMapReactIframeSnippetOptions extends HonuaMapIframeSnippetOptions {
+  componentName?: string;
+}
+
+export interface HonuaMapVueSnippetOptions extends HonuaMapSnippetOptions {
+}
+
+export interface HonuaMapVueIframeSnippetOptions extends HonuaMapIframeSnippetOptions {
+}
+
+export interface HonuaMapAngularSnippetOptions extends HonuaMapSnippetOptions {
+  componentName?: string;
+  selector?: string;
+}
+
+export interface HonuaMapAngularIframeSnippetOptions extends HonuaMapIframeSnippetOptions {
+  componentName?: string;
+  selector?: string;
+}
+
 export function applyHonuaMapOptions(
   element: HTMLElement,
   options: HonuaMapEmbedOptions,
@@ -188,6 +212,150 @@ export function createHonuaMapIframeSnippet(
   return `<iframe\n${lines.join('\n')}>\n</iframe>`;
 }
 
+export function createHonuaMapReactSnippet(
+  options: HonuaMapEmbedOptions,
+  snippetOptions: HonuaMapReactSnippetOptions = {},
+): string {
+  const componentName = snippetOptions.componentName ?? 'HonuaMapEmbed';
+  assertJsIdentifier(componentName);
+  const elementName = snippetOptions.elementName ?? 'honua-map';
+  assertCustomElementName(elementName);
+  const packageName = snippetOptions.packageName ?? '@honua-io/embed';
+  const indent = snippetOptions.indent ?? '  ';
+  const registration = createFrameworkRegistrationLines(
+    packageName,
+    elementName,
+    snippetOptions.includeScript ?? true,
+  );
+  const element = createReactElementMarkup(elementName, options, {
+    includeCredentials: snippetOptions.includeCredentials ?? false,
+    indent: `${indent}${indent}`,
+  });
+
+  return [
+    ...registration,
+    ...(registration.length > 0 ? [''] : []),
+    `export function ${componentName}() {`,
+    `${indent}return (`,
+    element,
+    `${indent});`,
+    '}',
+  ].join('\n');
+}
+
+export function createHonuaMapReactIframeSnippet(
+  options: HonuaMapEmbedOptions,
+  snippetOptions: HonuaMapReactIframeSnippetOptions = {},
+): string {
+  const componentName = snippetOptions.componentName ?? 'HonuaMapEmbed';
+  assertJsIdentifier(componentName);
+  const indent = snippetOptions.indent ?? '  ';
+  const element = createReactIframeMarkup(options, {
+    ...snippetOptions,
+    indent: `${indent}${indent}`,
+  });
+
+  return [
+    `export function ${componentName}() {`,
+    `${indent}return (`,
+    element,
+    `${indent});`,
+    '}',
+  ].join('\n');
+}
+
+export function createHonuaMapVueSnippet(
+  options: HonuaMapEmbedOptions,
+  snippetOptions: HonuaMapVueSnippetOptions = {},
+): string {
+  const elementName = snippetOptions.elementName ?? 'honua-map';
+  assertCustomElementName(elementName);
+  const packageName = snippetOptions.packageName ?? '@honua-io/embed';
+  const indent = snippetOptions.indent ?? '  ';
+  const registration = createFrameworkRegistrationLines(
+    packageName,
+    elementName,
+    snippetOptions.includeScript ?? true,
+  );
+  const element = createElementMarkup(elementName, options, {
+    includeCredentials: snippetOptions.includeCredentials ?? false,
+    indent,
+  });
+
+  return [
+    '<template>',
+    indentBlock(element, indent),
+    '</template>',
+    ...(registration.length > 0
+      ? [
+        '',
+        '<script setup lang="ts">',
+        ...registration,
+        '</script>',
+      ]
+      : []),
+  ].join('\n');
+}
+
+export function createHonuaMapVueIframeSnippet(
+  options: HonuaMapEmbedOptions,
+  snippetOptions: HonuaMapVueIframeSnippetOptions = {},
+): string {
+  const indent = snippetOptions.indent ?? '  ';
+  const iframe = createHonuaMapIframeSnippet(options, {
+    ...snippetOptions,
+    indent,
+  });
+
+  return [
+    '<template>',
+    indentBlock(iframe, indent),
+    '</template>',
+  ].join('\n');
+}
+
+export function createHonuaMapAngularSnippet(
+  options: HonuaMapEmbedOptions,
+  snippetOptions: HonuaMapAngularSnippetOptions = {},
+): string {
+  const componentName = snippetOptions.componentName ?? 'HonuaMapEmbedComponent';
+  assertJsIdentifier(componentName);
+  const selector = snippetOptions.selector ?? 'honua-map-embed';
+  assertCustomElementName(selector);
+  const elementName = snippetOptions.elementName ?? 'honua-map';
+  assertCustomElementName(elementName);
+  const packageName = snippetOptions.packageName ?? '@honua-io/embed';
+  const indent = snippetOptions.indent ?? '  ';
+  const registration = createFrameworkRegistrationLines(
+    packageName,
+    elementName,
+    snippetOptions.includeScript ?? true,
+  );
+  const element = createElementMarkup(elementName, options, {
+    includeCredentials: snippetOptions.includeCredentials ?? false,
+    indent,
+  });
+
+  return createAngularComponentSnippet(componentName, selector, registration, element, indent);
+}
+
+export function createHonuaMapAngularIframeSnippet(
+  options: HonuaMapEmbedOptions,
+  snippetOptions: HonuaMapAngularIframeSnippetOptions = {},
+): string {
+  const componentName = snippetOptions.componentName ?? 'HonuaMapEmbedComponent';
+  assertJsIdentifier(componentName);
+  const selector = snippetOptions.selector ?? 'honua-map-embed';
+  assertCustomElementName(selector);
+  const indent = snippetOptions.indent ?? '  ';
+  const iframe = createHonuaMapIframeSnippet(options, {
+    ...snippetOptions,
+    indent,
+  });
+
+  return createAngularComponentSnippet(componentName, selector, [], iframe, indent);
+}
+
 function createCdnScriptMarkup(
   scriptUrl: string,
   elementName: string,
@@ -225,6 +393,50 @@ function createCdnScriptMarkup(
   return `<script ${serialized}></script>`;
 }
 
+function createAngularComponentSnippet(
+  componentName: string,
+  selector: string,
+  setupLines: readonly string[],
+  template: string,
+  indent: string,
+): string {
+  const lines = [
+    'import { Component, CUSTOM_ELEMENTS_SCHEMA } from \'@angular/core\';',
+    ...setupLines,
+    '',
+    '@Component({',
+    `${indent}selector: '${escapeJsString(selector)}',`,
+    `${indent}standalone: true,`,
+    `${indent}schemas: [CUSTOM_ELEMENTS_SCHEMA],`,
+    `${indent}template: \``,
+    indentTemplateLiteral(template, indent),
+    `${indent}\`,`,
+    '})',
+    `export class ${componentName} {}`,
+  ];
+
+  return lines.join('\n');
+}
+
+function createFrameworkRegistrationLines(
+  packageName: string,
+  elementName: string,
+  includeScript: boolean,
+): string[] {
+  if (!includeScript) {
+    return [];
+  }
+
+  if (elementName === 'honua-map') {
+    return [`import '${escapeJsString(packageName)}';`];
+  }
+
+  return [
+    `import { defineHonuaMapElement } from '${escapeJsString(packageName)}';`,
+    `defineHonuaMapElement('${escapeJsString(elementName)}');`,
+  ];
+}
+
 function createElementMarkup(
   elementName: string,
   options: HonuaMapEmbedOptions,
@@ -245,6 +457,48 @@ function createElementMarkup(
     : `${config.indent}${name}="${escapeHtmlAttribute(value)}"`);
 
   return `<${elementName}\n${lines.join('\n')}>\n</${elementName}>`;
+}
+
+function createReactElementMarkup(
+  elementName: string,
+  options: HonuaMapEmbedOptions,
+  config: Required<Pick<HonuaMapSnippetOptions, 'includeCredentials' | 'indent'>>,
+): string {
+  const attributes = mapAttributes(options, config.includeCredentials);
+  const style = reactStyleObject(options.style);
+  const attributeIndent = `${config.indent}  `;
+  const lines = attributes.map(([name, value]) => value === true
+    ? `${attributeIndent}${name}`
+    : `${attributeIndent}${name}="${escapeHtmlAttribute(value)}"`);
+  if (style) {
+    lines.push(`${attributeIndent}style={${style}}`);
+  }
+
+  if (lines.length === 0) {
+    return `${config.indent}<${elementName} />`;
+  }
+
+  return `${config.indent}<${elementName}\n${lines.join('\n')}\n${config.indent}/>`;
+}
+
+function createReactIframeMarkup(
+  options: HonuaMapEmbedOptions,
+  snippetOptions: HonuaMapIframeSnippetOptions,
+): string {
+  const iframeUrl = snippetOptions.iframeUrl ?? 'https://cdn.honua.dev/embed/map.html';
+  const src = createIframeSrc(iframeUrl, options, {
+    includeCredentials: snippetOptions.includeCredentials ?? false,
+    parentOrigin: snippetOptions.parentOrigin,
+  });
+  const attributes = iframeAttributes(src, snippetOptions.iframe);
+  const indent = snippetOptions.indent ?? '    ';
+  const attributeIndent = `${indent}  `;
+  const lines = attributes.map(([name, value]) => {
+    const attributeName = reactIframeAttributeName(name);
+    return `${attributeIndent}${attributeName}="${escapeHtmlAttribute(value)}"`;
+  });
+
+  return `${indent}<iframe\n${lines.join('\n')}\n${indent}/>`;
 }
 
 function createIframeSrc(
@@ -376,6 +630,47 @@ function mapQueryParameters(
   return parameters;
 }
 
+function reactStyleObject(theme: HonuaMapThemeOptions | null | undefined): string | null {
+  const declarations = Object.entries(mapThemeVariables(theme))
+    .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+    .map(([property, value]) => `'${escapeJsString(property)}': '${escapeJsString(value)}'`);
+
+  if (declarations.length === 0) {
+    return null;
+  }
+
+  return `{ ${declarations.join(', ')} }`;
+}
+
+function reactIframeAttributeName(name: string): string {
+  if (name === 'class') {
+    return 'className';
+  }
+
+  if (name === 'referrerpolicy') {
+    return 'referrerPolicy';
+  }
+
+  return name;
+}
+
+function indentBlock(value: string, indent: string): string {
+  return value
+    .split('\n')
+    .map((line) => `${indent}${line}`)
+    .join('\n');
+}
+
+function indentTemplateLiteral(value: string, indent: string): string {
+  return value
+    .replaceAll('\\', '\\\\')
+    .replaceAll('`', '\\`')
+    .replaceAll('${', '\\${')
+    .split('\n')
+    .map((line) => `${indent}${indent}${line}`)
+    .join('\n');
+}
+
 function setOptionalAttribute(element: HTMLElement, name: string, value: string | null | undefined): void {
   if (value === undefined) {
     return;
@@ -501,5 +796,11 @@ function escapeJsString(value: string): string {
 function assertCustomElementName(name: string): void {
   if (!/^[a-z][.0-9_a-z-]*-[.0-9_a-z-]*$/.test(name)) {
     throw new Error(`Invalid custom element name: ${name}`);
+  }
+}
+
+function assertJsIdentifier(name: string): void {
+  if (!/^[$A-Z_a-z][$\w]*$/.test(name)) {
+    throw new Error(`Invalid JavaScript identifier: ${name}`);
   }
 }

--- a/src/Honua.Embed/src/snippets.ts
+++ b/src/Honua.Embed/src/snippets.ts
@@ -222,10 +222,11 @@ export function createHonuaMapReactSnippet(
   assertCustomElementName(elementName);
   const packageName = snippetOptions.packageName ?? '@honua-io/embed';
   const indent = snippetOptions.indent ?? '  ';
-  const registration = createFrameworkRegistrationLines(
+  const registration = createReactRegistrationSnippet(
     packageName,
     elementName,
     snippetOptions.includeScript ?? true,
+    indent,
   );
   const element = createReactElementMarkup(elementName, options, {
     includeCredentials: snippetOptions.includeCredentials ?? false,
@@ -233,13 +234,15 @@ export function createHonuaMapReactSnippet(
   });
 
   return [
-    ...registration,
-    ...(registration.length > 0 ? [''] : []),
+    ...registration.imports,
+    ...(registration.imports.length > 0 ? [''] : []),
     `export function ${componentName}() {`,
+    ...registration.effectLines,
     `${indent}return (`,
     element,
     `${indent});`,
     '}',
+    ...(registration.helpers.length > 0 ? ['', ...registration.helpers] : []),
   ].join('\n');
 }
 
@@ -272,7 +275,7 @@ export function createHonuaMapVueSnippet(
   assertCustomElementName(elementName);
   const packageName = snippetOptions.packageName ?? '@honua-io/embed';
   const indent = snippetOptions.indent ?? '  ';
-  const registration = createFrameworkRegistrationLines(
+  const registration = createVueRegistrationLines(
     packageName,
     elementName,
     snippetOptions.includeScript ?? true,
@@ -326,10 +329,11 @@ export function createHonuaMapAngularSnippet(
   assertCustomElementName(elementName);
   const packageName = snippetOptions.packageName ?? '@honua-io/embed';
   const indent = snippetOptions.indent ?? '  ';
-  const registration = createFrameworkRegistrationLines(
+  const registration = createAngularRegistrationSnippet(
     packageName,
     elementName,
     snippetOptions.includeScript ?? true,
+    indent,
   );
   const element = createElementMarkup(elementName, options, {
     includeCredentials: snippetOptions.includeCredentials ?? false,
@@ -353,7 +357,13 @@ export function createHonuaMapAngularIframeSnippet(
     indent,
   });
 
-  return createAngularComponentSnippet(componentName, selector, [], iframe, indent);
+  return createAngularComponentSnippet(
+    componentName,
+    selector,
+    emptyAngularRegistrationSnippet(),
+    iframe,
+    indent,
+  );
 }
 
 function createCdnScriptMarkup(
@@ -396,13 +406,12 @@ function createCdnScriptMarkup(
 function createAngularComponentSnippet(
   componentName: string,
   selector: string,
-  setupLines: readonly string[],
+  registration: AngularRegistrationSnippet,
   template: string,
   indent: string,
 ): string {
   const lines = [
-    'import { Component, CUSTOM_ELEMENTS_SCHEMA } from \'@angular/core\';',
-    ...setupLines,
+    `import { ${['Component', 'CUSTOM_ELEMENTS_SCHEMA', ...registration.coreImports].join(', ')} } from '@angular/core';`,
     '',
     '@Component({',
     `${indent}selector: '${escapeJsString(selector)}',`,
@@ -412,13 +421,57 @@ function createAngularComponentSnippet(
     indentTemplateLiteral(template, indent),
     `${indent}\`,`,
     '})',
-    `export class ${componentName} {}`,
+    registration.classBody.length > 0
+      ? [
+        `export class ${componentName}${registration.classImplements} {`,
+        ...registration.classBody,
+        '}',
+      ].join('\n')
+      : `export class ${componentName} {}`,
   ];
 
   return lines.join('\n');
 }
 
-function createFrameworkRegistrationLines(
+interface ReactRegistrationSnippet {
+  imports: string[];
+  effectLines: string[];
+  helpers: string[];
+}
+
+interface AngularRegistrationSnippet {
+  coreImports: string[];
+  classImplements: string;
+  classBody: string[];
+}
+
+function emptyAngularRegistrationSnippet(): AngularRegistrationSnippet {
+  return { coreImports: [], classImplements: '', classBody: [] };
+}
+
+function createReactRegistrationSnippet(
+  packageName: string,
+  elementName: string,
+  includeScript: boolean,
+  indent: string,
+): ReactRegistrationSnippet {
+  if (!includeScript) {
+    return { imports: [], effectLines: [], helpers: [] };
+  }
+
+  return {
+    imports: ['import { useEffect } from \'react\';'],
+    effectLines: [
+      `${indent}useEffect(() => {`,
+      `${indent}${indent}void registerHonuaMapElement();`,
+      `${indent}}, []);`,
+      '',
+    ],
+    helpers: createBrowserRegistrationHelper(packageName, elementName, ''),
+  };
+}
+
+function createVueRegistrationLines(
   packageName: string,
   elementName: string,
   includeScript: boolean,
@@ -427,13 +480,74 @@ function createFrameworkRegistrationLines(
     return [];
   }
 
-  if (elementName === 'honua-map') {
-    return [`import '${escapeJsString(packageName)}';`];
+  return [
+    'import { onMounted } from \'vue\';',
+    '',
+    'onMounted(() => {',
+    '  void registerHonuaMapElement();',
+    '});',
+    '',
+    ...createBrowserRegistrationHelper(packageName, elementName, ''),
+  ];
+}
+
+function createAngularRegistrationSnippet(
+  packageName: string,
+  elementName: string,
+  includeScript: boolean,
+  indent: string,
+): AngularRegistrationSnippet {
+  if (!includeScript) {
+    return emptyAngularRegistrationSnippet();
   }
 
+  return {
+    coreImports: ['AfterViewInit'],
+    classImplements: ' implements AfterViewInit',
+    classBody: [
+      `${indent}ngAfterViewInit(): void {`,
+      `${indent}${indent}void this.registerHonuaMapElement();`,
+      `${indent}}`,
+      '',
+      `${indent}private async registerHonuaMapElement(): Promise<void> {`,
+      ...createBrowserRegistrationBody(packageName, elementName, `${indent}${indent}`),
+      `${indent}}`,
+    ],
+  };
+}
+
+function createBrowserRegistrationHelper(
+  packageName: string,
+  elementName: string,
+  indent: string,
+): string[] {
   return [
-    `import { defineHonuaMapElement } from '${escapeJsString(packageName)}';`,
-    `defineHonuaMapElement('${escapeJsString(elementName)}');`,
+    `${indent}async function registerHonuaMapElement(): Promise<void> {`,
+    ...createBrowserRegistrationBody(packageName, elementName, `${indent}  `),
+    `${indent}}`,
+  ];
+}
+
+function createBrowserRegistrationBody(
+  packageName: string,
+  elementName: string,
+  indent: string,
+): string[] {
+  const escapedPackageName = escapeJsString(packageName);
+  const escapedElementName = escapeJsString(elementName);
+  const loadLine = elementName === 'honua-map'
+    ? `${indent}await import('${escapedPackageName}');`
+    : `${indent}const { defineHonuaMapElement } = await import('${escapedPackageName}');`;
+  const defineLine = elementName === 'honua-map'
+    ? null
+    : `${indent}defineHonuaMapElement('${escapedElementName}');`;
+  return [
+    `${indent}if (typeof window === 'undefined') {`,
+    `${indent}  return;`,
+    `${indent}}`,
+    '',
+    loadLine,
+    ...(defineLine ? [defineLine] : []),
   ];
 }
 
@@ -800,7 +914,56 @@ function assertCustomElementName(name: string): void {
 }
 
 function assertJsIdentifier(name: string): void {
-  if (!/^[$A-Z_a-z][$\w]*$/.test(name)) {
+  if (!/^[$A-Z_a-z][$\w]*$/.test(name) || JS_RESERVED_WORDS.has(name)) {
     throw new Error(`Invalid JavaScript identifier: ${name}`);
   }
 }
+
+const JS_RESERVED_WORDS = new Set([
+  'await',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'enum',
+  'export',
+  'extends',
+  'false',
+  'finally',
+  'for',
+  'function',
+  'if',
+  'implements',
+  'import',
+  'in',
+  'instanceof',
+  'interface',
+  'let',
+  'new',
+  'null',
+  'package',
+  'private',
+  'protected',
+  'public',
+  'return',
+  'static',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'typeof',
+  'var',
+  'void',
+  'while',
+  'with',
+  'yield',
+]);

--- a/src/Honua.Embed/tests/honua-snippets.test.ts
+++ b/src/Honua.Embed/tests/honua-snippets.test.ts
@@ -1,9 +1,15 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   applyHonuaMapOptions,
+  createHonuaMapAngularIframeSnippet,
+  createHonuaMapAngularSnippet,
   createHonuaMapCdnSnippet,
   createHonuaMapIframeSnippet,
+  createHonuaMapReactIframeSnippet,
+  createHonuaMapReactSnippet,
   createHonuaMapSnippet,
+  createHonuaMapVueIframeSnippet,
+  createHonuaMapVueSnippet,
   defineHonuaMapElement,
 } from '../src/index';
 
@@ -295,6 +301,150 @@ describe('honua map snippets', () => {
     expect(readIframe(snippet).getAttribute('src')).toBe(
       '//embed.example.test/map.html?tenant=city&service-url=https%3A%2F%2Fservices.example.test%2FFeatureServer&search=true#map',
     );
+  });
+
+  it('generates a React custom-element component without credentials by default', () => {
+    const snippet = createHonuaMapReactSnippet({
+      serviceUrl: 'https://services.example.test/FeatureServer?name="Assets"&team=<GIS>',
+      layerIds: ['assets'],
+      apiKey: 'secret-key',
+      interactive: true,
+      label: 'City "Assets" <Map> & Team',
+      style: {
+        accent: '#0f766e',
+        fontFamily: 'Aptos, sans-serif',
+      },
+    }, {
+      componentName: 'CityAssetMap',
+    });
+
+    expect(snippet).toContain('export function CityAssetMap()');
+    expect(snippet).toContain('import \'@honua-io/embed\';');
+    expect(snippet).toContain('<honua-map');
+    expect(snippet).toContain('service-url="https://services.example.test/FeatureServer?name=&quot;Assets&quot;&amp;team=&lt;GIS&gt;"');
+    expect(snippet).toContain('interactive');
+    expect(snippet).toContain('label="City &quot;Assets&quot; &lt;Map&gt; &amp; Team"');
+    expect(snippet).toContain('style={{ \'--honua-map-accent\': \'#0f766e\', \'--honua-map-font-family\': \'Aptos, sans-serif\' }}');
+    expect(snippet).not.toContain('secret-key');
+  });
+
+  it('registers custom framework element names when requested', () => {
+    const reactSnippet = createHonuaMapReactSnippet({
+      search: true,
+    }, {
+      elementName: 'city-map',
+      componentName: 'CityMap',
+    });
+    const vueSnippet = createHonuaMapVueSnippet({
+      identify: true,
+    }, {
+      elementName: 'city-vue-map',
+    });
+    const angularSnippet = createHonuaMapAngularSnippet({
+      interactive: true,
+    }, {
+      elementName: 'city-angular-map',
+      selector: 'city-angular-map-host',
+    });
+
+    expect(reactSnippet).toContain('import { defineHonuaMapElement } from \'@honua-io/embed\';');
+    expect(reactSnippet).toContain('defineHonuaMapElement(\'city-map\');');
+    expect(reactSnippet).toContain('<city-map');
+    expect(vueSnippet).toContain('defineHonuaMapElement(\'city-vue-map\');');
+    expect(vueSnippet).toContain('<city-vue-map');
+    expect(angularSnippet).toContain('defineHonuaMapElement(\'city-angular-map\');');
+    expect(angularSnippet).toContain('<city-angular-map');
+  });
+
+  it('omits custom-element registration for framework snippets when requested', () => {
+    const snippet = createHonuaMapVueSnippet({
+      search: true,
+    }, {
+      includeScript: false,
+    });
+
+    expect(snippet).not.toContain('<script');
+    expect(snippet).not.toContain('@honua-io/embed');
+  });
+
+  it('generates a React iframe fallback component with serialized iframe options', () => {
+    const snippet = createHonuaMapReactIframeSnippet({
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      apiKey: 'secret-key',
+      search: true,
+    }, {
+      componentName: 'CityAssetMapFrame',
+      iframeUrl: 'https://embed.example.test/map.html?tenant=city',
+      parentOrigin: 'https://portal.example.test',
+      iframe: {
+        title: 'City "Assets"',
+        referrerPolicy: 'no-referrer',
+        className: 'embed-frame',
+      },
+    });
+
+    expect(snippet).toContain('export function CityAssetMapFrame()');
+    expect(snippet).toContain('<iframe');
+    expect(snippet).toContain('src="https://embed.example.test/map.html?tenant=city&amp;service-url=https%3A%2F%2Fservices.example.test%2FFeatureServer&amp;search=true&amp;parent-origin=https%3A%2F%2Fportal.example.test"');
+    expect(snippet).toContain('title="City &quot;Assets&quot;"');
+    expect(snippet).toContain('referrerPolicy="no-referrer"');
+    expect(snippet).toContain('className="embed-frame"');
+    expect(snippet).not.toContain('secret-key');
+  });
+
+  it('generates Vue custom-element and iframe snippets', () => {
+    const elementSnippet = createHonuaMapVueSnippet({
+      layerIds: ['assets'],
+      apiKey: 'secret-key',
+      identify: true,
+      label: 'City asset map',
+    });
+    const iframeSnippet = createHonuaMapVueIframeSnippet({
+      basemap: 'satellite',
+    }, {
+      iframeUrl: '/embeds/map.html',
+    });
+
+    expect(elementSnippet).toContain('<template>\n  <honua-map');
+    expect(elementSnippet).toContain('    layer-ids="assets"');
+    expect(elementSnippet).toContain('    identify');
+    expect(elementSnippet).toContain('<script setup lang="ts">\nimport \'@honua-io/embed\';\n</script>');
+    expect(elementSnippet).not.toContain('secret-key');
+    expect(iframeSnippet).toContain('<template>\n  <iframe');
+    expect(iframeSnippet).toContain('    src="/embeds/map.html?basemap=satellite"');
+    expect(iframeSnippet).not.toContain('<script');
+  });
+
+  it('generates Angular custom-element and iframe components', () => {
+    const elementSnippet = createHonuaMapAngularSnippet({
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      apiKey: 'secret-key',
+      search: true,
+    }, {
+      componentName: 'CityAssetMapComponent',
+      selector: 'city-asset-map',
+    });
+    const iframeSnippet = createHonuaMapAngularIframeSnippet({
+      basemap: 'dark',
+    }, {
+      componentName: 'CityAssetMapFrameComponent',
+      selector: 'city-asset-map-frame',
+      iframeUrl: '/embeds/map.html',
+    });
+
+    expect(elementSnippet).toContain('import { Component, CUSTOM_ELEMENTS_SCHEMA } from \'@angular/core\';');
+    expect(elementSnippet).toContain('import \'@honua-io/embed\';');
+    expect(elementSnippet).toContain('selector: \'city-asset-map\'');
+    expect(elementSnippet).toContain('schemas: [CUSTOM_ELEMENTS_SCHEMA]');
+    expect(elementSnippet).toContain('<honua-map');
+    expect(elementSnippet).toContain('service-url="https://services.example.test/FeatureServer"');
+    expect(elementSnippet).toContain('search');
+    expect(elementSnippet).toContain('export class CityAssetMapComponent {}');
+    expect(elementSnippet).not.toContain('secret-key');
+    expect(iframeSnippet).toContain('selector: \'city-asset-map-frame\'');
+    expect(iframeSnippet).toContain('<iframe');
+    expect(iframeSnippet).toContain('src="/embeds/map.html?basemap=dark"');
+    expect(iframeSnippet).toContain('export class CityAssetMapFrameComponent {}');
   });
 });
 

--- a/src/Honua.Embed/tests/honua-snippets.test.ts
+++ b/src/Honua.Embed/tests/honua-snippets.test.ts
@@ -319,7 +319,9 @@ describe('honua map snippets', () => {
     });
 
     expect(snippet).toContain('export function CityAssetMap()');
-    expect(snippet).toContain('import \'@honua-io/embed\';');
+    expect(snippet).toContain('import { useEffect } from \'react\';');
+    expect(snippet).toContain('useEffect(() => {');
+    expect(snippet).toContain('await import(\'@honua-io/embed\');');
     expect(snippet).toContain('<honua-map');
     expect(snippet).toContain('service-url="https://services.example.test/FeatureServer?name=&quot;Assets&quot;&amp;team=&lt;GIS&gt;"');
     expect(snippet).toContain('interactive');
@@ -347,7 +349,7 @@ describe('honua map snippets', () => {
       selector: 'city-angular-map-host',
     });
 
-    expect(reactSnippet).toContain('import { defineHonuaMapElement } from \'@honua-io/embed\';');
+    expect(reactSnippet).toContain('const { defineHonuaMapElement } = await import(\'@honua-io/embed\');');
     expect(reactSnippet).toContain('defineHonuaMapElement(\'city-map\');');
     expect(reactSnippet).toContain('<city-map');
     expect(vueSnippet).toContain('defineHonuaMapElement(\'city-vue-map\');');
@@ -365,6 +367,15 @@ describe('honua map snippets', () => {
 
     expect(snippet).not.toContain('<script');
     expect(snippet).not.toContain('@honua-io/embed');
+  });
+
+  it('rejects reserved JavaScript words for generated component names', () => {
+    expect(() => createHonuaMapReactSnippet({}, {
+      componentName: 'default',
+    })).toThrow('Invalid JavaScript identifier: default');
+    expect(() => createHonuaMapAngularSnippet({}, {
+      componentName: 'class',
+    })).toThrow('Invalid JavaScript identifier: class');
   });
 
   it('generates a React iframe fallback component with serialized iframe options', () => {
@@ -408,7 +419,9 @@ describe('honua map snippets', () => {
     expect(elementSnippet).toContain('<template>\n  <honua-map');
     expect(elementSnippet).toContain('    layer-ids="assets"');
     expect(elementSnippet).toContain('    identify');
-    expect(elementSnippet).toContain('<script setup lang="ts">\nimport \'@honua-io/embed\';\n</script>');
+    expect(elementSnippet).toContain('<script setup lang="ts">\nimport { onMounted } from \'vue\';');
+    expect(elementSnippet).toContain('onMounted(() => {');
+    expect(elementSnippet).toContain('await import(\'@honua-io/embed\');');
     expect(elementSnippet).not.toContain('secret-key');
     expect(iframeSnippet).toContain('<template>\n  <iframe');
     expect(iframeSnippet).toContain('    src="/embeds/map.html?basemap=satellite"');
@@ -432,14 +445,15 @@ describe('honua map snippets', () => {
       iframeUrl: '/embeds/map.html',
     });
 
-    expect(elementSnippet).toContain('import { Component, CUSTOM_ELEMENTS_SCHEMA } from \'@angular/core\';');
-    expect(elementSnippet).toContain('import \'@honua-io/embed\';');
+    expect(elementSnippet).toContain('import { Component, CUSTOM_ELEMENTS_SCHEMA, AfterViewInit } from \'@angular/core\';');
+    expect(elementSnippet).toContain('export class CityAssetMapComponent implements AfterViewInit');
+    expect(elementSnippet).toContain('ngAfterViewInit(): void');
+    expect(elementSnippet).toContain('await import(\'@honua-io/embed\');');
     expect(elementSnippet).toContain('selector: \'city-asset-map\'');
     expect(elementSnippet).toContain('schemas: [CUSTOM_ELEMENTS_SCHEMA]');
     expect(elementSnippet).toContain('<honua-map');
     expect(elementSnippet).toContain('service-url="https://services.example.test/FeatureServer"');
     expect(elementSnippet).toContain('search');
-    expect(elementSnippet).toContain('export class CityAssetMapComponent {}');
     expect(elementSnippet).not.toContain('secret-key');
     expect(iframeSnippet).toContain('selector: \'city-asset-map-frame\'');
     expect(iframeSnippet).toContain('<iframe');


### PR DESCRIPTION
## Summary
- Add typed snippet helpers that generate React, Vue, and Angular starter components for the Honua map custom element.
- Add matching React, Vue, and Angular iframe fallback snippet helpers using the existing iframe serializer.
- Document framework snippet generation in the embed README and embeddable map guide.

## Issue
Refs #10

## Validation
- `git diff --check origin/main...HEAD`
- `npm test -- --run tests/honua-snippets.test.ts tests/honua-iframe.test.ts`
- `npm run typecheck`
- `npm run build`

## Remaining #10 Scope
CDN publishing, admin/embed builder UI, formal framework wrapper packages, and server-backed analytics/API-key/rate/CORS controls remain separate slices.