### PR TITLE
feat: add scene embed snippet helpers

### DIFF
--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -341,6 +341,58 @@ const angularIframeComponent = createHonuaMapAngularIframeSnippet({
 Use `applyHonuaMapOptions(element, options)` to apply the same options shape to
 an existing map element at runtime.
 
+## Generated Scene Snippets
+
+```ts
+import { createHonuaSceneSnippet } from '@honua-io/embed';
+
+const snippet = createHonuaSceneSnippet({
+  tilesetUrl: 'https://example.com/tileset.json',
+  terrainUrl: 'https://example.com/terrain',
+  metadataUrl: 'https://example.com/site.metadata.json',
+  center: { latitude: 21.3069, longitude: -157.8583 },
+  height: 1800,
+  heading: 20,
+  pitch: -35,
+  roll: 0,
+  theme: 'dark',
+  autoload: true,
+  cesiumBaseUrl: 'https://cdn.example.com/cesium/',
+}, {
+  elementName: 'city-construction-scene',
+});
+```
+
+Scene snippet helpers target public or externally hosted 3D Tiles, terrain, and
+metadata URLs. They do not create Honua server contracts or SDK scene metadata.
+Custom element names generate a script that calls
+`defineHonuaSceneElement(...)`. `ionToken` is omitted unless
+`includeCredentials: true` is passed.
+
+For CDN distribution, use `createHonuaSceneCdnSnippet`. It emits the CDN module
+script and the same white-label custom element markup. When a custom
+`elementName` is provided, the snippet imports `defineHonuaSceneElement(...)`
+from the CDN bundle and registers that branded tag name.
+
+```ts
+import { createHonuaSceneCdnSnippet } from '@honua-io/embed/snippets';
+
+const snippet = createHonuaSceneCdnSnippet({
+  tilesetUrl: 'https://example.com/tileset.json',
+  metadataUrl: 'https://example.com/site.metadata.json',
+  autoload: true,
+}, {
+  scriptUrl: 'https://cdn.honua.dev/embed.js',
+  scriptAttributes: {
+    integrity: 'sha384-...',
+    crossOrigin: 'anonymous',
+  },
+});
+```
+
+Use `applyHonuaSceneOptions(element, options)` to apply the same scene options
+shape to an existing scene element at runtime.
+
 ## Host Extensions
 
 ```ts

--- a/src/Honua.Embed/src/snippets.ts
+++ b/src/Honua.Embed/src/snippets.ts
@@ -1,4 +1,5 @@
 import type { HonuaMapBounds, HonuaMapCoordinate } from './map';
+import type { HonuaSceneCoordinate } from './scene';
 
 export interface HonuaMapThemeOptions {
   accent?: string | null;
@@ -43,6 +44,8 @@ export interface HonuaMapCdnScriptAttributes {
   referrerPolicy?: ReferrerPolicy | null;
 }
 
+export type HonuaSceneCdnScriptAttributes = HonuaMapCdnScriptAttributes;
+
 export interface HonuaMapCdnSnippetOptions {
   scriptUrl?: string;
   elementName?: string;
@@ -50,6 +53,38 @@ export interface HonuaMapCdnSnippetOptions {
   includeCredentials?: boolean;
   indent?: string;
   scriptAttributes?: HonuaMapCdnScriptAttributes;
+}
+
+export interface HonuaSceneEmbedOptions {
+  tilesetUrl?: string | null;
+  terrainUrl?: string | null;
+  metadataUrl?: string | null;
+  ionToken?: string | null;
+  cesiumBaseUrl?: string | null;
+  center?: HonuaSceneCoordinate | null;
+  height?: number | null;
+  heading?: number | null;
+  pitch?: number | null;
+  roll?: number | null;
+  theme?: 'light' | 'dark' | null;
+  autoload?: boolean | null;
+}
+
+export interface HonuaSceneSnippetOptions {
+  packageName?: string;
+  elementName?: string;
+  includeScript?: boolean;
+  includeCredentials?: boolean;
+  indent?: string;
+}
+
+export interface HonuaSceneCdnSnippetOptions {
+  scriptUrl?: string;
+  elementName?: string;
+  includeScript?: boolean;
+  includeCredentials?: boolean;
+  indent?: string;
+  scriptAttributes?: HonuaSceneCdnScriptAttributes;
 }
 
 export interface HonuaMapIframeAttributes {
@@ -136,6 +171,24 @@ export function applyHonuaMapTheme(element: HTMLElement, theme: HonuaMapThemeOpt
   }
 }
 
+export function applyHonuaSceneOptions(
+  element: HTMLElement,
+  options: HonuaSceneEmbedOptions,
+): void {
+  setOptionalAttribute(element, 'tileset-url', options.tilesetUrl);
+  setOptionalAttribute(element, 'terrain-url', options.terrainUrl);
+  setOptionalAttribute(element, 'metadata-url', options.metadataUrl);
+  setOptionalAttribute(element, 'ion-token', options.ionToken);
+  setOptionalAttribute(element, 'cesium-base-url', options.cesiumBaseUrl);
+  setOptionalAttribute(element, 'center', serializeCoordinate(options.center));
+  setOptionalAttribute(element, 'height', serializeNumber(options.height));
+  setOptionalAttribute(element, 'heading', serializeNumber(options.heading));
+  setOptionalAttribute(element, 'pitch', serializeNumber(options.pitch));
+  setOptionalAttribute(element, 'roll', serializeNumber(options.roll));
+  setOptionalAttribute(element, 'theme', options.theme);
+  setAutoloadAttribute(element, options.autoload);
+}
+
 export function createHonuaMapSnippet(
   options: HonuaMapEmbedOptions,
   snippetOptions: HonuaMapSnippetOptions = {},
@@ -171,6 +224,41 @@ export function createHonuaMapSnippet(
   return `${script}\n\n${element}`;
 }
 
+export function createHonuaSceneSnippet(
+  options: HonuaSceneEmbedOptions,
+  snippetOptions: HonuaSceneSnippetOptions = {},
+): string {
+  const elementName = snippetOptions.elementName ?? 'honua-scene';
+  assertCustomElementName(elementName);
+
+  const includeScript = snippetOptions.includeScript ?? true;
+  const packageName = snippetOptions.packageName ?? '@honua-io/embed';
+  const indent = snippetOptions.indent ?? '  ';
+  const element = createSceneElementMarkup(elementName, options, {
+    includeCredentials: snippetOptions.includeCredentials ?? false,
+    indent,
+  });
+
+  if (!includeScript) {
+    return element;
+  }
+
+  const script = elementName === 'honua-scene'
+    ? [
+      '<script type="module">',
+      `${indent}import '${escapeJsString(packageName)}';`,
+      '</script>',
+    ].join('\n')
+    : [
+      '<script type="module">',
+      `${indent}import { defineHonuaSceneElement } from '${escapeJsString(packageName)}';`,
+      `${indent}defineHonuaSceneElement('${escapeJsString(elementName)}');`,
+      '</script>',
+    ].join('\n');
+
+  return `${script}\n\n${element}`;
+}
+
 export function createHonuaMapCdnSnippet(
   options: HonuaMapEmbedOptions,
   snippetOptions: HonuaMapCdnSnippetOptions = {},
@@ -190,7 +278,37 @@ export function createHonuaMapCdnSnippet(
     return element;
   }
 
-  const script = createCdnScriptMarkup(scriptUrl, elementName, indent, snippetOptions.scriptAttributes);
+  const script = createMapCdnScriptMarkup(scriptUrl, elementName, indent, snippetOptions.scriptAttributes);
+  return `${script}\n\n${element}`;
+}
+
+export function createHonuaSceneCdnSnippet(
+  options: HonuaSceneEmbedOptions,
+  snippetOptions: HonuaSceneCdnSnippetOptions = {},
+): string {
+  const elementName = snippetOptions.elementName ?? 'honua-scene';
+  assertCustomElementName(elementName);
+
+  const includeScript = snippetOptions.includeScript ?? true;
+  const scriptUrl = snippetOptions.scriptUrl ?? 'https://cdn.honua.dev/embed.js';
+  const indent = snippetOptions.indent ?? '  ';
+  const element = createSceneElementMarkup(elementName, options, {
+    includeCredentials: snippetOptions.includeCredentials ?? false,
+    indent,
+  });
+
+  if (!includeScript) {
+    return element;
+  }
+
+  const script = createCdnScriptMarkup({
+    scriptUrl,
+    elementName,
+    defaultElementName: 'honua-scene',
+    defineExportName: 'defineHonuaSceneElement',
+    indent,
+    attributes: snippetOptions.scriptAttributes,
+  });
   return `${script}\n\n${element}`;
 }
 
@@ -367,40 +485,76 @@ export function createHonuaMapAngularIframeSnippet(
 }
 
 function createCdnScriptMarkup(
-  scriptUrl: string,
-  elementName: string,
-  indent: string,
-  attributes: HonuaMapCdnScriptAttributes | undefined,
+  config: {
+    scriptUrl: string;
+    elementName: string;
+    defaultElementName: string;
+    defineExportName: string;
+    indent: string;
+    attributes: HonuaMapCdnScriptAttributes | undefined;
+  },
 ): string {
-  if (elementName !== 'honua-map') {
-    const nonce = attributes?.nonce
-      ? ` nonce="${escapeHtmlAttribute(attributes.nonce)}"`
-      : '';
+  const {
+    scriptUrl,
+    elementName,
+    defaultElementName,
+    defineExportName,
+    indent,
+    attributes,
+  } = config;
+  if (elementName !== defaultElementName) {
+    const inlineScriptAttributes = serializeHtmlAttributes([
+      ['type', 'module'],
+      ['nonce', attributes?.nonce],
+      ['crossorigin', attributes?.crossOrigin],
+      ['referrerpolicy', attributes?.referrerPolicy],
+    ]);
     return [
-      `<script type="module"${nonce}>`,
-      `${indent}import { defineHonuaMapElement } from '${escapeJsString(scriptUrl)}';`,
-      `${indent}defineHonuaMapElement('${escapeJsString(elementName)}');`,
+      `<script ${inlineScriptAttributes}>`,
+      `${indent}import { ${defineExportName} } from '${escapeJsString(scriptUrl)}';`,
+      `${indent}${defineExportName}('${escapeJsString(elementName)}');`,
       '</script>',
     ].join('\n');
   }
 
-  const rawScriptAttributes: Array<[string, string | null | undefined]> = [
+  const serialized = serializeHtmlAttributes([
     ['type', 'module'],
     ['src', scriptUrl],
     ['nonce', attributes?.nonce],
     ['integrity', attributes?.integrity],
     ['crossorigin', attributes?.crossOrigin],
     ['referrerpolicy', attributes?.referrerPolicy],
-  ];
-  const scriptAttributes = rawScriptAttributes.filter((entry): entry is [string, string] => {
-    const value = entry[1];
-    return value !== undefined && value !== null && value !== '';
-  });
-  const serialized = scriptAttributes
-    .map(([name, value]) => `${name}="${escapeHtmlAttribute(value)}"`)
-    .join(' ');
+  ]);
 
   return `<script ${serialized}></script>`;
+}
+
+function serializeHtmlAttributes(
+  attributes: Array<[string, string | null | undefined]>,
+): string {
+  return attributes
+    .filter((entry): entry is [string, string] => {
+      const value = entry[1];
+      return value !== undefined && value !== null && value !== '';
+    })
+    .map(([name, value]) => `${name}="${escapeHtmlAttribute(value)}"`)
+    .join(' ');
+}
+
+function createMapCdnScriptMarkup(
+  scriptUrl: string,
+  elementName: string,
+  indent: string,
+  attributes: HonuaMapCdnScriptAttributes | undefined,
+): string {
+  return createCdnScriptMarkup({
+    scriptUrl,
+    elementName,
+    defaultElementName: 'honua-map',
+    defineExportName: 'defineHonuaMapElement',
+    indent,
+    attributes,
+  });
 }
 
 function createAngularComponentSnippet(
@@ -573,6 +727,23 @@ function createElementMarkup(
   return `<${elementName}\n${lines.join('\n')}>\n</${elementName}>`;
 }
 
+function createSceneElementMarkup(
+  elementName: string,
+  options: HonuaSceneEmbedOptions,
+  config: Required<Pick<HonuaSceneSnippetOptions, 'includeCredentials' | 'indent'>>,
+): string {
+  const attributes = sceneAttributes(options, config.includeCredentials);
+  if (attributes.length === 0) {
+    return `<${elementName}></${elementName}>`;
+  }
+
+  const lines = attributes.map(([name, value]) => value === true
+    ? `${config.indent}${name}`
+    : `${config.indent}${name}="${escapeHtmlAttribute(value)}"`);
+
+  return `<${elementName}\n${lines.join('\n')}>\n</${elementName}>`;
+}
+
 function createReactElementMarkup(
   elementName: string,
   options: HonuaMapEmbedOptions,
@@ -688,6 +859,29 @@ function mapAttributes(
     ['attribution', options.attribution],
     ['theme', options.theme],
     ['label', options.label],
+  ].filter((entry): entry is [string, string | true] => {
+    const value = entry[1];
+    return value !== undefined && value !== null && value !== '';
+  });
+}
+
+function sceneAttributes(
+  options: HonuaSceneEmbedOptions,
+  includeCredentials: boolean,
+): Array<[string, string | true]> {
+  return [
+    ['tileset-url', options.tilesetUrl],
+    ['terrain-url', options.terrainUrl],
+    ['metadata-url', options.metadataUrl],
+    ['ion-token', includeCredentials ? options.ionToken : undefined],
+    ['center', serializeCoordinate(options.center)],
+    ['height', serializeNumber(options.height)],
+    ['heading', serializeNumber(options.heading)],
+    ['pitch', serializeNumber(options.pitch)],
+    ['roll', serializeNumber(options.roll)],
+    ['theme', options.theme],
+    ['autoload', serializeAutoload(options.autoload)],
+    ['cesium-base-url', options.cesiumBaseUrl],
   ].filter((entry): entry is [string, string | true] => {
     const value = entry[1];
     return value !== undefined && value !== null && value !== '';
@@ -811,12 +1005,38 @@ function setBooleanAttribute(element: HTMLElement, name: string, value: boolean 
   element.removeAttribute(name);
 }
 
+function setAutoloadAttribute(element: HTMLElement, value: boolean | null | undefined): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (value === null) {
+    element.removeAttribute('autoload');
+    return;
+  }
+
+  if (value) {
+    element.setAttribute('autoload', '');
+    return;
+  }
+
+  element.setAttribute('autoload', 'false');
+}
+
 function serializeBoolean(value: boolean | null | undefined): true | null | undefined {
   if (value === undefined) {
     return undefined;
   }
 
   return value ? true : null;
+}
+
+function serializeAutoload(value: boolean | null | undefined): string | true | null | undefined {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  return value ? true : 'false';
 }
 
 function serializeList(value: readonly string[] | null | undefined): string | null | undefined {

--- a/src/Honua.Embed/tests/honua-snippets.test.ts
+++ b/src/Honua.Embed/tests/honua-snippets.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   applyHonuaMapOptions,
+  applyHonuaSceneOptions,
   createHonuaMapAngularIframeSnippet,
   createHonuaMapAngularSnippet,
   createHonuaMapCdnSnippet,
@@ -10,7 +11,10 @@ import {
   createHonuaMapSnippet,
   createHonuaMapVueIframeSnippet,
   createHonuaMapVueSnippet,
+  createHonuaSceneCdnSnippet,
+  createHonuaSceneSnippet,
   defineHonuaMapElement,
+  defineHonuaSceneElement,
 } from '../src/index';
 
 describe('honua map snippets', () => {
@@ -459,6 +463,144 @@ describe('honua map snippets', () => {
     expect(iframeSnippet).toContain('<iframe');
     expect(iframeSnippet).toContain('src="/embeds/map.html?basemap=dark"');
     expect(iframeSnippet).toContain('export class CityAssetMapFrameComponent {}');
+  });
+});
+
+describe('honua scene snippets', () => {
+  beforeEach(() => {
+    defineHonuaSceneElement();
+    document.body.replaceChildren();
+  });
+
+  it('generates a public 3D Tiles custom-element snippet without credentials by default', () => {
+    const snippet = createHonuaSceneSnippet({
+      tilesetUrl: 'https://tiles.example.test/site/tileset.json',
+      terrainUrl: 'https://terrain.example.test/world',
+      metadataUrl: 'https://metadata.example.test/site.json',
+      ionToken: 'secret-token',
+      center: { latitude: 21.3069, longitude: -157.8583 },
+      height: 1800,
+      heading: 20,
+      pitch: -35,
+      roll: 1,
+      theme: 'light',
+      autoload: true,
+      cesiumBaseUrl: 'https://cdn.example.test/cesium/',
+    }, {
+      elementName: 'city-construction-scene',
+    });
+
+    expect(snippet).toContain('defineHonuaSceneElement(\'city-construction-scene\')');
+    expect(snippet).toContain('<city-construction-scene');
+    expect(snippet).toContain('tileset-url="https://tiles.example.test/site/tileset.json"');
+    expect(snippet).toContain('terrain-url="https://terrain.example.test/world"');
+    expect(snippet).toContain('metadata-url="https://metadata.example.test/site.json"');
+    expect(snippet).toContain('center="21.3069,-157.8583"');
+    expect(snippet).toContain('height="1800"');
+    expect(snippet).toContain('heading="20"');
+    expect(snippet).toContain('pitch="-35"');
+    expect(snippet).toContain('roll="1"');
+    expect(snippet).toContain('theme="light"');
+    expect(snippet).toContain('autoload');
+    expect(snippet).toContain('cesium-base-url="https://cdn.example.test/cesium/"');
+    expect(snippet).not.toContain('secret-token');
+  });
+
+  it('includes scene credentials only when explicitly requested', () => {
+    const snippet = createHonuaSceneSnippet({
+      tilesetUrl: 'https://assets.cesium.com/123/tileset.json',
+      ionToken: 'public-browser-token',
+    }, {
+      includeCredentials: true,
+      includeScript: false,
+    });
+
+    expect(snippet).toContain('ion-token="public-browser-token"');
+    expect(snippet).not.toContain('<script');
+  });
+
+  it('generates a CDN scene snippet and registers branded scene tags', () => {
+    const snippet = createHonuaSceneCdnSnippet({
+      tilesetUrl: 'https://tiles.example.test/site/tileset.json',
+      ionToken: 'secret-token',
+      autoload: true,
+    }, {
+      scriptUrl: 'https://cdn.example.test/honua/embed.js',
+      elementName: 'city-scene',
+      scriptAttributes: {
+        nonce: 'nonce-value',
+        crossOrigin: 'anonymous',
+        referrerPolicy: 'strict-origin',
+      },
+    });
+
+    expect(snippet).toContain(
+      '<script type="module" nonce="nonce-value" crossorigin="anonymous" referrerpolicy="strict-origin">',
+    );
+    expect(snippet).toContain(
+      'import { defineHonuaSceneElement } from \'https://cdn.example.test/honua/embed.js\';',
+    );
+    expect(snippet).toContain('defineHonuaSceneElement(\'city-scene\')');
+    expect(snippet).toContain('<city-scene');
+    expect(snippet).toContain('tileset-url="https://tiles.example.test/site/tileset.json"');
+    expect(snippet).toContain('autoload');
+    expect(snippet).not.toContain('secret-token');
+  });
+
+  it('emits a default CDN scene script with attributes', () => {
+    const snippet = createHonuaSceneCdnSnippet({
+      metadataUrl: 'https://metadata.example.test/site.json',
+      autoload: false,
+    }, {
+      scriptAttributes: {
+        integrity: 'sha384-example',
+        crossOrigin: 'anonymous',
+        referrerPolicy: 'strict-origin',
+      },
+    });
+
+    expect(snippet).toContain(
+      '<script type="module" src="https://cdn.honua.dev/embed.js" integrity="sha384-example" crossorigin="anonymous" referrerpolicy="strict-origin"></script>',
+    );
+    expect(snippet).toContain('<honua-scene');
+    expect(snippet).toContain('metadata-url="https://metadata.example.test/site.json"');
+    expect(snippet).toContain('autoload="false"');
+  });
+
+  it('applies scene options to an existing element and removes null values', () => {
+    const element = document.createElement('honua-scene');
+    element.setAttribute('tileset-url', 'https://old.example.test/tileset.json');
+    element.setAttribute('ion-token', 'old-token');
+    element.setAttribute('autoload', '');
+    document.body.append(element);
+
+    applyHonuaSceneOptions(element, {
+      tilesetUrl: 'https://tiles.example.test/site/tileset.json',
+      terrainUrl: 'https://terrain.example.test/world',
+      metadataUrl: 'https://metadata.example.test/site.json',
+      ionToken: null,
+      center: { latitude: 21.3069, longitude: -157.8583 },
+      height: 1800,
+      heading: 20,
+      pitch: -35,
+      roll: 0,
+      theme: 'dark',
+      autoload: false,
+      cesiumBaseUrl: 'https://cdn.example.test/cesium/',
+    });
+
+    expect(element.getAttribute('tileset-url')).toBe('https://tiles.example.test/site/tileset.json');
+    expect(element.getAttribute('terrain-url')).toBe('https://terrain.example.test/world');
+    expect(element.getAttribute('metadata-url')).toBe('https://metadata.example.test/site.json');
+    expect(element.hasAttribute('ion-token')).toBe(false);
+    expect(element.getAttribute('center')).toBe('21.3069,-157.8583');
+    expect(element.getAttribute('height')).toBe('1800');
+    expect(element.getAttribute('heading')).toBe('20');
+    expect(element.getAttribute('pitch')).toBe('-35');
+    expect(element.getAttribute('roll')).toBe('0');
+    expect(element.getAttribute('theme')).toBe('dark');
+    expect(element.getAttribute('autoload')).toBe('false');
+    expect(element.getAttribute('cesium-base-url')).toBe('https://cdn.example.test/cesium/');
   });
 });
 


### PR DESCRIPTION
Refs #12

## Summary
- add scene embed options, runtime option application, and generated custom-element snippets
- add CDN scene snippet generation with branded tag registration
- omit scene credentials from generated markup unless explicitly requested

## Validation
- npm test --prefix src/Honua.Embed
- npm run typecheck --prefix src/Honua.Embed
- npm run build --prefix src/Honua.Embed
- git diff --check