### PR TITLE
feat: add iframe configure messaging

### DIFF
--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -149,6 +149,30 @@ const disconnect = addHonuaMapIframeMessageListener((message) => {
 });
 ```
 
+Hosts can also update iframe map options after initial load without rebuilding
+the iframe `src`. Send a typed configure command to the iframe content window
+and scope `targetOrigin` to the iframe shell origin.
+
+```js
+import { postHonuaMapIframeConfigure } from '@honua-io/embed/iframe';
+
+const iframe = document.querySelector('#asset-map-frame');
+
+postHonuaMapIframeConfigure(iframe.contentWindow, {
+  basemap: 'satellite',
+  search: true,
+  style: {
+    accent: '#334155',
+  },
+}, 'https://cdn.honua.dev');
+```
+
+The fallback shell accepts configure commands only from the window and origin
+declared by `parentOrigin` and applies the update with `applyHonuaMapOptions`.
+The command envelope uses `source: 'honua-map-host'`, `version: 1`,
+`type: 'honua-map-configure'`, and `options`; `isHonuaMapIframeCommand` is
+available for hosts that proxy or validate these messages.
+
 Framework teams can generate typed starter components around the same
 `<honua-map>` custom element or iframe fallback. `@honua-io/embed` does not
 depend on React, Vue, or Angular; these helpers only return code strings and

--- a/src/Honua.Embed/src/iframe.ts
+++ b/src/Honua.Embed/src/iframe.ts
@@ -17,6 +17,15 @@ export interface HonuaMapIframeMessage {
   detail: unknown;
 }
 
+export interface HonuaMapIframeConfigureCommand {
+  source: 'honua-map-host';
+  version: 1;
+  type: 'honua-map-configure';
+  options: HonuaMapEmbedOptions;
+}
+
+export type HonuaMapIframeCommand = HonuaMapIframeConfigureCommand;
+
 export type HonuaMapIframeMessageListener = (
   message: HonuaMapIframeMessage,
   event: MessageEvent<HonuaMapIframeMessage>,
@@ -24,6 +33,10 @@ export type HonuaMapIframeMessageListener = (
 
 export interface HonuaMapIframeMessageTarget {
   postMessage(message: HonuaMapIframeMessage, targetOrigin: string): void;
+}
+
+export interface HonuaMapIframeCommandTarget {
+  postMessage(message: HonuaMapIframeCommand, targetOrigin: string): void;
 }
 
 export interface HonuaMapIframeMessageListenerOptions {
@@ -66,6 +79,33 @@ const THEME_PARAMETERS: Array<[keyof HonuaMapThemeOptions, string]> = [
   ['fontFamily', '--honua-map-font-family'],
   ['controlSize', '--honua-map-control-size'],
 ];
+
+const EMBED_OPTION_KEYS = [
+  'serviceUrl',
+  'layerIds',
+  'apiKey',
+  'center',
+  'zoom',
+  'bounds',
+  'basemap',
+  'interactive',
+  'search',
+  'identify',
+  'attribution',
+  'theme',
+  'label',
+] as const;
+
+const THEME_OPTION_KEYS = [
+  'accent',
+  'background',
+  'foreground',
+  'muted',
+  'surface',
+  'border',
+  'fontFamily',
+  'controlSize',
+] as const;
 
 export function parseHonuaMapIframeConfig(
   input: URL | URLSearchParams | string | null | undefined = defaultLocation(),
@@ -113,7 +153,10 @@ export function hydrateHonuaMapIframe(
   const parent = options.parent === undefined ? targetWindow.parent : options.parent;
   const targetOrigin = options.targetOrigin?.trim() || config.parentOrigin;
   const disconnect = parent && parent !== targetWindow && targetOrigin
-    ? bridgeMapEvents(element, parent, targetOrigin)
+    ? composeDisconnects(
+      bridgeMapEvents(element, parent, targetOrigin),
+      listenForConfigureCommands(targetWindow, element, config, parent, targetOrigin),
+    )
     : () => {};
 
   if (!element.isConnected) {
@@ -126,6 +169,19 @@ export function hydrateHonuaMapIframe(
   return { element, config, disconnect };
 }
 
+export function postHonuaMapIframeConfigure(
+  target: HonuaMapIframeCommandTarget,
+  options: HonuaMapEmbedOptions,
+  targetOrigin: string,
+): void {
+  target.postMessage({
+    source: 'honua-map-host',
+    version: 1,
+    type: 'honua-map-configure',
+    options,
+  }, targetOrigin);
+}
+
 export function isHonuaMapIframeMessage(value: unknown): value is HonuaMapIframeMessage {
   if (typeof value !== 'object' || value === null) {
     return false;
@@ -136,6 +192,19 @@ export function isHonuaMapIframeMessage(value: unknown): value is HonuaMapIframe
     && candidate.version === 1
     && typeof candidate.type === 'string'
     && FORWARDED_EVENT_SET.has(candidate.type);
+}
+
+export function isHonuaMapIframeCommand(value: unknown): value is HonuaMapIframeCommand {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<HonuaMapIframeCommand>;
+  return candidate.source === 'honua-map-host'
+    && candidate.version === 1
+    && candidate.type === 'honua-map-configure'
+    && typeof candidate.options === 'object'
+    && candidate.options !== null;
 }
 
 export function addHonuaMapIframeMessageListener(
@@ -189,6 +258,89 @@ function bridgeMapEvents(
       remove();
     }
   };
+}
+
+function listenForConfigureCommands(
+  targetWindow: Window,
+  element: HonuaMapElement,
+  config: HonuaMapIframeConfig,
+  parent: HonuaMapIframeMessageTarget,
+  parentOrigin: string,
+): () => void {
+  const expectedOrigins = normalizeExpectedOrigins(parentOrigin);
+  const messageListener = (event: MessageEvent) => {
+    if (event.source !== parent) {
+      return;
+    }
+
+    if (!originMatches(event.origin, expectedOrigins)) {
+      return;
+    }
+
+    if (!isHonuaMapIframeCommand(event.data)) {
+      return;
+    }
+
+    config.options = mergeHonuaMapOptions(config.options, event.data.options);
+    applyHonuaMapOptions(element, event.data.options);
+  };
+
+  targetWindow.addEventListener('message', messageListener);
+  return () => targetWindow.removeEventListener('message', messageListener);
+}
+
+function composeDisconnects(...disconnects: Array<() => void>): () => void {
+  return () => {
+    for (const disconnect of disconnects) {
+      disconnect();
+    }
+  };
+}
+
+function mergeHonuaMapOptions(
+  current: HonuaMapEmbedOptions,
+  updates: HonuaMapEmbedOptions,
+): HonuaMapEmbedOptions {
+  const merged: HonuaMapEmbedOptions = { ...current };
+  for (const key of EMBED_OPTION_KEYS) {
+    assignDefinedOption(merged, updates, key);
+  }
+
+  if (updates.style !== undefined) {
+    merged.style = mergeHonuaMapThemeOptions(current.style, updates.style);
+  }
+
+  return merged;
+}
+
+function assignDefinedOption<TKey extends keyof HonuaMapEmbedOptions>(
+  target: HonuaMapEmbedOptions,
+  source: HonuaMapEmbedOptions,
+  key: TKey,
+): void {
+  const value = source[key];
+  if (value !== undefined) {
+    target[key] = value;
+  }
+}
+
+function mergeHonuaMapThemeOptions(
+  current: HonuaMapThemeOptions | null | undefined,
+  updates: HonuaMapThemeOptions | null,
+): HonuaMapThemeOptions | null {
+  if (updates === null) {
+    return null;
+  }
+
+  const merged: HonuaMapThemeOptions = current ? { ...current } : {};
+  for (const key of THEME_OPTION_KEYS) {
+    const value = updates[key];
+    if (value !== undefined) {
+      merged[key] = value;
+    }
+  }
+
+  return merged;
 }
 
 function defaultWindow(): Window {

--- a/src/Honua.Embed/tests/honua-iframe.test.ts
+++ b/src/Honua.Embed/tests/honua-iframe.test.ts
@@ -2,8 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   addHonuaMapIframeMessageListener,
   hydrateHonuaMapIframe,
+  isHonuaMapIframeCommand,
   isHonuaMapIframeMessage,
   parseHonuaMapIframeConfig,
+  postHonuaMapIframeConfigure,
+  type HonuaMapIframeCommand,
   type HonuaMapIframeMessage,
 } from '../src/iframe';
 
@@ -162,6 +165,202 @@ describe('honua map iframe fallback', () => {
       type: 'unscoped-event',
       detail: {},
     })).toBe(false);
+  });
+
+  it('posts typed configure commands to a map iframe target', () => {
+    const target = {
+      postMessage: vi.fn<(message: HonuaMapIframeCommand, targetOrigin: string) => void>(),
+    };
+
+    postHonuaMapIframeConfigure(target, {
+      basemap: 'satellite',
+      search: true,
+    }, 'https://cdn.honua.dev');
+
+    expect(target.postMessage).toHaveBeenCalledWith({
+      source: 'honua-map-host',
+      version: 1,
+      type: 'honua-map-configure',
+      options: {
+        basemap: 'satellite',
+        search: true,
+      },
+    }, 'https://cdn.honua.dev');
+  });
+
+  it('identifies iframe configure commands by source, version, type, and options', () => {
+    expect(isHonuaMapIframeCommand({
+      source: 'honua-map-host',
+      version: 1,
+      type: 'honua-map-configure',
+      options: {
+        basemap: 'satellite',
+      },
+    })).toBe(true);
+
+    expect(isHonuaMapIframeCommand({
+      source: 'honua-map-iframe',
+      version: 1,
+      type: 'honua-map-configure',
+      options: {},
+    })).toBe(false);
+
+    expect(isHonuaMapIframeCommand({
+      source: 'honua-map-host',
+      version: 1,
+      type: 'honua-map-configure',
+      options: null,
+    })).toBe(false);
+  });
+
+  it('applies configure commands from the declared parent origin and source', () => {
+    const parent = {
+      postMessage: vi.fn<(message: HonuaMapIframeMessage, targetOrigin: string) => void>(),
+    };
+    const parentSource = parent as unknown as MessageEventSource;
+
+    const url = new URL('/embed/map.html', window.location.href);
+    url.searchParams.set('service-url', 'https://services.example.test/FeatureServer');
+    url.searchParams.set('layer-ids', 'assets');
+    url.searchParams.set('search', 'false');
+    url.searchParams.set('--honua-map-accent', '#0f766e');
+    url.searchParams.set('parent-origin', 'https://portal.example.test');
+    window.history.replaceState(null, '', url);
+
+    const runtime = hydrateHonuaMapIframe({ parent });
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data: {
+        source: 'honua-map-host',
+        version: 1,
+        type: 'honua-map-configure',
+        options: {
+          basemap: 'satellite',
+          search: true,
+        },
+      },
+      origin: 'https://other.example.test',
+      source: parentSource,
+    }));
+    window.dispatchEvent(new MessageEvent('message', {
+      data: {
+        source: 'honua-map-host',
+        version: 1,
+        type: 'honua-map-configure',
+        options: {
+          basemap: 'dark',
+          identify: true,
+        },
+      },
+      origin: 'https://portal.example.test',
+      source: window,
+    }));
+    window.dispatchEvent(new MessageEvent('message', {
+      data: {
+        source: 'honua-map-host',
+        version: 1,
+        type: 'honua-map-configure',
+        options: {
+          basemap: 'streets',
+          search: true,
+          style: {
+            fontFamily: 'Aptos, sans-serif',
+          },
+        },
+      },
+      origin: 'https://portal.example.test',
+      source: parentSource,
+    }));
+
+    expect(runtime.element.getAttribute('basemap')).toBe('streets');
+    expect(runtime.element.hasAttribute('search')).toBe(true);
+    expect(runtime.element.hasAttribute('identify')).toBe(false);
+    expect(runtime.element.style.getPropertyValue('--honua-map-font-family')).toBe('Aptos, sans-serif');
+    expect(runtime.config.options).toMatchObject({
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      layerIds: ['assets'],
+      basemap: 'streets',
+      search: true,
+      style: {
+        accent: '#0f766e',
+        fontFamily: 'Aptos, sans-serif',
+      },
+    });
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data: {
+        source: 'honua-map-host',
+        version: 1,
+        type: 'honua-map-configure',
+        options: {
+          basemap: undefined,
+          search: undefined,
+          style: {
+            fontFamily: undefined,
+            foreground: '#111827',
+          },
+        },
+      },
+      origin: 'https://portal.example.test',
+      source: parentSource,
+    }));
+
+    expect(runtime.element.getAttribute('basemap')).toBe('streets');
+    expect(runtime.element.hasAttribute('search')).toBe(true);
+    expect(runtime.element.style.getPropertyValue('--honua-map-font-family')).toBe('Aptos, sans-serif');
+    expect(runtime.element.style.getPropertyValue('--honua-map-foreground')).toBe('#111827');
+    expect(runtime.config.options).toMatchObject({
+      basemap: 'streets',
+      search: true,
+      style: {
+        accent: '#0f766e',
+        fontFamily: 'Aptos, sans-serif',
+        foreground: '#111827',
+      },
+    });
+
+    runtime.disconnect();
+    window.dispatchEvent(new MessageEvent('message', {
+      data: {
+        source: 'honua-map-host',
+        version: 1,
+        type: 'honua-map-configure',
+        options: {
+          basemap: 'topographic',
+        },
+      },
+      origin: 'https://portal.example.test',
+      source: parentSource,
+    }));
+
+    expect(runtime.element.getAttribute('basemap')).toBe('streets');
+  });
+
+  it('does not listen for configure commands when parent-origin is invalid', () => {
+    const parent = {
+      postMessage: vi.fn<(message: HonuaMapIframeMessage, targetOrigin: string) => void>(),
+    };
+
+    const url = new URL('/embed/map.html', window.location.href);
+    url.searchParams.set('parent-origin', 'portal.example.test');
+    window.history.replaceState(null, '', url);
+
+    const runtime = hydrateHonuaMapIframe({ parent });
+    window.dispatchEvent(new MessageEvent('message', {
+      data: {
+        source: 'honua-map-host',
+        version: 1,
+        type: 'honua-map-configure',
+        options: {
+          basemap: 'satellite',
+        },
+      },
+      origin: 'https://portal.example.test',
+      source: parent as unknown as MessageEventSource,
+    }));
+
+    expect(runtime.config.parentOrigin).toBeNull();
+    expect(runtime.element.hasAttribute('basemap')).toBe(false);
   });
 
   it('subscribes to iframe fallback messages with origin and source filtering', () => {


### PR DESCRIPTION
Refs #10

## Summary
- add a typed host-to-iframe configure command for the map iframe fallback
- listen in `hydrateHonuaMapIframe` with parent source and origin filtering
- document runtime iframe option updates

## Validation
- npm test --prefix src/Honua.Embed
- npm run typecheck --prefix src/Honua.Embed
- npm run build --prefix src/Honua.Embed
- git diff --check HEAD~1..HEAD