### PR TITLE
feat: add scene iframe fallback

### DIFF
--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -393,6 +393,36 @@ const snippet = createHonuaSceneCdnSnippet({
 Use `applyHonuaSceneOptions(element, options)` to apply the same scene options
 shape to an existing scene element at runtime.
 
+For hosts that cannot load custom elements, use
+`createHonuaSceneIframeSnippet`. Scene options are encoded into the iframe URL
+query string, with `ionToken` omitted unless `includeCredentials: true` is
+passed. The package build includes the static fallback shell at
+`dist/embed/scene.html`; CDN deployments can serve that file as
+`https://cdn.honua.dev/embed/scene.html`.
+
+```ts
+import { createHonuaSceneIframeSnippet } from '@honua-io/embed/snippets';
+
+const snippet = createHonuaSceneIframeSnippet({
+  metadataUrl: 'https://example.com/site.metadata.json',
+  autoload: true,
+}, {
+  parentOrigin: 'https://portal.example.com',
+  iframe: {
+    title: 'Construction scene',
+  },
+});
+```
+
+The iframe shell imports `../iframe.js`, hydrates a full-frame `<honua-scene>`
+from the query string, and forwards only core scene events to the parent window:
+`honua-scene-ready`, `honua-scene-config-change`,
+`honua-scene-load-error`, `honua-scene-camera-change`,
+`honua-scene-identify`, `honua-scene-metadata-change`,
+`honua-scene-metadata-error`, and `honua-scene-layer-change`. Cesium widget,
+tileset, picked object, and error references are sanitized before forwarding so
+messages stay cloneable.
+
 ## Host Extensions
 
 ```ts

--- a/src/Honua.Embed/public/embed/scene.html
+++ b/src/Honua.Embed/public/embed/scene.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Embedded scene</title>
+    <style>
+      html,
+      body,
+      #honua-scene-frame-root {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+      }
+
+      body {
+        overflow: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="honua-scene-frame-root"></div>
+    <script type="module">
+      import { hydrateHonuaSceneIframe } from '../iframe.js';
+
+      hydrateHonuaSceneIframe();
+    </script>
+  </body>
+</html>

--- a/src/Honua.Embed/src/iframe.ts
+++ b/src/Honua.Embed/src/iframe.ts
@@ -1,12 +1,20 @@
 import { defineHonuaMapElement, type HonuaMapElement } from './map';
+import { defineHonuaSceneElement, type HonuaSceneElement } from './scene';
 import {
   applyHonuaMapOptions,
+  applyHonuaSceneOptions,
   type HonuaMapEmbedOptions,
   type HonuaMapThemeOptions,
+  type HonuaSceneEmbedOptions,
 } from './snippets';
 
 export interface HonuaMapIframeConfig {
   options: HonuaMapEmbedOptions;
+  parentOrigin: string | null;
+}
+
+export interface HonuaSceneIframeConfig {
+  options: HonuaSceneEmbedOptions;
   parentOrigin: string | null;
 }
 
@@ -17,6 +25,13 @@ export interface HonuaMapIframeMessage {
   detail: unknown;
 }
 
+export interface HonuaSceneIframeMessage {
+  source: 'honua-scene-iframe';
+  version: 1;
+  type: HonuaSceneIframeEventType;
+  detail: unknown;
+}
+
 export interface HonuaMapIframeConfigureCommand {
   source: 'honua-map-host';
   version: 1;
@@ -24,19 +39,40 @@ export interface HonuaMapIframeConfigureCommand {
   options: HonuaMapEmbedOptions;
 }
 
+export interface HonuaSceneIframeConfigureCommand {
+  source: 'honua-scene-host';
+  version: 1;
+  type: 'honua-scene-configure';
+  options: HonuaSceneEmbedOptions;
+}
+
 export type HonuaMapIframeCommand = HonuaMapIframeConfigureCommand;
+export type HonuaSceneIframeCommand = HonuaSceneIframeConfigureCommand;
 
 export type HonuaMapIframeMessageListener = (
   message: HonuaMapIframeMessage,
   event: MessageEvent<HonuaMapIframeMessage>,
 ) => void;
 
+export type HonuaSceneIframeMessageListener = (
+  message: HonuaSceneIframeMessage,
+  event: MessageEvent<HonuaSceneIframeMessage>,
+) => void;
+
 export interface HonuaMapIframeMessageTarget {
   postMessage(message: HonuaMapIframeMessage, targetOrigin: string): void;
 }
 
+export interface HonuaSceneIframeMessageTarget {
+  postMessage(message: HonuaSceneIframeMessage, targetOrigin: string): void;
+}
+
 export interface HonuaMapIframeCommandTarget {
   postMessage(message: HonuaMapIframeCommand, targetOrigin: string): void;
+}
+
+export interface HonuaSceneIframeCommandTarget {
+  postMessage(message: HonuaSceneIframeCommand, targetOrigin: string): void;
 }
 
 export interface HonuaMapIframeMessageListenerOptions {
@@ -58,16 +94,42 @@ export interface HonuaMapIframeRuntime {
   disconnect(): void;
 }
 
-const FORWARDED_EVENTS = [
+export interface HonuaSceneIframeHydrateOptions {
+  window?: Window;
+  element?: HonuaSceneElement | null;
+  parent?: HonuaSceneIframeMessageTarget | null;
+  targetOrigin?: string | null;
+}
+
+export interface HonuaSceneIframeRuntime {
+  element: HonuaSceneElement;
+  config: HonuaSceneIframeConfig;
+  disconnect(): void;
+}
+
+const MAP_FORWARDED_EVENTS = [
   'honua-map-ready',
   'honua-map-config-change',
   'honua-map-search',
   'honua-map-identify',
 ] as const;
 
-export type HonuaMapIframeEventType = (typeof FORWARDED_EVENTS)[number];
+const SCENE_FORWARDED_EVENTS = [
+  'honua-scene-ready',
+  'honua-scene-config-change',
+  'honua-scene-load-error',
+  'honua-scene-camera-change',
+  'honua-scene-identify',
+  'honua-scene-metadata-change',
+  'honua-scene-metadata-error',
+  'honua-scene-layer-change',
+] as const;
 
-const FORWARDED_EVENT_SET = new Set<string>(FORWARDED_EVENTS);
+export type HonuaMapIframeEventType = (typeof MAP_FORWARDED_EVENTS)[number];
+export type HonuaSceneIframeEventType = (typeof SCENE_FORWARDED_EVENTS)[number];
+
+const MAP_FORWARDED_EVENT_SET = new Set<string>(MAP_FORWARDED_EVENTS);
+const SCENE_FORWARDED_EVENT_SET = new Set<string>(SCENE_FORWARDED_EVENTS);
 
 const THEME_PARAMETERS: Array<[keyof HonuaMapThemeOptions, string]> = [
   ['accent', '--honua-map-accent'],
@@ -96,6 +158,21 @@ const EMBED_OPTION_KEYS = [
   'label',
 ] as const;
 
+const SCENE_EMBED_OPTION_KEYS = [
+  'tilesetUrl',
+  'terrainUrl',
+  'metadataUrl',
+  'ionToken',
+  'cesiumBaseUrl',
+  'center',
+  'height',
+  'heading',
+  'pitch',
+  'roll',
+  'theme',
+  'autoload',
+] as const;
+
 const THEME_OPTION_KEYS = [
   'accent',
   'background',
@@ -108,9 +185,9 @@ const THEME_OPTION_KEYS = [
 ] as const;
 
 export function parseHonuaMapIframeConfig(
-  input: URL | URLSearchParams | string | null | undefined = defaultLocation(),
+  input: URL | URLSearchParams | string | null | undefined = defaultMapLocation(),
 ): HonuaMapIframeConfig {
-  const params = searchParamsFrom(input);
+  const params = searchParamsFrom(input, defaultMapLocation());
   const style = parseThemeOptions(params);
   const options: HonuaMapEmbedOptions = {
     serviceUrl: param(params, 'service-url'),
@@ -127,6 +204,31 @@ export function parseHonuaMapIframeConfig(
     theme: parseTheme(param(params, 'theme')),
     label: param(params, 'label'),
     style: Object.keys(style).length > 0 ? style : undefined,
+  };
+
+  return {
+    options,
+    parentOrigin: parseParentOrigin(param(params, 'parent-origin')),
+  };
+}
+
+export function parseHonuaSceneIframeConfig(
+  input: URL | URLSearchParams | string | null | undefined = defaultSceneLocation(),
+): HonuaSceneIframeConfig {
+  const params = searchParamsFrom(input, defaultSceneLocation());
+  const options: HonuaSceneEmbedOptions = {
+    tilesetUrl: param(params, 'tileset-url'),
+    terrainUrl: param(params, 'terrain-url'),
+    metadataUrl: param(params, 'metadata-url'),
+    ionToken: param(params, 'ion-token'),
+    cesiumBaseUrl: param(params, 'cesium-base-url'),
+    center: parseCoordinate(param(params, 'center')),
+    height: parseNumber(param(params, 'height')),
+    heading: parseNumber(param(params, 'heading')),
+    pitch: parseNumber(param(params, 'pitch')),
+    roll: parseNumber(param(params, 'roll')),
+    theme: parseTheme(param(params, 'theme')),
+    autoload: parseBoolean(params, 'autoload'),
   };
 
   return {
@@ -169,6 +271,40 @@ export function hydrateHonuaMapIframe(
   return { element, config, disconnect };
 }
 
+export function hydrateHonuaSceneIframe(
+  options: HonuaSceneIframeHydrateOptions = {},
+): HonuaSceneIframeRuntime {
+  const targetWindow = options.window ?? window;
+  const document = targetWindow.document;
+  defineHonuaSceneElement();
+
+  const config = parseHonuaSceneIframeConfig(targetWindow.location.href);
+  const element = options.element
+    ?? document.querySelector<HonuaSceneElement>('honua-scene')
+    ?? document.createElement('honua-scene') as HonuaSceneElement;
+
+  applyHonuaSceneOptions(element, config.options);
+  applyFrameSizing(element);
+
+  const parent = options.parent === undefined ? targetWindow.parent : options.parent;
+  const targetOrigin = options.targetOrigin?.trim() || config.parentOrigin;
+  const disconnect = parent && parent !== targetWindow && targetOrigin
+    ? composeDisconnects(
+      bridgeSceneEvents(element, parent, targetOrigin),
+      listenForSceneConfigureCommands(targetWindow, element, config, parent, targetOrigin),
+    )
+    : () => {};
+
+  if (!element.isConnected) {
+    const mount = document.getElementById('honua-scene-frame-root')
+      ?? document.body
+      ?? document.documentElement;
+    mount.append(element);
+  }
+
+  return { element, config, disconnect };
+}
+
 export function postHonuaMapIframeConfigure(
   target: HonuaMapIframeCommandTarget,
   options: HonuaMapEmbedOptions,
@@ -182,6 +318,19 @@ export function postHonuaMapIframeConfigure(
   }, targetOrigin);
 }
 
+export function postHonuaSceneIframeConfigure(
+  target: HonuaSceneIframeCommandTarget,
+  options: HonuaSceneEmbedOptions,
+  targetOrigin: string,
+): void {
+  target.postMessage({
+    source: 'honua-scene-host',
+    version: 1,
+    type: 'honua-scene-configure',
+    options,
+  }, targetOrigin);
+}
+
 export function isHonuaMapIframeMessage(value: unknown): value is HonuaMapIframeMessage {
   if (typeof value !== 'object' || value === null) {
     return false;
@@ -191,7 +340,19 @@ export function isHonuaMapIframeMessage(value: unknown): value is HonuaMapIframe
   return candidate.source === 'honua-map-iframe'
     && candidate.version === 1
     && typeof candidate.type === 'string'
-    && FORWARDED_EVENT_SET.has(candidate.type);
+    && MAP_FORWARDED_EVENT_SET.has(candidate.type);
+}
+
+export function isHonuaSceneIframeMessage(value: unknown): value is HonuaSceneIframeMessage {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<HonuaSceneIframeMessage>;
+  return candidate.source === 'honua-scene-iframe'
+    && candidate.version === 1
+    && typeof candidate.type === 'string'
+    && SCENE_FORWARDED_EVENT_SET.has(candidate.type);
 }
 
 export function isHonuaMapIframeCommand(value: unknown): value is HonuaMapIframeCommand {
@@ -203,6 +364,19 @@ export function isHonuaMapIframeCommand(value: unknown): value is HonuaMapIframe
   return candidate.source === 'honua-map-host'
     && candidate.version === 1
     && candidate.type === 'honua-map-configure'
+    && typeof candidate.options === 'object'
+    && candidate.options !== null;
+}
+
+export function isHonuaSceneIframeCommand(value: unknown): value is HonuaSceneIframeCommand {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<HonuaSceneIframeCommand>;
+  return candidate.source === 'honua-scene-host'
+    && candidate.version === 1
+    && candidate.type === 'honua-scene-configure'
     && typeof candidate.options === 'object'
     && candidate.options !== null;
 }
@@ -234,18 +408,71 @@ export function addHonuaMapIframeMessageListener(
   return () => targetWindow.removeEventListener('message', messageListener);
 }
 
+export function addHonuaSceneIframeMessageListener(
+  listener: HonuaSceneIframeMessageListener,
+  options: HonuaMapIframeMessageListenerOptions = {},
+): () => void {
+  const targetWindow = options.window ?? defaultWindow();
+  const expectedOrigins = normalizeExpectedOrigins(options.origin);
+  const expectedSource = options.source;
+  const messageListener = (event: MessageEvent) => {
+    if (expectedSource !== undefined && event.source !== expectedSource) {
+      return;
+    }
+
+    if (!originMatches(event.origin, expectedOrigins)) {
+      return;
+    }
+
+    if (!isHonuaSceneIframeMessage(event.data)) {
+      return;
+    }
+
+    listener(event.data, event as MessageEvent<HonuaSceneIframeMessage>);
+  };
+
+  targetWindow.addEventListener('message', messageListener);
+  return () => targetWindow.removeEventListener('message', messageListener);
+}
+
 function bridgeMapEvents(
   element: HonuaMapElement,
   parent: HonuaMapIframeMessageTarget,
   targetOrigin: string,
 ): () => void {
-  const listeners = FORWARDED_EVENTS.map((type) => {
+  const listeners = MAP_FORWARDED_EVENTS.map((type) => {
     const listener: EventListener = (event) => {
       parent.postMessage({
         source: 'honua-map-iframe',
         version: 1,
         type,
         detail: 'detail' in event ? event.detail : undefined,
+      }, targetOrigin);
+    };
+
+    element.addEventListener(type, listener);
+    return () => element.removeEventListener(type, listener);
+  });
+
+  return () => {
+    for (const remove of listeners) {
+      remove();
+    }
+  };
+}
+
+function bridgeSceneEvents(
+  element: HonuaSceneElement,
+  parent: HonuaSceneIframeMessageTarget,
+  targetOrigin: string,
+): () => void {
+  const listeners = SCENE_FORWARDED_EVENTS.map((type) => {
+    const listener: EventListener = (event) => {
+      parent.postMessage({
+        source: 'honua-scene-iframe',
+        version: 1,
+        type,
+        detail: sanitizeSceneEventDetail(type, 'detail' in event ? event.detail : undefined),
       }, targetOrigin);
     };
 
@@ -289,12 +516,64 @@ function listenForConfigureCommands(
   return () => targetWindow.removeEventListener('message', messageListener);
 }
 
+function listenForSceneConfigureCommands(
+  targetWindow: Window,
+  element: HonuaSceneElement,
+  config: HonuaSceneIframeConfig,
+  parent: HonuaSceneIframeMessageTarget,
+  parentOrigin: string,
+): () => void {
+  const expectedOrigins = normalizeExpectedOrigins(parentOrigin);
+  const messageListener = (event: MessageEvent) => {
+    if (event.source !== parent) {
+      return;
+    }
+
+    if (!originMatches(event.origin, expectedOrigins)) {
+      return;
+    }
+
+    if (!isHonuaSceneIframeCommand(event.data)) {
+      return;
+    }
+
+    config.options = mergeHonuaSceneOptions(config.options, event.data.options);
+    applyHonuaSceneOptions(element, config.options);
+  };
+
+  targetWindow.addEventListener('message', messageListener);
+  return () => targetWindow.removeEventListener('message', messageListener);
+}
+
 function composeDisconnects(...disconnects: Array<() => void>): () => void {
   return () => {
     for (const disconnect of disconnects) {
       disconnect();
     }
   };
+}
+
+function mergeHonuaSceneOptions(
+  current: HonuaSceneEmbedOptions,
+  updates: HonuaSceneEmbedOptions,
+): HonuaSceneEmbedOptions {
+  const merged: HonuaSceneEmbedOptions = { ...current };
+  for (const key of SCENE_EMBED_OPTION_KEYS) {
+    assignDefinedSceneOption(merged, updates, key);
+  }
+
+  return merged;
+}
+
+function assignDefinedSceneOption<TKey extends keyof HonuaSceneEmbedOptions>(
+  target: HonuaSceneEmbedOptions,
+  source: HonuaSceneEmbedOptions,
+  key: TKey,
+): void {
+  const value = source[key];
+  if (value !== undefined) {
+    target[key] = value;
+  }
 }
 
 function mergeHonuaMapOptions(
@@ -343,6 +622,95 @@ function mergeHonuaMapThemeOptions(
   return merged;
 }
 
+function sanitizeSceneEventDetail(type: HonuaSceneIframeEventType, detail: unknown): unknown {
+  if (type === 'honua-scene-ready' && isObject(detail)) {
+    return {
+      config: cloneableValue(detail.config),
+      widget: null,
+      tileset: null,
+    };
+  }
+
+  if (type === 'honua-scene-load-error' && isObject(detail)) {
+    return {
+      config: cloneableValue(detail.config),
+      source: cloneableValue(detail.source),
+      code: cloneableValue(detail.code),
+      message: cloneableValue(detail.message),
+      error: sanitizeError(detail.error),
+    };
+  }
+
+  if (type === 'honua-scene-identify' && isObject(detail)) {
+    return {
+      config: cloneableValue(detail.config),
+      x: cloneableValue(detail.x),
+      y: cloneableValue(detail.y),
+      picked: cloneableValue(detail.picked),
+      position: cloneableValue(detail.position),
+    };
+  }
+
+  return cloneableValue(detail);
+}
+
+function sanitizeError(value: unknown): unknown {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+    };
+  }
+
+  return cloneableValue(value);
+}
+
+function cloneableValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (
+    value === null
+    || typeof value === 'string'
+    || typeof value === 'number'
+    || typeof value === 'boolean'
+  ) {
+    return value;
+  }
+
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (typeof value !== 'object') {
+    return undefined;
+  }
+
+  if (seen.has(value)) {
+    return undefined;
+  }
+  seen.add(value);
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneableValue(item, seen));
+  }
+
+  const output: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    const sanitized = cloneableValue(item, seen);
+    if (sanitized !== undefined) {
+      output[key] = sanitized;
+    }
+  }
+
+  return output;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 function defaultWindow(): Window {
   if (typeof window === 'undefined') {
     throw new Error('Honua map iframe message listeners require a browser Window.');
@@ -385,6 +753,7 @@ function applyFrameSizing(element: HTMLElement): void {
 
 function searchParamsFrom(
   input: URL | URLSearchParams | string | null | undefined,
+  fallbackUrl: string,
 ): URLSearchParams {
   if (input instanceof URLSearchParams) {
     return new URLSearchParams(input);
@@ -394,13 +763,21 @@ function searchParamsFrom(
     return new URLSearchParams(input.searchParams);
   }
 
-  const value = input ?? 'https://cdn.honua.dev/embed/map.html';
+  const value = input ?? fallbackUrl;
   return new URL(value, 'https://cdn.honua.dev').searchParams;
 }
 
-function defaultLocation(): string {
+function defaultMapLocation(): string {
   if (typeof location === 'undefined') {
     return 'https://cdn.honua.dev/embed/map.html';
+  }
+
+  return location.href;
+}
+
+function defaultSceneLocation(): string {
+  if (typeof location === 'undefined') {
+    return 'https://cdn.honua.dev/embed/scene.html';
   }
 
   return location.href;

--- a/src/Honua.Embed/src/snippets.ts
+++ b/src/Honua.Embed/src/snippets.ts
@@ -109,6 +109,14 @@ export interface HonuaMapIframeSnippetOptions {
   indent?: string;
 }
 
+export interface HonuaSceneIframeSnippetOptions {
+  iframeUrl?: string;
+  includeCredentials?: boolean;
+  parentOrigin?: string | null;
+  iframe?: HonuaMapIframeAttributes;
+  indent?: string;
+}
+
 export interface HonuaMapReactSnippetOptions extends HonuaMapSnippetOptions {
   componentName?: string;
 }
@@ -317,11 +325,27 @@ export function createHonuaMapIframeSnippet(
   snippetOptions: HonuaMapIframeSnippetOptions = {},
 ): string {
   const iframeUrl = snippetOptions.iframeUrl ?? 'https://cdn.honua.dev/embed/map.html';
-  const src = createIframeSrc(iframeUrl, options, {
-    includeCredentials: snippetOptions.includeCredentials ?? false,
+  const src = createIframeSrc(iframeUrl, mapQueryParameters(options, snippetOptions.includeCredentials ?? false), {
     parentOrigin: snippetOptions.parentOrigin,
   });
-  const attributes = iframeAttributes(src, snippetOptions.iframe);
+  const attributes = iframeAttributes(src, snippetOptions.iframe, 'Embedded map');
+  const indent = snippetOptions.indent ?? '  ';
+  const lines = attributes.map(([name, value]) => (
+    `${indent}${name}="${escapeHtmlAttribute(value)}"`
+  ));
+
+  return `<iframe\n${lines.join('\n')}>\n</iframe>`;
+}
+
+export function createHonuaSceneIframeSnippet(
+  options: HonuaSceneEmbedOptions,
+  snippetOptions: HonuaSceneIframeSnippetOptions = {},
+): string {
+  const iframeUrl = snippetOptions.iframeUrl ?? 'https://cdn.honua.dev/embed/scene.html';
+  const src = createIframeSrc(iframeUrl, sceneQueryParameters(options, snippetOptions.includeCredentials ?? false), {
+    parentOrigin: snippetOptions.parentOrigin,
+  });
+  const attributes = iframeAttributes(src, snippetOptions.iframe, 'Embedded scene');
   const indent = snippetOptions.indent ?? '  ';
   const lines = attributes.map(([name, value]) => (
     `${indent}${name}="${escapeHtmlAttribute(value)}"`
@@ -771,11 +795,10 @@ function createReactIframeMarkup(
   snippetOptions: HonuaMapIframeSnippetOptions,
 ): string {
   const iframeUrl = snippetOptions.iframeUrl ?? 'https://cdn.honua.dev/embed/map.html';
-  const src = createIframeSrc(iframeUrl, options, {
-    includeCredentials: snippetOptions.includeCredentials ?? false,
+  const src = createIframeSrc(iframeUrl, mapQueryParameters(options, snippetOptions.includeCredentials ?? false), {
     parentOrigin: snippetOptions.parentOrigin,
   });
-  const attributes = iframeAttributes(src, snippetOptions.iframe);
+  const attributes = iframeAttributes(src, snippetOptions.iframe, 'Embedded map');
   const indent = snippetOptions.indent ?? '    ';
   const attributeIndent = `${indent}  `;
   const lines = attributes.map(([name, value]) => {
@@ -788,14 +811,13 @@ function createReactIframeMarkup(
 
 function createIframeSrc(
   iframeUrl: string,
-  options: HonuaMapEmbedOptions,
+  parameters: Array<[string, string]>,
   config: {
-    includeCredentials: boolean;
     parentOrigin?: string | null;
   },
 ): string {
   const url = new URL(iframeUrl, 'https://cdn.honua.dev');
-  for (const [name, value] of mapQueryParameters(options, config.includeCredentials)) {
+  for (const [name, value] of parameters) {
     url.searchParams.set(name, value);
   }
 
@@ -821,10 +843,11 @@ function createIframeSrc(
 function iframeAttributes(
   src: string,
   custom: HonuaMapIframeAttributes | undefined,
+  defaultTitle: string,
 ): Array<[string, string]> {
   return [
     ['src', src],
-    ['title', custom?.title ?? 'Embedded map'],
+    ['title', custom?.title ?? defaultTitle],
     ['loading', custom?.loading ?? 'lazy'],
     ['referrerpolicy', custom?.referrerPolicy ?? 'strict-origin-when-cross-origin'],
     ['sandbox', serializeSandbox(custom?.sandbox) ?? 'allow-scripts allow-same-origin allow-forms'],
@@ -886,6 +909,14 @@ function sceneAttributes(
     const value = entry[1];
     return value !== undefined && value !== null && value !== '';
   });
+}
+
+function sceneQueryParameters(
+  options: HonuaSceneEmbedOptions,
+  includeCredentials: boolean,
+): Array<[string, string]> {
+  return sceneAttributes(options, includeCredentials)
+    .map(([name, value]): [string, string] => [name, value === true ? 'true' : value]);
 }
 
 function serializeTheme(theme: HonuaMapThemeOptions | null | undefined): string | null {

--- a/src/Honua.Embed/tests/honua-iframe.test.ts
+++ b/src/Honua.Embed/tests/honua-iframe.test.ts
@@ -1,13 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   addHonuaMapIframeMessageListener,
+  addHonuaSceneIframeMessageListener,
   hydrateHonuaMapIframe,
+  hydrateHonuaSceneIframe,
   isHonuaMapIframeCommand,
   isHonuaMapIframeMessage,
+  isHonuaSceneIframeCommand,
+  isHonuaSceneIframeMessage,
   parseHonuaMapIframeConfig,
+  parseHonuaSceneIframeConfig,
   postHonuaMapIframeConfigure,
+  postHonuaSceneIframeConfigure,
   type HonuaMapIframeCommand,
   type HonuaMapIframeMessage,
+  type HonuaSceneIframeCommand,
+  type HonuaSceneIframeMessage,
 } from '../src/iframe';
 
 describe('honua map iframe fallback', () => {
@@ -398,6 +406,304 @@ describe('honua map iframe fallback', () => {
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener.mock.calls[0]?.[0]).toBe(message);
     expect(listener.mock.calls[0]?.[1].origin).toBe('https://portal.example.test');
+
+    disconnect();
+    window.dispatchEvent(new MessageEvent('message', {
+      data: message,
+      origin: 'https://portal.example.test',
+      source,
+    }));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('honua scene iframe fallback', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    window.history.replaceState(null, '', '/embed/scene.html');
+  });
+
+  it('parses scene options and parent origin from iframe query parameters', () => {
+    const url = new URL('/embed/scene.html', window.location.href);
+    url.searchParams.set('tileset-url', 'https://tiles.example.test/site/tileset.json');
+    url.searchParams.set('terrain-url', 'https://terrain.example.test/world');
+    url.searchParams.set('metadata-url', 'https://metadata.example.test/site.json');
+    url.searchParams.set('ion-token', 'public-browser-token');
+    url.searchParams.set('cesium-base-url', 'https://cdn.example.test/cesium/');
+    url.searchParams.set('center', '21.3069,-157.8583');
+    url.searchParams.set('height', '1800');
+    url.searchParams.set('heading', '20');
+    url.searchParams.set('pitch', '-35');
+    url.searchParams.set('roll', '1');
+    url.searchParams.set('theme', 'dark');
+    url.searchParams.set('autoload', 'false');
+    url.searchParams.set('parent-origin', 'https://portal.example.test/admin');
+
+    const config = parseHonuaSceneIframeConfig(url);
+
+    expect(config.parentOrigin).toBe('https://portal.example.test');
+    expect(config.options).toMatchObject({
+      tilesetUrl: 'https://tiles.example.test/site/tileset.json',
+      terrainUrl: 'https://terrain.example.test/world',
+      metadataUrl: 'https://metadata.example.test/site.json',
+      ionToken: 'public-browser-token',
+      cesiumBaseUrl: 'https://cdn.example.test/cesium/',
+      center: { latitude: 21.3069, longitude: -157.8583 },
+      height: 1800,
+      heading: 20,
+      pitch: -35,
+      roll: 1,
+      theme: 'dark',
+      autoload: false,
+    });
+  });
+
+  it('hydrates a full-frame scene element from the current URL', () => {
+    const mount = document.createElement('div');
+    mount.id = 'honua-scene-frame-root';
+    document.body.append(mount);
+    const url = new URL('/embed/scene.html', window.location.href);
+    url.searchParams.set('tileset-url', 'https://tiles.example.test/site/tileset.json');
+    url.searchParams.set('autoload', 'false');
+    window.history.replaceState(null, '', url);
+
+    const runtime = hydrateHonuaSceneIframe({ parent: null });
+
+    expect(mount.querySelector('honua-scene')).toBe(runtime.element);
+    expect(runtime.element.getAttribute('tileset-url')).toBe('https://tiles.example.test/site/tileset.json');
+    expect(runtime.element.getAttribute('autoload')).toBe('false');
+    expect(runtime.element.style.height).toBe('100%');
+  });
+
+  it('forwards sanitized scene events to the parent frame with the scoped target origin', () => {
+    const url = new URL('/embed/scene.html', window.location.href);
+    url.searchParams.set('parent-origin', 'https://portal.example.test');
+    window.history.replaceState(null, '', url);
+    const parent = {
+      postMessage: vi.fn<(message: HonuaSceneIframeMessage, targetOrigin: string) => void>(),
+    };
+    const widget = { scene: { requestRender: () => undefined } };
+    const tileset = { root: { transform: () => undefined } };
+
+    const runtime = hydrateHonuaSceneIframe({ parent });
+    runtime.element.dispatchEvent(new CustomEvent('honua-scene-ready', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        config: { tilesetUrl: 'https://tiles.example.test/site/tileset.json' },
+        widget,
+        tileset,
+      },
+    }));
+    runtime.element.dispatchEvent(new CustomEvent('honua-scene-identify', {
+      detail: {
+        config: { theme: 'dark' },
+        x: 12,
+        y: 34,
+        picked: { id: 'feature-1', widget },
+        position: { latitude: 21, longitude: -157, height: 8 },
+      },
+    }));
+
+    expect(parent.postMessage).toHaveBeenNthCalledWith(1, {
+      source: 'honua-scene-iframe',
+      version: 1,
+      type: 'honua-scene-ready',
+      detail: {
+        config: { tilesetUrl: 'https://tiles.example.test/site/tileset.json' },
+        widget: null,
+        tileset: null,
+      },
+    }, 'https://portal.example.test');
+    expect(parent.postMessage).toHaveBeenNthCalledWith(2, {
+      source: 'honua-scene-iframe',
+      version: 1,
+      type: 'honua-scene-identify',
+      detail: {
+        config: { theme: 'dark' },
+        x: 12,
+        y: 34,
+        picked: { id: 'feature-1', widget: { scene: {} } },
+        position: { latitude: 21, longitude: -157, height: 8 },
+      },
+    }, 'https://portal.example.test');
+
+    runtime.disconnect();
+    runtime.element.dispatchEvent(new CustomEvent('honua-scene-camera-change', {
+      detail: { height: 100 },
+    }));
+
+    expect(parent.postMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('identifies scene iframe messages and configure commands by source, version, and type', () => {
+    expect(isHonuaSceneIframeMessage({
+      source: 'honua-scene-iframe',
+      version: 1,
+      type: 'honua-scene-camera-change',
+      detail: {},
+    })).toBe(true);
+    expect(isHonuaSceneIframeMessage({
+      source: 'honua-scene-iframe',
+      version: 1,
+      type: 'honua-scene-layer-toggle',
+      detail: {},
+    })).toBe(false);
+    expect(isHonuaSceneIframeCommand({
+      source: 'honua-scene-host',
+      version: 1,
+      type: 'honua-scene-configure',
+      options: { theme: 'light' },
+    })).toBe(true);
+    expect(isHonuaSceneIframeCommand({
+      source: 'honua-scene-host',
+      version: 1,
+      type: 'honua-scene-configure',
+      options: null,
+    })).toBe(false);
+  });
+
+  it('posts typed configure commands to a scene iframe target', () => {
+    const target = {
+      postMessage: vi.fn<(message: HonuaSceneIframeCommand, targetOrigin: string) => void>(),
+    };
+
+    postHonuaSceneIframeConfigure(target, {
+      metadataUrl: 'https://metadata.example.test/site.json',
+      autoload: false,
+    }, 'https://cdn.honua.dev');
+
+    expect(target.postMessage).toHaveBeenCalledWith({
+      source: 'honua-scene-host',
+      version: 1,
+      type: 'honua-scene-configure',
+      options: {
+        metadataUrl: 'https://metadata.example.test/site.json',
+        autoload: false,
+      },
+    }, 'https://cdn.honua.dev');
+  });
+
+  it('applies configure commands from the declared parent origin and source', () => {
+    const parent = {
+      postMessage: vi.fn<(message: HonuaSceneIframeMessage, targetOrigin: string) => void>(),
+    };
+    const parentSource = parent as unknown as MessageEventSource;
+    const url = new URL('/embed/scene.html', window.location.href);
+    url.searchParams.set('tileset-url', 'https://tiles.example.test/site/tileset.json');
+    url.searchParams.set('theme', 'dark');
+    url.searchParams.set('autoload', 'false');
+    url.searchParams.set('parent-origin', 'https://portal.example.test');
+    window.history.replaceState(null, '', url);
+
+    const runtime = hydrateHonuaSceneIframe({ parent });
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data: {
+        source: 'honua-scene-host',
+        version: 1,
+        type: 'honua-scene-configure',
+        options: { theme: 'light' },
+      },
+      origin: 'https://other.example.test',
+      source: parentSource,
+    }));
+    window.dispatchEvent(new MessageEvent('message', {
+      data: {
+        source: 'honua-scene-host',
+        version: 1,
+        type: 'honua-scene-configure',
+        options: { height: 900 },
+      },
+      origin: 'https://portal.example.test',
+      source: window,
+    }));
+    window.dispatchEvent(new MessageEvent('message', {
+      data: {
+        source: 'honua-scene-host',
+        version: 1,
+        type: 'honua-scene-configure',
+        options: {
+          theme: 'light',
+          autoload: true,
+          height: 1200,
+        },
+      },
+      origin: 'https://portal.example.test',
+      source: parentSource,
+    }));
+
+    expect(runtime.element.getAttribute('tileset-url')).toBe('https://tiles.example.test/site/tileset.json');
+    expect(runtime.element.getAttribute('theme')).toBe('light');
+    expect(runtime.element.hasAttribute('autoload')).toBe(true);
+    expect(runtime.element.getAttribute('height')).toBe('1200');
+    expect(runtime.config.options).toMatchObject({
+      tilesetUrl: 'https://tiles.example.test/site/tileset.json',
+      theme: 'light',
+      autoload: true,
+      height: 1200,
+    });
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data: {
+        source: 'honua-scene-host',
+        version: 1,
+        type: 'honua-scene-configure',
+        options: {
+          theme: undefined,
+          height: undefined,
+          pitch: -35,
+        },
+      },
+      origin: 'https://portal.example.test',
+      source: parentSource,
+    }));
+
+    expect(runtime.element.getAttribute('theme')).toBe('light');
+    expect(runtime.element.getAttribute('height')).toBe('1200');
+    expect(runtime.element.getAttribute('pitch')).toBe('-35');
+    expect(runtime.config.options).toMatchObject({
+      theme: 'light',
+      height: 1200,
+      pitch: -35,
+    });
+  });
+
+  it('subscribes to scene iframe fallback messages with origin and source filtering', () => {
+    const sourceFrame = document.createElement('iframe');
+    document.body.append(sourceFrame);
+    const source = sourceFrame.contentWindow;
+    const listener = vi.fn<(message: HonuaSceneIframeMessage, event: MessageEvent) => void>();
+    const message: HonuaSceneIframeMessage = {
+      source: 'honua-scene-iframe',
+      version: 1,
+      type: 'honua-scene-layer-change',
+      detail: { layerId: 'primary' },
+    };
+    const disconnect = addHonuaSceneIframeMessageListener(listener, {
+      origin: 'https://portal.example.test/admin/embed',
+      source,
+    });
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data: message,
+      origin: 'https://other.example.test',
+      source,
+    }));
+    window.dispatchEvent(new MessageEvent('message', {
+      data: message,
+      origin: 'https://portal.example.test',
+      source: window,
+    }));
+    window.dispatchEvent(new MessageEvent('message', {
+      data: message,
+      origin: 'https://portal.example.test',
+      source,
+    }));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0]?.[0]).toBe(message);
 
     disconnect();
     window.dispatchEvent(new MessageEvent('message', {

--- a/src/Honua.Embed/tests/honua-snippets.test.ts
+++ b/src/Honua.Embed/tests/honua-snippets.test.ts
@@ -12,6 +12,7 @@ import {
   createHonuaMapVueIframeSnippet,
   createHonuaMapVueSnippet,
   createHonuaSceneCdnSnippet,
+  createHonuaSceneIframeSnippet,
   createHonuaSceneSnippet,
   defineHonuaMapElement,
   defineHonuaSceneElement,
@@ -565,6 +566,92 @@ describe('honua scene snippets', () => {
     expect(snippet).toContain('<honua-scene');
     expect(snippet).toContain('metadata-url="https://metadata.example.test/site.json"');
     expect(snippet).toContain('autoload="false"');
+  });
+
+  it('generates a scene iframe fallback snippet without credentials by default', () => {
+    const snippet = createHonuaSceneIframeSnippet({
+      tilesetUrl: 'https://tiles.example.test/site/tileset.json',
+      metadataUrl: 'https://metadata.example.test/site.json',
+      ionToken: 'secret-token',
+      autoload: true,
+    });
+
+    const iframe = readIframe(snippet);
+
+    expect(iframe.getAttribute('title')).toBe('Embedded scene');
+    expect(iframe.getAttribute('loading')).toBe('lazy');
+    expect(iframe.getAttribute('src')).toContain('https://cdn.honua.dev/embed/scene.html');
+    expect(iframe.getAttribute('src')).toContain('tileset-url=');
+    expect(iframe.getAttribute('src')).toContain('autoload=true');
+    expect(iframe.getAttribute('src')).not.toContain('secret-token');
+    expect(snippet).not.toContain('ion-token');
+  });
+
+  it('serializes scene options into iframe query parameters', () => {
+    const snippet = createHonuaSceneIframeSnippet({
+      tilesetUrl: 'https://tiles.example.test/site/tileset.json',
+      terrainUrl: 'https://terrain.example.test/world',
+      metadataUrl: 'https://metadata.example.test/site.json',
+      ionToken: 'public-browser-token',
+      center: { latitude: 21.3069, longitude: -157.8583 },
+      height: 1800,
+      heading: 20,
+      pitch: -35,
+      roll: 1,
+      theme: 'dark',
+      autoload: false,
+      cesiumBaseUrl: 'https://cdn.example.test/cesium/',
+    }, {
+      iframeUrl: 'https://embed.example.test/scene.html?tenant=city',
+      includeCredentials: true,
+      parentOrigin: 'https://portal.example.test/admin/embed',
+    });
+
+    const src = readIframe(snippet).getAttribute('src');
+    const url = new URL(src ?? '');
+
+    expect(url.origin).toBe('https://embed.example.test');
+    expect(url.searchParams.get('tenant')).toBe('city');
+    expect(url.searchParams.get('parent-origin')).toBe('https://portal.example.test/admin/embed');
+    expect(url.searchParams.get('tileset-url')).toBe('https://tiles.example.test/site/tileset.json');
+    expect(url.searchParams.get('terrain-url')).toBe('https://terrain.example.test/world');
+    expect(url.searchParams.get('metadata-url')).toBe('https://metadata.example.test/site.json');
+    expect(url.searchParams.get('ion-token')).toBe('public-browser-token');
+    expect(url.searchParams.get('center')).toBe('21.3069,-157.8583');
+    expect(url.searchParams.get('height')).toBe('1800');
+    expect(url.searchParams.get('heading')).toBe('20');
+    expect(url.searchParams.get('pitch')).toBe('-35');
+    expect(url.searchParams.get('roll')).toBe('1');
+    expect(url.searchParams.get('theme')).toBe('dark');
+    expect(url.searchParams.get('autoload')).toBe('false');
+    expect(url.searchParams.get('cesium-base-url')).toBe('https://cdn.example.test/cesium/');
+  });
+
+  it('applies custom scene iframe fallback options and preserves protocol-relative URLs', () => {
+    const snippet = createHonuaSceneIframeSnippet({
+      metadataUrl: 'https://metadata.example.test/site.json',
+      autoload: true,
+    }, {
+      iframeUrl: '//embed.example.test/scene.html?tenant=city#scene',
+      iframe: {
+        title: 'Construction scene',
+        loading: 'eager',
+        width: '100%',
+        height: 420,
+        className: 'embed-frame',
+      },
+    });
+
+    const iframe = readIframe(snippet);
+
+    expect(iframe.getAttribute('src')).toBe(
+      '//embed.example.test/scene.html?tenant=city&metadata-url=https%3A%2F%2Fmetadata.example.test%2Fsite.json&autoload=true#scene',
+    );
+    expect(iframe.getAttribute('title')).toBe('Construction scene');
+    expect(iframe.getAttribute('loading')).toBe('eager');
+    expect(iframe.getAttribute('width')).toBe('100%');
+    expect(iframe.getAttribute('height')).toBe('420');
+    expect(iframe.className).toBe('embed-frame');
   });
 
   it('applies scene options to an existing element and removes null values', () => {


### PR DESCRIPTION
Refs #12

## Summary
- add scene iframe snippet generation and a static scene iframe shell
- add scene iframe parse/hydrate/configure/message listener APIs beside the existing map iframe APIs
- forward core scene events with sanitized, cloneable payloads

## Validation
- npm test --prefix src/Honua.Embed -- tests/honua-iframe.test.ts tests/honua-snippets.test.ts
- npm test --prefix src/Honua.Embed
- npm run typecheck --prefix src/Honua.Embed
- npm run build --prefix src/Honua.Embed
- git diff --check