### PR TITLE
feat: add embed CDN manifest

### DIFF
--- a/.github/workflows/publish-npm-embed.yml
+++ b/.github/workflows/publish-npm-embed.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Generate CDN manifest
+        run: npm run cdn:manifest
+
       - name: Pack npm package
         shell: bash
         run: |
@@ -81,12 +84,23 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
+      - name: Upload CDN dist artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: honua-mobile-embed-${{ github.run_id }}-cdn-dist
+          path: src/Honua.Embed/dist/
+          if-no-files-found: error
+          retention-days: 90
+
       - name: Dry-run summary
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}
         shell: bash
         run: |
           echo "Dry run complete. Built npm package:" >> "${GITHUB_STEP_SUMMARY}"
           ls -1 "${GITHUB_WORKSPACE}"/npm-packages/*.tgz >> "${GITHUB_STEP_SUMMARY}"
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
+          echo "CDN dist artifact includes manifest:" >> "${GITHUB_STEP_SUMMARY}"
+          echo "${GITHUB_WORKSPACE}/src/Honua.Embed/dist/cdn-manifest.json" >> "${GITHUB_STEP_SUMMARY}"
 
   publish:
     name: Publish to GitHub Packages

--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -75,6 +75,38 @@ const snippet = createHonuaMapCdnSnippet({
 });
 ```
 
+After building the package, create the CDN manifest from the generated `dist`
+folder:
+
+```bash
+npm run build --prefix src/Honua.Embed
+npm run cdn:manifest --prefix src/Honua.Embed
+```
+
+`dist/cdn-manifest.json` lists the package name/version, default URLs, and
+top-level JavaScript files with byte size, SHA-256 hash, and SHA-384 SRI
+integrity. It covers `embed.js`, `index.js`, `iframe.js`, `snippets.js`, and
+top-level Vite chunks; Cesium runtime assets under `dist/cesium` are copied for
+hosting but are not expanded into the manifest.
+The publish workflow uploads the built `dist/` directory as a CDN artifact so
+release operators can promote the static bundle separately from npm publishing.
+
+When generating snippets for a CDN-hosted build, read the `embed.js` entry and
+pass its integrity value through the existing helper:
+
+```js
+const manifest = await fetch('https://cdn.honua.dev/cdn-manifest.json').then((response) => response.json());
+const embedEntry = manifest.files.find((file) => file.path === 'embed.js');
+
+const snippet = createHonuaMapCdnSnippet(options, {
+  scriptUrl: embedEntry.url,
+  scriptAttributes: {
+    integrity: embedEntry.integrity,
+    crossOrigin: 'anonymous',
+  },
+});
+```
+
 The generated CDN markup stays white-label; it does not add Honua attribution.
 When `elementName` is customized, the helper emits an inline module import that
 registers the branded tag name from the CDN bundle.

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -251,6 +251,34 @@ const snippet = createHonuaMapCdnSnippet({
 });
 ```
 
+After `npm run build`, generate `dist/cdn-manifest.json` for CDN publishing
+metadata:
+
+```bash
+npm run cdn:manifest
+```
+
+The manifest records the package name/version, default CDN URLs, and each
+top-level JavaScript entry's byte size, SHA-256 hash, and SHA-384 SRI value. It
+includes `embed.js`, `index.js`, `iframe.js`, `snippets.js`, and top-level Vite
+chunks, but does not enumerate the copied Cesium asset tree. Use the manifest
+entry for the hosted script when emitting CDN snippets. The publish workflow
+also uploads the built `dist/` directory as a CDN artifact for operators that
+promote static assets separately from the npm package.
+
+```ts
+const manifest = await fetch('https://cdn.honua.dev/cdn-manifest.json').then((response) => response.json());
+const embedEntry = manifest.files.find((file) => file.path === 'embed.js');
+
+const snippet = createHonuaMapCdnSnippet(options, {
+  scriptUrl: embedEntry.url,
+  scriptAttributes: {
+    integrity: embedEntry.integrity,
+    crossOrigin: 'anonymous',
+  },
+});
+```
+
 Server-side builders that only generate markup can import from
 `@honua-io/embed/snippets` to avoid loading the browser custom element
 entrypoint.

--- a/src/Honua.Embed/package.json
+++ b/src/Honua.Embed/package.json
@@ -34,6 +34,7 @@
   ],
   "scripts": {
     "build": "vite build && tsc -p tsconfig.json --emitDeclarationOnly && node scripts/copy-cesium-assets.mjs",
+    "cdn:manifest": "node scripts/create-cdn-manifest.mjs",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/src/Honua.Embed/scripts/create-cdn-manifest.mjs
+++ b/src/Honua.Embed/scripts/create-cdn-manifest.mjs
@@ -1,0 +1,124 @@
+import { createHash } from 'node:crypto';
+import { readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { dirname, join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const requiredEntries = ['embed.js', 'index.js', 'iframe.js', 'snippets.js'];
+const defaultBaseUrl = 'https://cdn.honua.dev/';
+
+export async function createCdnManifest(options = {}) {
+  const packageRoot = options.packageRoot ?? dirname(dirname(fileURLToPath(import.meta.url)));
+  const distRoot = options.distRoot ?? join(packageRoot, 'dist');
+  const outputPath = options.outputPath ?? join(distRoot, 'cdn-manifest.json');
+  const baseUrl = normalizeBaseUrl(options.baseUrl ?? defaultBaseUrl);
+  const packageJson = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
+  const files = await collectCdnFiles(distRoot, baseUrl);
+
+  const manifest = {
+    schemaVersion: 1,
+    package: {
+      name: packageJson.name,
+      version: packageJson.version,
+    },
+    defaultBaseUrl: baseUrl,
+    defaultUrls: {
+      embed: new URL('embed.js', baseUrl).toString(),
+      iframe: new URL('embed/map.html', baseUrl).toString(),
+      manifest: new URL('cdn-manifest.json', baseUrl).toString(),
+    },
+    files,
+  };
+
+  await writeFile(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+export async function collectCdnFiles(distRoot, baseUrl = defaultBaseUrl) {
+  const entries = await readdir(distRoot, { withFileTypes: true });
+  const topLevelJsFiles = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.js'))
+    .map((entry) => entry.name)
+    .sort(compareFileNames);
+
+  const missingEntries = requiredEntries.filter((entry) => !topLevelJsFiles.includes(entry));
+  if (missingEntries.length > 0) {
+    throw new Error(`Missing required CDN entries in dist: ${missingEntries.join(', ')}`);
+  }
+
+  return Promise.all(topLevelJsFiles.map(async (name) => {
+    const path = join(distRoot, name);
+    const [metadata, content] = await Promise.all([stat(path), readFile(path)]);
+    const relativePath = relative(distRoot, path).split(sep).join('/');
+
+    return {
+      path: relativePath,
+      bytes: metadata.size,
+      sha256: createHash('sha256').update(content).digest('hex'),
+      integrity: `sha384-${createHash('sha384').update(content).digest('base64')}`,
+      url: new URL(relativePath, baseUrl).toString(),
+    };
+  }));
+}
+
+export function normalizeBaseUrl(value) {
+  const url = new URL(value);
+  if (!url.pathname.endsWith('/')) {
+    url.pathname = `${url.pathname}/`;
+  }
+
+  return url.toString();
+}
+
+function readCliOptions(argv) {
+  const options = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === '--base-url' && isValue(next)) {
+      options.baseUrl = next;
+      index += 1;
+    } else if (arg === '--package-root' && isValue(next)) {
+      options.packageRoot = next;
+      index += 1;
+    } else if (arg === '--dist-root' && isValue(next)) {
+      options.distRoot = next;
+      index += 1;
+    } else if (arg === '--output' && isValue(next)) {
+      options.outputPath = next;
+      index += 1;
+    } else {
+      throw new Error(`Unknown or incomplete argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function compareFileNames(left, right) {
+  if (left < right) {
+    return -1;
+  }
+
+  if (left > right) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function isValue(value) {
+  return typeof value === 'string' && !value.startsWith('--');
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  createCdnManifest(readCliOptions(process.argv.slice(2)))
+    .then((manifest) => {
+      console.log(`Wrote ${manifest.defaultUrls.manifest}`);
+    })
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exitCode = 1;
+    });
+}

--- a/src/Honua.Embed/tests/cdn-manifest.test.ts
+++ b/src/Honua.Embed/tests/cdn-manifest.test.ts
@@ -1,0 +1,97 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createCdnManifest } from '../scripts/create-cdn-manifest.mjs';
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })));
+  tempRoots.length = 0;
+});
+
+describe('CDN manifest generation', () => {
+  it('writes deterministic metadata for top-level CDN JavaScript entries', async () => {
+    const packageRoot = await createPackageFixture({
+      'embed.js': 'export const entry = "embed";\n',
+      'index.js': 'export const entry = "index";\n',
+      'iframe.js': 'export const entry = "iframe";\n',
+      'snippets.js': 'export const entry = "snippets";\n',
+      'shared-abc123.js': 'export const shared = true;\n',
+    });
+
+    await mkdir(join(packageRoot, 'dist', 'cesium'), { recursive: true });
+    await writeFile(join(packageRoot, 'dist', 'style.css'), 'body {}\n');
+    await writeFile(join(packageRoot, 'dist', 'cesium', 'Worker.js'), 'ignored\n');
+
+    const manifest = await createCdnManifest({
+      packageRoot,
+      baseUrl: 'https://cdn.example.test/honua/embed',
+    });
+    const manifestJson = JSON.parse(await readFile(join(packageRoot, 'dist', 'cdn-manifest.json'), 'utf8'));
+
+    expect(manifestJson).toEqual(manifest);
+    expect(manifest).toMatchObject({
+      schemaVersion: 1,
+      package: {
+        name: '@honua-io/embed',
+        version: '9.8.7',
+      },
+      defaultBaseUrl: 'https://cdn.example.test/honua/embed/',
+      defaultUrls: {
+        embed: 'https://cdn.example.test/honua/embed/embed.js',
+        iframe: 'https://cdn.example.test/honua/embed/embed/map.html',
+        manifest: 'https://cdn.example.test/honua/embed/cdn-manifest.json',
+      },
+    });
+    expect(manifest.files.map((file) => file.path)).toEqual([
+      'embed.js',
+      'iframe.js',
+      'index.js',
+      'shared-abc123.js',
+      'snippets.js',
+    ]);
+    expect(manifest.files).not.toContainEqual(expect.objectContaining({ path: 'cesium/Worker.js' }));
+
+    const embedContent = 'export const entry = "embed";\n';
+    expect(manifest.files[0]).toEqual({
+      path: 'embed.js',
+      bytes: Buffer.byteLength(embedContent),
+      sha256: createHash('sha256').update(embedContent).digest('hex'),
+      integrity: `sha384-${createHash('sha384').update(embedContent).digest('base64')}`,
+      url: 'https://cdn.example.test/honua/embed/embed.js',
+    });
+  });
+
+  it('fails when a required CDN entry is missing', async () => {
+    const packageRoot = await createPackageFixture({
+      'embed.js': '',
+      'index.js': '',
+      'iframe.js': '',
+    });
+
+    await expect(createCdnManifest({ packageRoot })).rejects.toThrow(
+      'Missing required CDN entries in dist: snippets.js',
+    );
+  });
+});
+
+async function createPackageFixture(files: Record<string, string>) {
+  const packageRoot = await mkdtemp(join(tmpdir(), 'honua-embed-cdn-'));
+  tempRoots.push(packageRoot);
+
+  await mkdir(join(packageRoot, 'dist'), { recursive: true });
+  await writeFile(join(packageRoot, 'package.json'), JSON.stringify({
+    name: '@honua-io/embed',
+    version: '9.8.7',
+  }));
+
+  await Promise.all(Object.entries(files).map(([name, content]) => (
+    writeFile(join(packageRoot, 'dist', name), content)
+  )));
+
+  return packageRoot;
+}


### PR DESCRIPTION
Refs #10

## Summary
- add a CDN manifest generator for @honua/embed build output with bytes, SHA-256, and SRI SHA-384 values
- include the manifest in npm package smoke and upload the built CDN dist artifact
- document using manifest integrity values in CDN snippets

## Validation
- npm test --prefix src/Honua.Embed -- tests/cdn-manifest.test.ts
- npm test --prefix src/Honua.Embed
- npm run typecheck --prefix src/Honua.Embed
- npm run build --prefix src/Honua.Embed
- npm run cdn:manifest --prefix src/Honua.Embed
- git diff --check