### PR TITLE
feat: add map builder snippet dispatcher

### DIFF
--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -115,6 +115,31 @@ Server-side builders that only generate markup can import from
 `@honua-io/embed/snippets`; that subpath avoids loading the browser custom
 element entrypoint.
 
+Embed configurators can route a user-selected output target through
+`createHonuaMapEmbedBuilderSnippet` instead of duplicating switch logic across
+the individual helpers. The default target is `web-component`; supported map
+targets are `web-component`, `cdn`, `iframe`, `react`, `react-iframe`, `vue`,
+`vue-iframe`, `angular`, and `angular-iframe`.
+
+```js
+import { createHonuaMapEmbedBuilderSnippet } from '@honua-io/embed/snippets';
+
+const snippet = createHonuaMapEmbedBuilderSnippet(options, {
+  target: selectedTarget,
+  cdn: {
+    scriptUrl: 'https://cdn.honua.dev/embed.js',
+    scriptAttributes: {
+      integrity: embedEntry.integrity,
+      crossOrigin: 'anonymous',
+    },
+  },
+  iframe: {
+    iframeUrl: 'https://cdn.honua.dev/embed/map.html',
+    parentOrigin: 'https://portal.example.com',
+  },
+});
+```
+
 Runtime hosts can apply the same configuration shape to an existing element:
 
 ```js

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -283,6 +283,31 @@ Server-side builders that only generate markup can import from
 `@honua-io/embed/snippets` to avoid loading the browser custom element
 entrypoint.
 
+Embed configurators can route a user-selected target through
+`createHonuaMapEmbedBuilderSnippet` instead of duplicating switch logic across
+the concrete helpers. The default target is `web-component`; supported map
+targets are `web-component`, `cdn`, `iframe`, `react`, `react-iframe`, `vue`,
+`vue-iframe`, `angular`, and `angular-iframe`.
+
+```ts
+import { createHonuaMapEmbedBuilderSnippet } from '@honua-io/embed/snippets';
+
+const snippet = createHonuaMapEmbedBuilderSnippet(options, {
+  target: selectedTarget,
+  cdn: {
+    scriptUrl: 'https://cdn.honua.dev/embed.js',
+    scriptAttributes: {
+      integrity: 'sha384-...',
+      crossOrigin: 'anonymous',
+    },
+  },
+  iframe: {
+    iframeUrl: 'https://cdn.honua.dev/embed/map.html',
+    parentOrigin: 'https://portal.example.com',
+  },
+});
+```
+
 For hosts that cannot load custom elements, use `createHonuaMapIframeSnippet`.
 Map options are encoded into the iframe URL query string, with `apiKey` omitted
 unless `includeCredentials: true` is passed. The package build includes the

--- a/src/Honua.Embed/src/snippets.ts
+++ b/src/Honua.Embed/src/snippets.ts
@@ -141,6 +141,30 @@ export interface HonuaMapAngularIframeSnippetOptions extends HonuaMapIframeSnipp
   selector?: string;
 }
 
+export type HonuaMapEmbedBuilderTarget =
+  | 'web-component'
+  | 'cdn'
+  | 'iframe'
+  | 'react'
+  | 'react-iframe'
+  | 'vue'
+  | 'vue-iframe'
+  | 'angular'
+  | 'angular-iframe';
+
+export interface HonuaMapEmbedBuilderSnippetOptions {
+  target?: HonuaMapEmbedBuilderTarget;
+  webComponent?: HonuaMapSnippetOptions;
+  cdn?: HonuaMapCdnSnippetOptions;
+  iframe?: HonuaMapIframeSnippetOptions;
+  react?: HonuaMapReactSnippetOptions;
+  reactIframe?: HonuaMapReactIframeSnippetOptions;
+  vue?: HonuaMapVueSnippetOptions;
+  vueIframe?: HonuaMapVueIframeSnippetOptions;
+  angular?: HonuaMapAngularSnippetOptions;
+  angularIframe?: HonuaMapAngularIframeSnippetOptions;
+}
+
 export function applyHonuaMapOptions(
   element: HTMLElement,
   options: HonuaMapEmbedOptions,
@@ -506,6 +530,36 @@ export function createHonuaMapAngularIframeSnippet(
     iframe,
     indent,
   );
+}
+
+export function createHonuaMapEmbedBuilderSnippet(
+  options: HonuaMapEmbedOptions,
+  snippetOptions: HonuaMapEmbedBuilderSnippetOptions = {},
+): string {
+  const target = snippetOptions.target ?? 'web-component';
+
+  switch (target) {
+    case 'web-component':
+      return createHonuaMapSnippet(options, snippetOptions.webComponent);
+    case 'cdn':
+      return createHonuaMapCdnSnippet(options, snippetOptions.cdn);
+    case 'iframe':
+      return createHonuaMapIframeSnippet(options, snippetOptions.iframe);
+    case 'react':
+      return createHonuaMapReactSnippet(options, snippetOptions.react);
+    case 'react-iframe':
+      return createHonuaMapReactIframeSnippet(options, snippetOptions.reactIframe);
+    case 'vue':
+      return createHonuaMapVueSnippet(options, snippetOptions.vue);
+    case 'vue-iframe':
+      return createHonuaMapVueIframeSnippet(options, snippetOptions.vueIframe);
+    case 'angular':
+      return createHonuaMapAngularSnippet(options, snippetOptions.angular);
+    case 'angular-iframe':
+      return createHonuaMapAngularIframeSnippet(options, snippetOptions.angularIframe);
+    default:
+      throw new Error(`Unsupported Honua map embed builder target: ${target}`);
+  }
 }
 
 function createCdnScriptMarkup(

--- a/src/Honua.Embed/tests/honua-snippets.test.ts
+++ b/src/Honua.Embed/tests/honua-snippets.test.ts
@@ -5,6 +5,7 @@ import {
   createHonuaMapAngularIframeSnippet,
   createHonuaMapAngularSnippet,
   createHonuaMapCdnSnippet,
+  createHonuaMapEmbedBuilderSnippet,
   createHonuaMapIframeSnippet,
   createHonuaMapReactIframeSnippet,
   createHonuaMapReactSnippet,
@@ -464,6 +465,93 @@ describe('honua map snippets', () => {
     expect(iframeSnippet).toContain('<iframe');
     expect(iframeSnippet).toContain('src="/embeds/map.html?basemap=dark"');
     expect(iframeSnippet).toContain('export class CityAssetMapFrameComponent {}');
+  });
+
+  it('dispatches builder map targets to the concrete snippet helpers', () => {
+    const options = {
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      apiKey: 'secret-key',
+      search: true,
+      label: 'City asset map',
+    };
+
+    expect(createHonuaMapEmbedBuilderSnippet(options, {
+      webComponent: { includeScript: false },
+    })).toBe(createHonuaMapSnippet(options, { includeScript: false }));
+    expect(createHonuaMapEmbedBuilderSnippet(options, {
+      target: 'cdn',
+      cdn: {
+        scriptUrl: 'https://cdn.example.test/embed.js',
+      },
+    })).toBe(createHonuaMapCdnSnippet(options, {
+      scriptUrl: 'https://cdn.example.test/embed.js',
+    }));
+    expect(createHonuaMapEmbedBuilderSnippet(options, {
+      target: 'iframe',
+      iframe: {
+        iframeUrl: '/embed/map.html',
+      },
+    })).toBe(createHonuaMapIframeSnippet(options, {
+      iframeUrl: '/embed/map.html',
+    }));
+    expect(createHonuaMapEmbedBuilderSnippet(options, {
+      target: 'react',
+      react: {
+        componentName: 'CityAssetMap',
+      },
+    })).toBe(createHonuaMapReactSnippet(options, {
+      componentName: 'CityAssetMap',
+    }));
+    expect(createHonuaMapEmbedBuilderSnippet(options, {
+      target: 'react-iframe',
+      reactIframe: {
+        componentName: 'CityAssetMapFrame',
+      },
+    })).toBe(createHonuaMapReactIframeSnippet(options, {
+      componentName: 'CityAssetMapFrame',
+    }));
+    expect(createHonuaMapEmbedBuilderSnippet(options, {
+      target: 'vue',
+      vue: {
+        includeScript: false,
+      },
+    })).toBe(createHonuaMapVueSnippet(options, {
+      includeScript: false,
+    }));
+    expect(createHonuaMapEmbedBuilderSnippet(options, {
+      target: 'vue-iframe',
+      vueIframe: {
+        iframeUrl: '/embed/map.html',
+      },
+    })).toBe(createHonuaMapVueIframeSnippet(options, {
+      iframeUrl: '/embed/map.html',
+    }));
+    expect(createHonuaMapEmbedBuilderSnippet(options, {
+      target: 'angular',
+      angular: {
+        componentName: 'CityAssetMapComponent',
+        selector: 'city-asset-map',
+      },
+    })).toBe(createHonuaMapAngularSnippet(options, {
+      componentName: 'CityAssetMapComponent',
+      selector: 'city-asset-map',
+    }));
+    expect(createHonuaMapEmbedBuilderSnippet(options, {
+      target: 'angular-iframe',
+      angularIframe: {
+        componentName: 'CityAssetMapFrameComponent',
+        selector: 'city-asset-map-frame',
+      },
+    })).toBe(createHonuaMapAngularIframeSnippet(options, {
+      componentName: 'CityAssetMapFrameComponent',
+      selector: 'city-asset-map-frame',
+    }));
+  });
+
+  it('rejects unsupported builder map targets at runtime', () => {
+    expect(() => createHonuaMapEmbedBuilderSnippet({}, {
+      target: 'native' as never,
+    })).toThrow('Unsupported Honua map embed builder target: native');
   });
 });
 


### PR DESCRIPTION
Refs #10.

## Summary
- Add a dispatcher that emits map embed snippets for supported builder targets.
- Cover runtime target validation and generated snippet paths.
- Document the helper in the embed README and embeddable map guide.

## Validation
- `npm test -- --run tests/honua-snippets.test.ts` passed, 29 tests.
- `npm run typecheck` passed.
- `git diff --check` passed.

Note: Vitest exits successfully but happy-dom still prints existing teardown `AbortError` noise.