### PR TITLE
feat: add scene framework snippet helpers

### DIFF
--- a/docs/guides/3d-scene-embed.md
+++ b/docs/guides/3d-scene-embed.md
@@ -1,10 +1,10 @@
 # 3D Scene Embed
 
-`@honua/embed` includes a CesiumJS-backed `<honua-scene>` custom element for loading external or Honua-hosted 3D Tiles datasets.
+`@honua-io/embed` includes a CesiumJS-backed `<honua-scene>` custom element for loading external or Honua-hosted 3D Tiles datasets.
 
 ```html
 <script type="module">
-  import '@honua/embed';
+  import '@honua-io/embed';
 </script>
 
 <honua-scene
@@ -62,6 +62,64 @@ scene.addEventListener('honua-scene-identify', (event) => {
   // could sample a surface at (x, y); otherwise null.
   console.log(event.detail.x, event.detail.y, event.detail.picked, event.detail.position);
 });
+```
+
+## Generated Snippets and Iframes
+
+Server-side builders can import from `@honua-io/embed/snippets` to generate
+scene markup without loading the browser custom-element entrypoint. The helpers
+omit credential-bearing `ionToken` values unless `includeCredentials: true` is
+passed.
+
+```ts
+import {
+  createHonuaSceneIframeSnippet,
+  createHonuaSceneReactSnippet,
+} from '@honua-io/embed/snippets';
+
+const reactSnippet = createHonuaSceneReactSnippet({
+  tilesetUrl: 'https://example.com/tileset.json',
+  metadataUrl: 'https://example.com/site.metadata.json',
+  autoload: true,
+}, {
+  componentName: 'ConstructionScene',
+});
+
+const iframeSnippet = createHonuaSceneIframeSnippet({
+  metadataUrl: 'https://example.com/site.metadata.json',
+  autoload: true,
+}, {
+  parentOrigin: 'https://portal.example.com',
+  iframe: {
+    title: 'Construction scene',
+  },
+});
+```
+
+The iframe shell hydrates a full-frame `<honua-scene>` from query parameters,
+accepts typed configure commands, and forwards cloneable scene events to the
+parent window when `parentOrigin` is set.
+
+```ts
+import {
+  addHonuaSceneIframeMessageListener,
+  postHonuaSceneIframeConfigure,
+} from '@honua-io/embed/iframe';
+
+const iframe = document.querySelector<HTMLIFrameElement>('#scene-frame');
+const disconnectSceneMessages = addHonuaSceneIframeMessageListener((message) => {
+  console.log(message.type, message.detail);
+}, {
+  origin: 'https://cdn.honua.dev',
+  source: iframe?.contentWindow ?? null,
+});
+window.addEventListener('pagehide', disconnectSceneMessages, { once: true });
+
+if (iframe?.contentWindow) {
+  postHonuaSceneIframeConfigure(iframe.contentWindow, {
+    theme: 'light',
+  }, 'https://cdn.honua.dev');
+}
 ```
 
 ## Asset Packaging

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -476,6 +476,37 @@ from the query string, and forwards only core scene events to the parent window:
 tileset, picked object, and error references are sanitized before forwarding so
 messages stay cloneable.
 
+Framework hosts can generate scene starter components with the same public URL
+and credential-omission behavior as the plain helpers:
+
+```ts
+import {
+  createHonuaSceneAngularIframeSnippet,
+  createHonuaSceneReactSnippet,
+  createHonuaSceneVueSnippet,
+} from '@honua-io/embed/snippets';
+
+const reactComponent = createHonuaSceneReactSnippet({
+  tilesetUrl: 'https://example.com/tileset.json',
+  metadataUrl: 'https://example.com/site.metadata.json',
+  autoload: true,
+}, {
+  componentName: 'ConstructionScene',
+});
+
+const vueComponent = createHonuaSceneVueSnippet({
+  metadataUrl: 'https://example.com/site.metadata.json',
+});
+
+const angularIframeComponent = createHonuaSceneAngularIframeSnippet({
+  metadataUrl: 'https://example.com/site.metadata.json',
+  autoload: true,
+}, {
+  iframeUrl: 'https://cdn.honua.dev/embed/scene.html',
+  parentOrigin: 'https://portal.example.com',
+});
+```
+
 ## Host Extensions
 
 ```ts

--- a/src/Honua.Embed/src/iframe.ts
+++ b/src/Honua.Embed/src/iframe.ts
@@ -81,6 +81,9 @@ export interface HonuaMapIframeMessageListenerOptions {
   source?: MessageEventSource | null;
 }
 
+export interface HonuaSceneIframeMessageListenerOptions extends HonuaMapIframeMessageListenerOptions {
+}
+
 export interface HonuaMapIframeHydrateOptions {
   window?: Window;
   element?: HonuaMapElement | null;
@@ -410,7 +413,7 @@ export function addHonuaMapIframeMessageListener(
 
 export function addHonuaSceneIframeMessageListener(
   listener: HonuaSceneIframeMessageListener,
-  options: HonuaMapIframeMessageListenerOptions = {},
+  options: HonuaSceneIframeMessageListenerOptions = {},
 ): () => void {
   const targetWindow = options.window ?? defaultWindow();
   const expectedOrigins = normalizeExpectedOrigins(options.origin);

--- a/src/Honua.Embed/src/snippets.ts
+++ b/src/Honua.Embed/src/snippets.ts
@@ -101,6 +101,9 @@ export interface HonuaMapIframeAttributes {
   style?: string | null;
 }
 
+export interface HonuaSceneIframeAttributes extends HonuaMapIframeAttributes {
+}
+
 export interface HonuaMapIframeSnippetOptions {
   iframeUrl?: string;
   includeCredentials?: boolean;
@@ -113,7 +116,7 @@ export interface HonuaSceneIframeSnippetOptions {
   iframeUrl?: string;
   includeCredentials?: boolean;
   parentOrigin?: string | null;
-  iframe?: HonuaMapIframeAttributes;
+  iframe?: HonuaSceneIframeAttributes;
   indent?: string;
 }
 
@@ -121,14 +124,28 @@ export interface HonuaMapReactSnippetOptions extends HonuaMapSnippetOptions {
   componentName?: string;
 }
 
+export interface HonuaSceneReactSnippetOptions extends HonuaSceneSnippetOptions {
+  componentName?: string;
+}
+
 export interface HonuaMapReactIframeSnippetOptions extends HonuaMapIframeSnippetOptions {
+  componentName?: string;
+}
+
+export interface HonuaSceneReactIframeSnippetOptions extends HonuaSceneIframeSnippetOptions {
   componentName?: string;
 }
 
 export interface HonuaMapVueSnippetOptions extends HonuaMapSnippetOptions {
 }
 
+export interface HonuaSceneVueSnippetOptions extends HonuaSceneSnippetOptions {
+}
+
 export interface HonuaMapVueIframeSnippetOptions extends HonuaMapIframeSnippetOptions {
+}
+
+export interface HonuaSceneVueIframeSnippetOptions extends HonuaSceneIframeSnippetOptions {
 }
 
 export interface HonuaMapAngularSnippetOptions extends HonuaMapSnippetOptions {
@@ -136,7 +153,17 @@ export interface HonuaMapAngularSnippetOptions extends HonuaMapSnippetOptions {
   selector?: string;
 }
 
+export interface HonuaSceneAngularSnippetOptions extends HonuaSceneSnippetOptions {
+  componentName?: string;
+  selector?: string;
+}
+
 export interface HonuaMapAngularIframeSnippetOptions extends HonuaMapIframeSnippetOptions {
+  componentName?: string;
+  selector?: string;
+}
+
+export interface HonuaSceneAngularIframeSnippetOptions extends HonuaSceneIframeSnippetOptions {
   componentName?: string;
   selector?: string;
 }
@@ -562,6 +589,160 @@ export function createHonuaMapEmbedBuilderSnippet(
   }
 }
 
+export function createHonuaSceneReactSnippet(
+  options: HonuaSceneEmbedOptions,
+  snippetOptions: HonuaSceneReactSnippetOptions = {},
+): string {
+  const componentName = snippetOptions.componentName ?? 'HonuaSceneEmbed';
+  assertJsIdentifier(componentName);
+  const elementName = snippetOptions.elementName ?? 'honua-scene';
+  assertCustomElementName(elementName);
+  const packageName = snippetOptions.packageName ?? '@honua-io/embed';
+  const indent = snippetOptions.indent ?? '  ';
+  const registration = createSceneReactRegistrationSnippet(
+    packageName,
+    elementName,
+    snippetOptions.includeScript ?? true,
+    indent,
+  );
+  const element = createSceneReactElementMarkup(elementName, options, {
+    includeCredentials: snippetOptions.includeCredentials ?? false,
+    indent: `${indent}${indent}`,
+  });
+
+  return [
+    ...registration.imports,
+    ...(registration.imports.length > 0 ? [''] : []),
+    `export function ${componentName}() {`,
+    ...registration.effectLines,
+    `${indent}return (`,
+    element,
+    `${indent});`,
+    '}',
+    ...(registration.helpers.length > 0 ? ['', ...registration.helpers] : []),
+  ].join('\n');
+}
+
+export function createHonuaSceneReactIframeSnippet(
+  options: HonuaSceneEmbedOptions,
+  snippetOptions: HonuaSceneReactIframeSnippetOptions = {},
+): string {
+  const componentName = snippetOptions.componentName ?? 'HonuaSceneEmbed';
+  assertJsIdentifier(componentName);
+  const indent = snippetOptions.indent ?? '  ';
+  const element = createSceneReactIframeMarkup(options, {
+    ...snippetOptions,
+    indent: `${indent}${indent}`,
+  });
+
+  return [
+    `export function ${componentName}() {`,
+    `${indent}return (`,
+    element,
+    `${indent});`,
+    '}',
+  ].join('\n');
+}
+
+export function createHonuaSceneVueSnippet(
+  options: HonuaSceneEmbedOptions,
+  snippetOptions: HonuaSceneVueSnippetOptions = {},
+): string {
+  const elementName = snippetOptions.elementName ?? 'honua-scene';
+  assertCustomElementName(elementName);
+  const packageName = snippetOptions.packageName ?? '@honua-io/embed';
+  const indent = snippetOptions.indent ?? '  ';
+  const registration = createSceneVueRegistrationLines(
+    packageName,
+    elementName,
+    snippetOptions.includeScript ?? true,
+  );
+  const element = createSceneElementMarkup(elementName, options, {
+    includeCredentials: snippetOptions.includeCredentials ?? false,
+    indent,
+  });
+
+  return [
+    '<template>',
+    indentBlock(element, indent),
+    '</template>',
+    ...(registration.length > 0
+      ? [
+        '',
+        '<script setup lang="ts">',
+        ...registration,
+        '</script>',
+      ]
+      : []),
+  ].join('\n');
+}
+
+export function createHonuaSceneVueIframeSnippet(
+  options: HonuaSceneEmbedOptions,
+  snippetOptions: HonuaSceneVueIframeSnippetOptions = {},
+): string {
+  const indent = snippetOptions.indent ?? '  ';
+  const iframe = createHonuaSceneIframeSnippet(options, {
+    ...snippetOptions,
+    indent,
+  });
+
+  return [
+    '<template>',
+    indentBlock(iframe, indent),
+    '</template>',
+  ].join('\n');
+}
+
+export function createHonuaSceneAngularSnippet(
+  options: HonuaSceneEmbedOptions,
+  snippetOptions: HonuaSceneAngularSnippetOptions = {},
+): string {
+  const componentName = snippetOptions.componentName ?? 'HonuaSceneEmbedComponent';
+  assertJsIdentifier(componentName);
+  const selector = snippetOptions.selector ?? 'honua-scene-embed';
+  assertCustomElementName(selector);
+  const elementName = snippetOptions.elementName ?? 'honua-scene';
+  assertCustomElementName(elementName);
+  const packageName = snippetOptions.packageName ?? '@honua-io/embed';
+  const indent = snippetOptions.indent ?? '  ';
+  const registration = createSceneAngularRegistrationSnippet(
+    packageName,
+    elementName,
+    snippetOptions.includeScript ?? true,
+    indent,
+  );
+  const element = createSceneElementMarkup(elementName, options, {
+    includeCredentials: snippetOptions.includeCredentials ?? false,
+    indent,
+  });
+
+  return createAngularComponentSnippet(componentName, selector, registration, element, indent);
+}
+
+export function createHonuaSceneAngularIframeSnippet(
+  options: HonuaSceneEmbedOptions,
+  snippetOptions: HonuaSceneAngularIframeSnippetOptions = {},
+): string {
+  const componentName = snippetOptions.componentName ?? 'HonuaSceneEmbedComponent';
+  assertJsIdentifier(componentName);
+  const selector = snippetOptions.selector ?? 'honua-scene-embed';
+  assertCustomElementName(selector);
+  const indent = snippetOptions.indent ?? '  ';
+  const iframe = createHonuaSceneIframeSnippet(options, {
+    ...snippetOptions,
+    indent,
+  });
+
+  return createAngularComponentSnippet(
+    componentName,
+    selector,
+    emptyAngularRegistrationSnippet(),
+    iframe,
+    indent,
+  );
+}
+
 function createCdnScriptMarkup(
   config: {
     scriptUrl: string;
@@ -748,6 +929,73 @@ function createAngularRegistrationSnippet(
   };
 }
 
+function createSceneReactRegistrationSnippet(
+  packageName: string,
+  elementName: string,
+  includeScript: boolean,
+  indent: string,
+): ReactRegistrationSnippet {
+  if (!includeScript) {
+    return { imports: [], effectLines: [], helpers: [] };
+  }
+
+  return {
+    imports: ['import { useEffect } from \'react\';'],
+    effectLines: [
+      `${indent}useEffect(() => {`,
+      `${indent}${indent}void registerHonuaSceneElement();`,
+      `${indent}}, []);`,
+      '',
+    ],
+    helpers: createSceneBrowserRegistrationHelper(packageName, elementName, ''),
+  };
+}
+
+function createSceneVueRegistrationLines(
+  packageName: string,
+  elementName: string,
+  includeScript: boolean,
+): string[] {
+  if (!includeScript) {
+    return [];
+  }
+
+  return [
+    'import { onMounted } from \'vue\';',
+    '',
+    'onMounted(() => {',
+    '  void registerHonuaSceneElement();',
+    '});',
+    '',
+    ...createSceneBrowserRegistrationHelper(packageName, elementName, ''),
+  ];
+}
+
+function createSceneAngularRegistrationSnippet(
+  packageName: string,
+  elementName: string,
+  includeScript: boolean,
+  indent: string,
+): AngularRegistrationSnippet {
+  if (!includeScript) {
+    return emptyAngularRegistrationSnippet();
+  }
+
+  return {
+    coreImports: ['AfterViewInit'],
+    classImplements: ' implements AfterViewInit',
+    classBody: [
+      `${indent}ngAfterViewInit(): void {`,
+      `${indent}${indent}void this.registerHonuaSceneElement();`,
+      `${indent}}`,
+      '',
+      `${indent}private async registerHonuaSceneElement(): Promise<void> {`,
+      ...createSceneBrowserRegistrationBody(packageName, elementName, `${indent}${indent}`),
+      `${indent}}`,
+    ],
+  };
+}
+
 function createBrowserRegistrationHelper(
   packageName: string,
   elementName: string,
@@ -773,6 +1021,41 @@ function createBrowserRegistrationBody(
   const defineLine = elementName === 'honua-map'
     ? null
     : `${indent}defineHonuaMapElement('${escapedElementName}');`;
+  return [
+    `${indent}if (typeof window === 'undefined') {`,
+    `${indent}  return;`,
+    `${indent}}`,
+    '',
+    loadLine,
+    ...(defineLine ? [defineLine] : []),
+  ];
+}
+
+function createSceneBrowserRegistrationHelper(
+  packageName: string,
+  elementName: string,
+  indent: string,
+): string[] {
+  return [
+    `${indent}async function registerHonuaSceneElement(): Promise<void> {`,
+    ...createSceneBrowserRegistrationBody(packageName, elementName, `${indent}  `),
+    `${indent}}`,
+  ];
+}
+
+function createSceneBrowserRegistrationBody(
+  packageName: string,
+  elementName: string,
+  indent: string,
+): string[] {
+  const escapedPackageName = escapeJsString(packageName);
+  const escapedElementName = escapeJsString(elementName);
+  const loadLine = elementName === 'honua-scene'
+    ? `${indent}await import('${escapedPackageName}');`
+    : `${indent}const { defineHonuaSceneElement } = await import('${escapedPackageName}');`;
+  const defineLine = elementName === 'honua-scene'
+    ? null
+    : `${indent}defineHonuaSceneElement('${escapedElementName}');`;
   return [
     `${indent}if (typeof window === 'undefined') {`,
     `${indent}  return;`,
@@ -844,6 +1127,24 @@ function createReactElementMarkup(
   return `${config.indent}<${elementName}\n${lines.join('\n')}\n${config.indent}/>`;
 }
 
+function createSceneReactElementMarkup(
+  elementName: string,
+  options: HonuaSceneEmbedOptions,
+  config: Required<Pick<HonuaSceneSnippetOptions, 'includeCredentials' | 'indent'>>,
+): string {
+  const attributes = sceneAttributes(options, config.includeCredentials);
+  const attributeIndent = `${config.indent}  `;
+  const lines = attributes.map(([name, value]) => value === true
+    ? `${attributeIndent}${name}`
+    : `${attributeIndent}${name}="${escapeHtmlAttribute(value)}"`);
+
+  if (lines.length === 0) {
+    return `${config.indent}<${elementName} />`;
+  }
+
+  return `${config.indent}<${elementName}\n${lines.join('\n')}\n${config.indent}/>`;
+}
+
 function createReactIframeMarkup(
   options: HonuaMapEmbedOptions,
   snippetOptions: HonuaMapIframeSnippetOptions,
@@ -853,6 +1154,25 @@ function createReactIframeMarkup(
     parentOrigin: snippetOptions.parentOrigin,
   });
   const attributes = iframeAttributes(src, snippetOptions.iframe, 'Embedded map');
+  const indent = snippetOptions.indent ?? '    ';
+  const attributeIndent = `${indent}  `;
+  const lines = attributes.map(([name, value]) => {
+    const attributeName = reactIframeAttributeName(name);
+    return `${attributeIndent}${attributeName}="${escapeHtmlAttribute(value)}"`;
+  });
+
+  return `${indent}<iframe\n${lines.join('\n')}\n${indent}/>`;
+}
+
+function createSceneReactIframeMarkup(
+  options: HonuaSceneEmbedOptions,
+  snippetOptions: HonuaSceneIframeSnippetOptions,
+): string {
+  const iframeUrl = snippetOptions.iframeUrl ?? 'https://cdn.honua.dev/embed/scene.html';
+  const src = createIframeSrc(iframeUrl, sceneQueryParameters(options, snippetOptions.includeCredentials ?? false), {
+    parentOrigin: snippetOptions.parentOrigin,
+  });
+  const attributes = iframeAttributes(src, snippetOptions.iframe, 'Embedded scene');
   const indent = snippetOptions.indent ?? '    ';
   const attributeIndent = `${indent}  `;
   const lines = attributes.map(([name, value]) => {

--- a/src/Honua.Embed/tests/honua-snippets.test.ts
+++ b/src/Honua.Embed/tests/honua-snippets.test.ts
@@ -12,9 +12,15 @@ import {
   createHonuaMapSnippet,
   createHonuaMapVueIframeSnippet,
   createHonuaMapVueSnippet,
+  createHonuaSceneAngularIframeSnippet,
+  createHonuaSceneAngularSnippet,
   createHonuaSceneCdnSnippet,
   createHonuaSceneIframeSnippet,
+  createHonuaSceneReactIframeSnippet,
+  createHonuaSceneReactSnippet,
   createHonuaSceneSnippet,
+  createHonuaSceneVueIframeSnippet,
+  createHonuaSceneVueSnippet,
   defineHonuaMapElement,
   defineHonuaSceneElement,
 } from '../src/index';
@@ -776,6 +782,95 @@ describe('honua scene snippets', () => {
     expect(element.getAttribute('theme')).toBe('dark');
     expect(element.getAttribute('autoload')).toBe('false');
     expect(element.getAttribute('cesium-base-url')).toBe('https://cdn.example.test/cesium/');
+  });
+
+  it('generates a React scene custom-element component without credentials by default', () => {
+    const snippet = createHonuaSceneReactSnippet({
+      tilesetUrl: 'https://tiles.example.test/site/tileset.json?name="Site"&team=<AEC>',
+      metadataUrl: 'https://metadata.example.test/site.json',
+      ionToken: 'secret-token',
+      autoload: true,
+    }, {
+      componentName: 'ConstructionScene',
+    });
+
+    expect(snippet).toContain('export function ConstructionScene()');
+    expect(snippet).toContain('import { useEffect } from \'react\';');
+    expect(snippet).toContain('void registerHonuaSceneElement();');
+    expect(snippet).toContain('await import(\'@honua-io/embed\');');
+    expect(snippet).toContain('<honua-scene');
+    expect(snippet).toContain('tileset-url="https://tiles.example.test/site/tileset.json?name=&quot;Site&quot;&amp;team=&lt;AEC&gt;"');
+    expect(snippet).toContain('metadata-url="https://metadata.example.test/site.json"');
+    expect(snippet).toContain('autoload');
+    expect(snippet).not.toContain('secret-token');
+  });
+
+  it('registers custom framework scene element names when requested', () => {
+    const reactSnippet = createHonuaSceneReactSnippet({
+      autoload: false,
+    }, {
+      elementName: 'city-scene',
+      componentName: 'CityScene',
+    });
+    const vueSnippet = createHonuaSceneVueSnippet({
+      metadataUrl: 'https://metadata.example.test/site.json',
+    }, {
+      elementName: 'city-vue-scene',
+    });
+    const angularSnippet = createHonuaSceneAngularSnippet({
+      terrainUrl: 'https://terrain.example.test/world',
+    }, {
+      elementName: 'city-angular-scene',
+      selector: 'city-angular-scene-host',
+    });
+
+    expect(reactSnippet).toContain('const { defineHonuaSceneElement } = await import(\'@honua-io/embed\');');
+    expect(reactSnippet).toContain('defineHonuaSceneElement(\'city-scene\');');
+    expect(reactSnippet).toContain('<city-scene');
+    expect(vueSnippet).toContain('defineHonuaSceneElement(\'city-vue-scene\');');
+    expect(vueSnippet).toContain('<city-vue-scene');
+    expect(angularSnippet).toContain('defineHonuaSceneElement(\'city-angular-scene\');');
+    expect(angularSnippet).toContain('<city-angular-scene');
+  });
+
+  it('generates scene framework iframe fallback snippets', () => {
+    const reactSnippet = createHonuaSceneReactIframeSnippet({
+      metadataUrl: 'https://metadata.example.test/site.json',
+      ionToken: 'secret-token',
+      autoload: true,
+    }, {
+      componentName: 'ConstructionSceneFrame',
+      iframeUrl: 'https://embed.example.test/scene.html?tenant=city',
+      parentOrigin: 'https://portal.example.test',
+      iframe: {
+        title: 'Construction scene',
+        className: 'embed-frame',
+      },
+    });
+    const vueSnippet = createHonuaSceneVueIframeSnippet({
+      tilesetUrl: 'https://tiles.example.test/site/tileset.json',
+    }, {
+      iframeUrl: '/embeds/scene.html',
+    });
+    const angularSnippet = createHonuaSceneAngularIframeSnippet({
+      terrainUrl: 'https://terrain.example.test/world',
+    }, {
+      componentName: 'ConstructionSceneFrameComponent',
+      selector: 'construction-scene-frame',
+      iframeUrl: '/embeds/scene.html',
+    });
+
+    expect(reactSnippet).toContain('export function ConstructionSceneFrame()');
+    expect(reactSnippet).toContain('<iframe');
+    expect(reactSnippet).toContain('src="https://embed.example.test/scene.html?tenant=city&amp;metadata-url=https%3A%2F%2Fmetadata.example.test%2Fsite.json&amp;autoload=true&amp;parent-origin=https%3A%2F%2Fportal.example.test"');
+    expect(reactSnippet).toContain('title="Construction scene"');
+    expect(reactSnippet).toContain('className="embed-frame"');
+    expect(reactSnippet).not.toContain('secret-token');
+    expect(vueSnippet).toContain('<template>\n  <iframe');
+    expect(vueSnippet).toContain('    src="/embeds/scene.html?tileset-url=https%3A%2F%2Ftiles.example.test%2Fsite%2Ftileset.json"');
+    expect(angularSnippet).toContain('selector: \'construction-scene-frame\'');
+    expect(angularSnippet).toContain('src="/embeds/scene.html?terrain-url=https%3A%2F%2Fterrain.example.test%2Fworld"');
+    expect(angularSnippet).toContain('export class ConstructionSceneFrameComponent {}');
   });
 });
 


### PR DESCRIPTION
Refs #12.

## Summary
- Add scene React, Vue, Angular, and iframe snippet helpers.
- Add the scene-named iframe listener options type.
- Document scene snippet usage and correct the scene embed package guidance.

## Validation
- `npm test --prefix src/Honua.Embed -- tests/honua-snippets.test.ts tests/honua-iframe.test.ts` passed, 47 tests.
- `npm run typecheck --prefix src/Honua.Embed` passed.
- `git diff --check` passed.

Note: Vitest exits successfully but happy-dom still prints existing teardown `AbortError` noise.