### PR TITLE
mobile: include AR device model in evidence

### DIFF
--- a/docs/guides/native-display-and-location.md
+++ b/docs/guides/native-display-and-location.md
@@ -106,8 +106,8 @@ state into the platform adapter.
   app remains responsible for resolving the authoritative scene/package data.
 - `HonuaNativeArEvidenceContext` snapshots the mobile runtime metadata that AR
   field photos, annotations, and reports should carry: scene/package ids,
-  online/offline state, runtime, active anchor mode, package state, accuracy
-  samples, control points, readiness, blockers, and warnings.
+  online/offline state, runtime, device model, active anchor mode, package
+  state, accuracy samples, control points, readiness, blockers, and warnings.
 
 ```csharp
 using Honua.Mobile.Maui;

--- a/docs/guides/native-scene-anchoring-requirements.md
+++ b/docs/guides/native-scene-anchoring-requirements.md
@@ -41,9 +41,9 @@ The initial mobile-owned implementation slice is
 `Honua.Mobile.Maui.SceneAnchoring`. It provides an ARKit/ARCore adapter
 interface, app lifecycle controller, and readiness policy for field UX gates.
 It intentionally accepts scene id, scene revision, package id, control-point
-ids, package quality, and accuracy telemetry only; authoritative scene
-metadata, package manifests, geometry, and vertical datum transforms remain in
-`Honua.Sdk.*` packages or server-backed contracts.
+ids, package quality, device model, and accuracy telemetry only; authoritative
+scene metadata, package manifests, geometry, and vertical datum transforms
+remain in `Honua.Sdk.*` packages or server-backed contracts.
 
 Use `HonuaNativeArSceneAnchoringController` to start the native adapter after
 the app resolves scene/package inputs, then bind `HonuaNativeArReadiness` to the

--- a/src/Honua.Mobile.Maui/SceneAnchoring/NativeSceneAnchoringContracts.cs
+++ b/src/Honua.Mobile.Maui/SceneAnchoring/NativeSceneAnchoringContracts.cs
@@ -288,6 +288,8 @@ public sealed record HonuaNativeArSessionStatus
 
     public string? PackageId { get; init; }
 
+    public string? DeviceModel { get; init; }
+
     public DateTimeOffset UpdatedAt { get; init; } = DateTimeOffset.UtcNow;
 
     public IReadOnlyList<string> Warnings { get; init; } = [];
@@ -301,6 +303,11 @@ public sealed record HonuaNativeArSessionStatus
         foreach (var warning in Warnings)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(warning);
+        }
+
+        if (DeviceModel is not null)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(DeviceModel);
         }
 
         if (ConfirmedControlPointCount < 0)
@@ -346,6 +353,8 @@ public sealed record HonuaNativeArEvidenceContext
     public bool IsOnline { get; init; }
 
     public HonuaNativeArRuntime Runtime { get; init; } = HonuaNativeArRuntime.Unknown;
+
+    public string? DeviceModel { get; init; }
 
     public HonuaNativeArReadinessLevel ReadinessLevel { get; init; }
 
@@ -397,6 +406,7 @@ public sealed record HonuaNativeArEvidenceContext
             IsOffline = request.IsOffline,
             IsOnline = status.IsOnline,
             Runtime = status.Runtime,
+            DeviceModel = status.DeviceModel,
             ReadinessLevel = readiness.Level,
             ActiveAnchoringMode = status.ActiveAnchoringMode,
             PackageState = status.PackageState,

--- a/tests/Honua.Mobile.Maui.Tests/HonuaNativeSceneAnchoringTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaNativeSceneAnchoringTests.cs
@@ -121,6 +121,14 @@ public sealed class HonuaNativeSceneAnchoringTests
     }
 
     [Fact]
+    public void Validate_WhenDeviceModelIsBlank_Throws()
+    {
+        var status = CreateStatus(deviceModel: " ");
+
+        Assert.Throws<ArgumentException>(status.Validate);
+    }
+
+    [Fact]
     public void EvaluateReadiness_PrecisionRequiresSurveyQualityControlPointsAndResidual()
     {
         var request = CreateRequest(
@@ -202,6 +210,7 @@ public sealed class HonuaNativeSceneAnchoringTests
                 yawAccuracyDegrees: 3,
                 calibrationResidualMeters: 0.2,
                 confirmedControlPointCount: 3,
+                deviceModel: "Pixel 8 Pro",
                 isOnline: false,
                 updatedAt: capturedAt),
             Status = CreateStatus(
@@ -213,6 +222,7 @@ public sealed class HonuaNativeSceneAnchoringTests
                 yawAccuracyDegrees: 3,
                 calibrationResidualMeters: 0.2,
                 confirmedControlPointCount: 3,
+                deviceModel: "Pixel 8 Pro",
                 isOnline: false,
                 updatedAt: capturedAt),
         };
@@ -233,6 +243,7 @@ public sealed class HonuaNativeSceneAnchoringTests
         Assert.True(evidence.IsOffline);
         Assert.False(evidence.IsOnline);
         Assert.Equal(HonuaNativeArRuntime.AndroidArCore, evidence.Runtime);
+        Assert.Equal("Pixel 8 Pro", evidence.DeviceModel);
         Assert.Equal(HonuaNativeArReadinessLevel.PrecisionInspection, evidence.ReadinessLevel);
         Assert.Equal(HonuaNativeArAnchoringMode.ControlPointCalibration, evidence.ActiveAnchoringMode);
         Assert.Equal(HonuaNativeArScenePackageState.Valid, evidence.PackageState);
@@ -349,6 +360,7 @@ public sealed class HonuaNativeSceneAnchoringTests
         double? yawAccuracyDegrees = null,
         double? calibrationResidualMeters = null,
         int confirmedControlPointCount = 0,
+        string? deviceModel = null,
         bool isOnline = true,
         DateTimeOffset? updatedAt = null)
         => new()
@@ -362,6 +374,7 @@ public sealed class HonuaNativeSceneAnchoringTests
             PackageId = packageId,
             PackageState = packageState,
             ConfirmedControlPointCount = confirmedControlPointCount,
+            DeviceModel = deviceModel,
             IsOnline = isOnline,
             UpdatedAt = updatedAt ?? DateTimeOffset.UtcNow,
             Accuracy = new HonuaNativeArAccuracySample


### PR DESCRIPTION
Refs #23.

## Summary
- Carry native AR device model status into field evidence metadata.
- Cover the device model propagation path in MAUI tests.
- Update native display and scene anchoring docs to describe the evidence field.

## Validation
- `git diff --check` passed.
- `dotnet format tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --verify-no-changes --no-restore --verbosity minimal` passed.
- Blocked: `dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --filter HonuaNativeSceneAnchoringTests --no-restore` fails before running tests in existing plugin manifest adapter code because the local restored package set does not expose `Honua.Sdk.Abstractions.Plugins`.

The branch was refreshed from current `origin/main` before publication.