### PR TITLE
test: add Android store prereq validator smoke test

### DIFF
--- a/docs/guides/mobile-store-prereqs.md
+++ b/docs/guides/mobile-store-prereqs.md
@@ -245,7 +245,27 @@ secrets before each production release and after any owner change.
 
 ## Repository Validation
 
-Run this check after changing app identifiers, TestFlight workflow inputs, or
+Run the Android check after changing package IDs, Android app target mappings,
+signing secret names, or the Android internal distribution workflow:
+
+```bash
+scripts/validate-android-store-prereqs.sh
+```
+
+Run the Android validator smoke test after changing the validator itself:
+
+```bash
+scripts/test-validate-android-store-prereqs.sh
+```
+
+The Android validator checks that `quality/android-store-prereqs.json`, the
+MAUI `ApplicationId` values, this guide, the Android internal distribution
+guide, and `.github/workflows/android-internal-distribution.yml` stay aligned.
+It does not read or verify secret values, keystore contents, Google Play
+Console app records, Play App Signing state, service account permissions, or
+tester access.
+
+Run the iOS check after changing app identifiers, TestFlight workflow inputs, or
 iOS signing secret names:
 
 ```bash

--- a/scripts/test-validate-android-store-prereqs.sh
+++ b/scripts/test-validate-android-store-prereqs.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+scripts/validate-android-store-prereqs.sh >/dev/null
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+swapped_workflow="${temp_dir}/android-internal-distribution-swapped.yml"
+failure_output="${temp_dir}/validation-output.txt"
+
+awk '
+  /^[[:space:]]*field-collection\)/ {
+    block = "field-collection"
+  }
+
+  /^[[:space:]]*mobile-app\)/ {
+    block = "mobile-app"
+  }
+
+  block == "field-collection" {
+    gsub("apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj", "apps/Honua.Mobile.App/Honua.Mobile.App.csproj")
+    gsub("io.honua.mobile.fieldcollection", "io.honua.mobile.app")
+    gsub("ANDROID_FIELD_COLLECTION_UPLOAD", "ANDROID_APP_UPLOAD")
+  }
+
+  block == "mobile-app" {
+    gsub("apps/Honua.Mobile.App/Honua.Mobile.App.csproj", "apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj")
+    gsub("io.honua.mobile.app", "io.honua.mobile.fieldcollection")
+    gsub("ANDROID_APP_UPLOAD", "ANDROID_FIELD_COLLECTION_UPLOAD")
+  }
+
+  {
+    print
+  }
+
+  block != "" && /^[[:space:]]*;;[[:space:]]*$/ {
+    block = ""
+  }
+' .github/workflows/android-internal-distribution.yml > "${swapped_workflow}"
+
+if HONUA_ANDROID_STORE_WORKFLOW="${swapped_workflow}" scripts/validate-android-store-prereqs.sh >"${failure_output}" 2>&1; then
+  echo "Expected swapped Android internal distribution workflow mapping to fail validation." >&2
+  exit 1
+fi
+
+grep -Fq "maps 'field-collection' without project 'apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj'" "${failure_output}"
+
+printf 'Validated Android store prerequisite smoke tests.\n'


### PR DESCRIPTION
Refs #82.
Refs #85.

## Summary
- Add an executable shell smoke test for Android store prereq validation.
- Document repo-local Android prereq validation and clarify which Play Console/signing items remain external.

## Validation
- `bash -n scripts/validate-android-store-prereqs.sh scripts/test-validate-android-store-prereqs.sh` passed.
- `scripts/validate-android-store-prereqs.sh` passed.
- `scripts/test-validate-android-store-prereqs.sh` passed.
- `npx --yes markdownlint-cli2 docs/guides/mobile-store-prereqs.md` passed.
- `git diff --check` passed.
- Blocked: the .NET smoke test restore was previously blocked by GitHub Packages `403 Forbidden` for private `Honua.Sdk.*` packages.