### PR TITLE
test: expose cloud TLS evidence details

### DIFF
--- a/docs/guides/disconnected-field-workflow-harness.md
+++ b/docs/guides/disconnected-field-workflow-harness.md
@@ -137,9 +137,15 @@ Failures are written into the failed phase details as `failureCategory`:
 | `package` | Replica creation, package extraction, or fixture payload download failed. | Confirm the seeded service id, layer ids, and replica endpoint support. |
 | `local-cache` | GeoPackage file, cursor, feature cache, or SQLite persistence failed. | Check database path permissions and remaining device or CI disk space. |
 | `edit-queue` | A planned operation could not be serialized, queued, claimed, or uploaded as a valid edit. | Inspect `plannedOperations`, operation payload metadata, and sync phase failures. |
-| `transport` | Network, auth, timeout, throttling, or server availability blocked upload/download. | Check cloud health, credentials, logs, and retryable server status codes. |
+| `transport` | Network, TLS/certificate validation, auth, timeout, throttling, or server availability blocked upload/download. | Check cloud health, certificate hostname/SANs for the configured base URL, credentials, logs, and retryable server status codes. |
 | `conflict` | Server state rejected an edit due to stale base token or feature version conflict. | Compare fixture seed state, `servergen` cursor, and the conflicting operation id. |
 
 Cloud failures should be reported with the evidence JSON, the full test command,
 the exact fixture identifiers, and the server-side correlation or request log
 ids when available.
+
+For the current staging closure path, a `transport` failure containing
+`RemoteCertificateNameMismatch` means the configured cloud host presented a
+certificate for a different hostname. Track that as an infrastructure blocker
+instead of changing mobile TLS validation; issue #92 currently points at
+`honua-io/honua-server#965` for this case.

--- a/docs/guides/offline-sync.md
+++ b/docs/guides/offline-sync.md
@@ -211,6 +211,12 @@ Evidence artifacts are written as `<run-id>.evidence.json` and use schema
 }
 ```
 
+When cloud acceptance fails with `failureCategory = "transport"`, inspect the
+phase error for TLS or certificate text before changing mobile sync code. A
+`RemoteCertificateNameMismatch` or certificate hostname/SAN mismatch means the
+configured Honua base URL is presenting a certificate for a different host; keep
+that tracked as a cloud/server infrastructure issue.
+
 The cloud harness now expects the honua-server#895 fixture path to support
 server-side readback on the editable FeatureServer layer. Before reconnect it
 asserts that no records carry the current `HONUA_MOBILE_ACCEPTANCE_RUN_ID` and

--- a/tests/Honua.Mobile.ServerIntegration.Tests/DisconnectedFieldWorkflowAcceptanceTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/DisconnectedFieldWorkflowAcceptanceTests.cs
@@ -458,7 +458,7 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
             return FailureCategoryTransport;
         }
 
-        var message = FormatExceptionForEvidence(ex);
+        var message = FlattenExceptionMessages(ex);
         if (message.Contains("HONUA_MOBILE_", StringComparison.OrdinalIgnoreCase) ||
             message.Contains("base url", StringComparison.OrdinalIgnoreCase) ||
             message.Contains("api key", StringComparison.OrdinalIgnoreCase))
@@ -473,6 +473,7 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
         }
 
         if (message.Contains("certificate", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("connection", StringComparison.OrdinalIgnoreCase) ||
             message.Contains("RemoteCertificate", StringComparison.OrdinalIgnoreCase) ||
             message.Contains("SSL", StringComparison.OrdinalIgnoreCase) ||
             message.Contains("TLS", StringComparison.OrdinalIgnoreCase))
@@ -481,7 +482,7 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
         }
 
         if (message.Contains("invalid offline payload", StringComparison.OrdinalIgnoreCase) ||
-            message.Contains("operation", StringComparison.OrdinalIgnoreCase))
+            message.Contains("offline operation", StringComparison.OrdinalIgnoreCase))
         {
             return FailureCategoryEditQueue;
         }
@@ -501,6 +502,17 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
         for (var current = ex; current is not null; current = current.InnerException)
         {
             messages.Add($"{current.GetType().Name}: {current.Message}");
+        }
+
+        return string.Join(" | ", messages);
+    }
+
+    private static string FlattenExceptionMessages(Exception ex)
+    {
+        var messages = new List<string>();
+        for (var current = ex; current is not null; current = current.InnerException)
+        {
+            messages.Add(current.Message);
         }
 
         return string.Join(" | ", messages);

--- a/tests/Honua.Mobile.ServerIntegration.Tests/DisconnectedFieldWorkflowAcceptanceTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/DisconnectedFieldWorkflowAcceptanceTests.cs
@@ -221,12 +221,30 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
     [InlineData("reconnect-sync", "conflict requires manual review", FailureCategoryConflict)]
     [InlineData("reconnect-sync", "Invalid offline payload", FailureCategoryEditQueue)]
     [InlineData("reconnect-sync", "Connection refused", FailureCategoryTransport)]
+    [InlineData("online-download", "RemoteCertificateNameMismatch", FailureCategoryTransport)]
+    [InlineData("online-download", "TLS certificate hostname mismatch", FailureCategoryTransport)]
+    [InlineData("online-download", "operation failed: RemoteCertificateNameMismatch", FailureCategoryTransport)]
     public void FailureClassifier_MapsHarnessFailuresToActionableCategories(
         string phaseName,
         string message,
         string expectedCategory)
     {
         Assert.Equal(expectedCategory, ClassifyFailure(new InvalidOperationException(message), phaseName));
+    }
+
+    [Fact]
+    public void FailedCloudGate_EvidenceIncludesInnerCertificateDetails()
+    {
+        var failure = new HttpRequestException(
+            "The SSL connection could not be established.",
+            new InvalidOperationException("RemoteCertificateNameMismatch"));
+
+        var evidence = DisconnectedFieldWorkflowEvidence.FailedCloudGate(_rootDirectory, failure);
+
+        var phase = Assert.Single(evidence.Phases);
+        Assert.Equal(FailureCategoryTransport, phase.Details["failureCategory"]);
+        Assert.Contains("The SSL connection could not be established.", phase.Details["error"], StringComparison.Ordinal);
+        Assert.Contains("RemoteCertificateNameMismatch", phase.Details["error"], StringComparison.Ordinal);
     }
 
     [Fact]
@@ -413,7 +431,7 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
         catch (Exception ex)
         {
             phase.Status = "failed";
-            phase.Details["error"] = ex.Message;
+            phase.Details["error"] = FormatExceptionForEvidence(ex);
             phase.Details["failureCategory"] = ClassifyFailure(ex, phaseName);
             throw;
         }
@@ -440,7 +458,7 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
             return FailureCategoryTransport;
         }
 
-        var message = ex.Message;
+        var message = FormatExceptionForEvidence(ex);
         if (message.Contains("HONUA_MOBILE_", StringComparison.OrdinalIgnoreCase) ||
             message.Contains("base url", StringComparison.OrdinalIgnoreCase) ||
             message.Contains("api key", StringComparison.OrdinalIgnoreCase))
@@ -452,6 +470,14 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
             message.Contains("precondition", StringComparison.OrdinalIgnoreCase))
         {
             return FailureCategoryConflict;
+        }
+
+        if (message.Contains("certificate", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("RemoteCertificate", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("SSL", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("TLS", StringComparison.OrdinalIgnoreCase))
+        {
+            return FailureCategoryTransport;
         }
 
         if (message.Contains("invalid offline payload", StringComparison.OrdinalIgnoreCase) ||
@@ -469,6 +495,17 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
         };
     }
 
+    private static string FormatExceptionForEvidence(Exception ex)
+    {
+        var messages = new List<string>();
+        for (var current = ex; current is not null; current = current.InnerException)
+        {
+            messages.Add($"{current.GetType().Name}: {current.Message}");
+        }
+
+        return string.Join(" | ", messages);
+    }
+
     private static string ClassifySyncFailureReason(string reason)
     {
         if (reason.Contains("conflict", StringComparison.OrdinalIgnoreCase) ||
@@ -477,19 +514,23 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
             return FailureCategoryConflict;
         }
 
+        if (reason.Contains("timeout", StringComparison.OrdinalIgnoreCase) ||
+            reason.Contains("connection", StringComparison.OrdinalIgnoreCase) ||
+            reason.Contains("unavailable", StringComparison.OrdinalIgnoreCase) ||
+            reason.Contains("certificate", StringComparison.OrdinalIgnoreCase) ||
+            reason.Contains("RemoteCertificate", StringComparison.OrdinalIgnoreCase) ||
+            reason.Contains("SSL", StringComparison.OrdinalIgnoreCase) ||
+            reason.Contains("TLS", StringComparison.OrdinalIgnoreCase) ||
+            reason.Contains("transport", StringComparison.OrdinalIgnoreCase))
+        {
+            return FailureCategoryTransport;
+        }
+
         if (reason.Contains("invalid offline payload", StringComparison.OrdinalIgnoreCase) ||
             reason.Contains("unsupported protocol", StringComparison.OrdinalIgnoreCase) ||
             reason.Contains("operation", StringComparison.OrdinalIgnoreCase))
         {
             return FailureCategoryEditQueue;
-        }
-
-        if (reason.Contains("timeout", StringComparison.OrdinalIgnoreCase) ||
-            reason.Contains("connection", StringComparison.OrdinalIgnoreCase) ||
-            reason.Contains("unavailable", StringComparison.OrdinalIgnoreCase) ||
-            reason.Contains("transport", StringComparison.OrdinalIgnoreCase))
-        {
-            return FailureCategoryTransport;
         }
 
         return FailureCategoryTransport;
@@ -502,7 +543,7 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
             [FailureCategoryPackage] = "The cloud/staging package or replica fixture cannot be created, downloaded, or decoded.",
             [FailureCategoryLocalCache] = "The mobile GeoPackage cache could not persist features, cursors, or queued operations.",
             [FailureCategoryEditQueue] = "A planned offline operation cannot be serialized, queued, claimed, or uploaded as a valid edit.",
-            [FailureCategoryTransport] = "Network transport, authentication, timeout, or server availability prevented an operation.",
+            [FailureCategoryTransport] = "Network transport, TLS/certificate validation, authentication, timeout, or server availability prevented an operation.",
             [FailureCategoryConflict] = "Server state rejected an offline edit because the base sync token or feature version conflicted.",
         };
 
@@ -1022,7 +1063,7 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
                 CompletedAtUtc = evidence.CompletedAtUtc,
                 Details =
                 {
-                    ["error"] = ex.Message,
+                    ["error"] = FormatExceptionForEvidence(ex),
                     ["failureCategory"] = ClassifyFailure(ex, "cloud-fixture-gate"),
                 },
             });


### PR DESCRIPTION
Refs #92.

## Summary
- Include inner exception details in disconnected field workflow failure evidence.
- Classify wrapped TLS/certificate failures, including `RemoteCertificateNameMismatch`, as transport failures.
- Document cloud acceptance TLS/certificate triage and the current external server blocker.

## Validation
- `dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --filter "FullyQualifiedName~FailedCloudGate_EvidenceIncludesInnerCertificateDetails" --no-restore --logger "console;verbosity=minimal"` passed.
- `git diff --check` passed.
- Blocked: broader server integration test restore was previously blocked by GitHub Packages `403 Forbidden` for private `Honua.Sdk.*` packages.

Remaining external blocker: staging certificate hostname/SAN mismatch tracked in `honua-server#965`. The branch was refreshed from current `origin/main` before publication.