### PR TITLE
test: tighten live exception upload coverage

### DIFF
--- a/docs/guides/mobile-exception-reporting.md
+++ b/docs/guides/mobile-exception-reporting.md
@@ -1,7 +1,8 @@
 # Mobile Exception Reporting
 
-Honua mobile exception reporting is opt-in. The first mobile slice provides a
-sanitized local reporting surface and offline queue for MAUI/mobile apps. It
+Honua mobile exception reporting is opt-in. The mobile implementation provides
+a sanitized local reporting surface, offline queue, bounded upload worker,
+tester consent gates, and an environment kill switch for MAUI/mobile apps. It
 does not define or implement the Honua Server ingestion endpoint.
 
 ## Enablement
@@ -136,6 +137,12 @@ that endpoint. The server-side slice needs to define the ingestion route, auth
 requirements, request headers, retention rules, log sink mapping, searchable
 metadata fields, schema versioning, and operational triage behavior. Mobile
 upload work should consume that versioned contract/package once it exists.
+
+The mobile server integration suite has loopback coverage for sanitized report
+delivery and opt-in live coverage through
+`HONUA_MOBILE_LIVE_SERVER_EXCEPTION_UPLOAD_PATH`. A live failure leaves the
+report queued, so enabled live tests should fail until the configured server
+route accepts the mobile report and records it in server observability.
 
 Recommended PR body note:
 

--- a/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
@@ -619,6 +619,11 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
         return http;
     }
 
+    private HttpClient CreateUnauthenticatedHttpClient()
+    {
+        return new HttpClient { BaseAddress = _server.BaseUri, Timeout = TimeSpan.FromSeconds(30) };
+    }
+
     private HonuaMobileClient CreateMobileClient(bool preferGrpc, bool allowRestFallbackOnGrpcFailure = true)
     {
         return new HonuaMobileClient(
@@ -897,8 +902,9 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
         };
         var queue = new FileMobileExceptionReportQueue(options);
         var reporter = new LocalMobileExceptionReporter(queue, options);
+        using var http = CreateUnauthenticatedHttpClient();
         var uploader = new HttpMobileExceptionReportUploader(
-            CreateHttpClient(),
+            http,
             options,
             [new FieldCollectionExceptionReportAuthHeader(auth)]);
         var worker = new MobileExceptionReportUploadWorker(queue, uploader, options);
@@ -911,6 +917,7 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
                 Properties = new Dictionary<string, object?> { ["apiKey"] = "secret" },
             });
         await worker.FlushPendingAsync();
+        await AssertQueueDrainedAsync(queue);
     }
 
     private async Task UploadMauiExceptionReportAsync()
@@ -933,6 +940,11 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
             new MobileExceptionReportContext { Source = "live-image-maui" });
         await worker.FlushPendingAsync();
 
+        await AssertQueueDrainedAsync(queue);
+    }
+
+    private static async Task AssertQueueDrainedAsync(IMobileExceptionReportQueue queue)
+    {
         var pending = new List<QueuedMobileExceptionReport>();
         await foreach (var report in queue.ReadPendingAsync())
         {


### PR DESCRIPTION
Refs #91.

## Summary
- Tighten live exception upload coverage to exercise the FieldCollection auth header customizer.
- Assert the exception upload queue drains after the live upload path.
- Update exception reporting docs with the current upload/consent/live validation behavior.

## Validation
- `git diff --check` passed.
- `dotnet format tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --verify-no-changes --no-restore --verbosity minimal` passed, with workspace-load warnings.
- Blocked: `dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --filter "FullyQualifiedName~FieldCollectionServerIntegrationTests|FullyQualifiedName~LiveImage_AuthRefreshAndExceptionUploads_RoundTrip"` was previously blocked by GitHub Packages `403 Forbidden` for private `Honua.Sdk.*` packages.

The branch was refreshed from current `origin/main` before publication.