### PR TITLE
ci: harden mobile release checkout refs

### DIFF
--- a/.github/workflows/android-internal-distribution.yml
+++ b/.github/workflows/android-internal-distribution.yml
@@ -5,10 +5,6 @@ name: Android Internal Distribution
 "on":
   workflow_dispatch:
     inputs:
-      source_ref:
-        description: "Branch, tag, or commit SHA to build. Leave blank for the workflow branch."
-        required: false
-        type: string
       environment:
         description: "Protected GitHub Environment that stores signing and Play upload secrets."
         required: true
@@ -71,7 +67,7 @@ jobs:
       - name: Checkout selected ref
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.source_ref || github.ref }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Resolve app target
@@ -112,12 +108,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          source_ref="${{ inputs.source_ref }}"
           version_code="${{ inputs.version_code }}"
-
-          if [[ -z "${source_ref}" ]]; then
-            source_ref="${GITHUB_REF_NAME}"
-          fi
+          workflow_ref="${GITHUB_REF_NAME}"
 
           if [[ -z "${version_code}" ]]; then
             version_code="${GITHUB_RUN_NUMBER}"
@@ -125,11 +117,11 @@ jobs:
 
           commit_sha="$(git rev-parse HEAD)"
           short_sha="$(git rev-parse --short=12 HEAD)"
-          safe_ref="$(printf '%s' "${source_ref}" | tr -c '[:alnum:]._-' '-')"
+          safe_ref="$(printf '%s' "${workflow_ref}" | tr -c '[:alnum:]._-' '-')"
           artifact_base="honua-android-${{ inputs.app_target }}-${{ inputs.channel }}-${{ inputs.artifact_type }}-${version_code}-${short_sha}"
 
           {
-            echo "source_ref=${source_ref}"
+            echo "workflow_ref=${workflow_ref}"
             echo "commit_sha=${commit_sha}"
             echo "short_sha=${short_sha}"
             echo "safe_ref=${safe_ref}"
@@ -397,7 +389,7 @@ jobs:
             echo "| --- | --- |"
             echo "| Environment | \`${{ inputs.environment }}\` |"
             echo "| Channel | \`${{ inputs.channel }}\` |"
-            echo "| Source ref | \`${{ steps.metadata.outputs.source_ref }}\` |"
+            echo "| Workflow ref | \`${{ steps.metadata.outputs.workflow_ref }}\` |"
             echo "| Commit SHA | \`${{ steps.metadata.outputs.commit_sha }}\` |"
             echo "| App target | \`${{ inputs.app_target }}\` |"
             echo "| App project | \`${{ steps.app.outputs.app_project }}\` |"
@@ -424,7 +416,7 @@ jobs:
             echo
             echo "### Rollback or rebuild"
             echo
-            echo "- To rebuild, rerun this workflow with the same source ref and a new version code."
+            echo "- To rebuild, rerun this workflow from the same branch or tag with a new version code."
             echo "- To roll back internal testers, promote a prior internal build in Play Console or rerun this workflow from the prior commit with a higher version code."
             echo "- Production tracks are not modified by this workflow."
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -5,10 +5,6 @@ name: iOS TestFlight
 on:
   workflow_dispatch:
     inputs:
-      source_ref:
-        description: "Branch, tag, or commit SHA to build. Leave empty to use the selected workflow ref."
-        required: false
-        type: string
       target_environment:
         description: "Protected GitHub Environment that owns iOS signing and App Store Connect secrets."
         required: true
@@ -39,7 +35,7 @@ permissions:
   packages: read
 
 concurrency:
-  group: ios-testflight-${{ inputs.target_environment }}-${{ inputs.app_target }}-${{ inputs.source_ref || github.ref }}
+  group: ios-testflight-${{ inputs.target_environment }}-${{ inputs.app_target }}-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -63,7 +59,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.source_ref || github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Resolve checked out commit
         id: checkout_ref
@@ -142,7 +138,6 @@ jobs:
           BUILD_NUMBER_INPUT: ${{ inputs.build_number }}
           CHECKOUT_SHA: ${{ steps.checkout_ref.outputs.commit_sha }}
           RELEASE_NOTES_INPUT: ${{ inputs.release_notes }}
-          SOURCE_REF_INPUT: ${{ inputs.source_ref }}
           TARGET_ENVIRONMENT_INPUT: ${{ inputs.target_environment }}
         run: |
           set -euo pipefail
@@ -173,7 +168,7 @@ jobs:
           fi
 
           short_sha="${CHECKOUT_SHA:0:12}"
-          source_name="${SOURCE_REF_INPUT:-${GITHUB_REF_NAME:-detached}}"
+          source_name="${GITHUB_REF_NAME:-detached}"
           if [[ -n "${GITHUB_HEAD_REF:-}" ]]; then
             source_name="${GITHUB_HEAD_REF}"
           fi

--- a/docs/guides/mobile-android-internal-distribution.md
+++ b/docs/guides/mobile-android-internal-distribution.md
@@ -11,8 +11,6 @@ Run **Android Internal Distribution** from the GitHub Actions tab.
 
 Inputs:
 
-- `source_ref`: branch, tag, or commit SHA to build. Leave blank to use the
-  workflow branch selected in the Actions UI.
 - `environment`: protected GitHub Environment that gates signing and upload.
   The default is `android-internal`.
 - `channel`: `internal-testing` for the Play internal testing track, or
@@ -29,12 +27,15 @@ Inputs:
   version code already active for the package.
 - `release_notes`: short tester-facing release summary.
 
-The workflow checks out the selected ref, resolves the selected app target,
-installs the Android MAUI workload, validates the project `ApplicationId`
-against the expected Google Play package name, publishes a signed release
-artifact, calculates a SHA-256 digest, stores the artifact on the workflow run,
-uploads to the selected internal Play channel, and writes a run summary with the
-version, commit SHA, environment, package name, artifact name, and digest.
+The workflow checks out the exact workflow-dispatch commit, resolves the
+selected app target, installs the Android MAUI workload, validates the project
+`ApplicationId` against the expected Google Play package name, publishes a
+signed release artifact, calculates a SHA-256 digest, stores the artifact on the
+workflow run, uploads to the selected internal Play channel, and writes a run
+summary with the version, commit SHA, environment, package name, artifact name,
+and digest. It does not accept a separate ref override because signing and Play
+upload secrets must only run against the reviewed workflow ref approved for the
+protected environment.
 
 Known Android app targets:
 
@@ -122,11 +123,12 @@ version, commit, and digest they should validate.
 
 Internal distribution does not touch production tracks.
 
-To rebuild the same source, rerun the workflow with the same `source_ref` and a
-new `version_code`. To roll testers back, select a prior internal build in Play
-Console when it is still available, or rerun the workflow from the prior commit
-with a higher version code. Tell testers which version name, version code,
-commit SHA, and artifact SHA-256 are expected before they retest.
+To rebuild the same source, rerun the workflow from the same workflow ref and
+commit with a new `version_code`. To roll testers back, select a prior internal
+build in Play Console when it is still available, or rerun the workflow from the
+prior reviewed workflow ref with a higher version code. Tell testers which
+version name, version code, commit SHA, and artifact SHA-256 are expected before
+they retest.
 
 When an uploaded build is bad, stop assigning it to tester groups in Play
 Console or replace it with a newer internal release. Do not promote the internal

--- a/docs/guides/mobile-testflight-builds.md
+++ b/docs/guides/mobile-testflight-builds.md
@@ -94,10 +94,8 @@ repository checks alone:
 ## Running a Build
 
 1. Open GitHub Actions and select `iOS TestFlight`.
-2. Select the workflow branch.
+2. Select the reviewed workflow branch or tag to build.
 3. Fill the dispatch inputs:
-   - `source_ref`: branch, tag, or commit SHA to check out. Leave blank to use
-     the selected workflow ref.
    - `target_environment`: normally `ios-testflight`.
    - `app_target`: `field-collection` or `mobile-app`.
    - `build_number`: optional numeric iOS build number. Leave blank to use the
@@ -106,6 +104,11 @@ repository checks alone:
 4. Start the run and wait for the protected environment approval.
 5. After upload, wait for App Store Connect processing to finish before asking
    testers to install.
+
+The workflow checks out the exact workflow-dispatch commit. It does not accept
+a separate ref override because Apple signing and App Store Connect secrets
+must only run against the reviewed workflow ref approved for the protected
+environment.
 
 The workflow uploads a signed artifact containing:
 


### PR DESCRIPTION
## Summary
- remove manual source ref overrides from Android internal distribution and iOS TestFlight workflows
- checkout the exact workflow-dispatch commit before release secrets are available
- update release docs and summaries to refer to the reviewed workflow ref

## Testing
- git diff --check
- checked workflows/docs for stale source_ref/source-ref references