### PR TITLE
fix: wire field collection sync transports

### DIFF
--- a/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
+++ b/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
@@ -56,16 +56,22 @@ public static class MauiProgram
         services.AddSingleton<IStorageService, StorageService>();
 
         // Register sync service factory
+        services.AddSingleton<IFieldCollectionChangeUploader, QueuedFieldCollectionChangeUploader>();
+        services.AddSingleton<IFieldCollectionChangePuller, LocalOnlyFieldCollectionChangePuller>();
         services.AddSingleton<ISyncService>(provider =>
         {
             var databaseService = provider.GetRequiredService<DatabaseService>();
             var authService = provider.GetRequiredService<IAuthenticationService>();
             var connectivityService = provider.GetRequiredService<IConnectivityService>();
+            var changeUploader = provider.GetRequiredService<IFieldCollectionChangeUploader>();
+            var changePuller = provider.GetRequiredService<IFieldCollectionChangePuller>();
             var logger = provider.GetRequiredService<ILogger<GeoPackageSyncService>>();
             var exceptionReporter = provider.GetRequiredService<IMobileExceptionReporter>();
             return databaseService.GetSyncService(
                 authService,
                 connectivityService,
+                changeUploader,
+                changePuller,
                 logger: logger,
                 exceptionReporter: exceptionReporter);
         });

--- a/apps/Honua.Mobile.FieldCollection/Services/Storage/DatabaseService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Storage/DatabaseService.cs
@@ -55,12 +55,22 @@ public class DatabaseService : IDisposable
 
     public async Task<GeoPackageSyncService> GetSyncServiceAsync(
         IAuthenticationService authService,
-        IConnectivityService connectivityService)
+        IConnectivityService connectivityService,
+        IFieldCollectionChangeUploader? changeUploader = null,
+        IFieldCollectionChangePuller? changePuller = null,
+        ILogger<GeoPackageSyncService>? logger = null,
+        IMobileExceptionReporter? exceptionReporter = null)
     {
         await _initLock.WaitAsync();
         try
         {
-            var syncService = GetSyncService(authService, connectivityService);
+            var syncService = GetSyncService(
+                authService,
+                connectivityService,
+                changeUploader,
+                changePuller,
+                logger,
+                exceptionReporter);
             if (_storageService != null && !await _storageService.InitializeAsync())
             {
                 throw new InvalidOperationException("Failed to initialize the GeoPackage database.");

--- a/apps/Honua.Mobile.FieldCollection/Services/Sync/FieldCollectionSyncTransports.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Sync/FieldCollectionSyncTransports.cs
@@ -1,0 +1,60 @@
+using Microsoft.Extensions.Logging;
+using StorageChangeRecord = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeRecord;
+
+namespace Honua.Mobile.FieldCollection.Services.Sync;
+
+internal sealed class QueuedFieldCollectionChangeUploader : IFieldCollectionChangeUploader
+{
+    private readonly ILogger<QueuedFieldCollectionChangeUploader>? _logger;
+
+    public QueuedFieldCollectionChangeUploader(ILogger<QueuedFieldCollectionChangeUploader>? logger = null)
+    {
+        _logger = logger;
+    }
+
+    public Task<bool> UploadChangeAsync(StorageChangeRecord change, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _logger?.LogWarning(
+            "Field collection change {ChangeId} for feature {FeatureId} in layer {LayerId} remains queued because remote field sync is not configured",
+            change.Id,
+            change.FeatureId,
+            change.LayerId);
+
+        return Task.FromResult(false);
+    }
+}
+
+internal sealed class LocalOnlyFieldCollectionChangePuller : IFieldCollectionChangePuller
+{
+    private readonly ILogger<LocalOnlyFieldCollectionChangePuller>? _logger;
+
+    public LocalOnlyFieldCollectionChangePuller(ILogger<LocalOnlyFieldCollectionChangePuller>? logger = null)
+    {
+        _logger = logger;
+    }
+
+    public Task<IReadOnlyList<ServerChange>> GetChangesAsync(
+        long sinceGeneration,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _logger?.LogDebug(
+            "Field collection pull requested from generation {Generation}; remote field sync is local-only",
+            sinceGeneration);
+        return Task.FromResult<IReadOnlyList<ServerChange>>([]);
+    }
+
+    public Task<long> GetLatestServerGenerationAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(0L);
+    }
+
+    public Task<long> GetLastSyncedGenerationAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(0L);
+    }
+}

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -4,6 +4,7 @@ using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using Honua.Mobile.FieldCollection.Services.Sync;
 using Honua.Mobile.FieldCollection.Services.Storage;
 using Honua.Mobile.Maui.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
 using StorageChangeRecord = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeRecord;
 using StorageChangeOperation = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeOperation;
 using StorageConflictRecord = Honua.Mobile.FieldCollection.Services.Storage.Models.ConflictRecord;
@@ -32,6 +33,43 @@ public sealed class GeoPackageSyncServiceTests
         Assert.False(result.IsSuccess);
         Assert.Contains("failed to upload", result.ErrorMessage);
         Assert.Single(await storage.GetPendingChangesAsync());
+    }
+
+    [Fact]
+    public async Task PushChangesAsync_WhenUsingQueuedProductionUploader_LeavesChangePendingWithoutConfigurationFailure()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.StoreFeatureAsync(CreateFeature("asset-1", version: 1));
+        using var sync = CreateSyncService(
+            storage,
+            uploader: new QueuedFieldCollectionChangeUploader(
+                NullLogger<QueuedFieldCollectionChangeUploader>.Instance));
+
+        var result = await sync.PushChangesAsync();
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("failed to upload", result.ErrorMessage);
+        Assert.DoesNotContain("not configured", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Single(await storage.GetPendingChangesAsync());
+    }
+
+    [Fact]
+    public async Task PullChangesAsync_WhenUsingLocalOnlyProductionPuller_ReturnsSuccessWithoutRemoteChanges()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        using var sync = CreateSyncService(
+            storage,
+            puller: new LocalOnlyFieldCollectionChangePuller(
+                NullLogger<LocalOnlyFieldCollectionChangePuller>.Instance));
+
+        var result = await sync.PullChangesAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, result.ChangesPulled);
     }
 
     [Fact]

--- a/tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj
+++ b/tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj
@@ -39,6 +39,7 @@
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\Diagnostics\FieldCollectionExceptionReporting.cs" Link="App\Services\Diagnostics\FieldCollectionExceptionReporting.cs" />
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\Storage\GeoPackageStorageService.cs" Link="App\Services\Storage\GeoPackageStorageService.cs" />
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\Storage\Models\StorageModels.cs" Link="App\Services\Storage\Models\StorageModels.cs" />
+    <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\Sync\FieldCollectionSyncTransports.cs" Link="App\Services\Sync\FieldCollectionSyncTransports.cs" />
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\Sync\GeoPackageSyncService.cs" Link="App\Services\Sync\GeoPackageSyncService.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- register FieldCollection sync uploader/puller implementations in MAUI DI
- keep local edits queued instead of throwing unconfigured transport exceptions until remote field sync is available
- pass sync collaborators through DatabaseService async/sync factories and cover production transport behavior in tests

## Testing
- git diff --check
- attempted dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --configuration Release; restore is blocked locally by GitHub Packages 403 for private Honua.Sdk.* 0.1.15-alpha.1 packages
- attempted fallback with cached 0.1.8-alpha.1 SDK train; restore succeeded but build is incompatible because that train lacks current plugin contracts