### PR TITLE
fix: make embed imports ssr safe

### DIFF
--- a/.github/workflows/publish-npm-embed.yml
+++ b/.github/workflows/publish-npm-embed.yml
@@ -64,17 +64,27 @@ jobs:
       - name: Test
         run: npm test
 
-      - name: Build
-        run: npm run build
-
-      - name: Generate CDN manifest
-        run: npm run cdn:manifest
-
       - name: Pack npm package
         shell: bash
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/npm-packages"
           npm pack --pack-destination "${GITHUB_WORKSPACE}/npm-packages"
+
+      - name: Verify packed package import
+        shell: bash
+        run: |
+          package="$(find "${GITHUB_WORKSPACE}/npm-packages" -maxdepth 1 -type f -name '*.tgz' | sort | head -n 1)"
+          tmp_dir="$(mktemp -d)"
+
+          npm install "${package}" --prefix "${tmp_dir}" --ignore-scripts
+          cd "${tmp_dir}"
+          node --input-type=module <<'NODE'
+          const embed = await import('@honua-io/embed');
+          if (typeof embed.defineHonuaMapElement !== 'function' ||
+              typeof embed.defineHonuaSceneElement !== 'function') {
+            throw new Error('Packed @honua-io/embed package does not expose expected entrypoints.');
+          }
+          NODE
 
       - name: Upload package artifacts
         uses: actions/upload-artifact@v7

--- a/src/Honua.Embed/package.json
+++ b/src/Honua.Embed/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "build": "vite build && tsc -p tsconfig.json --emitDeclarationOnly && node scripts/copy-cesium-assets.mjs",
     "cdn:manifest": "node scripts/create-cdn-manifest.mjs",
+    "prepack": "npm run build && npm run cdn:manifest",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/src/Honua.Embed/src/controls/bookmarks.ts
+++ b/src/Honua.Embed/src/controls/bookmarks.ts
@@ -5,8 +5,11 @@ import type {
 } from '../scene-metadata';
 import { HonuaSceneLink } from './scene-link';
 import {
+  assertHonuaDomAvailable,
   CONTROL_BASE_STYLES,
   controlTemplate,
+  defineHonuaCustomElement,
+  HonuaHTMLElementBase,
   upgradeProperty,
 } from './shared';
 
@@ -52,7 +55,7 @@ const template = controlTemplate(`
   </section>
 `);
 
-export class HonuaSceneBookmarksElement extends HTMLElement {
+export class HonuaSceneBookmarksElement extends HonuaHTMLElementBase {
   static get observedAttributes(): string[] {
     return ['for', 'heading'];
   }
@@ -62,6 +65,7 @@ export class HonuaSceneBookmarksElement extends HTMLElement {
 
   constructor() {
     super();
+    assertHonuaDomAvailable(ELEMENT_NAME);
     this.#root = this.attachShadow({ mode: 'open' });
     this.#root.append(template.content.cloneNode(true));
     this.#link = new HonuaSceneLink({
@@ -174,12 +178,7 @@ export class HonuaSceneBookmarksElement extends HTMLElement {
 }
 
 export function defineHonuaSceneBookmarksElement(name = ELEMENT_NAME): CustomElementConstructor {
-  const existing = customElements.get(name);
-  if (existing) {
-    return existing;
-  }
-  customElements.define(name, HonuaSceneBookmarksElement);
-  return HonuaSceneBookmarksElement;
+  return defineHonuaCustomElement(name, HonuaSceneBookmarksElement);
 }
 
 declare global {

--- a/src/Honua.Embed/src/controls/compare.ts
+++ b/src/Honua.Embed/src/controls/compare.ts
@@ -2,8 +2,11 @@ import type { HonuaSceneElement } from '../scene';
 import type { HonuaSceneCompareMode } from '../scene-metadata';
 import { HonuaSceneLink } from './scene-link';
 import {
+  assertHonuaDomAvailable,
   CONTROL_BASE_STYLES,
   controlTemplate,
+  defineHonuaCustomElement,
+  HonuaHTMLElementBase,
   resolveControlLayerIds,
   upgradeProperty,
 } from './shared';
@@ -67,7 +70,7 @@ const template = controlTemplate(`
   </section>
 `);
 
-export class HonuaSceneCompareElement extends HTMLElement {
+export class HonuaSceneCompareElement extends HonuaHTMLElementBase {
   static get observedAttributes(): string[] {
     return ['for', 'heading', 'mode', 'side'];
   }
@@ -79,6 +82,7 @@ export class HonuaSceneCompareElement extends HTMLElement {
 
   constructor() {
     super();
+    assertHonuaDomAvailable(ELEMENT_NAME);
     this.#root = this.attachShadow({ mode: 'open' });
     this.#root.append(template.content.cloneNode(true));
     this.#link = new HonuaSceneLink({
@@ -261,12 +265,7 @@ export class HonuaSceneCompareElement extends HTMLElement {
 }
 
 export function defineHonuaSceneCompareElement(name = ELEMENT_NAME): CustomElementConstructor {
-  const existing = customElements.get(name);
-  if (existing) {
-    return existing;
-  }
-  customElements.define(name, HonuaSceneCompareElement);
-  return HonuaSceneCompareElement;
+  return defineHonuaCustomElement(name, HonuaSceneCompareElement);
 }
 
 declare global {

--- a/src/Honua.Embed/src/controls/inspector.ts
+++ b/src/Honua.Embed/src/controls/inspector.ts
@@ -5,8 +5,11 @@ import type {
 import type { HonuaSceneInspectorField } from '../scene-metadata';
 import { HonuaSceneLink } from './scene-link';
 import {
+  assertHonuaDomAvailable,
   CONTROL_BASE_STYLES,
   controlTemplate,
+  defineHonuaCustomElement,
+  HonuaHTMLElementBase,
   upgradeProperty,
 } from './shared';
 
@@ -58,7 +61,7 @@ const template = controlTemplate(`
   </section>
 `);
 
-export class HonuaSceneInspectorElement extends HTMLElement {
+export class HonuaSceneInspectorElement extends HonuaHTMLElementBase {
   static get observedAttributes(): string[] {
     return ['for', 'heading'];
   }
@@ -71,6 +74,7 @@ export class HonuaSceneInspectorElement extends HTMLElement {
 
   constructor() {
     super();
+    assertHonuaDomAvailable(ELEMENT_NAME);
     this.#root = this.attachShadow({ mode: 'open' });
     this.#root.append(template.content.cloneNode(true));
     this.#link = new HonuaSceneLink({
@@ -304,12 +308,7 @@ function defaultFields(attributes: Record<string, unknown>): HonuaSceneInspector
 }
 
 export function defineHonuaSceneInspectorElement(name = ELEMENT_NAME): CustomElementConstructor {
-  const existing = customElements.get(name);
-  if (existing) {
-    return existing;
-  }
-  customElements.define(name, HonuaSceneInspectorElement);
-  return HonuaSceneInspectorElement;
+  return defineHonuaCustomElement(name, HonuaSceneInspectorElement);
 }
 
 declare global {

--- a/src/Honua.Embed/src/controls/layers.ts
+++ b/src/Honua.Embed/src/controls/layers.ts
@@ -5,8 +5,11 @@ import type {
 import type { HonuaSceneLayerMetadata } from '../scene-metadata';
 import { HonuaSceneLink, type HonuaSceneControlErrorDetail } from './scene-link';
 import {
+  assertHonuaDomAvailable,
   CONTROL_BASE_STYLES,
   controlTemplate,
+  defineHonuaCustomElement,
+  HonuaHTMLElementBase,
   upgradeProperty,
 } from './shared';
 
@@ -75,7 +78,7 @@ const template = controlTemplate(`
   </section>
 `);
 
-export class HonuaSceneLayersElement extends HTMLElement {
+export class HonuaSceneLayersElement extends HonuaHTMLElementBase {
   static get observedAttributes(): string[] {
     return ['for', 'heading'];
   }
@@ -89,6 +92,7 @@ export class HonuaSceneLayersElement extends HTMLElement {
 
   constructor() {
     super();
+    assertHonuaDomAvailable(ELEMENT_NAME);
     this.#root = this.attachShadow({ mode: 'open' });
     this.#root.append(template.content.cloneNode(true));
     this.#link = new HonuaSceneLink({
@@ -255,12 +259,7 @@ function listLayers(scene: HonuaSceneElement | null): HonuaSceneLayerMetadata[] 
 }
 
 export function defineHonuaSceneLayersElement(name = ELEMENT_NAME): CustomElementConstructor {
-  const existing = customElements.get(name);
-  if (existing) {
-    return existing;
-  }
-  customElements.define(name, HonuaSceneLayersElement);
-  return HonuaSceneLayersElement;
+  return defineHonuaCustomElement(name, HonuaSceneLayersElement);
 }
 
 export type { HonuaSceneControlErrorDetail, HonuaSceneLayerChangeDetail };

--- a/src/Honua.Embed/src/controls/measure.ts
+++ b/src/Honua.Embed/src/controls/measure.ts
@@ -1,8 +1,11 @@
 import type { HonuaSceneElement } from '../scene';
 import { HonuaSceneLink } from './scene-link';
 import {
+  assertHonuaDomAvailable,
   CONTROL_BASE_STYLES,
   controlTemplate,
+  defineHonuaCustomElement,
+  HonuaHTMLElementBase,
   upgradeProperty,
 } from './shared';
 
@@ -85,7 +88,7 @@ const template = controlTemplate(`
   </section>
 `);
 
-export class HonuaSceneMeasureElement extends HTMLElement {
+export class HonuaSceneMeasureElement extends HonuaHTMLElementBase {
   static get observedAttributes(): string[] {
     return ['for', 'heading'];
   }
@@ -99,6 +102,7 @@ export class HonuaSceneMeasureElement extends HTMLElement {
 
   constructor() {
     super();
+    assertHonuaDomAvailable(ELEMENT_NAME);
     this.#root = this.attachShadow({ mode: 'open' });
     this.#root.append(template.content.cloneNode(true));
     this.#wireControls();
@@ -394,12 +398,7 @@ function toRadians(value: number): number {
 }
 
 export function defineHonuaSceneMeasureElement(name = ELEMENT_NAME): CustomElementConstructor {
-  const existing = customElements.get(name);
-  if (existing) {
-    return existing;
-  }
-  customElements.define(name, HonuaSceneMeasureElement);
-  return HonuaSceneMeasureElement;
+  return defineHonuaCustomElement(name, HonuaSceneMeasureElement);
 }
 
 declare global {

--- a/src/Honua.Embed/src/controls/shared.ts
+++ b/src/Honua.Embed/src/controls/shared.ts
@@ -1,3 +1,11 @@
+import { createHonuaTemplate } from '../dom';
+
+export {
+  assertHonuaDomAvailable,
+  defineHonuaCustomElement,
+  HonuaHTMLElementBase,
+} from '../dom';
+
 export const CONTROL_BASE_STYLES = `
   <style>
     :host {
@@ -80,9 +88,7 @@ export const CONTROL_BASE_STYLES = `
 `;
 
 export function controlTemplate(html: string): HTMLTemplateElement {
-  const template = document.createElement('template');
-  template.innerHTML = html;
-  return template;
+  return createHonuaTemplate(html);
 }
 
 export function upgradeProperty(element: HTMLElement, propertyName: string): void {

--- a/src/Honua.Embed/src/controls/timeline.ts
+++ b/src/Honua.Embed/src/controls/timeline.ts
@@ -2,8 +2,11 @@ import type { HonuaSceneElement } from '../scene';
 import type { HonuaSceneTimelinePhase } from '../scene-metadata';
 import { HonuaSceneLink } from './scene-link';
 import {
+  assertHonuaDomAvailable,
   CONTROL_BASE_STYLES,
   controlTemplate,
+  defineHonuaCustomElement,
+  HonuaHTMLElementBase,
   resolveControlLayerIds,
   upgradeProperty,
 } from './shared';
@@ -59,7 +62,7 @@ const template = controlTemplate(`
   </section>
 `);
 
-export class HonuaSceneTimelineElement extends HTMLElement {
+export class HonuaSceneTimelineElement extends HonuaHTMLElementBase {
   static get observedAttributes(): string[] {
     return ['for', 'heading', 'phase'];
   }
@@ -70,6 +73,7 @@ export class HonuaSceneTimelineElement extends HTMLElement {
 
   constructor() {
     super();
+    assertHonuaDomAvailable(ELEMENT_NAME);
     this.#root = this.attachShadow({ mode: 'open' });
     this.#root.append(template.content.cloneNode(true));
     this.#link = new HonuaSceneLink({
@@ -223,12 +227,7 @@ function formatRange(value: string): string {
 }
 
 export function defineHonuaSceneTimelineElement(name = ELEMENT_NAME): CustomElementConstructor {
-  const existing = customElements.get(name);
-  if (existing) {
-    return existing;
-  }
-  customElements.define(name, HonuaSceneTimelineElement);
-  return HonuaSceneTimelineElement;
+  return defineHonuaCustomElement(name, HonuaSceneTimelineElement);
 }
 
 declare global {

--- a/src/Honua.Embed/src/dom.ts
+++ b/src/Honua.Embed/src/dom.ts
@@ -1,0 +1,48 @@
+export const HonuaHTMLElementBase: typeof HTMLElement =
+  typeof HTMLElement === 'undefined'
+    ? (class {} as unknown as typeof HTMLElement)
+    : HTMLElement;
+
+export function createHonuaTemplate(html: string): HTMLTemplateElement {
+  if (typeof document === 'undefined') {
+    return {
+      content: {
+        cloneNode: () => {
+          throw new Error('Honua embed elements require a browser DOM.');
+        },
+      },
+      innerHTML: html,
+    } as unknown as HTMLTemplateElement;
+  }
+
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  return template;
+}
+
+export function canDefineHonuaCustomElements(): boolean {
+  return typeof customElements !== 'undefined'
+    && typeof document !== 'undefined'
+    && typeof HTMLElement !== 'undefined';
+}
+
+export function assertHonuaDomAvailable(name: string): void {
+  if (!canDefineHonuaCustomElements()) {
+    throw new Error(`${name} requires a browser DOM with custom elements support.`);
+  }
+}
+
+export function defineHonuaCustomElement(
+  name: string,
+  constructor: CustomElementConstructor,
+): CustomElementConstructor {
+  assertHonuaDomAvailable(name);
+
+  const existing = customElements.get(name);
+  if (existing) {
+    return existing;
+  }
+
+  customElements.define(name, constructor);
+  return constructor;
+}

--- a/src/Honua.Embed/src/index.ts
+++ b/src/Honua.Embed/src/index.ts
@@ -25,8 +25,9 @@ export * from './controls';
 import { defineHonuaMapElement } from './map';
 import { defineHonuaSceneElement } from './scene';
 import { defineHonuaSceneControls } from './controls';
+import { canDefineHonuaCustomElements } from './dom';
 
-if (typeof customElements !== 'undefined') {
+if (canDefineHonuaCustomElements()) {
   defineHonuaMapElement();
   defineHonuaSceneElement();
   defineHonuaSceneControls();

--- a/src/Honua.Embed/src/map.ts
+++ b/src/Honua.Embed/src/map.ts
@@ -2,6 +2,12 @@ import {
   createHonuaEmbedExtensionHost,
   type HonuaEmbedExtensionHost,
 } from './extensions';
+import {
+  assertHonuaDomAvailable,
+  createHonuaTemplate,
+  defineHonuaCustomElement,
+  HonuaHTMLElementBase,
+} from './dom';
 
 export interface HonuaMapCoordinate {
   latitude: number;
@@ -45,8 +51,7 @@ export interface HonuaMapSearchDetail {
 const DEFAULT_ZOOM = 10;
 const ELEMENT_NAME = 'honua-map';
 
-const template = document.createElement('template');
-template.innerHTML = `
+const template = createHonuaTemplate(`
   <style>
     :host {
       --honua-map-background: #f4f7f9;
@@ -324,9 +329,9 @@ template.innerHTML = `
     <output class="popup" part="popup"></output>
     <div class="meta" part="attribution"></div>
   </section>
-`;
+`);
 
-export class HonuaMapElement extends HTMLElement {
+export class HonuaMapElement extends HonuaHTMLElementBase {
   static get observedAttributes(): string[] {
     return [
       'service-url',
@@ -351,6 +356,7 @@ export class HonuaMapElement extends HTMLElement {
 
   constructor() {
     super();
+    assertHonuaDomAvailable(ELEMENT_NAME);
     this.#root = this.attachShadow({ mode: 'open' });
     this.#root.append(template.content.cloneNode(true));
     this.#extensionHost = createHonuaEmbedExtensionHost({
@@ -524,13 +530,7 @@ export class HonuaMapElement extends HTMLElement {
 }
 
 export function defineHonuaMapElement(name = ELEMENT_NAME): CustomElementConstructor {
-  const existing = customElements.get(name);
-  if (existing) {
-    return existing;
-  }
-
-  customElements.define(name, HonuaMapElement);
-  return HonuaMapElement;
+  return defineHonuaCustomElement(name, HonuaMapElement);
 }
 
 function readConfig(element: HTMLElement): HonuaMapConfig {

--- a/src/Honua.Embed/src/scene.ts
+++ b/src/Honua.Embed/src/scene.ts
@@ -22,6 +22,12 @@ import {
   type HonuaSceneMetadata,
   type HonuaSceneViewSpec,
 } from './scene-metadata';
+import {
+  assertHonuaDomAvailable,
+  createHonuaTemplate,
+  defineHonuaCustomElement,
+  HonuaHTMLElementBase,
+} from './dom';
 
 export interface HonuaSceneCoordinate {
   latitude: number;
@@ -130,8 +136,7 @@ const DEFAULT_HEIGHT = 1200;
 const DEFAULT_PITCH = -45;
 const ELEMENT_NAME = 'honua-scene';
 
-const sceneTemplate = document.createElement('template');
-sceneTemplate.innerHTML = `
+const sceneTemplate = createHonuaTemplate(`
   <style>
     :host {
       --honua-scene-background: #101820;
@@ -237,9 +242,9 @@ sceneTemplate.innerHTML = `
     <div class="extension-controls" part="extension-controls" data-honua-extension-controls></div>
     <output class="status" part="status"></output>
   </section>
-`;
+`);
 
-export class HonuaSceneElement extends HTMLElement {
+export class HonuaSceneElement extends HonuaHTMLElementBase {
   static get observedAttributes(): string[] {
     return [
       'tileset-url',
@@ -280,6 +285,7 @@ export class HonuaSceneElement extends HTMLElement {
 
   constructor() {
     super();
+    assertHonuaDomAvailable(ELEMENT_NAME);
     this.#root = this.attachShadow({ mode: 'open' });
     this.#root.append(sceneTemplate.content.cloneNode(true));
     this.#extensionHost = createHonuaEmbedExtensionHost({
@@ -1367,13 +1373,7 @@ export class HonuaSceneElement extends HTMLElement {
 }
 
 export function defineHonuaSceneElement(name = ELEMENT_NAME): CustomElementConstructor {
-  const existing = customElements.get(name);
-  if (existing) {
-    return existing;
-  }
-
-  customElements.define(name, HonuaSceneElement);
-  return HonuaSceneElement;
+  return defineHonuaCustomElement(name, HonuaSceneElement);
 }
 
 function readSceneConfig(element: HTMLElement): HonuaSceneConfig {

--- a/src/Honua.Embed/tests/honua-ssr.test.ts
+++ b/src/Honua.Embed/tests/honua-ssr.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+describe('server-side package imports', () => {
+  it('can import the root package without browser globals', async () => {
+    expect(globalThis.document).toBeUndefined();
+    expect(globalThis.HTMLElement).toBeUndefined();
+
+    const embed = await import('../src/index');
+
+    expect(embed.HonuaMapElement).toBeTypeOf('function');
+    expect(embed.HonuaSceneElement).toBeTypeOf('function');
+    expect(embed.defineHonuaMapElement).toBeTypeOf('function');
+    expect(embed.defineHonuaSceneElement).toBeTypeOf('function');
+  });
+
+  it('reports a clear error when defining elements without a custom element registry', async () => {
+    const { defineHonuaMapElement } = await import('../src/map');
+
+    expect(() => defineHonuaMapElement()).toThrow(/requires a browser DOM/);
+  });
+});


### PR DESCRIPTION
## Summary
- move DOM template creation and custom-element registration through shared DOM guards
- make root @honua-io/embed imports safe in Node/SSR while preserving browser auto-registration
- add prepack dist/CDN manifest generation and verify packed package import in the npm publish workflow

## Testing
- npm ci
- npm run typecheck
- npm test (163 passed; happy-dom emitted an AbortError during teardown but exited 0)
- npm pack --pack-destination /tmp/honua-embed-pack-test
- installed packed tarball and imported @honua-io/embed from Node successfully
- git diff --check