### PR TITLE
fix: make offline writes and bbox indexing robust

### DIFF
--- a/apps/Honua.Mobile.FieldCollection/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Storage/GeoPackageStorageService.cs
@@ -304,16 +304,19 @@ public class GeoPackageStorageService : IDisposable
         await _dbLock.WaitAsync();
         try
         {
-            var deleted = await _connection.Table<LocalFeature>()
-                .DeleteAsync(f => f.Id == featureId && f.LayerId == layerId);
-
-            if (deleted > 0)
+            var deleted = 0;
+            await ExecuteInImmediateTransactionAsync(async () =>
             {
-                await RecordChange(featureId, layerId, ChangeOperation.Delete);
-                return true;
-            }
+                deleted = await _connection.Table<LocalFeature>()
+                    .DeleteAsync(f => f.Id == featureId && f.LayerId == layerId);
 
-            return false;
+                if (deleted > 0)
+                {
+                    await RecordChange(featureId, layerId, ChangeOperation.Delete);
+                }
+            });
+
+            return deleted > 0;
         }
         finally
         {
@@ -391,14 +394,43 @@ public class GeoPackageStorageService : IDisposable
             SyncStatus = syncStatus
         };
 
-        await _connection.InsertOrReplaceAsync(localFeature);
-
         if (trackChange)
         {
-            await RecordChange(feature.Id, feature.LayerId, operation);
+            await ExecuteInImmediateTransactionAsync(async () =>
+            {
+                await _connection.InsertOrReplaceAsync(localFeature);
+                await RecordChange(feature.Id, feature.LayerId, operation);
+            });
+        }
+        else
+        {
+            await _connection.InsertOrReplaceAsync(localFeature);
         }
 
         return feature.Id;
+    }
+
+    private async Task ExecuteInImmediateTransactionAsync(Func<Task> operation)
+    {
+        await _connection.ExecuteAsync("BEGIN IMMEDIATE");
+        try
+        {
+            await operation();
+            await _connection.ExecuteAsync("COMMIT");
+        }
+        catch
+        {
+            try
+            {
+                await _connection.ExecuteAsync("ROLLBACK");
+            }
+            catch
+            {
+                // Preserve the original write failure.
+            }
+
+            throw;
+        }
     }
 
     #endregion

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
@@ -1078,6 +1078,11 @@ ORDER BY f.object_id ASC;
             return geoJsonPointExtent;
         }
 
+        if (TryReadGeoJsonCoordinatesExtent(geometry, out var geoJsonCoordinatesExtent))
+        {
+            return geoJsonCoordinatesExtent;
+        }
+
         return null;
     }
 
@@ -1146,6 +1151,52 @@ ORDER BY f.object_id ASC;
 
         extent = default;
         return false;
+    }
+
+    private static bool TryReadGeoJsonCoordinatesExtent(JsonElement geometry, out FeatureExtent extent)
+    {
+        if (!geometry.TryGetProperty("type", out var type) ||
+            type.ValueKind != JsonValueKind.String ||
+            !geometry.TryGetProperty("coordinates", out var coordinates) ||
+            coordinates.ValueKind != JsonValueKind.Array)
+        {
+            extent = default;
+            return false;
+        }
+
+        var builder = new FeatureExtentBuilder();
+        AccumulateGeoJsonCoordinateExtent(coordinates, ref builder);
+        if (builder.HasValue)
+        {
+            extent = builder.ToFeatureExtent();
+            return true;
+        }
+
+        extent = default;
+        return false;
+    }
+
+    private static void AccumulateGeoJsonCoordinateExtent(JsonElement coordinates, ref FeatureExtentBuilder builder)
+    {
+        if (coordinates.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        if (coordinates.GetArrayLength() >= 2 &&
+            coordinates[0].ValueKind == JsonValueKind.Number &&
+            coordinates[1].ValueKind == JsonValueKind.Number &&
+            coordinates[0].TryGetDouble(out var x) &&
+            coordinates[1].TryGetDouble(out var y))
+        {
+            builder.Include(x, y);
+            return;
+        }
+
+        foreach (var item in coordinates.EnumerateArray())
+        {
+            AccumulateGeoJsonCoordinateExtent(item, ref builder);
+        }
     }
 
     private static bool TryGetDouble(JsonElement element, string propertyName, out double value)
@@ -1864,6 +1915,34 @@ LIMIT $limit;
         FeatureSpatialReference? SpatialReference);
 
     private readonly record struct FeatureExtent(double MinX, double MinY, double MaxX, double MaxY);
+
+    private struct FeatureExtentBuilder
+    {
+        private double _minX;
+        private double _minY;
+        private double _maxX;
+        private double _maxY;
+
+        public bool HasValue { get; private set; }
+
+        public void Include(double x, double y)
+        {
+            if (!HasValue)
+            {
+                _minX = _maxX = x;
+                _minY = _maxY = y;
+                HasValue = true;
+                return;
+            }
+
+            _minX = Math.Min(_minX, x);
+            _minY = Math.Min(_minY, y);
+            _maxX = Math.Max(_maxX, x);
+            _maxY = Math.Max(_maxY, y);
+        }
+
+        public readonly FeatureExtent ToFeatureExtent() => new(_minX, _minY, _maxX, _maxY);
+    }
 
     private readonly record struct FeatureSpatialReference(
         int SrsId,

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -5,6 +5,7 @@ using Honua.Mobile.FieldCollection.Services.Sync;
 using Honua.Mobile.FieldCollection.Services.Storage;
 using Honua.Mobile.Maui.Diagnostics;
 using Microsoft.Extensions.Logging.Abstractions;
+using SQLite;
 using StorageChangeRecord = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeRecord;
 using StorageChangeOperation = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeOperation;
 using StorageConflictRecord = Honua.Mobile.FieldCollection.Services.Storage.Models.ConflictRecord;
@@ -270,6 +271,39 @@ public sealed class GeoPackageSyncServiceTests
     }
 
     [Fact]
+    public async Task StoreFeatureAsync_WhenChangeJournalInsertFails_RollsBackFeatureWrite()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.InitializeAsync();
+        InstallFailingChangeRecordInsertTrigger(databasePath);
+
+        await Assert.ThrowsAsync<SQLiteException>(() =>
+            storage.StoreFeatureAsync(CreateFeature("asset-rollback", version: 1)));
+
+        Assert.Null(await storage.GetFeatureAsync("asset-rollback", 1));
+        Assert.Empty(await storage.GetPendingChangesAsync());
+    }
+
+    [Fact]
+    public async Task DeleteFeatureAsync_WhenChangeJournalInsertFails_RollsBackFeatureDelete()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.StoreFeatureAsync(CreateFeature("asset-delete", version: 1));
+        var pendingChanges = await storage.GetPendingChangesAsync();
+        await storage.MarkChangesAsSynced(pendingChanges.Select(change => change.Id).ToList());
+        InstallFailingChangeRecordInsertTrigger(databasePath);
+
+        await Assert.ThrowsAsync<SQLiteException>(() => storage.DeleteFeatureAsync("asset-delete", 1));
+
+        Assert.NotNull(await storage.GetFeatureAsync("asset-delete", 1));
+        Assert.Empty(await storage.GetPendingChangesAsync());
+    }
+
+    [Fact]
     public async Task GetOfflineCacheDiagnosticsAsync_SeparatesMetadataFeatureAndOperationState()
     {
         var databasePath = CreateDatabasePath();
@@ -401,6 +435,19 @@ public sealed class GeoPackageSyncServiceTests
     private static string CreateDatabasePath()
     {
         return Path.Combine(Path.GetTempPath(), $"honua-field-tests-{Guid.NewGuid():N}.gpkg");
+    }
+
+    private static void InstallFailingChangeRecordInsertTrigger(string databasePath)
+    {
+        using var connection = new SQLiteConnection(databasePath, SQLiteOpenFlags.ReadWrite);
+        connection.Execute(
+            """
+            CREATE TRIGGER fail_change_record_insert
+            BEFORE INSERT ON change_records
+            BEGIN
+                SELECT RAISE(FAIL, 'change journal insert failed');
+            END;
+            """);
     }
 
     private sealed class FixedResultUploader : IFieldCollectionChangeUploader

--- a/tests/Honua.Mobile.Offline.Tests/GeoPackageSyncStoreTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/GeoPackageSyncStoreTests.cs
@@ -244,6 +244,66 @@ public sealed class GeoPackageSyncStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task UpsertFeatureAsync_WithGeoJsonLineStringGeometry_CreatesRTreeIndexAndSupportsBboxQuery()
+    {
+        var store = CreateStore();
+        await store.InitializeAsync();
+
+        await store.UpsertFeatureAsync(
+            "routes",
+            """
+            {
+              "type": "Feature",
+              "properties": { "OBJECTID": 3, "name": "Route" },
+              "geometry": {
+                "type": "LineString",
+                "coordinates": [[-157.86, 21.29], [-157.81, 21.34]]
+              }
+            }
+            """);
+
+        var hits = await store.GetFeaturesAsync("routes", new BoundingBox(-157.9, 21.2, -157.8, 21.4));
+        var misses = await store.GetFeaturesAsync("routes", new BoundingBox(-158.3, 21.7, -158.1, 21.9));
+
+        Assert.Single(hits);
+        Assert.Contains("Route", hits[0], StringComparison.Ordinal);
+        Assert.Empty(misses);
+    }
+
+    [Fact]
+    public async Task UpsertFeatureAsync_WithGeoJsonPolygonGeometry_CreatesRTreeIndexAndSupportsBboxQuery()
+    {
+        var store = CreateStore();
+        await store.InitializeAsync();
+
+        await store.UpsertFeatureAsync(
+            "parcels",
+            """
+            {
+              "type": "Feature",
+              "properties": { "OBJECTID": 4, "name": "Parcel" },
+              "geometry": {
+                "type": "Polygon",
+                "coordinates": [[
+                  [-157.90, 21.30],
+                  [-157.82, 21.30],
+                  [-157.82, 21.36],
+                  [-157.90, 21.36],
+                  [-157.90, 21.30]
+                ]]
+              }
+            }
+            """);
+
+        var hits = await store.GetFeaturesAsync("parcels", new BoundingBox(-157.88, 21.31, -157.84, 21.34));
+        var misses = await store.GetFeaturesAsync("parcels", new BoundingBox(-158.3, 21.7, -158.1, 21.9));
+
+        Assert.Single(hits);
+        Assert.Contains("Parcel", hits[0], StringComparison.Ordinal);
+        Assert.Empty(misses);
+    }
+
+    [Fact]
     public async Task UpsertFeatureAsync_DefaultsFeatureLayerCrsMetadataToEpsg4326()
     {
         var store = CreateStore();


### PR DESCRIPTION
## Summary
- wrap local Field Collection feature writes/deletes and their `change_records` journal entries in a single SQLite transaction
- add rollback regression coverage for failed journal inserts
- index nested GeoJSON coordinate extents for offline bbox queries, including LineString and Polygon payloads serialized from SDK feature records

## Why
The full-codebase review found that a crash or SQLite error between a local feature mutation and the sync journal insert could leave changed data with no pending upload. It also found that bbox queries could miss cached SDK/GeoJSON features unless the geometry was ArcGIS point/envelope shaped.

## Validation
- `git diff --check`
- `dotnet test tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj --configuration Release` blocked locally by GitHub Packages 403 for private `Honua.Sdk.*` packages
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --configuration Release` blocked locally by the same package-auth issue
- retried both with `-p:RestoreIgnoreFailedSources=true`; restore still failed because the private SDK packages are unavailable in local cache