### PR TITLE
sdk: consume field contracts

### DIFF
--- a/apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj
+++ b/apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj
@@ -69,6 +69,8 @@
         <PackageReference Include="CommunityToolkit.Maui" Version="9.1.0" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
         <PackageReference Include="Microsoft.Maui.Controls.Maps" Version="$(MauiVersion)" />
+        <PackageReference Include="Honua.Sdk.Abstractions" Version="$(HonuaSdkDotNetTrainVersion)" />
+        <PackageReference Include="Honua.Sdk.Field" Version="$(HonuaSdkDotNetTrainVersion)" />
 
         <!-- SQLite and GeoPackage support -->
         <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />

--- a/apps/Honua.Mobile.FieldCollection/Models/CoreModels.cs
+++ b/apps/Honua.Mobile.FieldCollection/Models/CoreModels.cs
@@ -1,4 +1,8 @@
 using Microsoft.Maui.Devices.Sensors;
+using System.Globalization;
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Field.Records;
 
 namespace Honua.Mobile.FieldCollection.Models;
 
@@ -56,6 +60,49 @@ public class Feature
     public bool HasAttachments => Attachments.Count > 0;
 
     public int AttachmentsCount => Attachments.Count;
+
+    public FeatureRecord ToSdkFeatureRecord()
+    {
+        return new FeatureRecord
+        {
+            Id = Id,
+            Attributes = Attributes.ToDictionary(
+                attribute => attribute.Key,
+                attribute => JsonSerializer.SerializeToElement(attribute.Value)),
+            Geometry = Geometry == null ? null : GeometryJson.ToJsonElement(Geometry)
+        };
+    }
+
+    public static Feature FromSdkFeatureRecord(FeatureRecord record, int layerId)
+    {
+        return new Feature
+        {
+            Id = record.Id ?? string.Empty,
+            LayerId = layerId,
+            Geometry = record.Geometry.HasValue ? GeometryJson.FromJsonElement(record.Geometry.Value) : null,
+            Attributes = record.Attributes.ToDictionary(
+                attribute => attribute.Key,
+                attribute => JsonValueToObject(attribute.Value)),
+            CreatedAt = DateTime.UtcNow,
+            ModifiedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            Version = 1
+        };
+    }
+
+    private static object JsonValueToObject(JsonElement value)
+    {
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString() ?? string.Empty,
+            JsonValueKind.Number when value.TryGetInt64(out var integer) => integer,
+            JsonValueKind.Number when value.TryGetDouble(out var number) => number,
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Null => string.Empty,
+            _ => value.Clone()
+        };
+    }
 }
 
 public abstract class Geometry
@@ -93,33 +140,6 @@ public class Polygon : Geometry
     public List<List<Point>> Coordinates { get; set; } = new();
 }
 
-public class FormDefinition
-{
-    public int LayerId { get; set; }
-    public string Name { get; set; } = string.Empty;
-    public string Description { get; set; } = string.Empty;
-    public FieldDefinition[] Fields { get; set; } = Array.Empty<FieldDefinition>();
-    public string Version { get; set; } = "1.0";
-    public DateTime CreatedAt { get; set; }
-    public DateTime? UpdatedAt { get; set; }
-}
-
-public class FieldDefinition
-{
-    public string Name { get; set; } = string.Empty;
-    public string Type { get; set; } = string.Empty; // text, number, select, date, textarea, boolean, etc.
-    public string Label { get; set; } = string.Empty;
-    public string? Description { get; set; }
-    public bool Required { get; set; }
-    public string? DefaultValue { get; set; }
-    public string[]? Options { get; set; } // For select fields
-    public double? Min { get; set; } // For number fields
-    public double? Max { get; set; } // For number fields
-    public int? MaxLength { get; set; } // For text fields
-    public string? Pattern { get; set; } // Regex validation
-    public Dictionary<string, object> Properties { get; set; } = new();
-}
-
 public class FormData
 {
     public int LayerId { get; set; }
@@ -129,6 +149,41 @@ public class FormData
     public bool IsValid => ValidationErrors.Count == 0;
     public DateTime CreatedAt { get; set; }
     public DateTime? UpdatedAt { get; set; }
+
+    public FieldRecord ToSdkFieldRecord(FormDefinition? definition = null)
+    {
+        return new FieldRecord
+        {
+            RecordId = FeatureId ?? string.Empty,
+            FormId = definition?.FormId ?? LayerId.ToString(CultureInfo.InvariantCulture),
+            Values = new Dictionary<string, object>(Values),
+            CreatedAtUtc = ToDateTimeOffset(CreatedAt),
+        };
+    }
+
+    public static FormData FromSdkFieldRecord(FieldRecord record, int layerId)
+    {
+        return new FormData
+        {
+            LayerId = layerId,
+            FeatureId = record.RecordId,
+            Values = new Dictionary<string, object>(record.Values),
+            CreatedAt = record.CreatedAtUtc.UtcDateTime,
+            UpdatedAt = record.SubmittedAtUtc?.UtcDateTime ?? record.CompletedAtUtc?.UtcDateTime
+        };
+    }
+
+    private static DateTimeOffset ToDateTimeOffset(DateTime value)
+    {
+        if (value == default)
+        {
+            return DateTimeOffset.UtcNow;
+        }
+
+        return value.Kind == DateTimeKind.Unspecified
+            ? new DateTimeOffset(DateTime.SpecifyKind(value, DateTimeKind.Utc))
+            : value.ToUniversalTime();
+    }
 }
 
 public class AttachmentInfo
@@ -165,46 +220,6 @@ public class LayerInfo
     public FormDefinition? Form { get; set; }
     public List<FieldDefinition> Schema { get; set; } = new();
     public LayerStyle Style { get; set; } = new();
-}
-
-public class FeatureQuery
-{
-    public SpatialFilter? SpatialFilter { get; set; }
-    public string? WhereClause { get; set; }
-    public List<OrderByClause>? OrderBy { get; set; }
-    public int? MaxResults { get; set; }
-}
-
-public class SpatialFilter
-{
-    public Geometry? Geometry { get; set; }
-    public SpatialRelationship Relationship { get; set; } = SpatialRelationship.Intersects;
-}
-
-public enum SpatialRelationship
-{
-    Intersects,
-    Contains,
-    Within,
-    Overlaps,
-    Touches,
-    Crosses
-}
-
-public class OrderByClause
-{
-    public string FieldName { get; set; } = string.Empty;
-    public bool Ascending { get; set; } = true;
-}
-
-public enum GeometryType
-{
-    Point,
-    LineString,
-    Polygon,
-    MultiPoint,
-    MultiLineString,
-    MultiPolygon
 }
 
 public class LayerStyle
@@ -251,4 +266,97 @@ public class UserSession
     public DateTime LastActivityTime { get; set; }
     public string? ApiKey { get; set; }
     public Dictionary<string, object> Preferences { get; set; } = new();
+}
+
+internal static class GeometryJson
+{
+    public static JsonElement ToJsonElement(Geometry geometry)
+    {
+        var payload = ToGeoJson(geometry);
+        return JsonSerializer.SerializeToElement(payload);
+    }
+
+    public static Geometry? FromJsonElement(JsonElement geometry)
+    {
+        if (geometry.ValueKind != JsonValueKind.Object ||
+            !geometry.TryGetProperty("type", out var typeProperty) ||
+            typeProperty.GetString() is not { Length: > 0 } type ||
+            !geometry.TryGetProperty("coordinates", out var coordinates))
+        {
+            return null;
+        }
+
+        return type switch
+        {
+            "Point" => ReadPoint(coordinates),
+            "LineString" => new LineString
+            {
+                Coordinates = coordinates.EnumerateArray()
+                    .Select(ReadPoint)
+                    .Where(point => point != null)
+                    .Cast<Point>()
+                    .ToList()
+            },
+            "Polygon" => new Polygon
+            {
+                Coordinates = coordinates.EnumerateArray()
+                    .Select(ring => ring.EnumerateArray()
+                        .Select(ReadPoint)
+                        .Where(point => point != null)
+                        .Cast<Point>()
+                        .ToList())
+                    .ToList()
+            },
+            _ => null
+        };
+    }
+
+    private static object ToGeoJson(Geometry geometry)
+    {
+        return geometry switch
+        {
+            Point point => new
+            {
+                type = "Point",
+                coordinates = ToCoordinateArray(point)
+            },
+            LineString line => new
+            {
+                type = "LineString",
+                coordinates = line.Coordinates.Select(ToCoordinateArray).ToArray()
+            },
+            Polygon polygon => new
+            {
+                type = "Polygon",
+                coordinates = polygon.Coordinates
+                    .Select(ring => ring.Select(ToCoordinateArray).ToArray())
+                    .ToArray()
+            },
+            _ => throw new NotSupportedException($"Geometry type {geometry.Type} not supported")
+        };
+    }
+
+    private static double[] ToCoordinateArray(Point point)
+    {
+        return point.Altitude.HasValue
+            ? [point.Longitude, point.Latitude, point.Altitude.Value]
+            : [point.Longitude, point.Latitude];
+    }
+
+    private static Point? ReadPoint(JsonElement coordinates)
+    {
+        if (coordinates.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var values = coordinates.EnumerateArray()
+            .Where(value => value.ValueKind == JsonValueKind.Number)
+            .Select(value => value.GetDouble())
+            .ToArray();
+
+        return values.Length >= 2
+            ? new Point(values[1], values[0], values.Length >= 3 ? values[2] : null)
+            : null;
+    }
 }

--- a/apps/Honua.Mobile.FieldCollection/Models/CoreModels.cs
+++ b/apps/Honua.Mobile.FieldCollection/Models/CoreModels.cs
@@ -144,7 +144,7 @@ public class FormData
 {
     public int LayerId { get; set; }
     public string? FeatureId { get; set; }
-    public Dictionary<string, object> Values { get; set; } = new();
+    public Dictionary<string, object?> Values { get; set; } = new();
     public Dictionary<string, string> ValidationErrors { get; set; } = new();
     public bool IsValid => ValidationErrors.Count == 0;
     public DateTime CreatedAt { get; set; }
@@ -156,7 +156,7 @@ public class FormData
         {
             RecordId = FeatureId ?? string.Empty,
             FormId = definition?.FormId ?? LayerId.ToString(CultureInfo.InvariantCulture),
-            Values = new Dictionary<string, object>(Values),
+            Values = new Dictionary<string, object?>(Values),
             CreatedAtUtc = ToDateTimeOffset(CreatedAt),
         };
     }
@@ -167,7 +167,7 @@ public class FormData
         {
             LayerId = layerId,
             FeatureId = record.RecordId,
-            Values = new Dictionary<string, object>(record.Values),
+            Values = new Dictionary<string, object?>(record.Values),
             CreatedAt = record.CreatedAtUtc.UtcDateTime,
             UpdatedAt = record.SubmittedAtUtc?.UtcDateTime ?? record.CompletedAtUtc?.UtcDateTime
         };

--- a/apps/Honua.Mobile.FieldCollection/Models/CoreModels.cs
+++ b/apps/Honua.Mobile.FieldCollection/Models/CoreModels.cs
@@ -13,7 +13,7 @@ public class Feature
     public string Id { get; set; } = string.Empty;
     public int LayerId { get; set; }
     public Geometry? Geometry { get; set; }
-    public Dictionary<string, object> Attributes { get; set; } = new();
+    public Dictionary<string, object?> Attributes { get; set; } = new();
     public DateTime CreatedAt { get; set; }
     public DateTime? ModifiedAt { get; set; }
     public DateTime? UpdatedAt { get; set; }
@@ -90,7 +90,7 @@ public class Feature
         };
     }
 
-    private static object JsonValueToObject(JsonElement value)
+    private static object? JsonValueToObject(JsonElement value)
     {
         return value.ValueKind switch
         {
@@ -99,7 +99,7 @@ public class Feature
             JsonValueKind.Number when value.TryGetDouble(out var number) => number,
             JsonValueKind.True => true,
             JsonValueKind.False => false,
-            JsonValueKind.Null => string.Empty,
+            JsonValueKind.Null or JsonValueKind.Undefined => null,
             _ => value.Clone()
         };
     }
@@ -278,37 +278,156 @@ internal static class GeometryJson
 
     public static Geometry? FromJsonElement(JsonElement geometry)
     {
-        if (geometry.ValueKind != JsonValueKind.Object ||
-            !geometry.TryGetProperty("type", out var typeProperty) ||
-            typeProperty.GetString() is not { Length: > 0 } type ||
-            !geometry.TryGetProperty("coordinates", out var coordinates))
+        if (geometry.ValueKind != JsonValueKind.Object)
         {
             return null;
         }
 
-        return type switch
+        return TryReadGeoJson(geometry, out var geoJson)
+            ? geoJson
+            : ReadFeatureServerGeometry(geometry);
+    }
+
+    private static bool TryReadGeoJson(JsonElement geometry, out Geometry? parsedGeometry)
+    {
+        parsedGeometry = null;
+
+        if (!geometry.TryGetProperty("type", out var typeProperty) ||
+            typeProperty.GetString() is not { Length: > 0 } type ||
+            !geometry.TryGetProperty("coordinates", out var coordinates))
         {
-            "Point" => ReadPoint(coordinates),
+            return false;
+        }
+
+        var srid = ReadSrid(geometry);
+        parsedGeometry = type switch
+        {
+            "Point" => ReadPoint(coordinates, srid),
             "LineString" => new LineString
             {
-                Coordinates = coordinates.EnumerateArray()
-                    .Select(ReadPoint)
-                    .Where(point => point != null)
-                    .Cast<Point>()
-                    .ToList()
+                SRID = srid,
+                Coordinates = ReadPointArray(coordinates, srid)
             },
             "Polygon" => new Polygon
             {
-                Coordinates = coordinates.EnumerateArray()
-                    .Select(ring => ring.EnumerateArray()
-                        .Select(ReadPoint)
-                        .Where(point => point != null)
-                        .Cast<Point>()
-                        .ToList())
-                    .ToList()
+                SRID = srid,
+                Coordinates = ReadPointRings(coordinates, srid)
             },
             _ => null
         };
+
+        return true;
+    }
+
+    private static Geometry? ReadFeatureServerGeometry(JsonElement geometry)
+    {
+        var srid = ReadSrid(geometry);
+        if (TryGetDouble(geometry, "x", out var x) &&
+            TryGetDouble(geometry, "y", out var y))
+        {
+            return new Point(y, x, TryGetDouble(geometry, "z", out var z) ? z : null)
+            {
+                SRID = srid
+            };
+        }
+
+        if (geometry.TryGetProperty("paths", out var paths))
+        {
+            var coordinates = ReadFirstPointArray(paths, srid);
+            return coordinates.Count > 0
+                ? new LineString { SRID = srid, Coordinates = coordinates }
+                : null;
+        }
+
+        if (geometry.TryGetProperty("rings", out var rings))
+        {
+            var coordinates = ReadPointRings(rings, srid);
+            return coordinates.Count > 0
+                ? new Polygon { SRID = srid, Coordinates = coordinates }
+                : null;
+        }
+
+        return null;
+    }
+
+    private static List<Point> ReadFirstPointArray(JsonElement paths, int srid)
+    {
+        if (paths.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return paths.EnumerateArray()
+            .Where(path => path.ValueKind == JsonValueKind.Array)
+            .Select(path => ReadPointArray(path, srid))
+            .FirstOrDefault(points => points.Count > 0) ?? [];
+    }
+
+    private static List<List<Point>> ReadPointRings(JsonElement rings, int srid)
+    {
+        if (rings.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return rings.EnumerateArray()
+            .Where(ring => ring.ValueKind == JsonValueKind.Array)
+            .Select(ring => ReadPointArray(ring, srid))
+            .Where(ring => ring.Count > 0)
+            .ToList();
+    }
+
+    private static List<Point> ReadPointArray(JsonElement coordinates, int srid)
+    {
+        if (coordinates.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return coordinates.EnumerateArray()
+            .Select(coordinate => ReadPoint(coordinate, srid))
+            .Where(point => point != null)
+            .Cast<Point>()
+            .ToList();
+    }
+
+    private static int ReadSrid(JsonElement geometry)
+    {
+        if (TryGetInt(geometry, "srid", out var srid))
+        {
+            return srid;
+        }
+
+        if (geometry.TryGetProperty("spatialReference", out var spatialReference))
+        {
+            if (TryGetInt(spatialReference, "latestWkid", out var latestWkid))
+            {
+                return latestWkid;
+            }
+
+            if (TryGetInt(spatialReference, "wkid", out var wkid))
+            {
+                return wkid;
+            }
+        }
+
+        return 4326;
+    }
+
+    private static bool TryGetInt(JsonElement element, string propertyName, out int value)
+    {
+        value = default;
+        return element.TryGetProperty(propertyName, out var property) &&
+            property.ValueKind == JsonValueKind.Number &&
+            property.TryGetInt32(out value);
+    }
+
+    private static bool TryGetDouble(JsonElement element, string propertyName, out double value)
+    {
+        value = default;
+        return element.TryGetProperty(propertyName, out var property) &&
+            property.ValueKind == JsonValueKind.Number &&
+            property.TryGetDouble(out value);
     }
 
     private static object ToGeoJson(Geometry geometry)
@@ -343,7 +462,7 @@ internal static class GeometryJson
             : [point.Longitude, point.Latitude];
     }
 
-    private static Point? ReadPoint(JsonElement coordinates)
+    private static Point? ReadPoint(JsonElement coordinates, int srid)
     {
         if (coordinates.ValueKind != JsonValueKind.Array)
         {
@@ -355,8 +474,14 @@ internal static class GeometryJson
             .Select(value => value.GetDouble())
             .ToArray();
 
-        return values.Length >= 2
-            ? new Point(values[1], values[0], values.Length >= 3 ? values[2] : null)
-            : null;
+        if (values.Length < 2)
+        {
+            return null;
+        }
+
+        return new Point(values[1], values[0], values.Length >= 3 ? values[2] : null)
+        {
+            SRID = srid
+        };
     }
 }

--- a/apps/Honua.Mobile.FieldCollection/Models/SdkContractAliases.cs
+++ b/apps/Honua.Mobile.FieldCollection/Models/SdkContractAliases.cs
@@ -1,0 +1,3 @@
+global using FieldDefinition = Honua.Sdk.Field.Forms.FormField;
+global using FormDefinition = Honua.Sdk.Field.Forms.FormDefinition;
+global using GeometryType = Honua.Sdk.Abstractions.Features.FeatureSpatialGeometryType;

--- a/apps/Honua.Mobile.FieldCollection/Services/CoreServices.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/CoreServices.cs
@@ -194,7 +194,7 @@ public class FormService : IFormService
         return new FormData
         {
             LayerId = layerId,
-            Values = new Dictionary<string, object>()
+            Values = new Dictionary<string, object?>()
         };
     }
 }

--- a/apps/Honua.Mobile.FieldCollection/Services/CoreServices.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/CoreServices.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Honua.Mobile.FieldCollection.Models;
+using Honua.Sdk.Field.Forms;
 using Microsoft.Maui.Devices.Sensors;
 using Microsoft.Maui.Networking;
 using Microsoft.Maui.Storage;
@@ -175,16 +176,15 @@ public class FormService : IFormService
 
     public Task<bool> ValidateFormAsync(FormData formData, FormDefinition definition)
     {
-        foreach (var field in definition.Fields.Where(f => f.Required))
+        var result = FormValidator.Validate(definition, formData.ToSdkFieldRecord(definition));
+
+        formData.ValidationErrors.Clear();
+        foreach (var error in result.Errors)
         {
-            if (!formData.Values.TryGetValue(field.Name, out var value) ||
-                value == null || string.IsNullOrWhiteSpace(value.ToString()))
-            {
-                return Task.FromResult(false);
-            }
+            formData.ValidationErrors[error.FieldId] = error.Message;
         }
 
-        return Task.FromResult(true);
+        return Task.FromResult(result.IsValid);
     }
 
     public async Task<FormData> CreateEmptyFormAsync(int layerId)

--- a/apps/Honua.Mobile.FieldCollection/Services/Features/GeoPackageFeatureService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Features/GeoPackageFeatureService.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Sdk.Abstractions.Features;
 using Microsoft.Extensions.Logging;
 using CoreModels = Honua.Mobile.FieldCollection.Models;
 using StorageBoundingBox = Honua.Mobile.FieldCollection.Services.Storage.Models.BoundingBox;
@@ -43,9 +44,12 @@ public class GeoPackageFeatureService : IFeatureService
         {
             if (spatialFilter != null)
             {
-                return await QueryFeaturesAsync(layerId, new FeatureQuery
+                return await _storage.QueryFeaturesAsync(
+                    layerId,
+                    new StorageSpatialQuery
                 {
-                    SpatialFilter = new SpatialFilter { Geometry = spatialFilter }
+                    Bounds = ConvertToBoundingBox(spatialFilter),
+                    Relationship = StorageSpatialRelationship.Intersects
                 });
             }
 
@@ -71,21 +75,35 @@ public class GeoPackageFeatureService : IFeatureService
         }
     }
 
-    public async Task<List<Feature>> QueryFeaturesAsync(int layerId, FeatureQuery query)
+    public async Task<List<Feature>> QueryFeaturesAsync(int layerId, FeatureQueryRequest query)
     {
         try
         {
-            // Convert FeatureQuery to SpatialQuery for storage layer
             StorageSpatialQuery? spatialQuery = null;
 
-            if (query.SpatialFilter != null)
+            if (query.Bbox != null)
+            {
+                spatialQuery = new StorageSpatialQuery
+                {
+                    Bounds = StorageBoundingBox.FromCoordinates(
+                        query.Bbox.MinX,
+                        query.Bbox.MinY,
+                        query.Bbox.MaxX,
+                        query.Bbox.MaxY),
+                    Relationship = StorageSpatialRelationship.Intersects,
+                    MaxResults = string.IsNullOrWhiteSpace(query.Filter) && string.IsNullOrWhiteSpace(query.OrderBy)
+                        ? query.Limit
+                        : null
+                };
+            }
+            else if (query.SpatialFilter != null)
             {
                 spatialQuery = new StorageSpatialQuery
                 {
                     Bounds = ConvertToBoundingBox(query.SpatialFilter),
                     Relationship = ConvertToSpatialRelationship(query.SpatialFilter.Relationship),
-                    MaxResults = string.IsNullOrWhiteSpace(query.WhereClause) && query.OrderBy?.Any() != true
-                        ? query.MaxResults
+                    MaxResults = string.IsNullOrWhiteSpace(query.Filter) && string.IsNullOrWhiteSpace(query.OrderBy)
+                        ? query.Limit
                         : null
                 };
             }
@@ -93,19 +111,19 @@ public class GeoPackageFeatureService : IFeatureService
             var features = await _storage.QueryFeaturesAsync(layerId, spatialQuery);
 
             // Apply additional filters in memory
-            if (!string.IsNullOrEmpty(query.WhereClause))
+            if (!string.IsNullOrEmpty(query.Filter))
             {
-                features = ApplyWhereClause(features, query.WhereClause);
+                features = ApplyWhereClause(features, query.Filter);
             }
 
-            if (query.OrderBy?.Any() == true)
+            if (!string.IsNullOrWhiteSpace(query.OrderBy))
             {
                 features = ApplyOrderBy(features, query.OrderBy);
             }
 
-            if (query.MaxResults.HasValue)
+            if (query.Limit.HasValue)
             {
-                features = features.Take(query.MaxResults.Value).ToList();
+                features = features.Take(query.Limit.Value).ToList();
             }
 
             return features;
@@ -330,9 +348,17 @@ public class GeoPackageFeatureService : IFeatureService
 
     #region Helper Methods
 
-    private static StorageBoundingBox ConvertToBoundingBox(SpatialFilter spatialFilter)
+    private static StorageBoundingBox ConvertToBoundingBox(FeatureSpatialFilter spatialFilter)
     {
-        if (spatialFilter.Geometry is CoreModels.Point point)
+        var geometry = CoreModels.GeometryJson.FromJsonElement(spatialFilter.Geometry);
+        return geometry == null
+            ? throw new NotSupportedException("SDK spatial filters require a GeoJSON point, line, or polygon geometry.")
+            : ConvertToBoundingBox(geometry);
+    }
+
+    private static StorageBoundingBox ConvertToBoundingBox(CoreModels.Geometry geometry)
+    {
+        if (geometry is CoreModels.Point point)
         {
             var buffer = 0.001; // ~100m buffer for point queries
             return StorageBoundingBox.FromCoordinates(
@@ -340,12 +366,12 @@ public class GeoPackageFeatureService : IFeatureService
                 point.Longitude + buffer, point.Latitude + buffer);
         }
 
-        if (spatialFilter.Geometry is CoreModels.LineString line && line.Coordinates.Count > 0)
+        if (geometry is CoreModels.LineString line && line.Coordinates.Count > 0)
         {
             return ConvertPointsToBoundingBox(line.Coordinates);
         }
 
-        if (spatialFilter.Geometry is CoreModels.Polygon polygon)
+        if (geometry is CoreModels.Polygon polygon)
         {
             var points = polygon.Coordinates.SelectMany(ring => ring).ToList();
             if (points.Count > 0)
@@ -367,16 +393,16 @@ public class GeoPackageFeatureService : IFeatureService
             pointList.Max(point => point.Latitude));
     }
 
-    private static StorageSpatialRelationship ConvertToSpatialRelationship(CoreModels.SpatialRelationship relationship)
+    private static StorageSpatialRelationship ConvertToSpatialRelationship(FeatureSpatialRelationship relationship)
     {
         return relationship switch
         {
-            CoreModels.SpatialRelationship.Intersects => StorageSpatialRelationship.Intersects,
-            CoreModels.SpatialRelationship.Contains => StorageSpatialRelationship.Contains,
-            CoreModels.SpatialRelationship.Within => StorageSpatialRelationship.Within,
-            CoreModels.SpatialRelationship.Overlaps => StorageSpatialRelationship.Overlaps,
-            CoreModels.SpatialRelationship.Touches => StorageSpatialRelationship.Touches,
-            CoreModels.SpatialRelationship.Crosses => StorageSpatialRelationship.Crosses,
+            FeatureSpatialRelationship.Intersects => StorageSpatialRelationship.Intersects,
+            FeatureSpatialRelationship.Contains => StorageSpatialRelationship.Contains,
+            FeatureSpatialRelationship.Within => StorageSpatialRelationship.Within,
+            FeatureSpatialRelationship.Overlaps => StorageSpatialRelationship.Overlaps,
+            FeatureSpatialRelationship.Touches => StorageSpatialRelationship.Touches,
+            FeatureSpatialRelationship.Crosses => StorageSpatialRelationship.Crosses,
             _ => StorageSpatialRelationship.Intersects
         };
     }
@@ -394,22 +420,40 @@ public class GeoPackageFeatureService : IFeatureService
             .ToList();
     }
 
-    private static List<Feature> ApplyOrderBy(List<Feature> features, List<OrderByClause> orderBy)
+    private static List<Feature> ApplyOrderBy(List<Feature> features, string orderBy)
     {
-        // Simple implementation - order by first field
-        if (orderBy.FirstOrDefault() is var firstOrder && firstOrder != null)
+        var firstOrder = ParseFirstOrderBy(orderBy);
+        if (firstOrder == null)
         {
-            if (firstOrder.Ascending)
-            {
-                return features.OrderBy(f => GetFieldValue(f, firstOrder.FieldName)).ToList();
-            }
-            else
-            {
-                return features.OrderByDescending(f => GetFieldValue(f, firstOrder.FieldName)).ToList();
-            }
+            return features;
         }
 
-        return features;
+        return firstOrder.Ascending
+            ? features.OrderBy(f => GetFieldValue(f, firstOrder.FieldName)).ToList()
+            : features.OrderByDescending(f => GetFieldValue(f, firstOrder.FieldName)).ToList();
+    }
+
+    private static OrderByExpression? ParseFirstOrderBy(string orderBy)
+    {
+        var first = orderBy
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault();
+
+        if (string.IsNullOrWhiteSpace(first))
+        {
+            return null;
+        }
+
+        var parts = first.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length == 0)
+        {
+            return null;
+        }
+
+        var ascending = parts.Length < 2 ||
+            !string.Equals(parts[1], "DESC", StringComparison.OrdinalIgnoreCase);
+
+        return new OrderByExpression(parts[0], ascending);
     }
 
     private static object? GetFieldValue(Feature feature, string fieldName)
@@ -705,6 +749,8 @@ public class GeoPackageFeatureService : IFeatureService
     #endregion
 
     private sealed record WherePredicate(string FieldName, string Operator, object? Value);
+
+    private sealed record OrderByExpression(string FieldName, bool Ascending);
 }
 
 /// <summary>

--- a/apps/Honua.Mobile.FieldCollection/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Storage/GeoPackageStorageService.cs
@@ -698,7 +698,7 @@ public class GeoPackageStorageService : IDisposable
             Id = localFeature.Id,
             LayerId = localFeature.LayerId,
             Geometry = localFeature.Geometry != null ? ConvertFromNtsGeometry(_wkbReader.Read(localFeature.Geometry)) : null,
-            Attributes = JsonSerializer.Deserialize<Dictionary<string, object>>(localFeature.Attributes ?? "{}") ?? new(),
+            Attributes = JsonSerializer.Deserialize<Dictionary<string, object?>>(localFeature.Attributes ?? "{}") ?? new(),
             CreatedAt = localFeature.CreatedAt,
             ModifiedAt = localFeature.ModifiedAt,
             UpdatedAt = localFeature.ModifiedAt,

--- a/apps/Honua.Mobile.FieldCollection/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Storage/GeoPackageStorageService.cs
@@ -1,6 +1,7 @@
 using SQLite;
 using System.Globalization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using NetTopologySuite.IO;
 using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services.Diagnostics;
@@ -21,6 +22,11 @@ namespace Honua.Mobile.FieldCollection.Services.Storage;
 /// </summary>
 public class GeoPackageStorageService : IDisposable
 {
+    private static readonly JsonSerializerOptions SchemaJsonOptions = new()
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
     private readonly SQLiteAsyncConnection _connection;
     private readonly WKBWriter _wkbWriter;
     private readonly WKBReader _wkbReader;
@@ -639,7 +645,7 @@ public class GeoPackageStorageService : IDisposable
                 GeometryType = layer.GeometryType.ToString(),
                 SpatialReference = "EPSG:4326",
                 IsEditable = layer.IsEditable,
-                Schema = JsonSerializer.Serialize(layer.Schema),
+                Schema = JsonSerializer.Serialize(layer.Schema, SchemaJsonOptions),
                 CreatedAt = DateTime.UtcNow
             };
 
@@ -708,11 +714,143 @@ public class GeoPackageStorageService : IDisposable
             Id = metadata.Id,
             Name = metadata.Name,
             Description = metadata.Description,
-            GeometryType = Enum.Parse<CoreModels.GeometryType>(metadata.GeometryType),
+            GeometryType = ParseGeometryType(metadata.GeometryType),
             IsEditable = metadata.IsEditable,
             IsVisible = true,
-            Schema = JsonSerializer.Deserialize<List<FieldDefinition>>(metadata.Schema ?? "[]") ?? new()
+            Schema = DeserializeLayerSchema(metadata.Schema)
         };
+    }
+
+    private static GeometryType ParseGeometryType(string? value)
+    {
+        if (Enum.TryParse<GeometryType>(value, ignoreCase: true, out var geometryType))
+        {
+            return geometryType;
+        }
+
+        return string.Equals(value, "LineString", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "MultiLineString", StringComparison.OrdinalIgnoreCase)
+            ? GeometryType.Polyline
+            : GeometryType.Unspecified;
+    }
+
+    private static List<FieldDefinition> DeserializeLayerSchema(string? schema)
+    {
+        if (string.IsNullOrWhiteSpace(schema))
+        {
+            return [];
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<FieldDefinition>>(schema, SchemaJsonOptions) ?? [];
+        }
+        catch (JsonException)
+        {
+            return DeserializeLegacyLayerSchema(schema);
+        }
+    }
+
+    private static List<FieldDefinition> DeserializeLegacyLayerSchema(string schema)
+    {
+        using var document = JsonDocument.Parse(schema);
+        if (document.RootElement.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var fields = new List<FieldDefinition>();
+        foreach (var field in document.RootElement.EnumerateArray())
+        {
+            var name = ReadString(field, "Name") ?? ReadString(field, "FieldId");
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            fields.Add(new FieldDefinition
+            {
+                FieldId = name,
+                SourceFieldName = name,
+                Label = ReadString(field, "Label") ?? name,
+                HelpText = ReadString(field, "Description"),
+                Required = ReadBoolean(field, "Required"),
+                Type = MapLegacyFieldType(ReadString(field, "Type")),
+                Choices = ReadStringArray(field, "Options")
+                    .Select(option => new Honua.Sdk.Field.Forms.FieldChoice { Value = option, Label = option })
+                    .ToArray(),
+                Validation = new Honua.Sdk.Field.Forms.FieldValidationRule
+                {
+                    RegexPattern = ReadString(field, "Pattern"),
+                    MinNumericValue = ReadDouble(field, "Min"),
+                    MaxNumericValue = ReadDouble(field, "Max"),
+                    MaxLength = ReadInt(field, "MaxLength")
+                }
+            });
+        }
+
+        return fields;
+    }
+
+    private static Honua.Sdk.Field.Forms.FormFieldType MapLegacyFieldType(string? type)
+    {
+        return type?.Trim().ToLowerInvariant() switch
+        {
+            "number" or "numeric" => Honua.Sdk.Field.Forms.FormFieldType.Numeric,
+            "select" or "choice" or "singlechoice" => Honua.Sdk.Field.Forms.FormFieldType.SingleChoice,
+            "date" => Honua.Sdk.Field.Forms.FormFieldType.Date,
+            "datetime" => Honua.Sdk.Field.Forms.FormFieldType.DateTime,
+            "boolean" or "bool" or "yesno" => Honua.Sdk.Field.Forms.FormFieldType.YesNo,
+            "photo" or "image" => Honua.Sdk.Field.Forms.FormFieldType.Photo,
+            "video" => Honua.Sdk.Field.Forms.FormFieldType.Video,
+            "audio" => Honua.Sdk.Field.Forms.FormFieldType.Audio,
+            "file" => Honua.Sdk.Field.Forms.FormFieldType.File,
+            "location" => Honua.Sdk.Field.Forms.FormFieldType.Location,
+            _ => Honua.Sdk.Field.Forms.FormFieldType.Text
+        };
+    }
+
+    private static string? ReadString(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+    }
+
+    private static bool ReadBoolean(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out var property) &&
+            property.ValueKind == JsonValueKind.True;
+    }
+
+    private static int? ReadInt(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out var property) &&
+            property.ValueKind == JsonValueKind.Number &&
+            property.TryGetInt32(out var value)
+                ? value
+                : null;
+    }
+
+    private static double? ReadDouble(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out var property) &&
+            property.ValueKind == JsonValueKind.Number &&
+            property.TryGetDouble(out var value)
+                ? value
+                : null;
+    }
+
+    private static IReadOnlyList<string> ReadStringArray(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.Array
+            ? property.EnumerateArray()
+                .Where(item => item.ValueKind == JsonValueKind.String)
+                .Select(item => item.GetString())
+                .Where(item => !string.IsNullOrWhiteSpace(item))
+                .Cast<string>()
+                .ToArray()
+            : [];
     }
 
     private static NtsGeometry? ConvertToNtsGeometry(CoreModels.Geometry? geometry)

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/MapViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/MapViewModel.cs
@@ -75,7 +75,7 @@ public partial class MapViewModel : BaseViewModel
             Id = 2,
             Name = "Inspection Routes",
             Description = "Line features for route planning",
-            GeometryType = GeometryType.LineString,
+            GeometryType = GeometryType.Polyline,
             IsVisible = false,
             IsEditable = true,
             Style = new LayerStyle

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/RecordsViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/RecordsViewModel.cs
@@ -61,7 +61,7 @@ public partial class RecordsViewModel : BaseViewModel
             Id = 2,
             Name = "Inspection Routes",
             Description = "Line features for route planning",
-            GeometryType = GeometryType.LineString,
+            GeometryType = GeometryType.Polyline,
             IsVisible = false,
             IsEditable = true
         });

--- a/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionSdkContractMigrationTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionSdkContractMigrationTests.cs
@@ -1,0 +1,154 @@
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Sdk.Field.Forms;
+
+namespace Honua.Mobile.FieldCollection.Tests;
+
+public sealed class FieldCollectionSdkContractMigrationTests
+{
+    public FieldCollectionSdkContractMigrationTests()
+    {
+        SQLitePCL.Batteries_V2.Init();
+    }
+
+    [Fact]
+    public void Feature_ToSdkFeatureRecord_UsesSdkFeatureContractWithGeoJsonGeometry()
+    {
+        var feature = new Feature
+        {
+            Id = "asset-1",
+            LayerId = 7,
+            Geometry = new Point(21.3, -157.8, 12),
+            Attributes =
+            {
+                ["name"] = "Pump Station",
+                ["priority"] = 3,
+                ["active"] = true
+            }
+        };
+
+        var sdkFeature = feature.ToSdkFeatureRecord();
+
+        Assert.Equal("asset-1", sdkFeature.Id);
+        Assert.Equal("Pump Station", sdkFeature.Attributes["name"].GetString());
+        Assert.Equal(3, sdkFeature.Attributes["priority"].GetInt32());
+        Assert.True(sdkFeature.Attributes["active"].GetBoolean());
+        Assert.True(sdkFeature.Geometry.HasValue);
+        Assert.Equal("Point", sdkFeature.Geometry.Value.GetProperty("type").GetString());
+        Assert.Equal(-157.8, sdkFeature.Geometry.Value.GetProperty("coordinates")[0].GetDouble());
+        Assert.Equal(21.3, sdkFeature.Geometry.Value.GetProperty("coordinates")[1].GetDouble());
+
+        var mobileFeature = Feature.FromSdkFeatureRecord(sdkFeature, layerId: 7);
+
+        Assert.Equal(7, mobileFeature.LayerId);
+        Assert.Equal("asset-1", mobileFeature.Id);
+        var point = Assert.IsType<Point>(mobileFeature.Geometry);
+        Assert.Equal(21.3, point.Latitude);
+        Assert.Equal(-157.8, point.Longitude);
+        Assert.Equal(12, point.Altitude);
+        Assert.Equal("Pump Station", mobileFeature.Attributes["name"]);
+    }
+
+    [Fact]
+    public async Task FormService_ValidateFormAsync_UsesSdkFormValidator()
+    {
+        var definition = new FormDefinition
+        {
+            FormId = "inspection",
+            Name = "Inspection",
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "main",
+                    Label = "Main",
+                    Fields =
+                    [
+                        new FieldDefinition
+                        {
+                            FieldId = "site_name",
+                            Label = "Site name",
+                            Type = FormFieldType.Text,
+                            Required = true
+                        }
+                    ]
+                }
+            ]
+        };
+        var formData = new FormData { LayerId = 4 };
+        var service = new FormService();
+
+        var missingRequired = await service.ValidateFormAsync(formData, definition);
+
+        Assert.False(missingRequired);
+        Assert.Contains("site_name", formData.ValidationErrors.Keys);
+
+        formData.Values["site_name"] = "Honua Yard";
+        var valid = await service.ValidateFormAsync(formData, definition);
+
+        Assert.True(valid);
+        Assert.Empty(formData.ValidationErrors);
+    }
+
+    [Fact]
+    public async Task GeoPackageStorageService_CreateLayerAsync_StoresSdkFieldSchema()
+    {
+        var databasePath = Path.Combine(Path.GetTempPath(), $"honua-field-sdk-contracts-{Guid.NewGuid():N}.gpkg");
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+
+        await storage.CreateLayerAsync(new LayerInfo
+        {
+            Id = 12,
+            Name = "Routes",
+            Description = "Inspection routes",
+            GeometryType = GeometryType.Polyline,
+            Schema =
+            [
+                new FieldDefinition
+                {
+                    FieldId = "route_status",
+                    SourceFieldName = "route_status",
+                    Label = "Route status",
+                    Type = FormFieldType.SingleChoice,
+                    Required = true,
+                    Choices =
+                    [
+                        new FieldChoice { Value = "open", Label = "Open" },
+                        new FieldChoice { Value = "closed", Label = "Closed" }
+                    ]
+                }
+            ]
+        });
+
+        var layer = Assert.Single(await storage.GetLayersAsync());
+
+        Assert.Equal(GeometryType.Polyline, layer.GeometryType);
+        var field = Assert.Single(layer.Schema);
+        Assert.Equal("route_status", field.FieldId);
+        Assert.Equal(FormFieldType.SingleChoice, field.Type);
+        Assert.True(field.Required);
+        Assert.Equal(["open", "closed"], field.Choices.Select(choice => choice.Value).ToArray());
+    }
+
+    private sealed class DatabaseCleanup : IAsyncDisposable
+    {
+        private readonly string _databasePath;
+
+        public DatabaseCleanup(string databasePath)
+        {
+            _databasePath = databasePath;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (File.Exists(_databasePath))
+            {
+                File.Delete(_databasePath);
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionSdkContractMigrationTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionSdkContractMigrationTests.cs
@@ -1,7 +1,9 @@
 using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services;
 using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Field.Forms;
+using System.Text.Json;
 
 namespace Honua.Mobile.FieldCollection.Tests;
 
@@ -48,6 +50,50 @@ public sealed class FieldCollectionSdkContractMigrationTests
         Assert.Equal(-157.8, point.Longitude);
         Assert.Equal(12, point.Altitude);
         Assert.Equal("Pump Station", mobileFeature.Attributes["name"]);
+    }
+
+    [Fact]
+    public void Feature_FromSdkFeatureRecord_PreservesSdkNullAttributes()
+    {
+        var sdkFeature = new FeatureRecord
+        {
+            Id = "asset-null",
+            Attributes =
+            {
+                ["nullable"] = JsonSerializer.SerializeToElement<string?>(null),
+                ["name"] = JsonSerializer.SerializeToElement("Null Test")
+            }
+        };
+
+        var mobileFeature = Feature.FromSdkFeatureRecord(sdkFeature, layerId: 7);
+
+        Assert.True(mobileFeature.Attributes.ContainsKey("nullable"));
+        Assert.Null(mobileFeature.Attributes["nullable"]);
+        Assert.Equal("Null Test", mobileFeature.Attributes["name"]);
+    }
+
+    [Fact]
+    public void Feature_FromSdkFeatureRecord_ReadsFeatureServerGeometry()
+    {
+        var sdkFeature = new FeatureRecord
+        {
+            Id = "asset-feature-server",
+            Geometry = JsonSerializer.SerializeToElement(new
+            {
+                x = -157.8,
+                y = 21.3,
+                z = 12.0,
+                spatialReference = new { wkid = 3857 }
+            })
+        };
+
+        var mobileFeature = Feature.FromSdkFeatureRecord(sdkFeature, layerId: 7);
+
+        var point = Assert.IsType<Point>(mobileFeature.Geometry);
+        Assert.Equal(21.3, point.Latitude);
+        Assert.Equal(-157.8, point.Longitude);
+        Assert.Equal(12, point.Altitude);
+        Assert.Equal(3857, point.SRID);
     }
 
     [Fact]

--- a/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionSdkContractMigrationTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionSdkContractMigrationTests.cs
@@ -58,7 +58,7 @@ public sealed class FieldCollectionSdkContractMigrationTests
         var sdkFeature = new FeatureRecord
         {
             Id = "asset-null",
-            Attributes =
+            Attributes = new Dictionary<string, JsonElement>
             {
                 ["nullable"] = JsonSerializer.SerializeToElement<string?>(null),
                 ["name"] = JsonSerializer.SerializeToElement("Null Test")

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -267,7 +267,7 @@ public sealed class GeoPackageSyncServiceTests
         Assert.Empty(await sync.GetConflictsAsync());
         var resolvedFeature = await storage.GetFeatureAsync("asset-1", 1);
         Assert.NotNull(resolvedFeature);
-        Assert.Equal("server", resolvedFeature.Attributes["name"].ToString());
+        Assert.Equal("server", resolvedFeature.Attributes["name"]?.ToString());
     }
 
     [Fact]

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -425,7 +425,7 @@ public sealed class GeoPackageSyncServiceTests
             Geometry = geometry ?? new Point(21.3, -157.8),
             CreatedAt = DateTime.UtcNow.AddMinutes(-10),
             ModifiedAt = DateTime.UtcNow,
-            Attributes = new Dictionary<string, object>
+            Attributes = new Dictionary<string, object?>
             {
                 ["name"] = "local"
             }

--- a/tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj
+++ b/tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="coverlet.collector" Version="10.0.0" />
+    <PackageReference Include="Honua.Sdk.Abstractions" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.Field" Version="$(HonuaSdkDotNetTrainVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Maui.Essentials" Version="10.0.60" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
@@ -31,6 +33,7 @@
 
   <ItemGroup>
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Models\CoreModels.cs" Link="App\Models\CoreModels.cs" />
+    <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Models\SdkContractAliases.cs" Link="App\Models\SdkContractAliases.cs" />
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\CoreServices.cs" Link="App\Services\CoreServices.cs" />
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\Configuration\MobileBuildConfiguration.cs" Link="App\Services\Configuration\MobileBuildConfiguration.cs" />
     <Compile Include="..\..\apps\Honua.Mobile.FieldCollection\Services\IAuthenticationService.cs" Link="App\Services\IAuthenticationService.cs" />


### PR DESCRIPTION
## Summary
- replace Field Collection app-local form/field/query/geometry-type DTOs with SDK-owned `Honua.Sdk.*` contracts at the app boundary
- add SDK conversion helpers for the remaining mobile-owned feature storage shim
- persist SDK field schema metadata in GeoPackage layer metadata while retaining legacy schema/geometry-type compatibility
- add focused migration tests for feature conversion, SDK form validation, and layer schema round-tripping

## Why
Issue #173 tracks the full-codebase review finding that Field Collection still carried provider-neutral form, query, and geometry-type contracts locally. This keeps mobile-owned storage/UI state here while moving reusable contract surfaces to versioned SDK packages.

## Offline Impact
GeoPackage storage remains mobile-owned. Existing layer metadata is read through a legacy schema fallback, while new layer schema metadata is written using SDK field contracts.

## Validation
- `git diff --check`
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --configuration Release` could not restore locally because GitHub Packages returns 403 for private `Honua.Sdk.*` packages; CI has package access and should be authoritative.

Closes #173.