### PR TITLE
test: document mobile exception ingestion contract

### DIFF
--- a/docs/guides/mobile-exception-reporting.md
+++ b/docs/guides/mobile-exception-reporting.md
@@ -2,8 +2,9 @@
 
 Honua mobile exception reporting is opt-in. The mobile implementation provides
 a sanitized local reporting surface, offline queue, bounded upload worker,
-tester consent gates, and an environment kill switch for MAUI/mobile apps. It
-does not define or implement the Honua Server ingestion endpoint.
+tester consent gates, an environment kill switch, and a documented ingestion
+contract for MAUI/mobile apps. The Honua Server implementation remains owned by
+`honua-server`; mobile only posts sanitized reports to the configured endpoint.
 
 ## Enablement
 
@@ -47,7 +48,7 @@ services.AddHonuaMobileExceptionReporting(new MobileExceptionReportingOptions
 {
     Mode = MobileExceptionReportingMode.ServerUpload,
     QueueDirectory = exceptionQueueDirectory,
-    UploadEndpoint = new Uri("https://api.honua.example/mobile/exception-reports"),
+    UploadEndpoint = new Uri("https://api.honua.example/api/mobile/exceptions"),
     MaxUploadBatchSize = 10,
     UploadInitialBackoff = TimeSpan.FromSeconds(30),
     UploadMaxBackoff = TimeSpan.FromMinutes(15),
@@ -104,8 +105,25 @@ use HTTPS unless it is localhost for development. Apps that need approved
 request metadata, such as same-origin authentication headers, should register an
 `IMobileExceptionReportUploadRequestCustomizer` instead of creating a parallel
 exception-report DTO or hardcoded server client. Tenant routing and ingestion
-schema versioning should be added through the uploader boundary once the server
-endpoint contract exists.
+schema versioning should be added through the uploader boundary.
+
+## Server Ingestion Contract
+
+The mobile-owned contract is an authenticated `POST` to
+`/api/mobile/exceptions` with an `application/json` body serialized from the
+sanitized `MobileExceptionReport` shape. FieldCollection attaches its API key
+with `X-API-Key` only when the upload endpoint shares the authenticated Honua
+Server origin. Server implementations should reject unauthenticated uploads,
+accept valid reports with a success response, and leave retry semantics to the
+mobile queue when a non-success response is returned.
+
+The server log or observability entry should preserve searchable fields from the
+report: report id, fingerprint, occurrence and receipt times, source, operation,
+severity, exception type, correlation id, request id, app id, app version, build
+number, commit SHA, branch, environment, platform, OS version, device class, and
+small redacted context/metadata properties. It must not store auth headers,
+tokens, raw attachments, precise location, or form payloads unless an approved
+server retention policy explicitly allows those fields.
 
 The FieldCollection app keeps exception reporting off until both tester consent
 and the environment kill switch allow it. The Settings screen writes
@@ -121,8 +139,7 @@ and stores sanitized reports in the local queue. When
 app also maps the legacy `honua_exception_reporting_mode=Server` preference to
 `ServerUpload`, stamps build/device metadata from the mobile build
 configuration, and attaches its API key only when the configured upload endpoint
-shares the authenticated server origin. Mobile does not assume a server route
-before the ingestion contract is defined.
+shares the authenticated server origin.
 
 Do not flush from a blocking UI path or synchronously during app startup. Start
 flush work from lifecycle/background scheduling code and allow it to stop on
@@ -131,18 +148,18 @@ refresh, or field capture.
 
 ## Server Dependency
 
-Server ingestion is a separate dependency for issue #91. The mobile repo should
-not add a server API client, shared server DTO, or long-lived copied contract for
-that endpoint. The server-side slice needs to define the ingestion route, auth
-requirements, request headers, retention rules, log sink mapping, searchable
-metadata fields, schema versioning, and operational triage behavior. Mobile
-upload work should consume that versioned contract/package once it exists.
+Server ingestion is a separate server-owned implementation dependency. The
+mobile repo should not add a server API client, shared server DTO, or long-lived
+copied contract for that endpoint. Server issue
+[`honua-server#924`](https://github.com/honua-io/honua-server/issues/924)
+tracks the live image auth refresh and exception ingestion endpoint support that
+mobile uses for end-to-end verification.
 
 The mobile server integration suite has loopback coverage for sanitized report
-delivery and opt-in live coverage through
-`HONUA_MOBILE_LIVE_SERVER_EXCEPTION_UPLOAD_PATH`. A live failure leaves the
-report queued, so enabled live tests should fail until the configured server
-route accepts the mobile report and records it in server observability.
+delivery into a server-like log sink with searchable metadata, plus opt-in live
+coverage through `HONUA_MOBILE_LIVE_SERVER_EXCEPTION_UPLOAD_PATH`. A live
+failure leaves the report queued, so enabled live tests fail unless the
+configured server route accepts the mobile report.
 
 Recommended PR body note:
 

--- a/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReport.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReport.cs
@@ -55,7 +55,7 @@ public sealed record MobileExceptionReportContext
 }
 
 /// <summary>
-/// Sanitized mobile exception report stored on device. This is not a server ingestion contract.
+/// Sanitized mobile exception report stored on device and posted to configured ingestion endpoints.
 /// </summary>
 public sealed record MobileExceptionReport
 {

--- a/tests/Honua.Mobile.ServerIntegration.Tests/FieldCollectionServerIntegrationTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/FieldCollectionServerIntegrationTests.cs
@@ -46,6 +46,22 @@ public sealed class FieldCollectionServerIntegrationTests : IDisposable
             QueueDirectory = Path.Combine(_rootDirectory, "exception-queue"),
             UploadInitialBackoff = TimeSpan.Zero,
             UploadMaxBackoff = TimeSpan.Zero,
+            Metadata = new MobileExceptionReportMetadata
+            {
+                AppId = "honua.fieldcollection",
+                AppVersion = "1.2.3",
+                BuildNumber = "456",
+                CommitSha = "abc123",
+                Branch = "beta",
+                EnvironmentName = "IntegrationTest",
+                Platform = "Android",
+                OsVersion = "15",
+                DeviceClass = "Tablet",
+                Properties = new Dictionary<string, string?>
+                {
+                    ["tenant"] = "integration",
+                },
+            },
         };
         var queue = new FileMobileExceptionReportQueue(options);
         var reporter = new LocalMobileExceptionReporter(queue, options);
@@ -61,6 +77,9 @@ public sealed class FieldCollectionServerIntegrationTests : IDisposable
             new MobileExceptionReportContext
             {
                 Source = "integration-test",
+                Operation = "sync-push",
+                CorrelationId = "correlation-123",
+                RequestId = "request-456",
                 Properties = new Dictionary<string, object?>
                 {
                     ["layer"] = "assets",
@@ -76,7 +95,57 @@ public sealed class FieldCollectionServerIntegrationTests : IDisposable
         Assert.Contains("integration-test", request.Body);
         Assert.Contains("assets", request.Body);
         Assert.DoesNotContain("must-not-leak", request.Body);
+
+        var logEntry = Assert.Single(server.MobileExceptionLogEntries);
+        Assert.True(logEntry.Authenticated);
+        Assert.Equal("integration-test", logEntry.Source);
+        Assert.Equal("sync-push", logEntry.Operation);
+        Assert.Equal("correlation-123", logEntry.CorrelationId);
+        Assert.Equal("request-456", logEntry.RequestId);
+        Assert.Equal(MobileExceptionSeverity.Error, logEntry.Severity);
+        Assert.Equal(typeof(InvalidOperationException).FullName, logEntry.ExceptionType);
+        Assert.Equal("honua.fieldcollection", logEntry.AppId);
+        Assert.Equal("1.2.3", logEntry.AppVersion);
+        Assert.Equal("456", logEntry.BuildNumber);
+        Assert.Equal("abc123", logEntry.CommitSha);
+        Assert.Equal("beta", logEntry.Branch);
+        Assert.Equal("IntegrationTest", logEntry.EnvironmentName);
+        Assert.Equal("Android", logEntry.Platform);
+        Assert.Equal("15", logEntry.OsVersion);
+        Assert.Equal("Tablet", logEntry.DeviceClass);
+        Assert.Equal("integration", logEntry.MetadataProperties["tenant"]);
+        Assert.Equal("assets", logEntry.Context["layer"]);
+        Assert.Equal(MobileExceptionRedactor.RedactedValue, logEntry.Context["api_key"]);
         Assert.Empty(Directory.EnumerateFiles(Path.Combine(_rootDirectory, "exception-queue")));
+    }
+
+    [Fact]
+    public async Task MobileExceptionReportingPipeline_RetainsQueuedReportWhenServerRejectsUnauthenticatedUpload()
+    {
+        await using var server = await HonuaIntegrationServer.StartAsync();
+        using var http = new HttpClient();
+        var options = new MobileExceptionReportingOptions
+        {
+            Mode = MobileExceptionReportingMode.ServerUpload,
+            UploadEndpoint = server.Uri("/api/mobile/exceptions"),
+            QueueDirectory = Path.Combine(_rootDirectory, "unauthenticated-exception-queue"),
+            UploadInitialBackoff = TimeSpan.Zero,
+            UploadMaxBackoff = TimeSpan.Zero,
+        };
+        var queue = new FileMobileExceptionReportQueue(options);
+        var reporter = new LocalMobileExceptionReporter(queue, options);
+        var uploader = new HttpMobileExceptionReportUploader(http, options);
+        var worker = new MobileExceptionReportUploadWorker(queue, uploader, options);
+
+        await reporter.ReportAsync(
+            new InvalidOperationException("missing auth"),
+            new MobileExceptionReportContext { Source = "integration-test" });
+        await worker.FlushPendingAsync();
+
+        var request = server.SingleRequest("POST", "/api/mobile/exceptions");
+        Assert.Null(request.Header("X-API-Key"));
+        Assert.Empty(server.MobileExceptionLogEntries);
+        Assert.NotEmpty(Directory.EnumerateFiles(Path.Combine(_rootDirectory, "unauthenticated-exception-queue")));
     }
 
     public void Dispose()

--- a/tests/Honua.Mobile.ServerIntegration.Tests/HonuaIntegrationServer.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/HonuaIntegrationServer.cs
@@ -2,6 +2,8 @@ using System.Collections.Concurrent;
 using System.Net;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
+using Honua.Mobile.Maui.Diagnostics;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
@@ -15,8 +17,11 @@ namespace Honua.Mobile.ServerIntegration.Tests;
 
 internal sealed class HonuaIntegrationServer : IAsyncDisposable
 {
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
     private readonly WebApplication _app;
     private readonly ConcurrentQueue<RecordedRequest> _requests = new();
+    private readonly ConcurrentQueue<MobileExceptionLogEntry> _mobileExceptionLogEntries = new();
 
     private HonuaIntegrationServer(WebApplication app)
     {
@@ -26,6 +31,8 @@ internal sealed class HonuaIntegrationServer : IAsyncDisposable
     public Uri BaseUri { get; private set; } = null!;
 
     public IReadOnlyList<RecordedRequest> Requests => _requests.ToArray();
+
+    public IReadOnlyList<MobileExceptionLogEntry> MobileExceptionLogEntries => _mobileExceptionLogEntries.ToArray();
 
     public static async Task<HonuaIntegrationServer> StartAsync()
     {
@@ -66,7 +73,7 @@ internal sealed class HonuaIntegrationServer : IAsyncDisposable
             await next(context);
         });
 
-        MapEndpoints(app);
+        MapEndpoints(app, server);
 
         await app.StartAsync();
         var address = app.Services.GetRequiredService<IServer>()
@@ -99,7 +106,7 @@ internal sealed class HonuaIntegrationServer : IAsyncDisposable
         await _app.DisposeAsync();
     }
 
-    private static void MapEndpoints(IEndpointRouteBuilder app)
+    private static void MapEndpoints(IEndpointRouteBuilder app, HonuaIntegrationServer server)
     {
         app.MapGet("/health", () => Results.Ok(new { status = "ok" }));
         app.MapGet("/api/health", () => Results.Ok(new { status = "ok" }));
@@ -157,7 +164,45 @@ internal sealed class HonuaIntegrationServer : IAsyncDisposable
             }
             """));
 
-        app.MapPost("/api/mobile/exceptions", () => Results.Ok(new { accepted = true }));
+        app.MapPost("/api/mobile/exceptions", async (HttpContext context) =>
+        {
+            if (!HasApiKey(context))
+            {
+                return Results.Unauthorized();
+            }
+
+            MobileExceptionReport? report;
+            try
+            {
+                report = await JsonSerializer.DeserializeAsync<MobileExceptionReport>(
+                    context.Request.Body,
+                    JsonOptions,
+                    context.RequestAborted);
+            }
+            catch (JsonException)
+            {
+                return Results.BadRequest(new { error = "invalid_mobile_exception_report" });
+            }
+
+            if (report is null)
+            {
+                return Results.BadRequest(new { error = "missing_mobile_exception_report" });
+            }
+
+            server._mobileExceptionLogEntries.Enqueue(MobileExceptionLogEntry.From(
+                report,
+                receivedAtUtc: DateTimeOffset.UtcNow,
+                authenticated: true));
+
+            return Results.Accepted(
+                $"/api/mobile/exceptions/{Uri.EscapeDataString(report.Id)}",
+                new
+                {
+                    accepted = true,
+                    reportId = report.Id,
+                    report.Fingerprint,
+                });
+        });
         app.MapPost("/oauth/token", () => Json("""
             {
               "accessToken": "refreshed-access-token",
@@ -348,4 +393,61 @@ internal sealed record RecordedRequest(
 
     public string? Header(string name)
         => Headers.TryGetValue(name, out var values) ? values.FirstOrDefault() : null;
+}
+
+internal sealed record MobileExceptionLogEntry(
+    string ReportId,
+    string Fingerprint,
+    DateTimeOffset OccurredAtUtc,
+    DateTimeOffset ReceivedAtUtc,
+    string Source,
+    string? Operation,
+    string? CorrelationId,
+    string? RequestId,
+    MobileExceptionSeverity Severity,
+    string ExceptionType,
+    string? AppId,
+    string? AppVersion,
+    string? BuildNumber,
+    string? CommitSha,
+    string? Branch,
+    string? EnvironmentName,
+    string? Platform,
+    string? OsVersion,
+    string? DeviceClass,
+    IReadOnlyDictionary<string, string?> MetadataProperties,
+    IReadOnlyDictionary<string, string?> Context,
+    bool Authenticated)
+{
+    public static MobileExceptionLogEntry From(
+        MobileExceptionReport report,
+        DateTimeOffset receivedAtUtc,
+        bool authenticated)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        return new MobileExceptionLogEntry(
+            report.Id,
+            report.Fingerprint,
+            report.OccurredAtUtc,
+            receivedAtUtc,
+            report.Source,
+            report.Operation,
+            report.CorrelationId,
+            report.RequestId,
+            report.Severity,
+            report.ExceptionType,
+            report.Metadata.AppId,
+            report.Metadata.AppVersion,
+            report.Metadata.BuildNumber,
+            report.Metadata.CommitSha,
+            report.Metadata.Branch,
+            report.Metadata.EnvironmentName,
+            report.Metadata.Platform,
+            report.Metadata.OsVersion,
+            report.Metadata.DeviceClass,
+            report.Metadata.Properties,
+            report.Context,
+            authenticated);
+    }
 }

--- a/tests/Honua.Mobile.ServerIntegration.Tests/HonuaIntegrationServer.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/HonuaIntegrationServer.cs
@@ -195,7 +195,7 @@ internal sealed class HonuaIntegrationServer : IAsyncDisposable
                 authenticated: true));
 
             return Results.Accepted(
-                $"/api/mobile/exceptions/{Uri.EscapeDataString(report.Id)}",
+                $"/api/mobile/exceptions/{System.Uri.EscapeDataString(report.Id)}",
                 new
                 {
                     accepted = true,


### PR DESCRIPTION
## Summary
- turns the loopback `/api/mobile/exceptions` route into an authenticated exception ingestion sink that records searchable server-log metadata
- expands the FieldCollection integration test to assert sanitized upload, auth, metadata mapping, and queue retention on unauthenticated rejection
- documents the mobile-owned ingestion contract and server-owned implementation boundary

Closes #91

## Validation
- `git diff --check`
- `dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --filter "FullyQualifiedName~FieldCollectionServerIntegrationTests"` failed locally during restore because GitHub Packages returned 403 for Honua.Sdk.* 0.1.15-alpha.1 packages
- `dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --filter "FullyQualifiedName~FieldCollectionServerIntegrationTests" -p:HonuaSdkDotNetTrainVersion=0.1.8-alpha.1` restored from local cache but failed because that older SDK train lacks Honua.Sdk.Abstractions.Plugins types used by current main
