### PR TITLE
fix: secure scene package partial cleanup

### DIFF
--- a/src/Honua.Mobile.Offline/ScenePackages/ScenePackageDownloader.cs
+++ b/src/Honua.Mobile.Offline/ScenePackages/ScenePackageDownloader.cs
@@ -83,7 +83,7 @@ public sealed class ScenePackageDownloader : IHonuaScenePackageDownloader
                 }
                 catch (Exception ex) when (!asset.Required && ex is not OperationCanceledException)
                 {
-                    DeletePartialAsset(stagingDirectory, asset.Path);
+                    DeletePartialAsset(stagingDirectory, asset.Path, asset.Key);
                 }
             }
 
@@ -576,14 +576,26 @@ public sealed class ScenePackageDownloader : IHonuaScenePackageDownloader
         Directory.Move(backupDirectory, readyDirectory);
     }
 
-    private static void DeletePartialAsset(string stagingDirectory, string? assetPath)
+    private static void DeletePartialAsset(string stagingDirectory, string? assetPath, string? assetKey)
     {
         if (string.IsNullOrWhiteSpace(assetPath))
         {
             return;
         }
 
-        var partialPath = Path.Combine(stagingDirectory, assetPath.Replace('/', Path.DirectorySeparatorChar)) + ".partial";
+        string relativePath;
+        try
+        {
+            relativePath = RequireSafeRelativePath(
+                assetPath,
+                string.IsNullOrWhiteSpace(assetKey) ? "<unknown>" : assetKey);
+        }
+        catch (InvalidOperationException)
+        {
+            return;
+        }
+
+        var partialPath = BuildPackageFilePath(stagingDirectory, relativePath) + ".partial";
         if (File.Exists(partialPath))
         {
             File.Delete(partialPath);

--- a/tests/Honua.Mobile.Offline.Tests/ScenePackageDownloaderTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/ScenePackageDownloaderTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Headers;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using Honua.Mobile.Offline.GeoPackage;
@@ -166,6 +167,29 @@ public sealed class ScenePackageDownloaderTests : IDisposable
         Assert.False(File.Exists(Path.Combine(result.PackageDirectory, "textures", "overview.bin")));
         var record = Assert.Single(await store.ListScenePackagesAsync());
         Assert.Equal(["texture-overview"], record.MissingOptionalAssetKeys);
+    }
+
+    [Theory]
+    [InlineData("absolute")]
+    [InlineData("traversal")]
+    public async Task OptionalAssetCleanup_MaliciousManifestPath_DoesNotDeleteAttackerChosenPartial(string pathKind)
+    {
+        var outputDirectory = Path.Combine(_rootDirectory, "packages");
+        var stagingDirectory = Path.Combine(outputDirectory, "pkg_downtown_honolulu_2026_04.partial");
+        var attackerDirectory = Path.Combine(outputDirectory, "attacker");
+        var attackerPath = Path.Combine(attackerDirectory, "chosen-asset");
+        var attackerPartialPath = attackerPath + ".partial";
+        Directory.CreateDirectory(stagingDirectory);
+        Directory.CreateDirectory(attackerDirectory);
+        await File.WriteAllTextAsync(attackerPartialPath, "do-not-delete");
+        var manifestPath = pathKind == "absolute"
+            ? attackerPath
+            : "../attacker/chosen-asset";
+
+        InvokeOptionalPartialCleanup(stagingDirectory, manifestPath);
+
+        Assert.True(File.Exists(attackerPartialPath));
+        Assert.Equal("do-not-delete", await File.ReadAllTextAsync(attackerPartialPath));
     }
 
     [Fact]
@@ -435,6 +459,16 @@ public sealed class ScenePackageDownloaderTests : IDisposable
 
     private static string Sha256Hex(byte[] payload)
         => Convert.ToHexString(SHA256.HashData(payload)).ToLowerInvariant();
+
+    private static void InvokeOptionalPartialCleanup(string stagingDirectory, string assetPath)
+    {
+        var method = typeof(ScenePackageDownloader).GetMethod(
+            "DeletePartialAsset",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        method!.Invoke(null, [stagingDirectory, assetPath, "optional-texture"]);
+    }
 
     private sealed class StubHttpMessageHandler : HttpMessageHandler
     {


### PR DESCRIPTION
## Summary

Fixes optional scene package asset cleanup so a failed optional asset can only delete a `.partial` file resolved from the same safe package-relative path validation used by downloads. Invalid absolute or traversal manifest paths are ignored during cleanup instead of being combined directly with the staging directory.

Adds a regression test covering malicious absolute and traversal optional cleanup paths that point at attacker-chosen `.partial` files outside the staging directory.

## Offline Impact

Valid scene package asset paths keep the same retry and cleanup behavior. Invalid optional asset paths now leave any unrelated filesystem paths untouched and continue treating the optional asset as missing.

## Validation

- `git diff --check` passed.
- `dotnet test tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj --filter FullyQualifiedName~ScenePackageDownloaderTests --logger "console;verbosity=normal"` could not restore packages because GitHub Packages returned 403 for private `Honua.Sdk.*` feeds.
- `dotnet build tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj --no-restore -v:minimal` also failed due to the same unresolved private package restore state.
