### PR TITLE
fix: secure refresh token transport

### DIFF
--- a/src/Honua.Mobile.Sdk/Auth/RefreshingAuthTokenProvider.cs
+++ b/src/Honua.Mobile.Sdk/Auth/RefreshingAuthTokenProvider.cs
@@ -104,10 +104,13 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
                 return current;
             }
 
+            var refreshEndpoint = ResolveRefreshEndpoint(_options.RefreshEndpoint);
+            EnsureAllowedRefreshEndpoint(refreshEndpoint);
+
             using var content = JsonContent.Create(
                 new RefreshTokenRequest(current.RefreshToken),
                 HonuaMobileAuthJsonContext.Default.RefreshTokenRequest);
-            using var response = await _http.PostAsync(_options.RefreshEndpoint, content, ct).ConfigureAwait(false);
+            using var response = await _http.PostAsync(refreshEndpoint, content, ct).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -231,6 +234,39 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
         }
 
         return null;
+    }
+
+    private Uri ResolveRefreshEndpoint(Uri refreshEndpoint)
+    {
+        if (refreshEndpoint.IsAbsoluteUri)
+        {
+            return refreshEndpoint;
+        }
+
+        if (_http.BaseAddress is null)
+        {
+            throw new InvalidOperationException(
+                "RefreshingAuthTokenProvider requires an absolute refresh endpoint or HttpClient.BaseAddress.");
+        }
+
+        return new Uri(_http.BaseAddress, refreshEndpoint);
+    }
+
+    private static void EnsureAllowedRefreshEndpoint(Uri refreshEndpoint)
+    {
+        if (string.Equals(refreshEndpoint.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        if (string.Equals(refreshEndpoint.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
+            refreshEndpoint.IsLoopback)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "The Honua auth refresh endpoint must use HTTPS unless it points to a loopback HTTP development endpoint.");
     }
 }
 

--- a/tests/Honua.Mobile.Sdk.Tests/AuthTokenProviderTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/AuthTokenProviderTests.cs
@@ -229,6 +229,111 @@ public sealed class AuthTokenProviderTests
     }
 
     [Fact]
+    public async Task RefreshTokenAsync_WithHttpRefreshEndpoint_ThrowsAndDoesNotSendRequest()
+    {
+        var refreshCalls = 0;
+        var store = new InMemoryAuthTokenStore();
+        await store.WriteAsync(new HonuaAuthToken(
+            HonuaAuthScheme.Bearer,
+            "expired-token",
+            "refresh-token",
+            DateTimeOffset.UtcNow.AddMinutes(-5)));
+        var provider = new RefreshingAuthTokenProvider(
+            store,
+            new HttpClient(new StubHttpMessageHandler(_ =>
+            {
+                refreshCalls++;
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            })),
+            new RefreshingAuthTokenProviderOptions
+            {
+                RefreshEndpoint = new Uri("http://auth.honua.test/token/refresh"),
+            });
+
+        var exception = await Assert.ThrowsAsync<HonuaMobileAuthException>(async () => await provider.RefreshTokenAsync());
+
+        var inner = Assert.IsType<InvalidOperationException>(exception.InnerException);
+        Assert.Contains("must use HTTPS", inner.Message);
+        Assert.Equal(0, refreshCalls);
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_WithRelativeHttpRefreshEndpoint_ThrowsAndDoesNotSendRequest()
+    {
+        var refreshCalls = 0;
+        var store = new InMemoryAuthTokenStore();
+        await store.WriteAsync(new HonuaAuthToken(
+            HonuaAuthScheme.Bearer,
+            "expired-token",
+            "refresh-token",
+            DateTimeOffset.UtcNow.AddMinutes(-5)));
+        var http = new HttpClient(new StubHttpMessageHandler(_ =>
+        {
+            refreshCalls++;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }))
+        {
+            BaseAddress = new Uri("http://auth.honua.test"),
+        };
+        var provider = new RefreshingAuthTokenProvider(
+            store,
+            http,
+            new RefreshingAuthTokenProviderOptions
+            {
+                RefreshEndpoint = new Uri("/token/refresh", UriKind.Relative),
+            });
+
+        var exception = await Assert.ThrowsAsync<HonuaMobileAuthException>(async () => await provider.RefreshTokenAsync());
+
+        var inner = Assert.IsType<InvalidOperationException>(exception.InnerException);
+        Assert.Contains("must use HTTPS", inner.Message);
+        Assert.Equal(0, refreshCalls);
+    }
+
+    [Theory]
+    [InlineData("http://localhost:5000/token/refresh")]
+    [InlineData("http://127.0.0.1:5000/token/refresh")]
+    public async Task RefreshTokenAsync_WithLoopbackHttpRefreshEndpoint_SendsRequest(string refreshEndpoint)
+    {
+        var refreshCalls = 0;
+        var store = new InMemoryAuthTokenStore();
+        await store.WriteAsync(new HonuaAuthToken(
+            HonuaAuthScheme.Bearer,
+            "expired-token",
+            "refresh-token",
+            DateTimeOffset.UtcNow.AddMinutes(-5)));
+        var provider = new RefreshingAuthTokenProvider(
+            store,
+            new HttpClient(new StubHttpMessageHandler(request =>
+            {
+                refreshCalls++;
+                Assert.Equal(new Uri(refreshEndpoint), request.RequestUri);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """
+                        {
+                            "accessToken": "fresh-token",
+                            "refreshToken": "next-refresh-token",
+                            "expiresIn": 3600
+                        }
+                        """,
+                        Encoding.UTF8,
+                        "application/json"),
+                };
+            })),
+            new RefreshingAuthTokenProviderOptions
+            {
+                RefreshEndpoint = new Uri(refreshEndpoint),
+            });
+
+        var token = await provider.RefreshTokenAsync();
+
+        Assert.Equal("fresh-token", token?.AccessToken);
+        Assert.Equal(1, refreshCalls);
+    }
+
+    [Fact]
     public async Task GetTokenAsync_WhenRefreshReturnsProblemDetails_ThrowsMappedAuthException()
     {
         var now = new DateTimeOffset(2026, 5, 6, 12, 0, 0, TimeSpan.Zero);


### PR DESCRIPTION
## Summary
- Resolve configured refresh endpoints against `HttpClient.BaseAddress` before sending refresh-token requests.
- Refuse refresh-token POSTs over non-HTTPS transport, except HTTP loopback development endpoints.
- Add focused SDK auth tests for blocked HTTP endpoints, relative HTTP base-address resolution, and allowed loopback HTTP endpoints.

## Why
Refresh tokens must not be sent to non-HTTPS endpoints. The provider previously posted directly to the configured endpoint without enforcing the transport rules used elsewhere in mobile endpoint handling.

## Validation
- `git diff --check`
- `dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --filter AuthTokenProviderTests --no-restore -v normal` reached build target successfully but did not execute tests because restore/build artifacts were incomplete.
- `dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --filter AuthTokenProviderTests --logger "console;verbosity=normal"` blocked during restore: GitHub Packages returned `403 Forbidden` for private `Honua.Sdk.*` packages.
- `dotnet restore tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --ignore-failed-sources` also failed because the private `Honua.Sdk.*` packages were unavailable from the authenticated feed/local cache.