### PR TITLE
feat: add embed builder state helpers

### DIFF
--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -154,6 +154,57 @@ applyHonuaMapOptions(document.querySelector('honua-map'), {
 });
 ```
 
+## Embed Builder State
+
+Admin portals can build a live configurator with the typed builder helpers. The
+helpers normalize catalog layers, remove disabled or unknown selections, validate
+service URLs and map extents, apply preview attributes, and generate snippets
+through the existing web component, CDN, iframe, React, Vue, and Angular target
+helpers.
+
+```js
+import {
+  applyHonuaMapBuilderState,
+  createHonuaMapBuilderState,
+} from '@honua-io/embed';
+
+const state = createHonuaMapBuilderState({
+  serviceUrl: 'https://services.honua.example/FeatureServer',
+  availableLayers: [
+    { id: 'assets', label: 'Assets', defaultSelected: true },
+    { id: 'work-orders', label: 'Work orders' },
+  ],
+  selectedLayerIds: ['assets', 'work-orders'],
+  center: { latitude: 21.3069, longitude: -157.8583 },
+  zoom: 12,
+  interactive: true,
+  search: true,
+  identify: true,
+  label: 'City asset map',
+}, {
+  target: 'cdn',
+  cdn: {
+    scriptUrl: 'https://cdn.honua.dev/embed.js',
+    scriptAttributes: {
+      integrity: embedEntry.integrity,
+      crossOrigin: 'anonymous',
+    },
+  },
+});
+
+applyHonuaMapBuilderState(document.querySelector('honua-map'), state);
+
+if (state.canGenerateSnippet) {
+  console.log(state.snippet);
+}
+```
+
+Builder warnings can be shown inline without blocking snippet generation. Errors
+leave `state.snippet` null until the admin fixes required fields such as service
+URL, coordinate ranges, or custom element names. API keys are kept out of
+generated snippets unless credentials are explicitly enabled for the selected
+target.
+
 For hosts that cannot use web components, generate an iframe fallback with the
 same option shape. Map options are serialized into the iframe URL query string,
 and `apiKey` is omitted unless `includeCredentials: true` is set. The npm/CDN

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -394,6 +394,48 @@ const angularIframeComponent = createHonuaMapAngularIframeSnippet({
 Use `applyHonuaMapOptions(element, options)` to apply the same options shape to
 an existing map element at runtime.
 
+## Embed Builder State
+
+Admin portals can use the builder helpers to power a live configurator without
+hand-assembling layer selections, preview attributes, validation, and snippets.
+The state helper consumes catalog layer options, normalizes the selected layer
+ids, reports warnings/errors for the host UI, and delegates final snippet output
+to the existing web component, CDN, iframe, React, Vue, or Angular generators.
+
+```ts
+import {
+  applyHonuaMapBuilderState,
+  createHonuaMapBuilderState,
+} from '@honua-io/embed';
+
+const state = createHonuaMapBuilderState({
+  serviceUrl: 'https://services.honua.example/FeatureServer',
+  availableLayers: [
+    { id: 'assets', label: 'Assets', defaultSelected: true },
+    { id: 'work-orders', label: 'Work orders' },
+  ],
+  selectedLayerIds: ['assets', 'work-orders'],
+  center: { latitude: 21.3069, longitude: -157.8583 },
+  zoom: 12,
+  interactive: true,
+  search: true,
+  identify: true,
+  label: 'City asset map',
+}, {
+  target: 'cdn',
+  cdn: {
+    scriptUrl: 'https://cdn.honua.dev/embed.js',
+  },
+});
+
+applyHonuaMapBuilderState(document.querySelector('honua-map'), state);
+console.log(state.issues, state.snippet);
+```
+
+`state.issues` contains warning/error objects suitable for form validation.
+Credentials are omitted from generated snippets unless `includeCredentials` is
+explicitly enabled for the selected target.
+
 ## Generated Scene Snippets
 
 ```ts

--- a/src/Honua.Embed/src/builder.ts
+++ b/src/Honua.Embed/src/builder.ts
@@ -1,0 +1,391 @@
+import type { HonuaMapBounds, HonuaMapCoordinate } from './map';
+import {
+  applyHonuaMapOptions,
+  createHonuaMapEmbedBuilderSnippet,
+  type HonuaMapEmbedBuilderSnippetOptions,
+  type HonuaMapEmbedOptions,
+  type HonuaMapThemeOptions,
+} from './snippets';
+
+export type HonuaMapBuilderIssueSeverity = 'error' | 'warning';
+
+export interface HonuaMapBuilderLayerOption {
+  id: string;
+  label?: string | null;
+  description?: string | null;
+  defaultSelected?: boolean | null;
+  disabled?: boolean | null;
+}
+
+export interface HonuaMapBuilderInput {
+  serviceUrl?: string | null;
+  availableLayers?: readonly HonuaMapBuilderLayerOption[] | null;
+  selectedLayerIds?: readonly string[] | null;
+  layerIds?: readonly string[] | null;
+  apiKey?: string | null;
+  center?: HonuaMapCoordinate | null;
+  zoom?: number | null;
+  bounds?: HonuaMapBounds | null;
+  basemap?: string | null;
+  interactive?: boolean | null;
+  search?: boolean | null;
+  identify?: boolean | null;
+  attribution?: string | null;
+  theme?: 'light' | 'dark' | null;
+  label?: string | null;
+  style?: HonuaMapThemeOptions | null;
+}
+
+export interface HonuaMapBuilderIssue {
+  severity: HonuaMapBuilderIssueSeverity;
+  code: string;
+  field: string;
+  message: string;
+}
+
+export interface HonuaMapBuilderState {
+  options: HonuaMapEmbedOptions;
+  availableLayers: HonuaMapBuilderLayerOption[];
+  selectedLayers: HonuaMapBuilderLayerOption[];
+  selectedLayerIds: string[];
+  issues: HonuaMapBuilderIssue[];
+  canGenerateSnippet: boolean;
+  snippet: string | null;
+}
+
+export function createHonuaMapBuilderState(
+  input: HonuaMapBuilderInput,
+  snippetOptions: HonuaMapEmbedBuilderSnippetOptions = {},
+): HonuaMapBuilderState {
+  const issues: HonuaMapBuilderIssue[] = [];
+  const availableLayers = normalizeLayerOptions(input.availableLayers, issues);
+  const selectedLayerIds = normalizeSelectedLayerIds(input, availableLayers, issues);
+  const selectedLayers = selectedLayerIds.map((id) => {
+    return availableLayers.find((layer) => layer.id === id) ?? { id };
+  });
+  const options: HonuaMapEmbedOptions = {
+    serviceUrl: normalizeString(input.serviceUrl),
+    layerIds: selectedLayerIds,
+    apiKey: normalizeString(input.apiKey),
+    center: input.center ?? null,
+    zoom: input.zoom ?? null,
+    bounds: input.bounds ?? null,
+    basemap: normalizeString(input.basemap),
+    interactive: input.interactive ?? null,
+    search: input.search ?? null,
+    identify: input.identify ?? null,
+    attribution: normalizeString(input.attribution),
+    theme: input.theme ?? null,
+    label: normalizeString(input.label),
+    style: input.style ?? null,
+  };
+
+  validateOptions(options, snippetOptions, issues);
+
+  let snippet: string | null = null;
+  if (!hasErrors(issues)) {
+    try {
+      snippet = createHonuaMapEmbedBuilderSnippet(options, snippetOptions);
+    } catch (error) {
+      issues.push({
+        severity: 'error',
+        code: 'invalid-snippet-options',
+        field: 'snippetOptions',
+        message: error instanceof Error ? error.message : 'Invalid snippet options.',
+      });
+    }
+  }
+
+  return {
+    options,
+    availableLayers,
+    selectedLayers,
+    selectedLayerIds,
+    issues,
+    canGenerateSnippet: snippet !== null && !hasErrors(issues),
+    snippet,
+  };
+}
+
+export function createHonuaMapBuilderSnippet(
+  input: HonuaMapBuilderInput,
+  snippetOptions: HonuaMapEmbedBuilderSnippetOptions = {},
+): string {
+  const state = createHonuaMapBuilderState(input, snippetOptions);
+  if (!state.canGenerateSnippet || state.snippet === null) {
+    const summary = state.issues
+      .filter((issue) => issue.severity === 'error')
+      .map((issue) => issue.message)
+      .join(' ');
+    throw new Error(`Cannot create Honua map snippet. ${summary}`.trim());
+  }
+
+  return state.snippet;
+}
+
+export function applyHonuaMapBuilderState(
+  element: HTMLElement,
+  state: HonuaMapBuilderState,
+): void {
+  applyHonuaMapOptions(element, state.options);
+}
+
+function normalizeLayerOptions(
+  layers: readonly HonuaMapBuilderLayerOption[] | null | undefined,
+  issues: HonuaMapBuilderIssue[],
+): HonuaMapBuilderLayerOption[] {
+  const normalized: HonuaMapBuilderLayerOption[] = [];
+  const seen = new Set<string>();
+
+  for (const layer of layers ?? []) {
+    const id = layer.id.trim();
+    if (!id) {
+      issues.push({
+        severity: 'warning',
+        code: 'empty-layer-id',
+        field: 'availableLayers',
+        message: 'A layer option with an empty id was ignored.',
+      });
+      continue;
+    }
+
+    if (seen.has(id)) {
+      issues.push({
+        severity: 'warning',
+        code: 'duplicate-layer-id',
+        field: 'availableLayers',
+        message: `Duplicate layer option "${id}" was ignored.`,
+      });
+      continue;
+    }
+
+    seen.add(id);
+    normalized.push({
+      ...layer,
+      id,
+      label: normalizeString(layer.label),
+      description: normalizeString(layer.description),
+    });
+  }
+
+  return normalized;
+}
+
+function normalizeSelectedLayerIds(
+  input: HonuaMapBuilderInput,
+  availableLayers: readonly HonuaMapBuilderLayerOption[],
+  issues: HonuaMapBuilderIssue[],
+): string[] {
+  const selectedIds = input.selectedLayerIds ??
+    input.layerIds ??
+    availableLayers
+      .filter((layer) => layer.defaultSelected)
+      .map((layer) => layer.id);
+  const requested = normalizeStringList(selectedIds);
+  const availableById = new Map(availableLayers.map((layer) => [layer.id, layer]));
+  const selected: string[] = [];
+  const seen = new Set<string>();
+
+  for (const id of requested) {
+    if (seen.has(id)) {
+      continue;
+    }
+
+    seen.add(id);
+    const layer = availableById.get(id);
+    if (availableLayers.length > 0 && !layer) {
+      issues.push({
+        severity: 'warning',
+        code: 'unavailable-layer',
+        field: 'selectedLayerIds',
+        message: `Layer "${id}" is not in the available layer list and was ignored.`,
+      });
+      continue;
+    }
+
+    if (layer?.disabled) {
+      issues.push({
+        severity: 'warning',
+        code: 'disabled-layer',
+        field: 'selectedLayerIds',
+        message: `Layer "${id}" is disabled and was ignored.`,
+      });
+      continue;
+    }
+
+    selected.push(id);
+  }
+
+  return selected;
+}
+
+function validateOptions(
+  options: HonuaMapEmbedOptions,
+  snippetOptions: HonuaMapEmbedBuilderSnippetOptions,
+  issues: HonuaMapBuilderIssue[],
+): void {
+  validateServiceUrl(options.serviceUrl, issues);
+
+  if (options.apiKey && !snippetIncludesCredentials(snippetOptions)) {
+    issues.push({
+      severity: 'warning',
+      code: 'credentials-omitted',
+      field: 'apiKey',
+      message: 'The API key is available for preview but omitted from generated snippets by default.',
+    });
+  }
+
+  if (options.zoom !== null && options.zoom !== undefined) {
+    if (!Number.isFinite(options.zoom) || options.zoom < 0 || options.zoom > 24) {
+      issues.push({
+        severity: 'error',
+        code: 'invalid-zoom',
+        field: 'zoom',
+        message: 'Zoom must be a finite value from 0 through 24.',
+      });
+    }
+  }
+
+  if (options.center) {
+    validateCoordinate(options.center, 'center', issues);
+  }
+
+  if (options.bounds) {
+    validateBounds(options.bounds, issues);
+  }
+}
+
+function validateServiceUrl(
+  serviceUrl: string | null | undefined,
+  issues: HonuaMapBuilderIssue[],
+): void {
+  if (!serviceUrl) {
+    issues.push({
+      severity: 'error',
+      code: 'missing-service-url',
+      field: 'serviceUrl',
+      message: 'A service URL is required before generating an embed snippet.',
+    });
+    return;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(serviceUrl);
+  } catch {
+    issues.push({
+      severity: 'error',
+      code: 'invalid-service-url',
+      field: 'serviceUrl',
+      message: 'Service URL must be an absolute URL.',
+    });
+    return;
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    issues.push({
+      severity: 'error',
+      code: 'unsupported-service-url-scheme',
+      field: 'serviceUrl',
+      message: 'Service URL must use HTTP or HTTPS.',
+    });
+    return;
+  }
+
+  if (parsed.protocol === 'http:' && parsed.hostname !== 'localhost' && parsed.hostname !== '127.0.0.1') {
+    issues.push({
+      severity: 'warning',
+      code: 'insecure-service-url',
+      field: 'serviceUrl',
+      message: 'Non-local embed service URLs should use HTTPS.',
+    });
+  }
+}
+
+function validateCoordinate(
+  coordinate: HonuaMapCoordinate,
+  field: string,
+  issues: HonuaMapBuilderIssue[],
+): void {
+  if (!isValidLatitude(coordinate.latitude) || !isValidLongitude(coordinate.longitude)) {
+    issues.push({
+      severity: 'error',
+      code: 'invalid-coordinate',
+      field,
+      message: 'Center must contain latitude from -90 through 90 and longitude from -180 through 180.',
+    });
+  }
+}
+
+function validateBounds(
+  bounds: HonuaMapBounds,
+  issues: HonuaMapBuilderIssue[],
+): void {
+  if (
+    !isValidLongitude(bounds.minLongitude) ||
+    !isValidLongitude(bounds.maxLongitude) ||
+    !isValidLatitude(bounds.minLatitude) ||
+    !isValidLatitude(bounds.maxLatitude) ||
+    bounds.minLongitude >= bounds.maxLongitude ||
+    bounds.minLatitude >= bounds.maxLatitude
+  ) {
+    issues.push({
+      severity: 'error',
+      code: 'invalid-bounds',
+      field: 'bounds',
+      message: 'Bounds must be ordered as minLon,minLat,maxLon,maxLat within valid coordinate ranges.',
+    });
+  }
+}
+
+function snippetIncludesCredentials(snippetOptions: HonuaMapEmbedBuilderSnippetOptions): boolean {
+  switch (snippetOptions.target ?? 'web-component') {
+    case 'web-component':
+      return snippetOptions.webComponent?.includeCredentials === true;
+    case 'cdn':
+      return snippetOptions.cdn?.includeCredentials === true;
+    case 'iframe':
+      return snippetOptions.iframe?.includeCredentials === true;
+    case 'react':
+      return snippetOptions.react?.includeCredentials === true;
+    case 'react-iframe':
+      return snippetOptions.reactIframe?.includeCredentials === true;
+    case 'vue':
+      return snippetOptions.vue?.includeCredentials === true;
+    case 'vue-iframe':
+      return snippetOptions.vueIframe?.includeCredentials === true;
+    case 'angular':
+      return snippetOptions.angular?.includeCredentials === true;
+    case 'angular-iframe':
+      return snippetOptions.angularIframe?.includeCredentials === true;
+    default:
+      return false;
+  }
+}
+
+function normalizeString(value: string | null | undefined): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function normalizeStringList(value: readonly string[] | null | undefined): string[] {
+  return (value ?? [])
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function isValidLatitude(value: number): boolean {
+  return Number.isFinite(value) && value >= -90 && value <= 90;
+}
+
+function isValidLongitude(value: number): boolean {
+  return Number.isFinite(value) && value >= -180 && value <= 180;
+}
+
+function hasErrors(issues: readonly HonuaMapBuilderIssue[]): boolean {
+  return issues.some((issue) => issue.severity === 'error');
+}

--- a/src/Honua.Embed/src/index.ts
+++ b/src/Honua.Embed/src/index.ts
@@ -3,6 +3,7 @@ export * from './scene';
 export * from './scene-metadata';
 export * from './scene-package-cache';
 export * from './display-adapter';
+export * from './builder';
 export type {
   HonuaEmbedConfigByTarget,
   HonuaEmbedContribution,

--- a/src/Honua.Embed/tests/honua-builder.test.ts
+++ b/src/Honua.Embed/tests/honua-builder.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyHonuaMapBuilderState,
+  createHonuaMapBuilderSnippet,
+  createHonuaMapBuilderState,
+} from '../src/index';
+
+describe('honua map builder', () => {
+  it('normalizes layer selections and generates a credential-safe snippet', () => {
+    const state = createHonuaMapBuilderState({
+      serviceUrl: ' https://services.example.test/FeatureServer ',
+      apiKey: 'secret-browser-key',
+      availableLayers: [
+        { id: ' assets ', label: 'Assets', defaultSelected: true },
+        { id: 'work-orders', label: 'Work orders' },
+        { id: 'drafts', label: 'Draft layers', disabled: true },
+      ],
+      selectedLayerIds: ['work-orders', 'missing', 'drafts', 'work-orders'],
+      center: { latitude: 21.3069, longitude: -157.8583 },
+      zoom: 12,
+      basemap: 'streets',
+      interactive: true,
+      search: true,
+      identify: true,
+      label: 'Field operations',
+    }, {
+      webComponent: {
+        elementName: 'field-ops-map',
+      },
+    });
+
+    expect(state.canGenerateSnippet).toBe(true);
+    expect(state.options.serviceUrl).toBe('https://services.example.test/FeatureServer');
+    expect(state.selectedLayerIds).toEqual(['work-orders']);
+    expect(state.selectedLayers).toEqual([
+      expect.objectContaining({ id: 'work-orders', label: 'Work orders' }),
+    ]);
+    expect(state.issues.map((issue) => issue.code)).toEqual([
+      'unavailable-layer',
+      'disabled-layer',
+      'credentials-omitted',
+    ]);
+    expect(state.snippet).toContain('defineHonuaMapElement(\'field-ops-map\')');
+    expect(state.snippet).toContain('layer-ids="work-orders"');
+    expect(state.snippet).not.toContain('secret-browser-key');
+  });
+
+  it('supports existing embed-builder snippet targets', () => {
+    const state = createHonuaMapBuilderState({
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      layerIds: ['assets'],
+      label: 'CDN map',
+    }, {
+      target: 'cdn',
+      cdn: {
+        scriptUrl: 'https://cdn.example.test/embed.js',
+        scriptAttributes: {
+          integrity: 'sha384-test',
+          crossOrigin: 'anonymous',
+        },
+      },
+    });
+
+    expect(state.canGenerateSnippet).toBe(true);
+    expect(state.snippet).toContain('src="https://cdn.example.test/embed.js"');
+    expect(state.snippet).toContain('integrity="sha384-test"');
+    expect(state.snippet).toContain('<honua-map');
+  });
+
+  it('surfaces validation errors before generating snippets', () => {
+    const state = createHonuaMapBuilderState({
+      serviceUrl: 'ftp://services.example.test/FeatureServer',
+      center: { latitude: 121, longitude: -157.8583 },
+      bounds: {
+        minLongitude: -157.6,
+        minLatitude: 21.6,
+        maxLongitude: -158.3,
+        maxLatitude: 21.2,
+      },
+      zoom: 30,
+    });
+
+    expect(state.canGenerateSnippet).toBe(false);
+    expect(state.snippet).toBeNull();
+    expect(state.issues.filter((issue) => issue.severity === 'error').map((issue) => issue.code)).toEqual([
+      'unsupported-service-url-scheme',
+      'invalid-zoom',
+      'invalid-coordinate',
+      'invalid-bounds',
+    ]);
+  });
+
+  it('applies builder preview state to an existing map element', () => {
+    const element = document.createElement('honua-map');
+    const state = createHonuaMapBuilderState({
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      layerIds: ['assets'],
+      interactive: true,
+      search: false,
+      style: {
+        accent: '#0f766e',
+      },
+    }, {
+      webComponent: {
+        includeScript: false,
+      },
+    });
+
+    applyHonuaMapBuilderState(element, state);
+
+    expect(element.getAttribute('service-url')).toBe('https://services.example.test/FeatureServer');
+    expect(element.getAttribute('layer-ids')).toBe('assets');
+    expect(element.hasAttribute('interactive')).toBe(true);
+    expect(element.hasAttribute('search')).toBe(false);
+    expect(element.style.getPropertyValue('--honua-map-accent')).toBe('#0f766e');
+  });
+
+  it('throws a compact summary when required builder fields are invalid', () => {
+    expect(() => createHonuaMapBuilderSnippet({
+      serviceUrl: '',
+    })).toThrow('A service URL is required before generating an embed snippet.');
+  });
+});


### PR DESCRIPTION
## Summary

Refs #10.

Adds a headless embed-builder state layer for `@honua-io/embed` so admin portals can normalize layer selections, validate map config, apply live preview state, and generate snippets through the existing web component/CDN/iframe/framework target helpers.

## Details

- Adds `createHonuaMapBuilderState`, `createHonuaMapBuilderSnippet`, and `applyHonuaMapBuilderState`.
- Reports structured warnings/errors for unavailable layers, disabled layers, invalid URLs, invalid coordinates/bounds, invalid zoom, and omitted credentials.
- Delegates final output to the existing multi-target `createHonuaMapEmbedBuilderSnippet` path.
- Documents the builder-state workflow in the package README and embeddable-map guide.

## Validation

- `npm ci`
- `npm test` (passed: 17 files, 168 tests; happy-dom printed an AbortError during teardown but exited 0)
- `npm run typecheck`
- `git diff --check`

`dotnet restore Honua.Mobile.sln` could not complete in this clean worktree because the current local GitHub token lacks package read access for Honua SDK packages from GitHub Packages, so the .NET suite was not rerun here. This PR only changes `src/Honua.Embed` TypeScript/docs plus the embed guide.
