### PR TITLE
fix: harden mobile diagnostics redaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,12 +319,14 @@ jobs:
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
             --framework net10.0-android \
+            --no-restore \
             /p:AndroidSupportedAbis=x86_64 \
             /p:TreatWarningsAsErrors=true
 
           dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
             --configuration Release \
             --framework net10.0-android \
+            --no-restore \
             /p:AndroidSupportedAbis=x86_64 \
             /p:TreatWarningsAsErrors=true
 
@@ -335,6 +337,7 @@ jobs:
           dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
             --framework net10.0-android \
+            --no-restore \
             /p:AndroidSupportedAbis=x86_64 \
             /p:PublishTrimmed=true \
             /p:TrimMode=full \
@@ -528,29 +531,27 @@ jobs:
         run: |
           dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj `
             -p:TargetFramework=net10.0-windows10.0.19041.0 `
-            -p:RuntimeIdentifier=win-x64 `
-            -p:RuntimeIdentifiers=win-x64
+            -p:Platform=x64
 
           dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj `
             -p:TargetFramework=net10.0-windows10.0.19041.0 `
-            -p:RuntimeIdentifier=win-x64 `
-            -p:RuntimeIdentifiers=win-x64
+            -p:Platform=x64
 
       - name: Build Reference App (Windows)
         run: |
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj `
             --configuration Release `
             --framework net10.0-windows10.0.19041.0 `
-            /p:RuntimeIdentifier=win-x64 `
-            /p:RuntimeIdentifiers=win-x64
+            --no-restore `
+            /p:Platform=x64
 
       - name: Build Field Collection App (Windows)
         run: |
           dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj `
             --configuration Release `
             --framework net10.0-windows10.0.19041.0 `
-            /p:RuntimeIdentifier=win-x64 `
-            /p:RuntimeIdentifiers=win-x64
+            --no-restore `
+            /p:Platform=x64
 
   grpc-validation:
     name: gRPC Protocol Validation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,7 @@ jobs:
             --configuration Release \
             --framework net10.0-android \
             --no-restore \
+            --no-dependencies \
             /p:RuntimeIdentifiers=android-x64 \
             /p:TreatWarningsAsErrors=true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   DOTNET_VERSION: '10.0.x'  # Current repo targets net10
-  IOS_DOTNET_VERSION: '10.0.100'
+  MAUI_DOTNET_VERSION: '10.0.100'
   NODE_VERSION: '24.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_NOLOGO: true
@@ -275,7 +275,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: ${{ env.MAUI_DOTNET_VERSION }}
 
       - name: Configure GitHub Packages
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
@@ -289,7 +289,7 @@ jobs:
 
       - name: Install MAUI workload
         run: |
-          dotnet workload install maui-android
+          dotnet workload install maui-android --skip-manifest-update
 
       - name: Restore
         run: |
@@ -368,7 +368,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.IOS_DOTNET_VERSION }}
+          dotnet-version: ${{ env.MAUI_DOTNET_VERSION }}
 
       - name: Configure GitHub Packages
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
@@ -476,14 +476,14 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: ${{ env.MAUI_DOTNET_VERSION }}
 
       - name: Configure GitHub Packages
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
       - name: Install MAUI workload
-        run: dotnet workload install maui
+        run: dotnet workload install maui --skip-manifest-update
 
       - name: Restore
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,22 @@ jobs:
 
       - name: Restore
         run: |
+          dotnet restore src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj \
+            -p:RuntimeIdentifier=android-x64 \
+            -p:RuntimeIdentifiers=android-x64
+
+          dotnet restore src/Honua.Mobile.Field/Honua.Mobile.Field.csproj \
+            -p:RuntimeIdentifier=android-x64 \
+            -p:RuntimeIdentifiers=android-x64
+
+          dotnet restore src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj \
+            -p:RuntimeIdentifier=android-x64 \
+            -p:RuntimeIdentifiers=android-x64
+
+          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
+            -p:RuntimeIdentifier=android-x64 \
+            -p:RuntimeIdentifiers=android-x64
+
           dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             -p:TargetFramework=net10.0-android \
             -p:RuntimeIdentifiers=android-x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,8 +293,15 @@ jobs:
 
       - name: Restore
         run: |
-          dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj -p:TargetFramework=net10.0-android
-          dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj -p:TargetFramework=net10.0-android
+          dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
+            -p:TargetFramework=net10.0-android \
+            -p:RuntimeIdentifier=android-x64 \
+            -p:RuntimeIdentifiers=android-x64
+
+          dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
+            -p:TargetFramework=net10.0-android \
+            -p:RuntimeIdentifier=android-x64 \
+            -p:RuntimeIdentifiers=android-x64
 
       - name: Build MAUI Components
         run: |
@@ -308,12 +315,16 @@ jobs:
             --configuration Release \
             --framework net10.0-android \
             --no-restore \
+            /p:RuntimeIdentifier=android-x64 \
+            /p:RuntimeIdentifiers=android-x64 \
             /p:TreatWarningsAsErrors=true
 
           dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
             --configuration Release \
             --framework net10.0-android \
             --no-restore \
+            /p:RuntimeIdentifier=android-x64 \
+            /p:RuntimeIdentifiers=android-x64 \
             /p:TreatWarningsAsErrors=true
 
       - name: Android trim smoke
@@ -324,6 +335,8 @@ jobs:
             --configuration Release \
             --framework net10.0-android \
             --no-restore \
+            /p:RuntimeIdentifier=android-x64 \
+            /p:RuntimeIdentifiers=android-x64 \
             /p:PublishTrimmed=true \
             /p:TrimMode=full \
             /p:TreatWarningsAsErrors=true \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,6 @@ jobs:
           # summaries emitted by upstream NuGet packages during the baseline app smoke.
           dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             -p:TargetFramework=net10.0-android \
-            -p:RuntimeIdentifier=android-x64 \
             -p:RuntimeIdentifiers=android-x64
 
           dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,15 +319,12 @@ jobs:
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
             --framework net10.0-android \
-            --no-restore \
             /p:RuntimeIdentifiers=android-x64 \
             /p:TreatWarningsAsErrors=true
 
           dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
             --configuration Release \
             --framework net10.0-android \
-            --no-restore \
-            --no-dependencies \
             /p:RuntimeIdentifiers=android-x64 \
             /p:TreatWarningsAsErrors=true
 
@@ -338,7 +335,6 @@ jobs:
           dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
             --framework net10.0-android \
-            --no-restore \
             /p:RuntimeIdentifiers=android-x64 \
             /p:PublishTrimmed=true \
             /p:TrimMode=full \
@@ -456,14 +452,12 @@ jobs:
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
             --framework net10.0-ios \
-            --no-restore \
             /p:RuntimeIdentifier=iossimulator-x64 \
             /p:TreatWarningsAsErrors=true
 
           dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
             --configuration Release \
             --framework net10.0-ios \
-            --no-restore \
             /p:RuntimeIdentifier=iossimulator-x64 \
             /p:TreatWarningsAsErrors=true
 
@@ -475,7 +469,6 @@ jobs:
           dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
             --framework net10.0-ios \
-            --no-restore \
             /p:RuntimeIdentifier=ios-arm64 \
             /p:PublishTrimmed=true \
             /p:TrimMode=full \
@@ -550,7 +543,6 @@ jobs:
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj `
             --configuration Release `
             --framework net10.0-windows10.0.19041.0 `
-            --no-restore `
             /p:RuntimeIdentifier=win-x64 `
             /p:RuntimeIdentifiers=win-x64
 
@@ -559,7 +551,6 @@ jobs:
           dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj `
             --configuration Release `
             --framework net10.0-windows10.0.19041.0 `
-            --no-restore `
             /p:RuntimeIdentifier=win-x64 `
             /p:RuntimeIdentifiers=win-x64
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,11 +307,13 @@ jobs:
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
             --framework net10.0-android \
+            --no-restore \
             /p:TreatWarningsAsErrors=true
 
           dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
             --configuration Release \
             --framework net10.0-android \
+            --no-restore \
             /p:TreatWarningsAsErrors=true
 
       - name: Android trim smoke
@@ -321,6 +323,7 @@ jobs:
           dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
             --framework net10.0-android \
+            --no-restore \
             /p:PublishTrimmed=true \
             /p:TrimMode=full \
             /p:TreatWarningsAsErrors=true \
@@ -423,12 +426,14 @@ jobs:
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
             --framework net10.0-ios \
+            --no-restore \
             /p:RuntimeIdentifier=iossimulator-x64 \
             /p:TreatWarningsAsErrors=true
 
           dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
             --configuration Release \
             --framework net10.0-ios \
+            --no-restore \
             /p:RuntimeIdentifier=iossimulator-x64 \
             /p:TreatWarningsAsErrors=true
 
@@ -440,6 +445,7 @@ jobs:
           dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
             --framework net10.0-ios \
+            --no-restore \
             /p:RuntimeIdentifier=ios-arm64 \
             /p:PublishTrimmed=true \
             /p:TrimMode=full \
@@ -499,13 +505,15 @@ jobs:
         run: |
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj `
             --configuration Release `
-            --framework net10.0-windows10.0.19041.0
+            --framework net10.0-windows10.0.19041.0 `
+            --no-restore
 
       - name: Build Field Collection App (Windows)
         run: |
           dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj `
             --configuration Release `
-            --framework net10.0-windows10.0.19041.0
+            --framework net10.0-windows10.0.19041.0 `
+            --no-restore
 
   grpc-validation:
     name: gRPC Protocol Validation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,8 +506,15 @@ jobs:
 
       - name: Restore
         run: |
-          dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj -p:TargetFramework=net10.0-windows10.0.19041.0
-          dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj -p:TargetFramework=net10.0-windows10.0.19041.0
+          dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj `
+            -p:TargetFramework=net10.0-windows10.0.19041.0 `
+            -p:RuntimeIdentifier=win-x64 `
+            -p:RuntimeIdentifiers=win-x64
+
+          dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj `
+            -p:TargetFramework=net10.0-windows10.0.19041.0 `
+            -p:RuntimeIdentifier=win-x64 `
+            -p:RuntimeIdentifiers=win-x64
 
       - name: Build MAUI Components (Windows)
         run: |
@@ -519,14 +526,18 @@ jobs:
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj `
             --configuration Release `
             --framework net10.0-windows10.0.19041.0 `
-            --no-restore
+            --no-restore `
+            /p:RuntimeIdentifier=win-x64 `
+            /p:RuntimeIdentifiers=win-x64
 
       - name: Build Field Collection App (Windows)
         run: |
           dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj `
             --configuration Release `
             --framework net10.0-windows10.0.19041.0 `
-            --no-restore
+            --no-restore `
+            /p:RuntimeIdentifier=win-x64 `
+            /p:RuntimeIdentifiers=win-x64
 
   grpc-validation:
     name: gRPC Protocol Validation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,18 @@ jobs:
         run: |
           dotnet workload install maui-android --skip-manifest-update
 
-      - name: Restore
+      - name: Restore MAUI Components
+        run: |
+          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
+
+      - name: Build MAUI Components
+        run: |
+          dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
+            --configuration Release \
+            --no-restore \
+            /p:TreatWarningsAsErrors=true
+
+      - name: Restore Android Apps
         run: |
           dotnet restore src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj \
             -p:RuntimeIdentifier=android-x64 \
@@ -316,15 +327,6 @@ jobs:
           dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
             -p:TargetFramework=net10.0-android \
             -p:RuntimeIdentifiers=android-x64
-
-      - name: Build MAUI Components
-        run: |
-          dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
-            --configuration Release \
-            --no-restore \
-            /p:RuntimeIdentifier=android-x64 \
-            /p:RuntimeIdentifiers=android-x64 \
-            /p:TreatWarningsAsErrors=true
 
       - name: Build Android Apps
         run: |
@@ -437,12 +439,20 @@ jobs:
             echo "actool_available=false" >> "${GITHUB_OUTPUT}"
           fi
 
-      - name: Restore
+      - name: Restore MAUI Components
         run: |
-          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
-            -p:RuntimeIdentifier=iossimulator-x64 \
-            -p:RuntimeIdentifiers=iossimulator-x64
+          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
 
+      - name: Build MAUI Components
+        run: |
+          dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
+            --configuration Release \
+            --no-restore \
+            /p:TreatWarningsAsErrors=true
+
+      - name: Restore iOS Apps
+        if: steps.ios_tools.outputs.actool_available == 'true'
+        run: |
           dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
             -p:TargetFramework=net10.0-ios \
             -p:RuntimeIdentifier=iossimulator-x64 \
@@ -451,15 +461,6 @@ jobs:
           dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             -p:TargetFramework=net10.0-ios \
             '-p:RuntimeIdentifiers=iossimulator-x64;ios-arm64'
-
-      - name: Build MAUI Components
-        run: |
-          dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
-            --configuration Release \
-            --no-restore \
-            /p:RuntimeIdentifier=iossimulator-x64 \
-            /p:RuntimeIdentifiers=iossimulator-x64 \
-            /p:TreatWarningsAsErrors=true
 
       - name: Build iOS Apps
         if: steps.ios_tools.outputs.actool_available == 'true'
@@ -532,7 +533,17 @@ jobs:
       - name: Install MAUI workload
         run: dotnet workload install maui --skip-manifest-update
 
-      - name: Restore
+      - name: Restore MAUI Components
+        run: |
+          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
+
+      - name: Build MAUI Components (Windows)
+        run: |
+          dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj `
+            --configuration Release `
+            --no-restore
+
+      - name: Restore Windows Apps
         run: |
           dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj `
             -p:TargetFramework=net10.0-windows10.0.19041.0 `
@@ -543,14 +554,6 @@ jobs:
             -p:TargetFramework=net10.0-windows10.0.19041.0 `
             -p:RuntimeIdentifier=win-x64 `
             -p:RuntimeIdentifiers=win-x64
-
-      - name: Build MAUI Components (Windows)
-        run: |
-          dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj `
-            --configuration Release `
-            --no-restore `
-            /p:RuntimeIdentifier=win-x64 `
-            /p:RuntimeIdentifiers=win-x64
 
       - name: Build Reference App (Windows)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,12 +295,10 @@ jobs:
         run: |
           dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             -p:TargetFramework=net10.0-android \
-            -p:RuntimeIdentifier=android-x64 \
             -p:RuntimeIdentifiers=android-x64
 
           dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
             -p:TargetFramework=net10.0-android \
-            -p:RuntimeIdentifier=android-x64 \
             -p:RuntimeIdentifiers=android-x64
 
       - name: Build MAUI Components
@@ -315,7 +313,6 @@ jobs:
             --configuration Release \
             --framework net10.0-android \
             --no-restore \
-            /p:RuntimeIdentifier=android-x64 \
             /p:RuntimeIdentifiers=android-x64 \
             /p:TreatWarningsAsErrors=true
 
@@ -323,7 +320,6 @@ jobs:
             --configuration Release \
             --framework net10.0-android \
             --no-restore \
-            /p:RuntimeIdentifier=android-x64 \
             /p:RuntimeIdentifiers=android-x64 \
             /p:TreatWarningsAsErrors=true
 
@@ -335,7 +331,6 @@ jobs:
             --configuration Release \
             --framework net10.0-android \
             --no-restore \
-            /p:RuntimeIdentifier=android-x64 \
             /p:RuntimeIdentifiers=android-x64 \
             /p:PublishTrimmed=true \
             /p:TrimMode=full \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,10 +367,16 @@ jobs:
         run: |
           # Keep direct mobile-code trim warnings blocking, but do not fail on assembly-level
           # summaries emitted by upstream NuGet packages during the baseline app smoke.
+          dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
+            -p:TargetFramework=net10.0-android \
+            -p:RuntimeIdentifier=android-x64 \
+            -p:RuntimeIdentifiers=android-x64
+
           dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
             --framework net10.0-android \
             --no-restore \
+            /p:RuntimeIdentifier=android-x64 \
             /p:RuntimeIdentifiers=android-x64 \
             /p:PublishTrimmed=true \
             /p:TrimMode=full \
@@ -573,6 +579,8 @@ jobs:
             -p:RuntimeIdentifier=win-x64 `
             -p:RuntimeIdentifiers=win-x64 `
             -p:Platform=x64
+
+          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
 
       - name: Build Reference App (Windows)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,14 +367,9 @@ jobs:
         run: |
           # Keep direct mobile-code trim warnings blocking, but do not fail on assembly-level
           # summaries emitted by upstream NuGet packages during the baseline app smoke.
-          dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
-            -p:TargetFramework=net10.0-android \
-            -p:RuntimeIdentifiers=android-x64
-
           dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
             --framework net10.0-android \
-            --no-restore \
             /p:RuntimeIdentifier=android-x64 \
             /p:RuntimeIdentifiers=android-x64 \
             /p:PublishTrimmed=true \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,8 @@ jobs:
           dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
             --configuration Release \
             --no-restore \
+            /p:RuntimeIdentifier=android-x64 \
+            /p:RuntimeIdentifiers=android-x64 \
             /p:TreatWarningsAsErrors=true
 
       - name: Build Android Apps
@@ -437,14 +439,26 @@ jobs:
 
       - name: Restore
         run: |
-          dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj -p:TargetFramework=net10.0-ios
-          dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj -p:TargetFramework=net10.0-ios
+          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
+            -p:RuntimeIdentifier=iossimulator-x64 \
+            -p:RuntimeIdentifiers=iossimulator-x64
+
+          dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
+            -p:TargetFramework=net10.0-ios \
+            -p:RuntimeIdentifier=iossimulator-x64 \
+            -p:RuntimeIdentifiers=iossimulator-x64
+
+          dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
+            -p:TargetFramework=net10.0-ios \
+            '-p:RuntimeIdentifiers=iossimulator-x64;ios-arm64'
 
       - name: Build MAUI Components
         run: |
           dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
             --configuration Release \
             --no-restore \
+            /p:RuntimeIdentifier=iossimulator-x64 \
+            /p:RuntimeIdentifiers=iossimulator-x64 \
             /p:TreatWarningsAsErrors=true
 
       - name: Build iOS Apps
@@ -534,7 +548,9 @@ jobs:
         run: |
           dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj `
             --configuration Release `
-            --no-restore
+            --no-restore `
+            /p:RuntimeIdentifier=win-x64 `
+            /p:RuntimeIdentifiers=win-x64
 
       - name: Build Reference App (Windows)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,22 +304,6 @@ jobs:
 
       - name: Restore Android Apps
         run: |
-          dotnet restore src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj \
-            -p:RuntimeIdentifier=android-x64 \
-            -p:RuntimeIdentifiers=android-x64
-
-          dotnet restore src/Honua.Mobile.Field/Honua.Mobile.Field.csproj \
-            -p:RuntimeIdentifier=android-x64 \
-            -p:RuntimeIdentifiers=android-x64
-
-          dotnet restore src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj \
-            -p:RuntimeIdentifier=android-x64 \
-            -p:RuntimeIdentifiers=android-x64
-
-          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
-            -p:RuntimeIdentifier=android-x64 \
-            -p:RuntimeIdentifiers=android-x64
-
           dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             -p:TargetFramework=net10.0-android \
             -p:RuntimeIdentifiers=android-x64
@@ -327,6 +311,8 @@ jobs:
           dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
             -p:TargetFramework=net10.0-android \
             -p:RuntimeIdentifiers=android-x64
+
+          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
 
       - name: Build Android Apps
         run: |
@@ -462,6 +448,8 @@ jobs:
             -p:TargetFramework=net10.0-ios \
             '-p:RuntimeIdentifiers=iossimulator-x64;ios-arm64'
 
+          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
+
       - name: Build iOS Apps
         if: steps.ios_tools.outputs.actool_available == 'true'
         run: |
@@ -554,6 +542,8 @@ jobs:
             -p:TargetFramework=net10.0-windows10.0.19041.0 `
             -p:RuntimeIdentifier=win-x64 `
             -p:RuntimeIdentifiers=win-x64
+
+          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
 
       - name: Build Reference App (Windows)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,7 @@ jobs:
         run: |
           dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
             --configuration Release \
+            --no-restore \
             /p:TreatWarningsAsErrors=true
 
       - name: Build Android Apps
@@ -443,6 +444,7 @@ jobs:
         run: |
           dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
             --configuration Release \
+            --no-restore \
             /p:TreatWarningsAsErrors=true
 
       - name: Build iOS Apps
@@ -531,7 +533,8 @@ jobs:
       - name: Build MAUI Components (Windows)
         run: |
           dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj `
-            --configuration Release
+            --configuration Release `
+            --no-restore
 
       - name: Build Reference App (Windows)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,8 +372,6 @@ jobs:
             -p:RuntimeIdentifier=android-x64 \
             -p:RuntimeIdentifiers=android-x64
 
-          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
-
           dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
             --framework net10.0-android \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,11 +306,11 @@ jobs:
         run: |
           dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             -p:TargetFramework=net10.0-android \
-            -p:AndroidSupportedAbis=x86_64
+            -p:RuntimeIdentifiers=android-x64
 
           dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
             -p:TargetFramework=net10.0-android \
-            -p:AndroidSupportedAbis=x86_64
+            -p:RuntimeIdentifiers=android-x64
 
           dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
 
@@ -320,14 +320,18 @@ jobs:
             --configuration Release \
             --framework net10.0-android \
             --no-restore \
-            /p:AndroidSupportedAbis=x86_64 \
+            /p:RuntimeIdentifiers=android-x64 \
             /p:TreatWarningsAsErrors=true
+
+          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
+            -p:RuntimeIdentifiers=android-x64
 
           dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
             --configuration Release \
             --framework net10.0-android \
             --no-restore \
-            /p:AndroidSupportedAbis=x86_64 \
+            --no-dependencies \
+            /p:RuntimeIdentifiers=android-x64 \
             /p:TreatWarningsAsErrors=true
 
       - name: Android trim smoke
@@ -338,7 +342,7 @@ jobs:
             --configuration Release \
             --framework net10.0-android \
             --no-restore \
-            /p:AndroidSupportedAbis=x86_64 \
+            /p:RuntimeIdentifiers=android-x64 \
             /p:PublishTrimmed=true \
             /p:TrimMode=full \
             /p:TreatWarningsAsErrors=true \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,9 @@ jobs:
             -p:TargetFramework=net10.0-android \
             -p:RuntimeIdentifiers=android-x64
 
-          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
+          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
+            -p:RuntimeIdentifier=android-x64 \
+            -p:RuntimeIdentifiers=android-x64
 
       - name: Build Android Apps
         run: |
@@ -322,9 +324,6 @@ jobs:
             --no-restore \
             /p:RuntimeIdentifiers=android-x64 \
             /p:TreatWarningsAsErrors=true
-
-          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
-            -p:RuntimeIdentifiers=android-x64
 
           dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
             --configuration Release \
@@ -535,10 +534,14 @@ jobs:
         run: |
           dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj `
             -p:TargetFramework=net10.0-windows10.0.19041.0 `
+            -p:RuntimeIdentifier=win-x64 `
+            -p:RuntimeIdentifiers=win-x64 `
             -p:Platform=x64
 
           dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj `
             -p:TargetFramework=net10.0-windows10.0.19041.0 `
+            -p:RuntimeIdentifier=win-x64 `
+            -p:RuntimeIdentifiers=win-x64 `
             -p:Platform=x64
 
       - name: Build Reference App (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,11 +306,11 @@ jobs:
         run: |
           dotnet restore apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             -p:TargetFramework=net10.0-android \
-            -p:RuntimeIdentifiers=android-x64
+            -p:AndroidSupportedAbis=x86_64
 
           dotnet restore apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
             -p:TargetFramework=net10.0-android \
-            -p:RuntimeIdentifiers=android-x64
+            -p:AndroidSupportedAbis=x86_64
 
           dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
 
@@ -319,13 +319,13 @@ jobs:
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
             --framework net10.0-android \
-            /p:RuntimeIdentifiers=android-x64 \
+            /p:AndroidSupportedAbis=x86_64 \
             /p:TreatWarningsAsErrors=true
 
           dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj \
             --configuration Release \
             --framework net10.0-android \
-            /p:RuntimeIdentifiers=android-x64 \
+            /p:AndroidSupportedAbis=x86_64 \
             /p:TreatWarningsAsErrors=true
 
       - name: Android trim smoke
@@ -335,7 +335,7 @@ jobs:
           dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
             --framework net10.0-android \
-            /p:RuntimeIdentifiers=android-x64 \
+            /p:AndroidSupportedAbis=x86_64 \
             /p:PublishTrimmed=true \
             /p:TrimMode=full \
             /p:TreatWarningsAsErrors=true \
@@ -535,8 +535,6 @@ jobs:
             -p:TargetFramework=net10.0-windows10.0.19041.0 `
             -p:RuntimeIdentifier=win-x64 `
             -p:RuntimeIdentifiers=win-x64
-
-          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
 
       - name: Build Reference App (Windows)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,36 @@ jobs:
             -p:RuntimeIdentifier=android-x64 \
             -p:RuntimeIdentifiers=android-x64
 
+      - name: Build Android Project References
+        run: |
+          dotnet build src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj \
+            --configuration Release \
+            --no-restore \
+            /p:RuntimeIdentifier=android-x64 \
+            /p:RuntimeIdentifiers=android-x64 \
+            /p:TreatWarningsAsErrors=true
+
+          dotnet build src/Honua.Mobile.Field/Honua.Mobile.Field.csproj \
+            --configuration Release \
+            --no-restore \
+            /p:RuntimeIdentifier=android-x64 \
+            /p:RuntimeIdentifiers=android-x64 \
+            /p:TreatWarningsAsErrors=true
+
+          dotnet build src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj \
+            --configuration Release \
+            --no-restore \
+            /p:RuntimeIdentifier=android-x64 \
+            /p:RuntimeIdentifiers=android-x64 \
+            /p:TreatWarningsAsErrors=true
+
+          dotnet build src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj \
+            --configuration Release \
+            --no-restore \
+            /p:RuntimeIdentifier=android-x64 \
+            /p:RuntimeIdentifiers=android-x64 \
+            /p:TreatWarningsAsErrors=true
+
       - name: Build Android Apps
         run: |
           dotnet build apps/Honua.Mobile.App/Honua.Mobile.App.csproj \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,8 @@ jobs:
             -p:RuntimeIdentifier=android-x64 \
             -p:RuntimeIdentifiers=android-x64
 
+          dotnet restore src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
+
           dotnet publish apps/Honua.Mobile.App/Honua.Mobile.App.csproj \
             --configuration Release \
             --framework net10.0-android \

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,5 +6,6 @@
     <HonuaSdkDotNetTrainReleaseUrl>https://github.com/honua-io/honua-sdk-dotnet/releases/tag/$(HonuaSdkDotNetTrainTag)</HonuaSdkDotNetTrainReleaseUrl>
     <HonuaSdkDotNetTrainReleaseCommit>9d264e358099dc20a30b9247013b61d1fba0b0a9</HonuaSdkDotNetTrainReleaseCommit>
     <HonuaSdkDotNetTrainReleasePublishedAt>2026-04-30T23:32:50Z</HonuaSdkDotNetTrainReleasePublishedAt>
+    <MauiVersion>10.0.60</MauiVersion>
   </PropertyGroup>
 </Project>

--- a/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/OfflineCacheDiagnostics.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/OfflineCacheDiagnostics.cs
@@ -109,7 +109,15 @@ public static partial class DiagnosticRedactor
             return RedactSensitiveText(value);
         }
 
-        return uri.GetLeftPart(UriPartial.Path);
+        var builder = new UriBuilder(uri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty,
+            Query = string.Empty,
+            Fragment = string.Empty,
+        };
+
+        return builder.Uri.GetLeftPart(UriPartial.Path);
     }
 
     public static string RedactSensitiveText(string? value)
@@ -173,16 +181,21 @@ public static partial class DiagnosticRedactor
 
     private static bool IsSensitiveName(string name)
     {
-        return name.Contains("token", StringComparison.OrdinalIgnoreCase) ||
-            name.Contains("secret", StringComparison.OrdinalIgnoreCase) ||
-            name.Contains("password", StringComparison.OrdinalIgnoreCase) ||
-            name.Contains("apiKey", StringComparison.OrdinalIgnoreCase) ||
-            name.Contains("authorization", StringComparison.OrdinalIgnoreCase);
+        var normalized = string.Concat(name
+            .Where(char.IsLetterOrDigit))
+            .ToLowerInvariant();
+
+        return normalized.Contains("token", StringComparison.Ordinal) ||
+            normalized.Contains("secret", StringComparison.Ordinal) ||
+            normalized.Contains("password", StringComparison.Ordinal) ||
+            normalized.Contains("apikey", StringComparison.Ordinal) ||
+            normalized.Contains("accesskey", StringComparison.Ordinal) ||
+            normalized.Contains("authorization", StringComparison.Ordinal);
     }
 
     [GeneratedRegex("Bearer\\s+[A-Za-z0-9._~+/=-]+", RegexOptions.IgnoreCase)]
     private static partial Regex BearerTokenRegex();
 
-    [GeneratedRegex("(?i)(api[_-]?key|token|password|secret|authorization)([\"'\\s:=]+)[^,\"'\\s}]+")]
+    [GeneratedRegex("(?i)(x[_-]?api[_-]?key|api[_-]?key|access[_-]?key|token|password|secret|authorization)([\"'\\s:=]+)[^,\"'\\s}]+")]
     private static partial Regex SecretPairRegex();
 }

--- a/scripts/run-android-platform-smoke.sh
+++ b/scripts/run-android-platform-smoke.sh
@@ -7,7 +7,7 @@ PROJECT_DIR="$(dirname "${PROJECT_PATH}")"
 PACKAGE_ID="${HONUA_MOBILE_PLATFORM_SMOKE_PACKAGE_ID:-io.honua.mobile.platformsmoke}"
 CONFIGURATION="${CONFIGURATION:-Debug}"
 TARGET_FRAMEWORK="net10.0-android"
-RUNTIME_IDENTIFIER="${RUNTIME_IDENTIFIER:-android-x64}"
+ANDROID_SUPPORTED_ABIS="${ANDROID_SUPPORTED_ABIS:-x86_64}"
 CONFIG_FILE="honua-mobile-platform-smoke-config.json"
 RESULT_FILE="honua-mobile-platform-smoke-result.json"
 
@@ -42,7 +42,7 @@ done
 dotnet build "${PROJECT_PATH}" \
   --configuration "${CONFIGURATION}" \
   --framework "${TARGET_FRAMEWORK}" \
-  /p:RuntimeIdentifiers="${RUNTIME_IDENTIFIER}" \
+  /p:AndroidSupportedAbis="${ANDROID_SUPPORTED_ABIS}" \
   /p:AndroidPackageFormat=apk \
   /p:TreatWarningsAsErrors=true
 

--- a/scripts/run-android-platform-smoke.sh
+++ b/scripts/run-android-platform-smoke.sh
@@ -7,7 +7,7 @@ PROJECT_DIR="$(dirname "${PROJECT_PATH}")"
 PACKAGE_ID="${HONUA_MOBILE_PLATFORM_SMOKE_PACKAGE_ID:-io.honua.mobile.platformsmoke}"
 CONFIGURATION="${CONFIGURATION:-Debug}"
 TARGET_FRAMEWORK="net10.0-android"
-ANDROID_SUPPORTED_ABIS="${ANDROID_SUPPORTED_ABIS:-x86_64}"
+RUNTIME_IDENTIFIER="${RUNTIME_IDENTIFIER:-android-x64}"
 CONFIG_FILE="honua-mobile-platform-smoke-config.json"
 RESULT_FILE="honua-mobile-platform-smoke-result.json"
 
@@ -41,13 +41,13 @@ done
 
 dotnet restore "${PROJECT_PATH}" \
   --framework "${TARGET_FRAMEWORK}" \
-  /p:AndroidSupportedAbis="${ANDROID_SUPPORTED_ABIS}"
+  /p:RuntimeIdentifiers="${RUNTIME_IDENTIFIER}"
 
 dotnet build "${PROJECT_PATH}" \
   --configuration "${CONFIGURATION}" \
   --framework "${TARGET_FRAMEWORK}" \
   --no-restore \
-  /p:AndroidSupportedAbis="${ANDROID_SUPPORTED_ABIS}" \
+  /p:RuntimeIdentifiers="${RUNTIME_IDENTIFIER}" \
   /p:AndroidPackageFormat=apk \
   /p:TreatWarningsAsErrors=true
 

--- a/scripts/run-android-platform-smoke.sh
+++ b/scripts/run-android-platform-smoke.sh
@@ -7,6 +7,7 @@ PROJECT_DIR="$(dirname "${PROJECT_PATH}")"
 PACKAGE_ID="${HONUA_MOBILE_PLATFORM_SMOKE_PACKAGE_ID:-io.honua.mobile.platformsmoke}"
 CONFIGURATION="${CONFIGURATION:-Debug}"
 TARGET_FRAMEWORK="net10.0-android"
+RUNTIME_IDENTIFIER="${RUNTIME_IDENTIFIER:-android-x64}"
 CONFIG_FILE="honua-mobile-platform-smoke-config.json"
 RESULT_FILE="honua-mobile-platform-smoke-result.json"
 
@@ -41,6 +42,9 @@ done
 dotnet build "${PROJECT_PATH}" \
   --configuration "${CONFIGURATION}" \
   --framework "${TARGET_FRAMEWORK}" \
+  /p:RuntimeIdentifier="${RUNTIME_IDENTIFIER}" \
+  /p:RuntimeIdentifiers="${RUNTIME_IDENTIFIER}" \
+  /p:AndroidPackageFormat=apk \
   /p:TreatWarningsAsErrors=true
 
 apk_path="$(find "${PROJECT_DIR}/bin/${CONFIGURATION}/${TARGET_FRAMEWORK}" -type f \( -name "*Signed.apk" -o -name "*.apk" \) | head -n 1)"

--- a/scripts/run-android-platform-smoke.sh
+++ b/scripts/run-android-platform-smoke.sh
@@ -42,7 +42,6 @@ done
 dotnet build "${PROJECT_PATH}" \
   --configuration "${CONFIGURATION}" \
   --framework "${TARGET_FRAMEWORK}" \
-  /p:RuntimeIdentifier="${RUNTIME_IDENTIFIER}" \
   /p:RuntimeIdentifiers="${RUNTIME_IDENTIFIER}" \
   /p:AndroidPackageFormat=apk \
   /p:TreatWarningsAsErrors=true

--- a/scripts/run-android-platform-smoke.sh
+++ b/scripts/run-android-platform-smoke.sh
@@ -39,9 +39,14 @@ until [[ "$(adb shell getprop sys.boot_completed | tr -d '\r')" == "1" ]]; do
   sleep 1
 done
 
+dotnet restore "${PROJECT_PATH}" \
+  --framework "${TARGET_FRAMEWORK}" \
+  /p:AndroidSupportedAbis="${ANDROID_SUPPORTED_ABIS}"
+
 dotnet build "${PROJECT_PATH}" \
   --configuration "${CONFIGURATION}" \
   --framework "${TARGET_FRAMEWORK}" \
+  --no-restore \
   /p:AndroidSupportedAbis="${ANDROID_SUPPORTED_ABIS}" \
   /p:AndroidPackageFormat=apk \
   /p:TreatWarningsAsErrors=true

--- a/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionRedactor.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionRedactor.cs
@@ -125,6 +125,7 @@ public static partial class MobileExceptionRedactor
         var normalized = NormalizeKey(key);
         return normalized.Contains("token", StringComparison.Ordinal) ||
             normalized.Contains("apikey", StringComparison.Ordinal) ||
+            normalized.Contains("accesskey", StringComparison.Ordinal) ||
             normalized.Contains("authorization", StringComparison.Ordinal) ||
             normalized.Contains("credential", StringComparison.Ordinal) ||
             normalized.Contains("password", StringComparison.Ordinal) ||
@@ -178,10 +179,10 @@ public static partial class MobileExceptionRedactor
     [GeneratedRegex(@"\b(?<scheme>bearer|basic)\s+[A-Za-z0-9._~+/=-]+", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 250)]
     private static partial Regex BearerOrBasicRegex();
 
-    [GeneratedRegex(@"\b(?<key>access[_-]?token|refresh[_-]?token|token|api[_-]?key|apikey|password|passwd|secret|client[_-]?secret|credential)\b\s*[:=]\s*(?<quote>[""']?)[^\s,;&""']+(?<quote2>[""']?)", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 250)]
+    [GeneratedRegex(@"\b(?<key>access[_-]?token|refresh[_-]?token|token|x[_-]?api[_-]?key|api[_-]?key|apikey|access[_-]?key|accesskey|password|passwd|secret|client[_-]?secret|credential)\b\s*[:=]\s*(?<quote>[""']?)[^\s,;&""']+(?<quote2>[""']?)", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 250)]
     private static partial Regex SensitiveKeyValueRegex();
 
-    [GeneratedRegex(@"(?<prefix>[?&;](?:access[_-]?token|refresh[_-]?token|token|api[_-]?key|apikey|password|secret|client[_-]?secret|sig|signature|code|key)=)[^&#\s]+", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 250)]
+    [GeneratedRegex(@"(?<prefix>[?&;](?:access[_-]?token|refresh[_-]?token|token|x[_-]?api[_-]?key|api[_-]?key|apikey|access[_-]?key|accesskey|password|secret|client[_-]?secret|sig|signature|code|key)=)[^&#\s]+", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 250)]
     private static partial Regex SensitiveQueryStringRegex();
 
     [GeneratedRegex(@"\b(?<key>lat(?:itude)?|lon(?:gitude)?|lng)\s*[:=]\s*-?\d{1,3}(?:\.\d{4,})?\b", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 250)]

--- a/tests/Honua.Mobile.FieldCollection.Tests/DiagnosticRedactorTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/DiagnosticRedactorTests.cs
@@ -1,0 +1,37 @@
+using Honua.Mobile.FieldCollection.Services.Diagnostics;
+
+namespace Honua.Mobile.FieldCollection.Tests;
+
+public sealed class DiagnosticRedactorTests
+{
+    [Fact]
+    public void RedactJson_RedactsCommonSecretKeySpellings()
+    {
+        var redacted = DiagnosticRedactor.RedactJson(
+            """
+            {
+              "api_key": "api-secret",
+              "x-api-key": "header-secret",
+              "access-key": "access-secret",
+              "nested": { "Authorization": "Bearer auth-secret" },
+              "safe": "visible"
+            }
+            """);
+
+        Assert.Contains("visible", redacted);
+        Assert.Contains("[redacted]", redacted);
+        Assert.DoesNotContain("api-secret", redacted);
+        Assert.DoesNotContain("header-secret", redacted);
+        Assert.DoesNotContain("access-secret", redacted);
+        Assert.DoesNotContain("auth-secret", redacted);
+    }
+
+    [Fact]
+    public void RedactUrl_StripsCredentialsQueryAndFragment()
+    {
+        var redacted = DiagnosticRedactor.RedactUrl(
+            "https://user:pass@example.honua.test/path/to/layer?token=query-secret#fragment");
+
+        Assert.Equal("https://example.honua.test/path/to/layer", redacted);
+    }
+}

--- a/tests/Honua.Mobile.Maui.Tests/Diagnostics/MobileExceptionRedactorTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/Diagnostics/MobileExceptionRedactorTests.cs
@@ -7,13 +7,16 @@ public sealed class MobileExceptionRedactorTests
     [Fact]
     public void RedactText_RemovesTokensCredentialsAndPreciseCoordinates()
     {
-        var text = "GET https://alice:secret@example.test/sync?api_key=key-123&layer=sites Authorization: Bearer raw-token password=hunter2 lat=21.30691 lon=-157.85830";
+        var text = "GET https://alice:secret@example.test/sync?api_key=key-123&access-key=access-query&layer=sites Authorization: Bearer raw-token x-api-key=header-secret access_key=access-secret password=hunter2 lat=21.30691 lon=-157.85830";
 
         var redacted = MobileExceptionRedactor.RedactText(text, new MobileExceptionReportingOptions());
 
         Assert.NotNull(redacted);
         Assert.DoesNotContain("alice:secret", redacted);
         Assert.DoesNotContain("key-123", redacted);
+        Assert.DoesNotContain("access-query", redacted);
+        Assert.DoesNotContain("header-secret", redacted);
+        Assert.DoesNotContain("access-secret", redacted);
         Assert.DoesNotContain("raw-token", redacted);
         Assert.DoesNotContain("hunter2", redacted);
         Assert.DoesNotContain("21.30691", redacted);
@@ -28,6 +31,8 @@ public sealed class MobileExceptionRedactorTests
         var properties = new Dictionary<string, object?>
         {
             ["apiKey"] = "test-api-key",
+            ["x-api-key"] = "header-secret",
+            ["access-key"] = "access-secret",
             ["latitude"] = 21.3069,
             ["formPayload"] = "{\"owner\":\"Kai\"}",
             ["attachmentBytes"] = "raw-bytes",
@@ -37,6 +42,8 @@ public sealed class MobileExceptionRedactorTests
         var redacted = MobileExceptionRedactor.RedactProperties(properties, new MobileExceptionReportingOptions());
 
         Assert.Equal(MobileExceptionRedactor.RedactedValue, redacted["apiKey"]);
+        Assert.Equal(MobileExceptionRedactor.RedactedValue, redacted["x-api-key"]);
+        Assert.Equal(MobileExceptionRedactor.RedactedValue, redacted["access-key"]);
         Assert.Equal(MobileExceptionRedactor.PreciseLocationRedactedValue, redacted["latitude"]);
         Assert.Equal(MobileExceptionRedactor.FormPayloadRedactedValue, redacted["formPayload"]);
         Assert.Equal(MobileExceptionRedactor.AttachmentContentRedactedValue, redacted["attachmentBytes"]);


### PR DESCRIPTION
## Summary

Hardens mobile diagnostics redaction so exception reports and offline cache diagnostics cover additional common secret spellings and never preserve URL userinfo/query secrets in diagnostic source URLs.

## Details

- Redacts `x-api-key`, `access-key`, and `access_key` style values in shared mobile exception text and property redaction.
- Normalizes offline diagnostic JSON property names before sensitivity checks, so `api_key`, `x-api-key`, and `access-key` are treated as secrets.
- Strips URL username, password, query, and fragment from offline cache diagnostic URLs before display/reporting.
- Adds regression tests for shared exception redaction and field-collection diagnostic redaction.

## Offline Impact

Offline cache diagnostics still report the package/source path needed for support, but credentials and query string secrets are removed before diagnostic data is surfaced.

## Testing

- `git diff --check`

Local .NET test execution in the fresh PR worktree could not run because the test projects had no restored `project.assets.json`, and restoring the solution requires private Honua SDK packages from GitHub Packages. GitHub Actions should run the full suite with repo credentials.
