### PR TITLE
fix: gate unconfigured field sync

### DIFF
--- a/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/DiagnosticService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/DiagnosticService.cs
@@ -109,6 +109,7 @@ public class DiagnosticService
         var diagnostics = new SyncDiagnostics
         {
             IsSyncing = _syncService.IsSyncing,
+            IsRemoteSyncConfigured = _syncService.IsRemoteSyncConfigured,
             LastSyncTime = _syncService.LastSyncTime,
             PendingChanges = _syncService.PendingChangesCount,
             SyncStatus = _syncService.Status.ToString(),
@@ -370,6 +371,7 @@ public class ConnectivityDiagnostics
 public class SyncDiagnostics
 {
     public bool IsSyncing { get; set; }
+    public bool IsRemoteSyncConfigured { get; set; }
     public DateTime? LastSyncTime { get; set; }
     public int PendingChanges { get; set; }
     public string SyncStatus { get; set; } = string.Empty;

--- a/apps/Honua.Mobile.FieldCollection/Services/ISyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/ISyncService.cs
@@ -5,6 +5,7 @@ namespace Honua.Mobile.FieldCollection.Services;
 public interface ISyncService : INotifyPropertyChanged
 {
     bool IsSyncing { get; }
+    bool IsRemoteSyncConfigured { get; }
     DateTime? LastSyncTime { get; }
     SyncStatus Status { get; }
     int PendingChangesCount { get; }
@@ -109,6 +110,8 @@ public class SyncService : ISyncService
     private int _pendingChangesCount;
 
     public event PropertyChangedEventHandler? PropertyChanged;
+
+    public bool IsRemoteSyncConfigured => false;
 
     public bool IsSyncing
     {

--- a/apps/Honua.Mobile.FieldCollection/Services/Sync/FieldCollectionSyncTransports.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Sync/FieldCollectionSyncTransports.cs
@@ -3,7 +3,9 @@ using StorageChangeRecord = Honua.Mobile.FieldCollection.Services.Storage.Models
 
 namespace Honua.Mobile.FieldCollection.Services.Sync;
 
-internal sealed class QueuedFieldCollectionChangeUploader : IFieldCollectionChangeUploader
+internal sealed class QueuedFieldCollectionChangeUploader :
+    IFieldCollectionChangeUploader,
+    IFieldCollectionRemoteSyncCapability
 {
     private readonly ILogger<QueuedFieldCollectionChangeUploader>? _logger;
 
@@ -11,6 +13,8 @@ internal sealed class QueuedFieldCollectionChangeUploader : IFieldCollectionChan
     {
         _logger = logger;
     }
+
+    public bool IsRemoteSyncConfigured => false;
 
     public Task<bool> UploadChangeAsync(StorageChangeRecord change, CancellationToken cancellationToken = default)
     {
@@ -26,7 +30,9 @@ internal sealed class QueuedFieldCollectionChangeUploader : IFieldCollectionChan
     }
 }
 
-internal sealed class LocalOnlyFieldCollectionChangePuller : IFieldCollectionChangePuller
+internal sealed class LocalOnlyFieldCollectionChangePuller :
+    IFieldCollectionChangePuller,
+    IFieldCollectionRemoteSyncCapability
 {
     private readonly ILogger<LocalOnlyFieldCollectionChangePuller>? _logger;
 
@@ -34,6 +40,8 @@ internal sealed class LocalOnlyFieldCollectionChangePuller : IFieldCollectionCha
     {
         _logger = logger;
     }
+
+    public bool IsRemoteSyncConfigured => false;
 
     public Task<IReadOnlyList<ServerChange>> GetChangesAsync(
         long sinceGeneration,

--- a/apps/Honua.Mobile.FieldCollection/Services/Sync/GeoPackageSyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Sync/GeoPackageSyncService.cs
@@ -37,6 +37,14 @@ public interface IFieldCollectionChangePuller
 }
 
 /// <summary>
+/// Marks sync transports that intentionally do not connect to a remote field sync endpoint.
+/// </summary>
+public interface IFieldCollectionRemoteSyncCapability
+{
+    bool IsRemoteSyncConfigured { get; }
+}
+
+/// <summary>
 /// Real implementation of sync service with GeoPackage-based delta sync
 /// Implements last-write-wins conflict resolution with manual merge support
 /// </summary>
@@ -75,6 +83,8 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
     [ObservableProperty]
     private string? syncMessage;
 
+    public bool IsRemoteSyncConfigured { get; }
+
     public GeoPackageSyncService(
         GeoPackageStorageService storage,
         IAuthenticationService authService,
@@ -91,6 +101,9 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         _changePuller = changePuller ?? new UnconfiguredFieldCollectionChangePuller();
         _exceptionReporter = exceptionReporter ?? new NoOpMobileExceptionReporter();
         _logger = logger;
+        IsRemoteSyncConfigured =
+            IsConfiguredRemoteTransport(_changeUploader) &&
+            IsConfiguredRemoteTransport(_changePuller);
 
         // Update pending changes count periodically
         _pendingChangesTask = Task.Run(() => UpdatePendingChangesAsync(_pendingChangesCancellation.Token));
@@ -133,13 +146,10 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
 
     public async Task<SyncResult> SyncAsync()
     {
-        if (!await CanSyncAsync())
+        var unavailableReason = GetSyncUnavailableReason();
+        if (unavailableReason != null)
         {
-            return new SyncResult
-            {
-                IsSuccess = false,
-                ErrorMessage = "Cannot sync - check authentication and connectivity"
-            };
+            return SyncUnavailableResult("sync", unavailableReason);
         }
 
         await _syncLock.WaitAsync();
@@ -251,13 +261,10 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
 
     public async Task<SyncResult> PullChangesAsync()
     {
-        if (!await CanSyncAsync())
+        var unavailableReason = GetSyncUnavailableReason();
+        if (unavailableReason != null)
         {
-            return new SyncResult
-            {
-                IsSuccess = false,
-                ErrorMessage = "Cannot pull changes - check authentication and connectivity"
-            };
+            return SyncUnavailableResult("pull changes", unavailableReason);
         }
 
         await _syncLock.WaitAsync();
@@ -351,13 +358,10 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
 
     public async Task<SyncResult> PushChangesAsync()
     {
-        if (!await CanSyncAsync())
+        var unavailableReason = GetSyncUnavailableReason();
+        if (unavailableReason != null)
         {
-            return new SyncResult
-            {
-                IsSuccess = false,
-                ErrorMessage = "Cannot push changes - check authentication and connectivity"
-            };
+            return SyncUnavailableResult("push changes", unavailableReason);
         }
 
         await _syncLock.WaitAsync();
@@ -908,9 +912,40 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
 
     #region Helper Methods
 
-    private Task<bool> CanSyncAsync()
+    private static bool IsConfiguredRemoteTransport(object transport)
     {
-        return Task.FromResult(_connectivityService.IsConnected && _authService.IsAuthenticated);
+        return transport is not IFieldCollectionRemoteSyncCapability capability ||
+            capability.IsRemoteSyncConfigured;
+    }
+
+    private string? GetSyncUnavailableReason()
+    {
+        if (!IsRemoteSyncConfigured)
+        {
+            return "remote field sync is not configured";
+        }
+
+        if (!_connectivityService.IsConnected)
+        {
+            return "the device is offline";
+        }
+
+        if (!_authService.IsAuthenticated)
+        {
+            return "authentication is required";
+        }
+
+        return null;
+    }
+
+    private static SyncResult SyncUnavailableResult(string operation, string reason)
+    {
+        return new SyncResult
+        {
+            IsSuccess = false,
+            ErrorMessage = $"Cannot {operation} - {reason}",
+            CompletedAt = DateTime.UtcNow
+        };
     }
 
     public Task CancelSyncAsync()
@@ -955,8 +990,12 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
     #endregion
 }
 
-internal sealed class UnconfiguredFieldCollectionChangeUploader : IFieldCollectionChangeUploader
+internal sealed class UnconfiguredFieldCollectionChangeUploader :
+    IFieldCollectionChangeUploader,
+    IFieldCollectionRemoteSyncCapability
 {
+    public bool IsRemoteSyncConfigured => false;
+
     public Task<bool> UploadChangeAsync(StorageChangeRecord change, CancellationToken cancellationToken = default)
     {
         throw new InvalidOperationException(
@@ -964,8 +1003,12 @@ internal sealed class UnconfiguredFieldCollectionChangeUploader : IFieldCollecti
     }
 }
 
-internal sealed class UnconfiguredFieldCollectionChangePuller : IFieldCollectionChangePuller
+internal sealed class UnconfiguredFieldCollectionChangePuller :
+    IFieldCollectionChangePuller,
+    IFieldCollectionRemoteSyncCapability
 {
+    public bool IsRemoteSyncConfigured => false;
+
     public Task<IReadOnlyList<ServerChange>> GetChangesAsync(
         long sinceGeneration,
         CancellationToken cancellationToken = default)

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/BaseViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/BaseViewModel.cs
@@ -214,6 +214,12 @@ public partial class MainViewModel : BaseViewModel
     [RelayCommand]
     private async Task QuickSync()
     {
+        if (!_syncService.IsRemoteSyncConfigured)
+        {
+            await ShowError("Sync Not Configured", "Remote field sync is not configured for this app build. Pending changes remain on this device.");
+            return;
+        }
+
         if (!IsOnline)
         {
             await ShowError("No Connection", "Please check your internet connection and try again.");

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/SyncCenterViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/SyncCenterViewModel.cs
@@ -30,6 +30,12 @@ public partial class SyncCenterViewModel : BaseViewModel
     private bool isOnline;
 
     [ObservableProperty]
+    private bool isRemoteSyncConfigured;
+
+    [ObservableProperty]
+    private bool canRunSyncOperations;
+
+    [ObservableProperty]
     private SyncStatistics? lastSyncStatistics;
 
     [ObservableProperty]
@@ -64,10 +70,13 @@ public partial class SyncCenterViewModel : BaseViewModel
         // Subscribe to service events
         _syncService.PropertyChanged += OnSyncServicePropertyChanged;
         _connectivityService.ConnectivityChanged += OnConnectivityChanged;
+        _authService.PropertyChanged += OnAuthServicePropertyChanged;
 
         // Initialize properties
         UpdateFromSyncService();
         IsOnline = _connectivityService.IsConnected;
+        UpdateSyncActionState();
+        UpdateSyncStatusMessage();
     }
 
     private void OnSyncServicePropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -78,22 +87,49 @@ public partial class SyncCenterViewModel : BaseViewModel
     private void OnConnectivityChanged(object? sender, bool isConnected)
     {
         IsOnline = isConnected;
+        UpdateSyncActionState();
         UpdateSyncStatusMessage();
+    }
+
+    private void OnAuthServicePropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(IAuthenticationService.IsAuthenticated))
+        {
+            UpdateSyncActionState();
+            UpdateSyncStatusMessage();
+        }
     }
 
     private void UpdateFromSyncService()
     {
         IsSyncing = _syncService.IsSyncing;
+        IsRemoteSyncConfigured = _syncService.IsRemoteSyncConfigured;
         SyncStatus = _syncService.Status;
         PendingChangesCount = _syncService.PendingChangesCount;
         LastSyncTime = _syncService.LastSyncTime;
 
+        UpdateSyncActionState();
         UpdateSyncStatusMessage();
+    }
+
+    private void UpdateSyncActionState()
+    {
+        CanRunSyncOperations =
+            IsRemoteSyncConfigured &&
+            IsOnline &&
+            _authService.IsAuthenticated &&
+            !IsSyncing;
     }
 
     private void UpdateSyncStatusMessage()
     {
-        if (!IsOnline)
+        if (!IsRemoteSyncConfigured)
+        {
+            SyncStatusMessage = PendingChangesCount > 0
+                ? $"Remote sync not configured - {PendingChangesCount} changes remain on this device"
+                : "Remote sync not configured";
+        }
+        else if (!IsOnline)
         {
             SyncStatusMessage = "Offline - sync unavailable";
         }
@@ -131,6 +167,12 @@ public partial class SyncCenterViewModel : BaseViewModel
         if (IsSyncing)
         {
             await ShowMessage("Sync In Progress", "A sync operation is already running.");
+            return;
+        }
+
+        if (!IsRemoteSyncConfigured)
+        {
+            await ShowError("Sync Not Configured", "Remote field sync is not configured for this app build. Pending changes remain on this device.");
             return;
         }
 
@@ -209,6 +251,12 @@ public partial class SyncCenterViewModel : BaseViewModel
     [RelayCommand]
     private async Task PullChangesOnly()
     {
+        if (!IsRemoteSyncConfigured)
+        {
+            await ShowError("Sync Not Configured", "Remote field sync is not configured for this app build.");
+            return;
+        }
+
         if (!IsOnline || !_authService.IsAuthenticated)
         {
             await ShowError("Cannot Pull", "Please check your connection and authentication.");
@@ -232,6 +280,12 @@ public partial class SyncCenterViewModel : BaseViewModel
     [RelayCommand]
     private async Task PushChangesOnly()
     {
+        if (!IsRemoteSyncConfigured)
+        {
+            await ShowError("Sync Not Configured", "Remote field sync is not configured for this app build. Pending changes remain on this device.");
+            return;
+        }
+
         if (!IsOnline || !_authService.IsAuthenticated)
         {
             await ShowError("Cannot Push", "Please check your connection and authentication.");

--- a/apps/Honua.Mobile.FieldCollection/Views/SyncCenterPage.xaml
+++ b/apps/Honua.Mobile.FieldCollection/Views/SyncCenterPage.xaml
@@ -53,7 +53,7 @@
                             <Button Text="🔄"
                                     Style="{StaticResource BaseButtonStyle}"
                                     Command="{Binding StartFullSyncCommand}"
-                                    IsEnabled="{Binding IsSyncing, Converter={StaticResource InvertedBoolConverter}}"
+                                    IsEnabled="{Binding CanRunSyncOperations}"
                                     WidthRequest="60" />
 
                             <Button Text="⏹️"
@@ -81,13 +81,13 @@
                                     Text="⬇️ Pull Only"
                                     Style="{StaticResource SecondaryButtonStyle}"
                                     Command="{Binding PullChangesOnlyCommand}"
-                                    IsEnabled="{Binding IsOnline}" />
+                                    IsEnabled="{Binding CanRunSyncOperations}" />
 
                             <Button Grid.Column="1"
                                     Text="⬆️ Push Only"
                                     Style="{StaticResource SecondaryButtonStyle}"
                                     Command="{Binding PushChangesOnlyCommand}"
-                                    IsEnabled="{Binding IsOnline}" />
+                                    IsEnabled="{Binding CanRunSyncOperations}" />
                         </Grid>
 
                         <Label Text="⬇️ Pull: Download latest changes from server"

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -37,7 +37,7 @@ public sealed class GeoPackageSyncServiceTests
     }
 
     [Fact]
-    public async Task PushChangesAsync_WhenUsingQueuedProductionUploader_LeavesChangePendingWithoutConfigurationFailure()
+    public async Task PushChangesAsync_WhenUsingQueuedProductionUploader_ReturnsConfigurationFailureAndLeavesChangePending()
     {
         var databasePath = CreateDatabasePath();
         await using var cleanup = new DatabaseCleanup(databasePath);
@@ -51,13 +51,13 @@ public sealed class GeoPackageSyncServiceTests
         var result = await sync.PushChangesAsync();
 
         Assert.False(result.IsSuccess);
-        Assert.Contains("failed to upload", result.ErrorMessage);
-        Assert.DoesNotContain("not configured", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.False(sync.IsRemoteSyncConfigured);
+        Assert.Contains("remote field sync is not configured", result.ErrorMessage);
         Assert.Single(await storage.GetPendingChangesAsync());
     }
 
     [Fact]
-    public async Task PullChangesAsync_WhenUsingLocalOnlyProductionPuller_ReturnsSuccessWithoutRemoteChanges()
+    public async Task PullChangesAsync_WhenUsingLocalOnlyProductionPuller_ReturnsConfigurationFailure()
     {
         var databasePath = CreateDatabasePath();
         await using var cleanup = new DatabaseCleanup(databasePath);
@@ -69,8 +69,9 @@ public sealed class GeoPackageSyncServiceTests
 
         var result = await sync.PullChangesAsync();
 
-        Assert.True(result.IsSuccess);
-        Assert.Equal(0, result.ChangesPulled);
+        Assert.False(result.IsSuccess);
+        Assert.False(sync.IsRemoteSyncConfigured);
+        Assert.Contains("remote field sync is not configured", result.ErrorMessage);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add an explicit remote-sync capability flag to the field sync service
- mark queued/local-only/unconfigured transports as not remote-configured
- disable and guard Sync Center plus Quick Sync actions when remote sync is not configured
- expose the capability in sync diagnostics and adjust regression tests

## Validation
- `git diff --check`
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --filter FullyQualifiedName~GeoPackageSyncServiceTests --logger "console;verbosity=normal"` (blocked locally by GitHub Packages 403 for private `Honua.Sdk.*` packages)

Addresses the full-repo review finding that the FieldCollection app exposed server sync even when only local-only/queued transports are registered.