### PR TITLE
chore: remove example sibling sdk references

### DIFF
--- a/examples/field-data-collection/HonuaFieldCollector.csproj
+++ b/examples/field-data-collection/HonuaFieldCollector.csproj
@@ -70,11 +70,6 @@
     <PackageReference Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\sdk\react-native\packages\@honua\react-native-sdk\native\HonuaReactNative.csproj" Condition="Exists('..\..\..\sdk\react-native\packages\@honua\react-native-sdk\native\HonuaReactNative.csproj')" />
-    <ProjectReference Include="..\..\..\sdk\dotnet\Honua.Mobile.AR\Honua.Mobile.AR.csproj" Condition="Exists('..\..\..\sdk\dotnet\Honua.Mobile.AR\Honua.Mobile.AR.csproj')" />
-  </ItemGroup>
-
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
     <PackageReference Include="Xamarin.Google.Android.Maps" Version="18.2.0" />
     <PackageReference Include="Xamarin.GooglePlayServices.Location" Version="118.0.0.4" />

--- a/examples/shared/Honua.Mobile.SharedComponents.csproj
+++ b/examples/shared/Honua.Mobile.SharedComponents.csproj
@@ -44,10 +44,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\sdk\dotnet\Honua.Mobile.AR\Honua.Mobile.AR.csproj" Condition="Exists('..\..\..\sdk\dotnet\Honua.Mobile.AR\Honua.Mobile.AR.csproj')" />
-  </ItemGroup>
-
-  <ItemGroup>
     <MauiAsset Include="Resources\**" />
     <MauiFont Include="Fonts\**" />
     <MauiImage Include="Images\**" />


### PR DESCRIPTION
## Summary
- remove conditional sibling `sdk` ProjectReference hooks from the shared components example
- remove conditional sibling `sdk` ProjectReference hooks from the field collector example
- keep examples independent of local sibling checkout layout and aligned with package-consumption guidance

## Validation
- `rg -n "ProjectReference Include=\".*sdk|\.\./\.\./\.\./sdk" examples -S` (no matches)
- `git diff --check`

Addresses the full-repo review finding about long-lived sibling SDK ProjectReferences in examples.