### PR TITLE
feat: add embed framework wrapper entry points

### DIFF
--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -85,9 +85,10 @@ npm run cdn:manifest --prefix src/Honua.Embed
 
 `dist/cdn-manifest.json` lists the package name/version, default URLs, and
 top-level JavaScript files with byte size, SHA-256 hash, and SHA-384 SRI
-integrity. It covers `embed.js`, `index.js`, `iframe.js`, `snippets.js`, and
-top-level Vite chunks; Cesium runtime assets under `dist/cesium` are copied for
-hosting but are not expanded into the manifest.
+integrity. It covers core entries such as `embed.js`, `index.js`, `iframe.js`,
+and `snippets.js`, plus React/Vue wrapper entries and top-level Vite chunks;
+Cesium runtime assets under `dist/cesium` are copied for hosting but are not
+expanded into the manifest.
 The publish workflow uploads the built `dist/` directory as a CDN artifact so
 release operators can promote the static bundle separately from npm publishing.
 
@@ -344,6 +345,86 @@ const angularComponent = createHonuaMapAngularSnippet({
   selector: 'city-asset-map',
 });
 ```
+
+When teams want maintained wrapper entry points instead of generated source,
+import the optional peer packages directly from the `@honua-io/embed` subpaths.
+The wrappers bind typed props/events to the underlying custom elements and keep
+the core package framework-agnostic. The Angular subpath is partial-compiled for
+Angular application builds and should be processed by the Angular linker in the
+host application.
+
+```tsx
+import { HonuaMap, HonuaMapBuilder } from '@honua-io/embed/react';
+
+export function CityAssetEmbed() {
+  return (
+    <>
+      <HonuaMap
+        serviceUrl="https://services.honua.example/FeatureServer"
+        layerIds={['assets', 'work-orders']}
+        search
+        identify
+        label="City asset map"
+        themeStyle={{ accent: '#0f766e' }}
+        onIdentify={(detail) => console.log(detail.x, detail.y)}
+      />
+      <HonuaMapBuilder
+        serviceUrl="https://services.honua.example/FeatureServer"
+        target="web-component"
+        onChange={(detail) => console.log(detail.state.issues)}
+      />
+    </>
+  );
+}
+```
+
+```vue
+<script setup lang="ts">
+import { HonuaMap } from '@honua-io/embed/vue';
+
+const layerIds = ['assets', 'work-orders'];
+</script>
+
+<template>
+  <HonuaMap
+    service-url="https://services.honua.example/FeatureServer"
+    :layer-ids="layerIds"
+    search
+    identify
+    label="City asset map"
+    @config-change="(config) => console.log(config.zoom)"
+  />
+</template>
+```
+
+```ts
+import { Component } from '@angular/core';
+import { HonuaMapComponent } from '@honua-io/embed/angular';
+
+@Component({
+  selector: 'city-asset-map',
+  standalone: true,
+  imports: [HonuaMapComponent],
+  template: `
+    <honua-map-wrapper
+      [serviceUrl]="'https://services.honua.example/FeatureServer'"
+      [layerIds]="['assets', 'work-orders']"
+      [search]="true"
+      [identify]="true"
+      [label]="'City asset map'"
+      (identifyEvent)="handleIdentify($event)">
+    </honua-map-wrapper>
+  `,
+})
+export class CityAssetMapComponent {
+  handleIdentify(detail: { x: number; y: number }) {
+    console.log(detail.x, detail.y);
+  }
+}
+```
+
+Use the wrapper `themeStyle` prop for Honua CSS custom properties. Framework
+native `style` bindings remain available for host layout concerns.
 
 ## Integration Events
 

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -260,11 +260,12 @@ npm run cdn:manifest
 
 The manifest records the package name/version, default CDN URLs, and each
 top-level JavaScript entry's byte size, SHA-256 hash, and SHA-384 SRI value. It
-includes `embed.js`, `index.js`, `iframe.js`, `snippets.js`, and top-level Vite
-chunks, but does not enumerate the copied Cesium asset tree. Use the manifest
-entry for the hosted script when emitting CDN snippets. The publish workflow
-also uploads the built `dist/` directory as a CDN artifact for operators that
-promote static assets separately from the npm package.
+includes core entries such as `embed.js`, `index.js`, `iframe.js`, and
+`snippets.js`, plus React/Vue wrapper entries and top-level Vite chunks. It does
+not enumerate the copied Cesium asset tree. Use the manifest entry for the
+hosted script when emitting CDN snippets. The publish workflow also uploads the
+built `dist/` directory as a CDN artifact for operators that promote static
+assets separately from the npm package.
 
 ```ts
 const manifest = await fetch('https://cdn.honua.dev/cdn-manifest.json').then((response) => response.json());
@@ -390,6 +391,88 @@ const angularIframeComponent = createHonuaMapAngularIframeSnippet({
   parentOrigin: 'https://portal.example.com',
 });
 ```
+
+Framework hosts that want package entry points instead of generated source can
+import typed wrappers from `@honua-io/embed/react`, `@honua-io/embed/vue`, or
+`@honua-io/embed/angular`. React, Vue, and Angular are optional peer
+dependencies and are not bundled into the core custom element entrypoint. The
+Angular subpath is partial-compiled for Angular application builds and should be
+processed by the Angular linker in the host application.
+
+```tsx
+import { HonuaMap, HonuaMapBuilder } from '@honua-io/embed/react';
+
+export function AssetMap() {
+  return (
+    <>
+      <HonuaMap
+        serviceUrl="https://services.honua.example/FeatureServer"
+        layerIds={['assets', 'work-orders']}
+        search
+        identify
+        label="City asset map"
+        themeStyle={{ accent: '#0f766e' }}
+        onSearch={(detail) => console.log(detail.query)}
+      />
+      <HonuaMapBuilder
+        serviceUrl="https://services.honua.example/FeatureServer"
+        target="cdn"
+        scriptUrl="https://cdn.honua.dev/embed.js"
+        onChange={(detail) => console.log(detail.state.snippet)}
+      />
+    </>
+  );
+}
+```
+
+```vue
+<script setup lang="ts">
+import { HonuaMap } from '@honua-io/embed/vue';
+
+const layers = ['assets', 'work-orders'];
+</script>
+
+<template>
+  <HonuaMap
+    service-url="https://services.honua.example/FeatureServer"
+    :layer-ids="layers"
+    search
+    identify
+    label="City asset map"
+    @search="(detail) => console.log(detail.query)"
+  />
+</template>
+```
+
+```ts
+import { Component } from '@angular/core';
+import { HonuaMapComponent } from '@honua-io/embed/angular';
+
+@Component({
+  selector: 'asset-map',
+  standalone: true,
+  imports: [HonuaMapComponent],
+  template: `
+    <honua-map-wrapper
+      [serviceUrl]="'https://services.honua.example/FeatureServer'"
+      [layerIds]="['assets', 'work-orders']"
+      [search]="true"
+      [identify]="true"
+      [label]="'City asset map'"
+      (searchEvent)="handleSearch($event)">
+    </honua-map-wrapper>
+  `,
+})
+export class AssetMapComponent {
+  handleSearch(detail: { query: string }) {
+    console.log(detail.query);
+  }
+}
+```
+
+The wrapper prop names follow the typed embed option shape. Use `themeStyle` for
+Honua CSS custom properties so framework-native `style` bindings remain
+available for layout.
 
 Use `applyHonuaMapOptions(element, options)` to apply the same options shape to
 an existing map element at runtime.

--- a/src/Honua.Embed/package-lock.json
+++ b/src/Honua.Embed/package-lock.json
@@ -16,10 +16,373 @@
         "maplibre-gl": "^5.24.0"
       },
       "devDependencies": {
+        "@angular/compiler": "^21.2.12",
+        "@angular/compiler-cli": "^21.2.12",
+        "@angular/core": "^21.2.12",
+        "@types/react": "^19.2.14",
         "happy-dom": "^20.0.10",
+        "react": "^19.2.6",
+        "rxjs": "^7.8.2",
         "typescript": "^6.0.3",
         "vite": "^8.0.11",
-        "vitest": "^4.0.15"
+        "vitest": "^4.0.15",
+        "vue": "^3.5.34",
+        "zone.js": "^0.16.2"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=17 <22",
+        "react": ">=18 <20",
+        "vue": ">=3.4 <4"
+      },
+      "peerDependenciesMeta": {
+        "@angular/core": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular/compiler": {
+      "version": "21.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.12.tgz",
+      "integrity": "sha512-246iBwMAVGzrYPqu/Wwzb9L/kt+dkT12Hllr/dYZu6aHeIxaHPRZoPBKSweAgOPXeOl+q+nlPtK34glsMb1CRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@angular/compiler-cli": {
+      "version": "21.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.2.12.tgz",
+      "integrity": "sha512-YQ15Yp2OWBS1NnzZH77HLH1ZDn+/A5Mc1EobKl4CX8dYUEPIB/KwmGKLaKtbJ0KNcVsDlmsTTWodRgqe2n5erw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "7.29.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14",
+        "chokidar": "^5.0.0",
+        "convert-source-map": "^1.5.1",
+        "reflect-metadata": "^0.2.0",
+        "semver": "^7.0.0",
+        "tslib": "^2.3.0",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "ng-xi18n": "bundles/src/bin/ng_xi18n.js",
+        "ngc": "bundles/src/bin/ngc.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler": "21.2.12",
+        "typescript": ">=5.9 <6.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular/compiler-cli/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@angular/core": {
+      "version": "21.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.12.tgz",
+      "integrity": "sha512-wcD6tzE30nwg58KmAU19347Jf/1F/vFg2CEd9Qcu5cA1Z4s3umzvaqs/7988ne4HaS4iJEpvTbRvGss7EYZEfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler": "21.2.12",
+        "rxjs": "^6.5.3 || ^7.4.0",
+        "zone.js": "~0.15.0 || ~0.16.0"
+      },
+      "peerDependenciesMeta": {
+        "@angular/compiler": {
+          "optional": true
+        },
+        "zone.js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cesium/engine": {
@@ -173,12 +536,55 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@loaders.gl/core": {
       "version": "4.4.1",
@@ -864,6 +1270,16 @@
       "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@types/supercluster": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
@@ -1010,6 +1426,129 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
+      "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@vue/shared": "3.5.34",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
+      "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.34",
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
+      "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@vue/compiler-core": "3.5.34",
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.14",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
+      "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
+      "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
+      "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.34",
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
+      "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.34",
+        "@vue/runtime-core": "3.5.34",
+        "@vue/shared": "3.5.34",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
+      "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34"
+      },
+      "peerDependencies": {
+        "vue": "3.5.34"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
+      "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@zip.js/zip.js": {
       "version": "2.8.26",
       "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.26.tgz",
@@ -1019,6 +1558,19 @@
         "bun": ">=0.7.0",
         "deno": ">=1.0.0",
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -1102,11 +1654,79 @@
         "pnpm": ">=10.10.0"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bitmap-sdf": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.4.tgz",
       "integrity": "sha512-1G3U4n5JE6RAiALMxu0p1XmeZkTeCwGKykzsLTCqVzfSDaN6S7fKnkIkfejogz+iwqBWc0UYAIKnKHNN7pSfDg==",
       "license": "MIT"
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/cesium": {
       "version": "1.141.0",
@@ -1165,6 +1785,37 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/color-convert": {
@@ -1236,6 +1887,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1267,6 +1943,20 @@
       "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
       "license": "ISC"
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.354",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.354.tgz",
+      "integrity": "sha512-JaBHwWcfIdmSAfWM5l3uwjGd431j8YEMikZ+K/2nXVuBqJKyZ0f+2h4n4JY5AyNiZmnY9qQr2RU3v9DxDmHMNg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/entities": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
@@ -1286,6 +1976,16 @@
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -1363,6 +2063,39 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gl-matrix": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
@@ -1402,6 +2135,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsep": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
@@ -1409,6 +2149,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/json-bignum": {
@@ -1424,6 +2177,19 @@
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
       "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/kdbush": {
       "version": "4.0.2",
@@ -1716,6 +2482,16 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1787,6 +2563,13 @@
       "integrity": "sha512-siX3YCG7N2HnmN1xMH3cK4JkUZJhbkhRFJL+G5N1vH0mh1t5088rJknIoqDFWDIU6NPGvRRgLnYW3ZHjSMEBLA==",
       "license": "MIT"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/murmurhash-js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
@@ -1811,6 +2594,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nosleep.js": {
       "version": "0.12.0",
@@ -1944,6 +2734,37 @@
         "quickselect": "^3.0.0"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/resolve-protobuf-schema": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
@@ -1993,6 +2814,29 @@
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -2023,6 +2867,40 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/supercluster": {
       "version": "8.0.1",
@@ -2156,6 +3034,37 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
     },
     "node_modules/urijs": {
       "version": "1.19.11",
@@ -2331,6 +3240,28 @@
         }
       }
     },
+    "node_modules/vue": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
+      "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-sfc": "3.5.34",
+        "@vue/runtime-dom": "3.5.34",
+        "@vue/server-renderer": "3.5.34",
+        "@vue/shared": "3.5.34"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -2367,6 +3298,37 @@
         "node": ">=12.17"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -2388,6 +3350,58 @@
           "optional": true
         }
       }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/zone.js": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.2.tgz",
+      "integrity": "sha512-Eky7p2Z1Ig3NnbfodSPoARCjKBSTFMnE/ACsP1L/XJEfY4SdOFce19BsUCWVwL6K5ABZFy5J3bjcMWffX+YM3Q==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/src/Honua.Embed/package.json
+++ b/src/Honua.Embed/package.json
@@ -26,6 +26,18 @@
     "./iframe": {
       "types": "./dist/iframe.d.ts",
       "import": "./dist/iframe.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js"
+    },
+    "./vue": {
+      "types": "./dist/vue.d.ts",
+      "import": "./dist/vue.js"
+    },
+    "./angular": {
+      "types": "./dist/angular/angular.d.ts",
+      "import": "./dist/angular/angular.js"
     }
   },
   "files": [
@@ -33,7 +45,8 @@
     "README.md"
   ],
   "scripts": {
-    "build": "vite build && tsc -p tsconfig.json --emitDeclarationOnly && node scripts/copy-cesium-assets.mjs",
+    "build": "vite build && tsc -p tsconfig.json --emitDeclarationOnly && npm run build:angular && node scripts/copy-cesium-assets.mjs",
+    "build:angular": "ngc -p tsconfig.angular.json && node scripts/bundle-angular-entry.mjs",
     "cdn:manifest": "node scripts/create-cdn-manifest.mjs",
     "prepack": "npm run build && npm run cdn:manifest",
     "test": "vitest run",
@@ -49,11 +62,35 @@
     "gis"
   ],
   "license": "Apache-2.0",
+  "peerDependencies": {
+    "@angular/core": ">=17 <22",
+    "react": ">=18 <20",
+    "vue": ">=3.4 <4"
+  },
+  "peerDependenciesMeta": {
+    "@angular/core": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "vue": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@angular/compiler": "^21.2.12",
+    "@angular/compiler-cli": "^21.2.12",
+    "@angular/core": "^21.2.12",
+    "@types/react": "^19.2.14",
     "happy-dom": "^20.0.10",
+    "react": "^19.2.6",
+    "rxjs": "^7.8.2",
     "typescript": "^6.0.3",
     "vite": "^8.0.11",
-    "vitest": "^4.0.15"
+    "vitest": "^4.0.15",
+    "vue": "^3.5.34",
+    "zone.js": "^0.16.2"
   },
   "dependencies": {
     "@deck.gl/core": "^9.3.2",

--- a/src/Honua.Embed/scripts/bundle-angular-entry.mjs
+++ b/src/Honua.Embed/scripts/bundle-angular-entry.mjs
@@ -1,0 +1,35 @@
+import { rename, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'vite';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const angularDist = join(packageRoot, 'dist', 'angular');
+const entryPath = join(angularDist, 'angular.js');
+const bundleDist = join(angularDist, '.bundle');
+const bundlePath = join(bundleDist, 'angular.js');
+
+await rm(bundleDist, { recursive: true, force: true });
+
+await build({
+  configFile: false,
+  logLevel: 'silent',
+  build: {
+    emptyOutDir: true,
+    lib: {
+      entry: entryPath,
+      formats: ['es'],
+      fileName: () => 'angular.js',
+    },
+    minify: false,
+    outDir: bundleDist,
+    rollupOptions: {
+      external: (id) => id.startsWith('@angular/'),
+    },
+    sourcemap: false,
+    target: 'es2022',
+  },
+});
+
+await rename(bundlePath, entryPath);
+await rm(bundleDist, { recursive: true, force: true });

--- a/src/Honua.Embed/src/angular.ts
+++ b/src/Honua.Embed/src/angular.ts
@@ -1,0 +1,237 @@
+import {
+  Component,
+  CUSTOM_ELEMENTS_SCHEMA,
+  ElementRef,
+  EventEmitter,
+  Input,
+  NgModule,
+  Output,
+  ViewChild,
+  type AfterViewInit,
+  type OnChanges,
+  type OnDestroy,
+} from '@angular/core';
+import type { HonuaMapBuilderChangeDetail, HonuaMapBuilderElement } from './builder-element';
+import type { HonuaMapBuilderLayerOption } from './builder';
+import type {
+  HonuaMapBuilderWrapperOptions,
+  HonuaMapWrapperOptions,
+} from './framework';
+import {
+  addHonuaMapBuilderElementEventListeners,
+  addHonuaMapElementEventListeners,
+  applyHonuaMapBuilderElementOptions,
+  applyHonuaMapElementOptions,
+} from './framework';
+import type {
+  HonuaMapBounds,
+  HonuaMapConfig,
+  HonuaMapCoordinate,
+  HonuaMapElement,
+  HonuaMapIdentifyDetail,
+  HonuaMapSearchDetail,
+} from './map';
+import type { HonuaMapEmbedBuilderTarget, HonuaMapThemeOptions } from './snippets';
+
+@Component({
+  selector: 'honua-map-wrapper',
+  standalone: true,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  template: '<honua-map #element><ng-content /></honua-map>',
+})
+export class HonuaMapComponent implements AfterViewInit, OnChanges, OnDestroy {
+  @ViewChild('element', { static: true })
+  elementRef?: ElementRef<HonuaMapElement>;
+
+  @Input() serviceUrl: string | null | undefined = undefined;
+  @Input() layerIds: readonly string[] | null | undefined = undefined;
+  @Input() apiKey: string | null | undefined = undefined;
+  @Input() center: HonuaMapCoordinate | null | undefined = undefined;
+  @Input() zoom: number | null | undefined = undefined;
+  @Input() bounds: HonuaMapBounds | null | undefined = undefined;
+  @Input() basemap: string | null | undefined = undefined;
+  @Input() interactive: boolean | null | undefined = undefined;
+  @Input() search: boolean | null | undefined = undefined;
+  @Input() identify: boolean | null | undefined = undefined;
+  @Input() attribution: string | null | undefined = undefined;
+  @Input() theme: 'light' | 'dark' | null | undefined = undefined;
+  @Input() label: string | null | undefined = undefined;
+  @Input() themeStyle: HonuaMapThemeOptions | null | undefined = undefined;
+
+  @Output() readonly ready = new EventEmitter<HonuaMapConfig>();
+  @Output() readonly configChange = new EventEmitter<HonuaMapConfig>();
+  @Output() readonly searchEvent = new EventEmitter<HonuaMapSearchDetail>();
+  @Output() readonly identifyEvent = new EventEmitter<HonuaMapIdentifyDetail>();
+
+  #viewReady = false;
+  #disconnect = noop;
+
+  ngAfterViewInit(): void {
+    this.#viewReady = true;
+    const element = this.elementRef?.nativeElement;
+    if (!element) {
+      return;
+    }
+
+    this.#disconnect = addHonuaMapElementEventListeners(element, {
+      ready: (detail) => this.ready.emit(detail),
+      configChange: (detail) => this.configChange.emit(detail),
+      search: (detail) => this.searchEvent.emit(detail),
+      identify: (detail) => this.identifyEvent.emit(detail),
+    });
+    this.#apply();
+  }
+
+  ngOnChanges(): void {
+    this.#apply();
+  }
+
+  ngOnDestroy(): void {
+    this.#disconnect();
+  }
+
+  #apply(): void {
+    if (!this.#viewReady || !this.elementRef?.nativeElement) {
+      return;
+    }
+
+    applyHonuaMapElementOptions(this.elementRef.nativeElement, this.options);
+  }
+
+  get element(): HonuaMapElement | null {
+    return this.elementRef?.nativeElement ?? null;
+  }
+
+  get options(): HonuaMapWrapperOptions {
+    return {
+      serviceUrl: this.serviceUrl,
+      layerIds: this.layerIds,
+      apiKey: this.apiKey,
+      center: this.center,
+      zoom: this.zoom,
+      bounds: this.bounds,
+      basemap: this.basemap,
+      interactive: this.interactive,
+      search: this.search,
+      identify: this.identify,
+      attribution: this.attribution,
+      theme: this.theme,
+      label: this.label,
+      themeStyle: this.themeStyle,
+    };
+  }
+}
+
+@Component({
+  selector: 'honua-map-builder-wrapper',
+  standalone: true,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  template: '<honua-map-builder #element></honua-map-builder>',
+})
+export class HonuaMapBuilderComponent implements AfterViewInit, OnChanges, OnDestroy {
+  @ViewChild('element', { static: true })
+  elementRef?: ElementRef<HonuaMapBuilderElement>;
+
+  @Input() serviceUrl: string | null | undefined = undefined;
+  @Input() availableLayers: readonly HonuaMapBuilderLayerOption[] | null | undefined = undefined;
+  @Input() selectedLayerIds: readonly string[] | null | undefined = undefined;
+  @Input() layerIds: readonly string[] | null | undefined = undefined;
+  @Input() apiKey: string | null | undefined = undefined;
+  @Input() center: HonuaMapCoordinate | null | undefined = undefined;
+  @Input() zoom: number | null | undefined = undefined;
+  @Input() bounds: HonuaMapBounds | null | undefined = undefined;
+  @Input() basemap: string | null | undefined = undefined;
+  @Input() interactive: boolean | null | undefined = undefined;
+  @Input() search: boolean | null | undefined = undefined;
+  @Input() identify: boolean | null | undefined = undefined;
+  @Input() attribution: string | null | undefined = undefined;
+  @Input() theme: 'light' | 'dark' | null | undefined = undefined;
+  @Input() label: string | null | undefined = undefined;
+  @Input() themeStyle: HonuaMapThemeOptions | null | undefined = undefined;
+  @Input() target: HonuaMapEmbedBuilderTarget | null | undefined = undefined;
+  @Input() elementName: string | null | undefined = undefined;
+  @Input() includeCredentials: boolean | null | undefined = undefined;
+  @Input() scriptUrl: string | null | undefined = undefined;
+  @Input() iframeUrl: string | null | undefined = undefined;
+  @Input() parentOrigin: string | null | undefined = undefined;
+
+  @Output() readonly builderChange = new EventEmitter<HonuaMapBuilderChangeDetail>();
+
+  #viewReady = false;
+  #disconnect = noop;
+
+  ngAfterViewInit(): void {
+    this.#viewReady = true;
+    const element = this.elementRef?.nativeElement;
+    if (!element) {
+      return;
+    }
+
+    this.#disconnect = addHonuaMapBuilderElementEventListeners(element, {
+      change: (detail) => this.builderChange.emit(detail),
+    });
+    this.#apply();
+  }
+
+  ngOnChanges(): void {
+    this.#apply();
+  }
+
+  ngOnDestroy(): void {
+    this.#disconnect();
+  }
+
+  #apply(): void {
+    if (!this.#viewReady || !this.elementRef?.nativeElement) {
+      return;
+    }
+
+    applyHonuaMapBuilderElementOptions(this.elementRef.nativeElement, this.options);
+  }
+
+  get element(): HonuaMapBuilderElement | null {
+    return this.elementRef?.nativeElement ?? null;
+  }
+
+  get options(): HonuaMapBuilderWrapperOptions {
+    return {
+      serviceUrl: this.serviceUrl,
+      availableLayers: this.availableLayers,
+      selectedLayerIds: this.selectedLayerIds,
+      layerIds: this.layerIds,
+      apiKey: this.apiKey,
+      center: this.center,
+      zoom: this.zoom,
+      bounds: this.bounds,
+      basemap: this.basemap,
+      interactive: this.interactive,
+      search: this.search,
+      identify: this.identify,
+      attribution: this.attribution,
+      theme: this.theme,
+      label: this.label,
+      themeStyle: this.themeStyle,
+      target: this.target,
+      elementName: this.elementName,
+      includeCredentials: this.includeCredentials,
+      scriptUrl: this.scriptUrl,
+      iframeUrl: this.iframeUrl,
+      parentOrigin: this.parentOrigin,
+    };
+  }
+}
+
+@NgModule({
+  imports: [HonuaMapComponent, HonuaMapBuilderComponent],
+  exports: [HonuaMapComponent, HonuaMapBuilderComponent],
+})
+export class HonuaEmbedModule {
+}
+
+function noop(): void {
+}
+
+export type {
+  HonuaMapBuilderWrapperOptions,
+  HonuaMapWrapperOptions,
+} from './framework';

--- a/src/Honua.Embed/src/framework.ts
+++ b/src/Honua.Embed/src/framework.ts
@@ -1,0 +1,197 @@
+import {
+  type HonuaMapBuilderChangeDetail,
+  HonuaMapBuilderElement,
+  defineHonuaMapBuilderElement,
+} from './builder-element';
+import type { HonuaMapBuilderInput } from './builder';
+import { canDefineHonuaCustomElements } from './dom';
+import {
+  type HonuaMapConfig,
+  type HonuaMapElement,
+  type HonuaMapIdentifyDetail,
+  type HonuaMapSearchDetail,
+  defineHonuaMapElement,
+} from './map';
+import {
+  applyHonuaMapOptions,
+  type HonuaMapEmbedBuilderTarget,
+  type HonuaMapEmbedOptions,
+  type HonuaMapThemeOptions,
+} from './snippets';
+
+export type HonuaElementEventHandler<TDetail> = (
+  detail: TDetail,
+  event: CustomEvent<TDetail>,
+) => void;
+
+export interface HonuaFrameworkElementNames {
+  map?: string;
+  mapBuilder?: string;
+}
+
+export interface HonuaMapWrapperOptions extends Omit<HonuaMapEmbedOptions, 'style'> {
+  themeStyle?: HonuaMapThemeOptions | null;
+}
+
+export interface HonuaMapBuilderWrapperOptions extends Omit<HonuaMapBuilderInput, 'style'> {
+  themeStyle?: HonuaMapThemeOptions | null;
+  target?: HonuaMapEmbedBuilderTarget | null;
+  elementName?: string | null;
+  includeCredentials?: boolean | null;
+  scriptUrl?: string | null;
+  iframeUrl?: string | null;
+  parentOrigin?: string | null;
+}
+
+export interface HonuaMapElementEventHandlers {
+  ready?: HonuaElementEventHandler<HonuaMapConfig>;
+  configChange?: HonuaElementEventHandler<HonuaMapConfig>;
+  search?: HonuaElementEventHandler<HonuaMapSearchDetail>;
+  identify?: HonuaElementEventHandler<HonuaMapIdentifyDetail>;
+}
+
+export interface HonuaMapBuilderElementEventHandlers {
+  change?: HonuaElementEventHandler<HonuaMapBuilderChangeDetail>;
+}
+
+export function defineHonuaFrameworkElements(names: HonuaFrameworkElementNames = {}): void {
+  if (!canDefineHonuaCustomElements()) {
+    return;
+  }
+
+  defineHonuaMapElement(names.map);
+  defineHonuaMapBuilderElement(names.mapBuilder);
+}
+
+export function applyHonuaMapElementOptions(
+  element: HTMLElement,
+  options: HonuaMapWrapperOptions,
+): void {
+  defineHonuaFrameworkElements();
+  applyHonuaMapOptions(element, toDeclarativeMapOptions(options));
+}
+
+export function applyHonuaMapBuilderElementOptions(
+  element: HonuaMapBuilderElement,
+  options: HonuaMapBuilderWrapperOptions,
+): void {
+  defineHonuaFrameworkElements();
+  const {
+    target,
+    elementName,
+    includeCredentials,
+    scriptUrl,
+    iframeUrl,
+    parentOrigin,
+    themeStyle,
+    ...builderInput
+  } = options;
+
+  setOptionalAttribute(element, 'target', target);
+  setOptionalAttribute(element, 'element-name', elementName);
+  setBooleanAttribute(element, 'include-credentials', includeCredentials);
+  setOptionalAttribute(element, 'script-url', scriptUrl);
+  setOptionalAttribute(element, 'iframe-url', iframeUrl);
+  setOptionalAttribute(element, 'parent-origin', parentOrigin);
+  element.value = {
+    ...builderInput,
+    style: themeStyle,
+  };
+}
+
+export function addHonuaMapElementEventListeners(
+  element: HonuaMapElement,
+  handlers: HonuaMapElementEventHandlers,
+): () => void {
+  return combineCleanups([
+    addCustomEventListener(element, 'honua-map-ready', handlers.ready),
+    addCustomEventListener(element, 'honua-map-config-change', handlers.configChange),
+    addCustomEventListener(element, 'honua-map-search', handlers.search),
+    addCustomEventListener(element, 'honua-map-identify', handlers.identify),
+  ]);
+}
+
+export function addHonuaMapBuilderElementEventListeners(
+  element: HonuaMapBuilderElement,
+  handlers: HonuaMapBuilderElementEventHandlers,
+): () => void {
+  return addCustomEventListener(element, 'honua-map-builder-change', handlers.change);
+}
+
+function addCustomEventListener<TDetail>(
+  element: HTMLElement,
+  eventName: string,
+  handler: HonuaElementEventHandler<TDetail> | null | undefined,
+): () => void {
+  if (!handler) {
+    return noop;
+  }
+
+  const listener: EventListener = (event) => {
+    handler((event as CustomEvent<TDetail>).detail, event as CustomEvent<TDetail>);
+  };
+  element.addEventListener(eventName, listener);
+  return () => element.removeEventListener(eventName, listener);
+}
+
+function combineCleanups(cleanups: ReadonlyArray<() => void>): () => void {
+  return () => {
+    for (const cleanup of cleanups) {
+      cleanup();
+    }
+  };
+}
+
+function noop(): void {
+}
+
+function setOptionalAttribute(
+  element: HTMLElement,
+  name: string,
+  value: string | null | undefined,
+): void {
+  if (value === null || value === undefined || value === '') {
+    element.removeAttribute(name);
+    return;
+  }
+
+  element.setAttribute(name, value);
+}
+
+function setBooleanAttribute(
+  element: HTMLElement,
+  name: string,
+  value: boolean | null | undefined,
+): void {
+  if (value === true) {
+    element.setAttribute(name, '');
+    return;
+  }
+
+  if (value === false || value === null || value === undefined) {
+    element.removeAttribute(name);
+  }
+}
+
+function toDeclarativeMapOptions(options: HonuaMapWrapperOptions): HonuaMapEmbedOptions {
+  return {
+    serviceUrl: optionalToNull(options.serviceUrl),
+    layerIds: optionalToNull(options.layerIds),
+    apiKey: optionalToNull(options.apiKey),
+    center: optionalToNull(options.center),
+    zoom: optionalToNull(options.zoom),
+    bounds: optionalToNull(options.bounds),
+    basemap: optionalToNull(options.basemap),
+    interactive: optionalToNull(options.interactive),
+    search: optionalToNull(options.search),
+    identify: optionalToNull(options.identify),
+    attribution: optionalToNull(options.attribution),
+    theme: optionalToNull(options.theme),
+    label: optionalToNull(options.label),
+    style: optionalToNull(options.themeStyle),
+  };
+}
+
+function optionalToNull<TValue>(value: TValue | null | undefined): TValue | null {
+  return value === undefined ? null : value;
+}

--- a/src/Honua.Embed/src/react.ts
+++ b/src/Honua.Embed/src/react.ts
@@ -1,0 +1,247 @@
+"use client";
+
+import {
+  createElement,
+  forwardRef,
+  useEffect,
+  useRef,
+  type CSSProperties,
+  type ForwardedRef,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
+import type { HonuaMapBuilderChangeDetail, HonuaMapBuilderElement } from './builder-element';
+import type {
+  HonuaElementEventHandler,
+  HonuaMapBuilderWrapperOptions,
+  HonuaMapWrapperOptions,
+} from './framework';
+import {
+  addHonuaMapBuilderElementEventListeners,
+  addHonuaMapElementEventListeners,
+  applyHonuaMapBuilderElementOptions,
+  applyHonuaMapElementOptions,
+} from './framework';
+import type {
+  HonuaMapConfig,
+  HonuaMapElement,
+  HonuaMapIdentifyDetail,
+  HonuaMapSearchDetail,
+} from './map';
+
+type HonuaNativeElementProps = Omit<
+  HTMLAttributes<HTMLElement>,
+  'children' | 'onChange' | 'onSearch' | 'style'
+>;
+
+export interface HonuaMapProps extends HonuaMapWrapperOptions, HonuaNativeElementProps {
+  children?: ReactNode;
+  style?: CSSProperties;
+  onReady?: HonuaElementEventHandler<HonuaMapConfig>;
+  onConfigChange?: HonuaElementEventHandler<HonuaMapConfig>;
+  onSearch?: HonuaElementEventHandler<HonuaMapSearchDetail>;
+  onIdentify?: HonuaElementEventHandler<HonuaMapIdentifyDetail>;
+}
+
+export interface HonuaMapBuilderProps extends HonuaMapBuilderWrapperOptions, HonuaNativeElementProps {
+  style?: CSSProperties;
+  onChange?: HonuaElementEventHandler<HonuaMapBuilderChangeDetail>;
+}
+
+export const HonuaMap = forwardRef<HonuaMapElement, HonuaMapProps>(function HonuaMap(
+  props,
+  forwardedRef,
+) {
+  const {
+    serviceUrl,
+    layerIds,
+    apiKey,
+    center,
+    zoom,
+    bounds,
+    basemap,
+    interactive,
+    search,
+    identify,
+    attribution,
+    theme,
+    label,
+    themeStyle,
+    onReady,
+    onConfigChange,
+    onSearch,
+    onIdentify,
+    children,
+    ...nativeProps
+  } = props;
+  const elementRef = useRef<HonuaMapElement | null>(null);
+  const readyObservedRef = useRef(false);
+
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element) {
+      return undefined;
+    }
+
+    return addHonuaMapElementEventListeners(element, {
+      ready: onReady ? (detail, event) => {
+        readyObservedRef.current = true;
+        onReady(detail, event);
+      } : undefined,
+      configChange: onConfigChange,
+      search: onSearch,
+      identify: onIdentify,
+    });
+  });
+
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element) {
+      return;
+    }
+
+    applyHonuaMapElementOptions(element, {
+      serviceUrl,
+      layerIds,
+      apiKey,
+      center,
+      zoom,
+      bounds,
+      basemap,
+      interactive,
+      search,
+      identify,
+      attribution,
+      theme,
+      label,
+      themeStyle,
+    });
+    redispatchMissedMapReady(element, readyObservedRef, onReady !== undefined);
+  });
+
+  return createElement('honua-map', {
+    ...nativeProps,
+    ref: assignElementRef(elementRef, forwardedRef),
+  }, children);
+});
+
+export const HonuaMapBuilder = forwardRef<HonuaMapBuilderElement, HonuaMapBuilderProps>(
+  function HonuaMapBuilder(props, forwardedRef) {
+    const {
+      serviceUrl,
+      availableLayers,
+      selectedLayerIds,
+      layerIds,
+      apiKey,
+      center,
+      zoom,
+      bounds,
+      basemap,
+      interactive,
+      search,
+      identify,
+      attribution,
+      theme,
+      label,
+      themeStyle,
+      target,
+      elementName,
+      includeCredentials,
+      scriptUrl,
+      iframeUrl,
+      parentOrigin,
+      onChange,
+      ...nativeProps
+    } = props;
+    const elementRef = useRef<HonuaMapBuilderElement | null>(null);
+
+    useEffect(() => {
+      const element = elementRef.current;
+      if (!element) {
+        return undefined;
+      }
+
+      return addHonuaMapBuilderElementEventListeners(element, {
+        change: onChange,
+      });
+    });
+
+    useEffect(() => {
+      const element = elementRef.current;
+      if (!element) {
+        return;
+      }
+
+      applyHonuaMapBuilderElementOptions(element, {
+        serviceUrl,
+        availableLayers,
+        selectedLayerIds,
+        layerIds,
+        apiKey,
+        center,
+        zoom,
+        bounds,
+        basemap,
+        interactive,
+        search,
+        identify,
+        attribution,
+        theme,
+        label,
+        themeStyle,
+        target,
+        elementName,
+        includeCredentials,
+        scriptUrl,
+        iframeUrl,
+        parentOrigin,
+      });
+    });
+
+    return createElement('honua-map-builder', {
+      ...nativeProps,
+      ref: assignElementRef(elementRef, forwardedRef),
+    });
+  },
+);
+
+function assignElementRef<TElement>(
+  localRef: { current: TElement | null },
+  forwardedRef: ForwardedRef<TElement>,
+): (element: TElement | null) => void {
+  return (element) => {
+    localRef.current = element;
+
+    if (typeof forwardedRef === 'function') {
+      forwardedRef(element);
+      return;
+    }
+
+    if (forwardedRef) {
+      forwardedRef.current = element;
+    }
+  };
+}
+
+function redispatchMissedMapReady(
+  element: HonuaMapElement,
+  readyObservedRef: { current: boolean },
+  hasReadyHandler: boolean,
+): void {
+  if (!hasReadyHandler || readyObservedRef.current) {
+    return;
+  }
+
+  readyObservedRef.current = true;
+  element.dispatchEvent(new CustomEvent<HonuaMapConfig>('honua-map-ready', {
+    bubbles: true,
+    composed: true,
+    detail: element.config,
+  }));
+}
+
+export type {
+  HonuaElementEventHandler,
+  HonuaMapBuilderWrapperOptions,
+  HonuaMapWrapperOptions,
+} from './framework';

--- a/src/Honua.Embed/src/vue.ts
+++ b/src/Honua.Embed/src/vue.ts
@@ -1,0 +1,199 @@
+import {
+  defineComponent,
+  h,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+  type PropType,
+} from 'vue';
+import type { HonuaMapBuilderChangeDetail, HonuaMapBuilderElement } from './builder-element';
+import type { HonuaMapBuilderWrapperOptions, HonuaMapWrapperOptions } from './framework';
+import {
+  addHonuaMapBuilderElementEventListeners,
+  addHonuaMapElementEventListeners,
+  applyHonuaMapBuilderElementOptions,
+  applyHonuaMapElementOptions,
+} from './framework';
+import type {
+  HonuaMapBounds,
+  HonuaMapConfig,
+  HonuaMapCoordinate,
+  HonuaMapElement,
+  HonuaMapIdentifyDetail,
+  HonuaMapSearchDetail,
+} from './map';
+import type { HonuaMapBuilderLayerOption } from './builder';
+import type { HonuaMapEmbedBuilderTarget, HonuaMapThemeOptions } from './snippets';
+
+export type HonuaVueMapReadyHandler = (
+  detail: HonuaMapConfig,
+  event: CustomEvent<HonuaMapConfig>,
+) => void;
+export type HonuaVueMapConfigChangeHandler = HonuaVueMapReadyHandler;
+export type HonuaVueMapSearchHandler = (
+  detail: HonuaMapSearchDetail,
+  event: CustomEvent<HonuaMapSearchDetail>,
+) => void;
+export type HonuaVueMapIdentifyHandler = (
+  detail: HonuaMapIdentifyDetail,
+  event: CustomEvent<HonuaMapIdentifyDetail>,
+) => void;
+export type HonuaVueMapBuilderChangeHandler = (
+  detail: HonuaMapBuilderChangeDetail,
+  event: CustomEvent<HonuaMapBuilderChangeDetail>,
+) => void;
+
+interface HonuaVueMapProps extends HonuaMapWrapperOptions {
+}
+
+interface HonuaVueMapBuilderProps extends HonuaMapBuilderWrapperOptions {
+}
+
+const mapProps = {
+  serviceUrl: { type: String as PropType<string | null>, default: undefined },
+  layerIds: { type: Array as PropType<readonly string[] | null>, default: undefined },
+  apiKey: { type: String as PropType<string | null>, default: undefined },
+  center: { type: Object as PropType<HonuaMapCoordinate | null>, default: undefined },
+  zoom: { type: Number as PropType<number | null>, default: undefined },
+  bounds: { type: Object as PropType<HonuaMapBounds | null>, default: undefined },
+  basemap: { type: String as PropType<string | null>, default: undefined },
+  interactive: { type: Boolean as PropType<boolean | null>, default: undefined },
+  search: { type: Boolean as PropType<boolean | null>, default: undefined },
+  identify: { type: Boolean as PropType<boolean | null>, default: undefined },
+  attribution: { type: String as PropType<string | null>, default: undefined },
+  theme: { type: String as PropType<'light' | 'dark' | null>, default: undefined },
+  label: { type: String as PropType<string | null>, default: undefined },
+  themeStyle: { type: Object as PropType<HonuaMapThemeOptions | null>, default: undefined },
+};
+
+const builderProps = {
+  ...mapProps,
+  availableLayers: {
+    type: Array as PropType<readonly HonuaMapBuilderLayerOption[] | null>,
+    default: undefined,
+  },
+  selectedLayerIds: { type: Array as PropType<readonly string[] | null>, default: undefined },
+  target: { type: String as PropType<HonuaMapEmbedBuilderTarget | null>, default: undefined },
+  elementName: { type: String as PropType<string | null>, default: undefined },
+  includeCredentials: { type: Boolean as PropType<boolean | null>, default: undefined },
+  scriptUrl: { type: String as PropType<string | null>, default: undefined },
+  iframeUrl: { type: String as PropType<string | null>, default: undefined },
+  parentOrigin: { type: String as PropType<string | null>, default: undefined },
+};
+
+export const HonuaMap = defineComponent({
+  name: 'HonuaMap',
+  inheritAttrs: false,
+  props: mapProps,
+  emits: ['ready', 'config-change', 'search', 'identify'],
+  setup(props, { attrs, emit, expose, slots }) {
+    const element = ref<HonuaMapElement | null>(null);
+    let disconnect = noop;
+
+    const apply = () => {
+      if (element.value) {
+        applyHonuaMapElementOptions(element.value, mapOptionsFromProps(props));
+      }
+    };
+
+    onMounted(() => {
+      if (!element.value) {
+        return;
+      }
+
+      disconnect = addHonuaMapElementEventListeners(element.value, {
+        ready: (detail, event) => emit('ready', detail, event),
+        configChange: (detail, event) => emit('config-change', detail, event),
+        search: (detail, event) => emit('search', detail, event),
+        identify: (detail, event) => emit('identify', detail, event),
+      });
+      apply();
+    });
+    onBeforeUnmount(() => disconnect());
+    watch(props, apply, { deep: true });
+    expose({ element });
+
+    return () => h('honua-map', {
+      ...attrs,
+      ref: element,
+    }, slots.default?.());
+  },
+});
+
+export const HonuaMapBuilder = defineComponent({
+  name: 'HonuaMapBuilder',
+  inheritAttrs: false,
+  props: builderProps,
+  emits: ['change'],
+  setup(props, { attrs, emit, expose }) {
+    const element = ref<HonuaMapBuilderElement | null>(null);
+    let disconnect = noop;
+
+    const apply = () => {
+      if (element.value) {
+        applyHonuaMapBuilderElementOptions(element.value, builderOptionsFromProps(props));
+      }
+    };
+
+    onMounted(() => {
+      if (!element.value) {
+        return;
+      }
+
+      disconnect = addHonuaMapBuilderElementEventListeners(element.value, {
+        change: (detail, event) => emit('change', detail, event),
+      });
+      apply();
+    });
+    onBeforeUnmount(() => disconnect());
+    watch(props, apply, { deep: true });
+    expose({ element });
+
+    return () => h('honua-map-builder', {
+      ...attrs,
+      ref: element,
+    });
+  },
+});
+
+function mapOptionsFromProps(props: Readonly<HonuaVueMapProps>): HonuaMapWrapperOptions {
+  return {
+    serviceUrl: props.serviceUrl,
+    layerIds: props.layerIds,
+    apiKey: props.apiKey,
+    center: props.center,
+    zoom: props.zoom,
+    bounds: props.bounds,
+    basemap: props.basemap,
+    interactive: props.interactive,
+    search: props.search,
+    identify: props.identify,
+    attribution: props.attribution,
+    theme: props.theme,
+    label: props.label,
+    themeStyle: props.themeStyle,
+  };
+}
+
+function builderOptionsFromProps(props: Readonly<HonuaVueMapBuilderProps>): HonuaMapBuilderWrapperOptions {
+  return {
+    ...mapOptionsFromProps(props),
+    availableLayers: props.availableLayers,
+    selectedLayerIds: props.selectedLayerIds,
+    target: props.target,
+    elementName: props.elementName,
+    includeCredentials: props.includeCredentials,
+    scriptUrl: props.scriptUrl,
+    iframeUrl: props.iframeUrl,
+    parentOrigin: props.parentOrigin,
+  };
+}
+
+function noop(): void {
+}
+
+export type {
+  HonuaMapBuilderWrapperOptions,
+  HonuaMapWrapperOptions,
+} from './framework';

--- a/src/Honua.Embed/tests/honua-framework.test.ts
+++ b/src/Honua.Embed/tests/honua-framework.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import type { HonuaMapBuilderElement } from '../src/builder-element';
+import {
+  addHonuaMapBuilderElementEventListeners,
+  addHonuaMapElementEventListeners,
+  applyHonuaMapBuilderElementOptions,
+  applyHonuaMapElementOptions,
+  defineHonuaFrameworkElements,
+} from '../src/framework';
+import type { HonuaMapElement, HonuaMapSearchDetail } from '../src/map';
+
+describe('framework wrapper bindings', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    defineHonuaFrameworkElements();
+  });
+
+  it('applies typed map wrapper options to the custom element', () => {
+    const element = document.createElement('honua-map') as HonuaMapElement;
+    document.body.append(element);
+
+    applyHonuaMapElementOptions(element, {
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      layerIds: ['assets', 'work-orders'],
+      apiKey: 'public-browser-key',
+      center: { latitude: 21.3069, longitude: -157.8583 },
+      zoom: 12,
+      basemap: 'dark',
+      interactive: true,
+      search: true,
+      identify: false,
+      label: 'City asset map',
+      themeStyle: {
+        accent: '#0f766e',
+      },
+    });
+
+    expect(element.getAttribute('service-url')).toBe('https://services.example.test/FeatureServer');
+    expect(element.getAttribute('layer-ids')).toBe('assets,work-orders');
+    expect(element.getAttribute('api-key')).toBe('public-browser-key');
+    expect(element.getAttribute('center')).toBe('21.3069,-157.8583');
+    expect(element.getAttribute('zoom')).toBe('12');
+    expect(element.getAttribute('basemap')).toBe('dark');
+    expect(element.hasAttribute('interactive')).toBe(true);
+    expect(element.hasAttribute('search')).toBe(true);
+    expect(element.hasAttribute('identify')).toBe(false);
+    expect(element.getAttribute('label')).toBe('City asset map');
+    expect(element.style.getPropertyValue('--honua-map-accent')).toBe('#0f766e');
+  });
+
+  it('clears map wrapper options when props are removed', () => {
+    const element = document.createElement('honua-map') as HonuaMapElement;
+    document.body.append(element);
+
+    applyHonuaMapElementOptions(element, {
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      search: true,
+      label: 'City asset map',
+      themeStyle: {
+        accent: '#0f766e',
+      },
+    });
+    applyHonuaMapElementOptions(element, {});
+
+    expect(element.hasAttribute('service-url')).toBe(false);
+    expect(element.hasAttribute('search')).toBe(false);
+    expect(element.hasAttribute('label')).toBe(false);
+    expect(element.style.getPropertyValue('--honua-map-accent')).toBe('');
+  });
+
+  it('wires map custom events to typed handlers', () => {
+    const element = document.createElement('honua-map') as HonuaMapElement;
+    const observed: HonuaMapSearchDetail[] = [];
+    const disconnect = addHonuaMapElementEventListeners(element, {
+      search: (detail) => observed.push(detail),
+    });
+    const detail: HonuaMapSearchDetail = {
+      query: 'hydrant',
+      config: element.config,
+    };
+
+    element.dispatchEvent(new CustomEvent('honua-map-search', { detail }));
+    disconnect();
+    element.dispatchEvent(new CustomEvent('honua-map-search', { detail }));
+
+    expect(observed).toEqual([detail]);
+  });
+
+  it('applies typed builder wrapper options to the builder element', () => {
+    const element = document.createElement('honua-map-builder') as HonuaMapBuilderElement;
+    document.body.append(element);
+
+    applyHonuaMapBuilderElementOptions(element, {
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      availableLayers: [
+        { id: 'assets', label: 'Assets', defaultSelected: true },
+        { id: 'work-orders', label: 'Work orders' },
+      ],
+      selectedLayerIds: ['assets'],
+      target: 'cdn',
+      elementName: 'city-asset-map',
+      includeCredentials: true,
+      scriptUrl: 'https://cdn.example.test/embed.js',
+      themeStyle: {
+        accent: '#0f766e',
+      },
+    });
+
+    expect(element.getAttribute('target')).toBe('cdn');
+    expect(element.getAttribute('element-name')).toBe('city-asset-map');
+    expect(element.hasAttribute('include-credentials')).toBe(true);
+    expect(element.getAttribute('script-url')).toBe('https://cdn.example.test/embed.js');
+    expect(element.value.serviceUrl).toBe('https://services.example.test/FeatureServer');
+    expect(element.value.selectedLayerIds).toEqual(['assets']);
+    expect(element.availableLayers.map((layer) => layer.id)).toEqual(['assets', 'work-orders']);
+    expect(element.state.snippet).toContain('https://cdn.example.test/embed.js');
+  });
+
+  it('wires builder custom events to typed handlers', () => {
+    const element = document.createElement('honua-map-builder') as HonuaMapBuilderElement;
+    document.body.append(element);
+    const observed: string[] = [];
+    const disconnect = addHonuaMapBuilderElementEventListeners(element, {
+      change: (detail) => observed.push(detail.target),
+    });
+
+    applyHonuaMapBuilderElementOptions(element, {
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      target: 'iframe',
+    });
+    disconnect();
+    applyHonuaMapBuilderElementOptions(element, {
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      target: 'cdn',
+    });
+
+    expect(observed).toContain('iframe');
+    expect(observed).not.toContain('cdn');
+  });
+
+  it('exports framework adapter entry points', async () => {
+    const [react, vue, angular] = await Promise.all([
+      import('../src/react'),
+      import('../src/vue'),
+      import('../src/angular'),
+    ]);
+
+    expect(react.HonuaMap).toBeTruthy();
+    expect(react.HonuaMapBuilder).toBeTruthy();
+    expect(vue.HonuaMap.name).toBe('HonuaMap');
+    expect(vue.HonuaMapBuilder.name).toBe('HonuaMapBuilder');
+    expect(angular.HonuaMapComponent).toBeTypeOf('function');
+    expect(angular.HonuaMapBuilderComponent).toBeTypeOf('function');
+    expect(angular.HonuaEmbedModule).toBeTypeOf('function');
+  });
+});

--- a/src/Honua.Embed/tests/honua-ssr.test.ts
+++ b/src/Honua.Embed/tests/honua-ssr.test.ts
@@ -19,4 +19,19 @@ describe('server-side package imports', () => {
 
     expect(() => defineHonuaMapElement()).toThrow(/requires a browser DOM/);
   });
+
+  it('can import framework wrapper entry points without browser globals', async () => {
+    expect(globalThis.document).toBeUndefined();
+    expect(globalThis.HTMLElement).toBeUndefined();
+
+    const [react, vue, angular] = await Promise.all([
+      import('../src/react'),
+      import('../src/vue'),
+      import('../src/angular'),
+    ]);
+
+    expect(react.HonuaMap).toBeTruthy();
+    expect(vue.HonuaMap.name).toBe('HonuaMap');
+    expect(angular.HonuaEmbedModule).toBeTypeOf('function');
+  });
 });

--- a/src/Honua.Embed/tsconfig.angular.json
+++ b/src/Honua.Embed/tsconfig.angular.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": false,
+    "outDir": "dist/angular",
+    "sourceMap": false
+  },
+  "angularCompilerOptions": {
+    "compilationMode": "partial",
+    "strictTemplates": true
+  },
+  "files": ["src/angular.ts"],
+  "include": []
+}

--- a/src/Honua.Embed/tsconfig.json
+++ b/src/Honua.Embed/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["DOM", "ES2022"],
     "declaration": true,
     "declarationMap": true,
+    "experimentalDecorators": true,
     "sourceMap": true,
     "outDir": "dist",
     "rootDir": "src",

--- a/src/Honua.Embed/vite.config.ts
+++ b/src/Honua.Embed/vite.config.ts
@@ -7,12 +7,15 @@ export default defineConfig({
       entry: {
         index: resolve(__dirname, 'src/index.ts'),
         iframe: resolve(__dirname, 'src/iframe.ts'),
+        react: resolve(__dirname, 'src/react.ts'),
         snippets: resolve(__dirname, 'src/snippets.ts'),
+        vue: resolve(__dirname, 'src/vue.ts'),
       },
       formats: ['es'],
       fileName: (_format, entryName) => `${entryName}.js`,
     },
     rollupOptions: {
+      external: ['react', 'vue'],
       output: {
         assetFileNames: '[name][extname]',
         chunkFileNames: '[name]-[hash].js',


### PR DESCRIPTION
## Summary
- add React, Vue, and Angular wrapper entry points for `<honua-map>` and `<honua-map-builder>`
- share typed DOM binding helpers so wrappers apply existing embed/builder options and custom events
- publish subpath exports, optional peer deps, build entries, and docs/examples for framework hosts

## Validation
- `git diff --check`
- `npm run typecheck --prefix src/Honua.Embed`
- `npm test --prefix src/Honua.Embed`
- `npm run build --prefix src/Honua.Embed`
- `npm run cdn:manifest --prefix src/Honua.Embed`
- `node -e "import('@angular/compiler').then(() => import('./dist/angular/angular.js')).then((m)=>console.log(Object.keys(m).sort().join(',')))"` from `src/Honua.Embed`
- `node -e "import('./src/Honua.Embed/dist/react.js').then((m)=>console.log(Object.keys(m).sort().join(',')))"`
- `node -e "import('./src/Honua.Embed/dist/vue.js').then((m)=>console.log(Object.keys(m).sort().join(',')))"`

Refs #10