### PR TITLE
docs: FieldCollection design handoff bundle for Claude Design

### DIFF
--- a/docs/design-handoff/README.md
+++ b/docs/design-handoff/README.md
@@ -1,0 +1,38 @@
+# Honua FieldCollection - Design Handoff
+
+This bundle is a self-contained snapshot of the FieldCollection mobile UI surface, prepared so that Claude Design (or any other design reviewer) can audit layout, hierarchy, and design-token usage without needing to build the .NET MAUI project.
+
+Everything here was extracted from the live XAML in `apps/Honua.Mobile.FieldCollection/` plus the customer-facing starter template in `templates/honua-fieldcollector/`. No screenshots are included; each page is reconstructed as a static HTML mock that uses the real design tokens (CSS custom properties) so visual fidelity matches the app's intent.
+
+## Pages in this bundle
+
+| Folder | Page | Purpose | Primary actions | Key ViewModel |
+| --- | --- | --- | --- | --- |
+| `shell/` | `AppShell` | Bottom tab navigation host | Switch between Map / Records / Sync / Settings | (Shell, no VM) |
+| `main/` | `MainPage` | Dashboard / landing card with status + quick actions | Quick-sync, jump to Map/Records/Settings | `MainViewModel` |
+| `map/` | `MapPage` | Map view with layer picker and capture overlay | Zoom to me, zoom to features, add feature, pick layer | `MapViewModel` |
+| `records/` | `RecordsPage` | Filterable feature list per layer | Search, filter pending, view/edit/delete records, FAB create | `RecordsViewModel` |
+| `sync-center/` | `SyncCenterPage` | Sync state, statistics, conflicts, history, offline diagnostics | Full sync, pull-only, push-only, resolve / review conflicts | `SyncCenterViewModel` |
+| `settings/` | `SettingsPage` | Account, preferences, device info, developer & danger zones | Sign out, toggle preferences, adjust sliders, reset app | `SettingsViewModel` |
+| `template-starter/` | `MainPage` (template) | Customer-facing starter template for new FieldCollector apps | Collect tab (form), Map tab, Stats tab | (code-behind only) |
+
+## What's in each subfolder
+
+- `notes.md` - purpose, primary actions, key controls, bindings, navigation in / out.
+- `mock.html` - standalone HTML/CSS mock (390x844 mobile viewport, single file, no JS). Open it directly in a browser.
+- `xaml-source.md` - the original XAML for that page in a fenced code block, for reference.
+
+## Top-level files
+
+- `tokens.md` / `tokens.json` - the full design system extracted from `Resources/Styles/Colors.xaml`, `Resources/Styles/Styles.xaml`, and the inline styles in `App.xaml`. Includes colors, type ramp, spacing, radius, and elevation tokens.
+- `questions.md` - specific open UX questions for Mike, grounded in the current XAML.
+- `feedback-loop.md` - how Claude Design feedback flows back into the codebase (which XAML file maps to which mock, where to update tokens, and the PR convention).
+
+## How to import into Claude Design
+
+1. In Claude Design, create a new project for "Honua FieldCollection".
+2. Upload the entire `docs/design-handoff/` folder as the project source. All paths in this bundle are relative, so the folder is self-contained.
+3. Use the `README.md` (this file) as the project overview, `tokens.md` as the design-system reference, and each page subfolder as a separate review surface.
+4. When proposing changes, edit the relevant `mock.html` and, in parallel, mark which XAML file in `apps/Honua.Mobile.FieldCollection/Views/` needs to change (see `feedback-loop.md` for the convention).
+
+> Note: emojis appear in the mocks only where they appear in the original XAML (icons baked into button text, status badges, section headers). The bundle adds none.

--- a/docs/design-handoff/feedback-loop.md
+++ b/docs/design-handoff/feedback-loop.md
@@ -1,0 +1,34 @@
+# Feedback loop
+
+How Claude Design's feedback flows back into the codebase.
+
+## Mock to XAML mapping
+
+| Mock | Source XAML to edit |
+| --- | --- |
+| `shell/mock.html` | `apps/Honua.Mobile.FieldCollection/AppShell.xaml` |
+| `main/mock.html` | `apps/Honua.Mobile.FieldCollection/Views/MainPage.xaml` |
+| `map/mock.html` | `apps/Honua.Mobile.FieldCollection/Views/MapPage.xaml` |
+| `records/mock.html` | `apps/Honua.Mobile.FieldCollection/Views/RecordsPage.xaml` |
+| `sync-center/mock.html` | `apps/Honua.Mobile.FieldCollection/Views/SyncCenterPage.xaml` |
+| `settings/mock.html` | `apps/Honua.Mobile.FieldCollection/Views/SettingsPage.xaml` |
+| `template-starter/mock.html` | `templates/honua-fieldcollector/MainPage.xaml` |
+
+## Tokens to source
+
+- Color tokens live in `apps/Honua.Mobile.FieldCollection/Resources/Styles/Colors.xaml`. Renames cascade to every `{StaticResource <Token>}` reference.
+- Typography, spacing, control defaults (Switch / Slider / SearchBar / etc.) live in `apps/Honua.Mobile.FieldCollection/Resources/Styles/Styles.xaml`.
+- App-wide button / card / header styles (`BaseButtonStyle`, `SecondaryButtonStyle`, `DangerButtonStyle`, `PageTitleStyle`, `SectionHeaderStyle`, `CardFrameStyle`) are inline in `apps/Honua.Mobile.FieldCollection/App.xaml`.
+- Shell-level theming is in `apps/Honua.Mobile.FieldCollection/AppShell.xaml` (`BaseStyle`).
+
+## Change convention
+
+For each Claude Design proposal:
+
+1. Edit the relevant `mock.html` in this folder to show the proposed UI.
+2. In the same PR, edit the matching XAML file from the table above. If a token changes, update `Colors.xaml` / `Styles.xaml` / `App.xaml` and let the cascade do the rest - do not hardcode hex values in the page XAML.
+3. Update `tokens.md` and `tokens.json` if the design system itself shifted.
+4. PR title format: `mobile(design): <page> - <one-line summary>`. Include both the mock screenshot/preview and a screenshot of the running MAUI app (Android or iOS) so reviewers can compare.
+5. If the proposal answers one of the items in `questions.md`, remove or strike that item in the same PR.
+
+Keep the mock and the XAML in lockstep: a mock that ships without the matching XAML edit (or vice versa) is a drift bug.

--- a/docs/design-handoff/main/mock.html
+++ b/docs/design-handoff/main/mock.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>MainPage - Honua FieldCollection</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+  :root {
+    --color-primary: #2E8B57;
+    --color-primary-dark: #1F5F3F;
+    --color-secondary: #3F51B5;
+    --color-tertiary: #FF5722;
+    --color-info: #2196F3;
+    --color-warning: #FF9800;
+    --color-danger: #F44336;
+    --color-danger-light: #FFEBEE;
+    --color-success: #4CAF50;
+    --color-white: #FFFFFF;
+    --color-gray-100: #F5F5F5;
+    --color-gray-200: #EEEEEE;
+    --color-gray-300: #E0E0E0;
+    --color-gray-400: #BDBDBD;
+    --color-gray-500: #9E9E9E;
+    --color-gray-600: #757575;
+    --color-on-surface: #212121;
+    --color-background: #FFFFFF;
+    --color-surface: #FAFAFA;
+    --color-status-bar: #1F5F3F;
+    --radius-sm: 8px;
+    --radius-md: 10px;
+    --radius-lg: 12px;
+    --shadow-common: 0 2px 8px rgba(0,0,0,0.16);
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; background: var(--color-gray-200); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; color: var(--color-on-surface); }
+  body { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .device { width: 390px; height: 844px; background: var(--color-background); border-radius: 32px; box-shadow: 0 24px 64px rgba(0,0,0,0.25); overflow: hidden; display: grid; grid-template-rows: 28px 56px 1fr 64px; }
+  .status-bar { background: var(--color-status-bar); color: var(--color-white); font-size: 11px; display: flex; justify-content: space-between; align-items: center; padding: 0 18px; }
+  .nav-bar { background: var(--color-primary); color: var(--color-white); display: flex; align-items: center; padding: 0 16px; font-size: 17px; font-weight: 700; }
+  main { background: var(--color-background); overflow-y: auto; padding: 0 30px; }
+  .stack { display: flex; flex-direction: column; gap: 25px; padding: 16px 0 24px 0; }
+  .card { background: var(--color-white); border: 1px solid var(--color-gray-200); border-radius: var(--radius-sm); padding: 16px; box-shadow: var(--shadow-common); }
+  .page-title { font-size: 32px; font-weight: 700; color: var(--color-primary); margin: 0 0 16px 0; }
+  .section-header { font-size: 18px; font-weight: 700; color: var(--color-primary); margin: 0; }
+  .subtitle { color: var(--color-gray-600); font-size: 16px; margin: 0; }
+  .status-strip { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px; margin-top: 10px; }
+  .status-tile { border: 1px solid var(--color-primary); border-radius: var(--radius-sm); padding: 10px 5px; text-align: center; }
+  .status-tile .glyph { font-size: 24px; }
+  .status-tile .value { font-size: 16px; font-weight: 700; }
+  .status-tile .value-sm { font-size: 12px; font-weight: 700; }
+  .status-tile .caption { font-size: 10px; }
+  .status-online { color: var(--color-success); }
+  .grid-2x2 { display: grid; grid-template-columns: 1fr 1fr; grid-template-rows: 1fr 1fr; gap: 15px; }
+  .btn { border: 0; cursor: pointer; padding: 12px 16px; border-radius: var(--radius-sm); font-size: 16px; color: var(--color-white); font-family: inherit; }
+  .btn-primary { background: var(--color-primary); }
+  .btn-secondary { background: var(--color-secondary); }
+  .btn-danger { background: var(--color-tertiary); }
+  .btn-disabled { opacity: 0.55; }
+  .warn-text { color: var(--color-warning); font-weight: 700; font-size: 16px; }
+  .offline-card { background: var(--color-warning); color: var(--color-white); border-radius: var(--radius-sm); padding: 16px; }
+  .offline-card .title { font-size: 16px; font-weight: 700; }
+  .offline-card .desc { font-size: 14px; margin-top: 5px; }
+  .tab-bar { background: var(--color-primary); color: var(--color-white); display: grid; grid-template-columns: repeat(4,1fr); }
+  .tab-bar .tab { display: flex; flex-direction: column; align-items: center; justify-content: center; font-size: 11px; gap: 4px; color: var(--color-gray-300); }
+  .tab-bar .tab.active { color: var(--color-white); font-weight: 700; }
+  .tab-bar .glyph { width: 22px; height: 22px; border-radius: 6px; background: rgba(255,255,255,0.15); display: inline-flex; align-items: center; justify-content: center; font-size: 12px; }
+</style>
+</head>
+<body>
+  <div class="device">
+    <header class="status-bar"><span>9:41</span><span>FieldCollection</span><span>100%</span></header>
+    <nav class="nav-bar">Honua Field Collection</nav>
+    <main>
+      <div class="stack">
+        <section class="card">
+          <h1 class="page-title">Welcome, Mike</h1>
+          <p class="subtitle">Your mobile field data collection companion</p>
+          <div class="status-strip">
+            <div class="status-tile">
+              <div class="glyph">🌐</div>
+              <div class="value-sm status-online">Online</div>
+            </div>
+            <div class="status-tile">
+              <div class="glyph">📝</div>
+              <div class="value">3</div>
+              <div class="caption">Pending</div>
+            </div>
+            <div class="status-tile">
+              <div class="glyph">🔄</div>
+              <div class="value-sm">09:14</div>
+              <div class="caption">Last Sync</div>
+            </div>
+          </div>
+        </section>
+
+        <h2 class="section-header">Quick Actions</h2>
+        <div class="grid-2x2">
+          <button class="btn btn-primary">📍 Map</button>
+          <button class="btn btn-primary">📋 Records</button>
+          <button class="btn btn-secondary">🔄 Sync</button>
+          <button class="btn btn-secondary">⚙️ Settings</button>
+        </div>
+
+        <section class="card">
+          <div class="warn-text">⚠️ Sync Required</div>
+          <p class="subtitle" style="margin: 10px 0;">You have 3 unsynced changes.</p>
+          <button class="btn btn-primary" style="width: 100%;">Sync Now</button>
+        </section>
+
+        <div class="offline-card" hidden>
+          <div class="title">📶 Offline Mode</div>
+          <div class="desc">You're working offline. Data will sync when connection is restored.</div>
+        </div>
+      </div>
+    </main>
+    <nav class="tab-bar">
+      <div class="tab"><span class="glyph">M</span><span>Map</span></div>
+      <div class="tab"><span class="glyph">R</span><span>Records</span></div>
+      <div class="tab"><span class="glyph">S</span><span>Sync</span></div>
+      <div class="tab"><span class="glyph">C</span><span>Settings</span></div>
+    </nav>
+  </div>
+</body>
+</html>

--- a/docs/design-handoff/main/notes.md
+++ b/docs/design-handoff/main/notes.md
@@ -1,0 +1,37 @@
+# MainPage (Dashboard)
+
+**Source:** `apps/Honua.Mobile.FieldCollection/Views/MainPage.xaml`
+**ViewModel:** `MainViewModel` (Title default from `BaseViewModel`: "Honua Field Collection")
+
+## Purpose
+Landing / dashboard screen surfaced when the user is not on a specific feature tab. Provides at-a-glance connectivity, sync state, and quick-action shortcuts.
+
+## Layout
+A pull-to-refresh (`RefreshView`) scroll container with vertical stacking, 30dp horizontal padding, 25dp inter-section spacing. Top-level `ActivityIndicator` overlay handles busy state.
+
+## Sections (top to bottom)
+
+1. **Welcome card** (`CardFrameStyle`)
+   - `WelcomeMessage` bound from `BaseViewModel` (defaults vary based on auth).
+   - Subtitle: "Your mobile field data collection companion".
+   - 3-column status strip with outline frames, `Primary`-colored borders:
+     - 🌐 Online / Offline (color-coded green / red via `BoolToColorConverter`).
+     - 📝 `PendingChangesCount` + caption "Pending".
+     - 🔄 `LastSyncTime` formatted `HH:mm` (or "Never") + caption "Last Sync".
+2. **Quick Actions** (`SectionHeaderStyle` heading, 2x2 grid of buttons)
+   - `BaseButtonStyle`: 📍 Map -> `NavigateToMapCommand`, 📋 Records -> `NavigateToRecordsCommand`.
+   - `SecondaryButtonStyle`: 🔄 Sync (disabled offline) -> `QuickSyncCommand`, ⚙️ Settings -> `NavigateToSettingsCommand`.
+3. **Sync Required** card (only when `PendingChangesCount > 0`)
+   - "⚠️ Sync Required" in `Warning` orange.
+   - Caption with pending count, full-width Sync Now button.
+4. **Offline Notice** card (only when `IsOnline == false`)
+   - Card background swapped to `Warning`, white text. Title "📶 Offline Mode", caption explains queueing.
+
+## Bindings of note
+- `IsRefreshing` <-> `RefreshCommand`
+- `IsBusy` -> activity indicator visibility/run state
+- `IsOnline` drives quick-sync `IsEnabled`, online/offline label and the offline-mode card visibility (`InvertedBoolConverter`).
+
+## Navigation in / out
+- **In:** Direct navigation only (not a Shell tab; the Shell goes straight to MapPage). Code-behind / DI is responsible for routing here.
+- **Out:** Each quick-action button issues a `Navigate*Command` to a `RecordsPage`, `MapPage`, `SettingsPage`, or triggers `QuickSyncCommand` in place.

--- a/docs/design-handoff/main/xaml-source.md
+++ b/docs/design-handoff/main/xaml-source.md
@@ -1,0 +1,106 @@
+# MainPage - XAML source
+
+File: `apps/Honua.Mobile.FieldCollection/Views/MainPage.xaml`
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:Honua.Mobile.FieldCollection.ViewModels"
+             x:Class="Honua.Mobile.FieldCollection.Views.MainPage"
+             Title="{Binding Title}"
+             x:DataType="vm:MainViewModel">
+
+    <RefreshView IsRefreshing="{Binding IsRefreshing}"
+                 Command="{Binding RefreshCommand}">
+        <ScrollView>
+            <VerticalStackLayout Spacing="25" Padding="30,0">
+
+                <!-- Welcome Section -->
+                <Frame Style="{StaticResource CardFrameStyle}">
+                    <VerticalStackLayout Spacing="10">
+                        <Label Text="{Binding WelcomeMessage}"
+                               Style="{StaticResource PageTitleStyle}" />
+                        <Label Text="Your mobile field data collection companion"
+                               FontSize="16"
+                               TextColor="{StaticResource Gray600}" />
+
+                        <Grid ColumnDefinitions="*,*,*" ColumnSpacing="10" Margin="0,10,0,0">
+                            <Frame Grid.Column="0" BorderColor="{StaticResource Primary}" BackgroundColor="Transparent">
+                                <VerticalStackLayout Spacing="5">
+                                    <Label Text="🌐" FontSize="24" HorizontalOptions="Center" />
+                                    <Label Text="{Binding IsOnline, Converter={StaticResource BoolToStringConverter}, ConverterParameter='Online|Offline'}"
+                                           FontSize="12" HorizontalOptions="Center" FontAttributes="Bold"
+                                           TextColor="{Binding IsOnline, Converter={StaticResource BoolToColorConverter}, ConverterParameter='Green|Red'}" />
+                                </VerticalStackLayout>
+                            </Frame>
+                            <Frame Grid.Column="1" BorderColor="{StaticResource Primary}" BackgroundColor="Transparent">
+                                <VerticalStackLayout Spacing="5">
+                                    <Label Text="📝" FontSize="24" HorizontalOptions="Center" />
+                                    <Label Text="{Binding PendingChangesCount}" FontSize="16" HorizontalOptions="Center" FontAttributes="Bold" />
+                                    <Label Text="Pending" FontSize="10" HorizontalOptions="Center" />
+                                </VerticalStackLayout>
+                            </Frame>
+                            <Frame Grid.Column="2" BorderColor="{StaticResource Primary}" BackgroundColor="Transparent">
+                                <VerticalStackLayout Spacing="5">
+                                    <Label Text="🔄" FontSize="24" HorizontalOptions="Center" />
+                                    <Label Text="{Binding LastSyncTime, StringFormat='{0:HH:mm}', TargetNullValue='Never'}"
+                                           FontSize="12" HorizontalOptions="Center" FontAttributes="Bold" />
+                                    <Label Text="Last Sync" FontSize="10" HorizontalOptions="Center" />
+                                </VerticalStackLayout>
+                            </Frame>
+                        </Grid>
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Quick Actions -->
+                <Label Text="Quick Actions" Style="{StaticResource SectionHeaderStyle}" />
+                <Grid ColumnDefinitions="*,*" RowDefinitions="*,*" ColumnSpacing="15" RowSpacing="15">
+                    <Button Grid.Row="0" Grid.Column="0" Text="📍 Map"
+                            Style="{StaticResource BaseButtonStyle}"
+                            Command="{Binding NavigateToMapCommand}" />
+                    <Button Grid.Row="0" Grid.Column="1" Text="📋 Records"
+                            Style="{StaticResource BaseButtonStyle}"
+                            Command="{Binding NavigateToRecordsCommand}" />
+                    <Button Grid.Row="1" Grid.Column="0" Text="🔄 Sync"
+                            Style="{StaticResource SecondaryButtonStyle}"
+                            Command="{Binding QuickSyncCommand}"
+                            IsEnabled="{Binding IsOnline}" />
+                    <Button Grid.Row="1" Grid.Column="1" Text="⚙️ Settings"
+                            Style="{StaticResource SecondaryButtonStyle}"
+                            Command="{Binding NavigateToSettingsCommand}" />
+                </Grid>
+
+                <!-- Sync Status -->
+                <Frame Style="{StaticResource CardFrameStyle}"
+                       IsVisible="{Binding PendingChangesCount, Converter={StaticResource IntToBoolConverter}}">
+                    <VerticalStackLayout Spacing="10">
+                        <Label Text="⚠️ Sync Required" FontSize="16" FontAttributes="Bold"
+                               TextColor="{StaticResource Warning}" />
+                        <Label Text="{Binding PendingChangesCount, StringFormat='You have {0} unsynced changes.'}"
+                               FontSize="14" TextColor="{StaticResource Gray600}" />
+                        <Button Text="Sync Now" Style="{StaticResource BaseButtonStyle}"
+                                Command="{Binding QuickSyncCommand}" IsEnabled="{Binding IsOnline}" />
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Offline Notice -->
+                <Frame Style="{StaticResource CardFrameStyle}"
+                       IsVisible="{Binding IsOnline, Converter={StaticResource InvertedBoolConverter}}"
+                       BackgroundColor="{StaticResource Warning}">
+                    <VerticalStackLayout Spacing="5">
+                        <Label Text="📶 Offline Mode" FontSize="16" FontAttributes="Bold"
+                               TextColor="{StaticResource White}" />
+                        <Label Text="You're working offline. Data will sync when connection is restored."
+                               FontSize="14" TextColor="{StaticResource White}" />
+                    </VerticalStackLayout>
+                </Frame>
+            </VerticalStackLayout>
+        </ScrollView>
+    </RefreshView>
+
+    <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}"
+                       Color="{StaticResource Primary}"
+                       HorizontalOptions="Center" VerticalOptions="Center" />
+</ContentPage>
+```

--- a/docs/design-handoff/map/mock.html
+++ b/docs/design-handoff/map/mock.html
@@ -1,0 +1,176 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>MapPage - Honua FieldCollection</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+  :root {
+    --color-primary: #2E8B57;
+    --color-primary-dark: #1F5F3F;
+    --color-secondary: #3F51B5;
+    --color-white: #FFFFFF;
+    --color-gray-100: #F5F5F5;
+    --color-gray-200: #EEEEEE;
+    --color-gray-300: #E0E0E0;
+    --color-gray-600: #757575;
+    --color-on-surface: #212121;
+    --color-background: #FFFFFF;
+    --color-surface: #FAFAFA;
+    --color-status-bar: #1F5F3F;
+    --radius-sm: 8px;
+    --shadow-common: 0 2px 8px rgba(0,0,0,0.16);
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; background: var(--color-gray-200); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; color: var(--color-on-surface); }
+  body { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .device { width: 390px; height: 844px; background: var(--color-background); border-radius: 32px; box-shadow: 0 24px 64px rgba(0,0,0,0.25); overflow: hidden; display: grid; grid-template-rows: 28px 56px 1fr 64px; }
+  .status-bar { background: var(--color-status-bar); color: var(--color-white); font-size: 11px; display: flex; justify-content: space-between; align-items: center; padding: 0 18px; }
+  .nav-bar { background: var(--color-primary); color: var(--color-white); display: flex; align-items: center; padding: 0 16px; font-size: 17px; font-weight: 700; }
+  main { position: relative; overflow: hidden; }
+  .map-canvas {
+    position: absolute; inset: 0;
+    background:
+      linear-gradient(120deg, #2c5d3a 0%, #3a7148 25%, #5d8866 50%, #87a187 75%, #b4c8af 100%);
+    overflow: hidden;
+  }
+  .map-canvas::before {
+    content: "";
+    position: absolute; inset: 0;
+    background-image:
+      linear-gradient(rgba(255,255,255,0.06) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(255,255,255,0.06) 1px, transparent 1px);
+    background-size: 40px 40px;
+  }
+  .map-pin {
+    position: absolute;
+    width: 14px; height: 14px;
+    border-radius: 50%;
+    background: var(--color-primary);
+    box-shadow: 0 0 0 3px var(--color-white), var(--shadow-common);
+  }
+  .user-dot {
+    position: absolute;
+    width: 18px; height: 18px;
+    border-radius: 50%;
+    background: var(--color-secondary);
+    box-shadow: 0 0 0 4px rgba(63, 81, 181, 0.25), 0 0 0 8px rgba(63,81,181,0.12);
+  }
+  .map-controls {
+    position: absolute;
+    top: 10px; right: 10px;
+    display: flex; flex-direction: column; gap: 10px;
+  }
+  .icon-btn {
+    width: 50px; height: 50px;
+    border: 0; border-radius: var(--radius-sm);
+    color: var(--color-white);
+    font-size: 20px;
+    cursor: pointer;
+    box-shadow: var(--shadow-common);
+    font-family: inherit;
+  }
+  .icon-btn.primary { background: var(--color-primary); }
+  .icon-btn.secondary { background: var(--color-secondary); }
+  .capture-overlay {
+    position: absolute;
+    top: 20px; left: 50%; transform: translateX(-50%);
+    background: var(--color-primary);
+    color: var(--color-white);
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+    display: flex; align-items: center; gap: 10px;
+    box-shadow: var(--shadow-common);
+    font-size: 14px;
+  }
+  .capture-overlay .cancel-btn {
+    background: var(--color-secondary);
+    color: var(--color-white);
+    border: 0; padding: 6px 12px; border-radius: var(--radius-sm); font-size: 13px;
+    font-family: inherit; cursor: pointer;
+  }
+  .bottom-panel {
+    position: absolute; left: 10px; right: 10px; bottom: 10px;
+    background: var(--color-white);
+    border: 1px solid var(--color-gray-200);
+    border-radius: var(--radius-sm);
+    padding: 16px;
+    box-shadow: var(--shadow-common);
+    display: grid; gap: 10px;
+  }
+  .layer-row { display: grid; grid-template-columns: auto 1fr auto; gap: 10px; align-items: center; }
+  .layer-row label { font-weight: 700; font-size: 14px; }
+  .picker {
+    background: var(--color-surface);
+    border: 1px solid var(--color-gray-300);
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+    display: flex; align-items: center; justify-content: space-between;
+    color: var(--color-on-surface);
+    font-size: 16px;
+  }
+  .picker .caret { color: var(--color-gray-600); }
+  .layer-info {
+    display: flex; flex-wrap: wrap; gap: 20px;
+    align-items: center; font-size: 12px; color: var(--color-on-surface);
+    margin-top: 10px;
+  }
+  .layer-info .chip { display: inline-flex; gap: 5px; align-items: center; }
+  .checkbox {
+    width: 18px; height: 18px; border: 2px solid var(--color-primary); border-radius: 3px;
+    display: inline-flex; align-items: center; justify-content: center;
+    background: var(--color-primary); color: var(--color-white); font-size: 12px;
+  }
+  .tab-bar { background: var(--color-primary); color: var(--color-white); display: grid; grid-template-columns: repeat(4,1fr); }
+  .tab-bar .tab { display: flex; flex-direction: column; align-items: center; justify-content: center; font-size: 11px; gap: 4px; color: var(--color-gray-300); }
+  .tab-bar .tab.active { color: var(--color-white); font-weight: 700; }
+  .tab-bar .glyph { width: 22px; height: 22px; border-radius: 6px; background: rgba(255,255,255,0.15); display: inline-flex; align-items: center; justify-content: center; font-size: 12px; }
+</style>
+</head>
+<body>
+  <div class="device">
+    <header class="status-bar"><span>9:41</span><span>FieldCollection</span><span>100%</span></header>
+    <nav class="nav-bar">Map</nav>
+    <main>
+      <div class="map-canvas" aria-label="Map view (Hybrid)">
+        <div class="map-pin" style="top: 28%; left: 30%;"></div>
+        <div class="map-pin" style="top: 42%; left: 58%;"></div>
+        <div class="map-pin" style="top: 52%; left: 38%;"></div>
+        <div class="map-pin" style="top: 35%; left: 72%;"></div>
+        <div class="map-pin" style="top: 60%; left: 64%;"></div>
+        <div class="user-dot" style="top: 48%; left: 47%;"></div>
+      </div>
+
+      <div class="capture-overlay" role="status">
+        <span>📍 Tap on the map to add a feature</span>
+        <button class="cancel-btn">Cancel</button>
+      </div>
+
+      <div class="map-controls">
+        <button class="icon-btn primary" title="Zoom to current location">📍</button>
+        <button class="icon-btn primary" title="Zoom to features">🎯</button>
+        <button class="icon-btn secondary" title="Add new feature">📐</button>
+      </div>
+
+      <div class="bottom-panel">
+        <div class="layer-row">
+          <label>Layer:</label>
+          <div class="picker"><span>Field Sites</span><span class="caret">v</span></div>
+          <button class="icon-btn secondary" style="width: 44px; height: 44px; font-size: 16px;">⚙️</button>
+        </div>
+        <div class="layer-info">
+          <span class="chip">📊 12 features</span>
+          <span class="chip">🎨 Point</span>
+          <span class="chip"><span class="checkbox">✓</span> Visible</span>
+        </div>
+      </div>
+    </main>
+    <nav class="tab-bar">
+      <div class="tab active"><span class="glyph">M</span><span>Map</span></div>
+      <div class="tab"><span class="glyph">R</span><span>Records</span></div>
+      <div class="tab"><span class="glyph">S</span><span>Sync</span></div>
+      <div class="tab"><span class="glyph">C</span><span>Settings</span></div>
+    </nav>
+  </div>
+</body>
+</html>

--- a/docs/design-handoff/map/notes.md
+++ b/docs/design-handoff/map/notes.md
@@ -1,0 +1,31 @@
+# MapPage
+
+**Source:** `apps/Honua.Mobile.FieldCollection/Views/MapPage.xaml`
+**ViewModel:** `MapViewModel` (Title: "Map")
+
+## Purpose
+Show the active layer's features on a `maps:Map` control and provide layer-aware capture.
+
+## Layout
+Two-row grid: row 0 is the full-bleed map plus floating overlays; row 1 is a card-style bottom panel for layer selection and stats. A full-screen `ActivityIndicator` overlays both rows for busy state.
+
+## Map control
+- `IsShowingUser="True"`, `MapType="Hybrid"`.
+- Pins are bound from `MapFeatures` (collection binding is wired up in code-behind / from the ViewModel; not declarative in XAML).
+
+## Floating actions (top-right vertical stack, 10dp gap)
+1. **📍 Zoom to current location** -> `ZoomToCurrentLocationCommand` (`BaseButtonStyle`, 50x50).
+2. **🎯 Zoom to features** -> `ZoomToFeaturesCommand` (`BaseButtonStyle`, 50x50).
+3. **📐 Add new feature** -> `StartAddingFeatureCommand` (`SecondaryButtonStyle`). Visible only when `SelectedLayer.IsEditable` is true.
+
+## Capture-mode overlay (top, centered)
+- Becomes visible while `IsAddingFeature` is true.
+- Frame background `Primary`, label "📍 Tap on the map to add a feature" + `Cancel` button (`SecondaryButtonStyle`) bound to `CancelAddingFeatureCommand`.
+
+## Bottom panel (`CardFrameStyle`, 10dp side margin)
+- Row 0: "Layer:" label | Picker bound to `AvailableLayers` (display by `Name`, selected -> `SelectedLayer`) | `⚙️` settings button (`OpenLayerSettingsCommand`, only when a layer is selected).
+- Row 1 (only when a layer is selected): horizontal row with `📊 N features`, `🎨 GeometryType`, and a `CheckBox` + "Visible" label bound to `SelectedLayer.IsVisible`.
+
+## Navigation in / out
+- **In:** Shell tab "Map" (default landing tab).
+- **Out:** `OpenLayerSettingsCommand` is expected to navigate to a layer-settings modal (not in this folder); capture flows post-tap.

--- a/docs/design-handoff/map/xaml-source.md
+++ b/docs/design-handoff/map/xaml-source.md
@@ -1,0 +1,96 @@
+# MapPage - XAML source
+
+File: `apps/Honua.Mobile.FieldCollection/Views/MapPage.xaml`
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:Honua.Mobile.FieldCollection.ViewModels"
+             xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
+             x:Class="Honua.Mobile.FieldCollection.Views.MapPage"
+             Title="{Binding Title}"
+             x:DataType="vm:MapViewModel">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0" StrokeThickness="0">
+            <maps:Map x:Name="MapView" IsShowingUser="True" MapType="Hybrid" />
+        </Border>
+
+        <!-- Map Controls Overlay -->
+        <Grid Grid.Row="0" Margin="10" VerticalOptions="Start" HorizontalOptions="End">
+            <VerticalStackLayout Spacing="10">
+                <Button Text="📍" WidthRequest="50" HeightRequest="50"
+                        Style="{StaticResource BaseButtonStyle}"
+                        Command="{Binding ZoomToCurrentLocationCommand}"
+                        ToolTipProperties.Text="Zoom to current location" />
+                <Button Text="🎯" WidthRequest="50" HeightRequest="50"
+                        Style="{StaticResource BaseButtonStyle}"
+                        Command="{Binding ZoomToFeaturesCommand}"
+                        ToolTipProperties.Text="Zoom to features" />
+                <Button Text="📐" WidthRequest="50" HeightRequest="50"
+                        Style="{StaticResource SecondaryButtonStyle}"
+                        Command="{Binding StartAddingFeatureCommand}"
+                        IsVisible="{Binding SelectedLayer.IsEditable, FallbackValue=False}"
+                        ToolTipProperties.Text="Add new feature" />
+            </VerticalStackLayout>
+        </Grid>
+
+        <!-- Adding Feature Overlay -->
+        <Frame Grid.Row="0" IsVisible="{Binding IsAddingFeature}"
+               BackgroundColor="{StaticResource Primary}"
+               HorizontalOptions="Center" VerticalOptions="Start" Margin="20">
+            <StackLayout Orientation="Horizontal" Spacing="10">
+                <Label Text="📍 Tap on the map to add a feature"
+                       TextColor="{StaticResource White}" FontAttributes="Bold" />
+                <Button Text="Cancel" Style="{StaticResource SecondaryButtonStyle}"
+                        Command="{Binding CancelAddingFeatureCommand}" />
+            </StackLayout>
+        </Frame>
+
+        <!-- Bottom Panel -->
+        <Frame Grid.Row="1" Style="{StaticResource CardFrameStyle}" Margin="10,0,10,10">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto">
+                    <Label Grid.Column="0" Text="Layer:" FontAttributes="Bold" VerticalOptions="Center" />
+                    <Picker Grid.Column="1" ItemsSource="{Binding AvailableLayers}"
+                            SelectedItem="{Binding SelectedLayer}"
+                            ItemDisplayBinding="{Binding Name}" Title="Select Layer" />
+                    <Button Grid.Column="2" Text="⚙️"
+                            Style="{StaticResource SecondaryButtonStyle}"
+                            Command="{Binding OpenLayerSettingsCommand}"
+                            IsVisible="{Binding SelectedLayer, Converter={StaticResource IsNotNullConverter}}" />
+                </Grid>
+
+                <StackLayout Grid.Row="1" Orientation="Horizontal" Spacing="20" Margin="0,10,0,0"
+                             IsVisible="{Binding SelectedLayer, Converter={StaticResource IsNotNullConverter}}">
+                    <StackLayout Orientation="Horizontal" Spacing="5">
+                        <Label Text="📊" FontSize="14" />
+                        <Label Text="{Binding MapFeatures.Count, StringFormat='{0} features'}" FontSize="12" />
+                    </StackLayout>
+                    <StackLayout Orientation="Horizontal" Spacing="5">
+                        <Label Text="🎨" FontSize="14" />
+                        <Label Text="{Binding SelectedLayer.GeometryType}" FontSize="12" />
+                    </StackLayout>
+                    <CheckBox IsChecked="{Binding SelectedLayer.IsVisible}" />
+                    <Label Text="Visible" FontSize="12" VerticalOptions="Center" />
+                </StackLayout>
+            </Grid>
+        </Frame>
+
+        <ActivityIndicator Grid.RowSpan="2" IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}"
+                          Color="{StaticResource Primary}"
+                          HorizontalOptions="Center" VerticalOptions="Center" />
+    </Grid>
+</ContentPage>
+```

--- a/docs/design-handoff/questions.md
+++ b/docs/design-handoff/questions.md
@@ -1,0 +1,23 @@
+# Open UX questions
+
+Each question is grounded in something in the current XAML. Answers will shape the next round of mock revisions and corresponding XAML edits.
+
+1. **SyncCenterPage surfaces `ActiveConflicts` as a flat `CollectionView` and `ConflictReviewItems` as a second flat list right below it.** When a partner returns from a week in the field with 50+ conflicts spanning Culverts, Headwalls, and Crews, would grouping by layer (with collapsible sections, totals, and a per-group "Resolve all") be more usable than two long flat lists? Or should the two lists be merged with a status filter chip row?
+
+2. **MapPage's capture-action FAB (📐) is bolted to the top-right map controls stack, not the bottom thumb zone.** Field crews use the phone one-handed in PPE gloves. Should we move "Add new feature" to a bottom-center primary action bar and reserve the top-right stack for non-destructive view controls (zoom-to-me, zoom-to-features)? Should we mirror left/right per `Settings.HandPreference`?
+
+3. **RecordsPage row status is conveyed by an 8x40dp colored bar (`Orange` = pending, `Green` = synced) and an "orange" pill badge.** Is that the only sync-state nuance needed, or do we also want distinct visual states for: locally created but never synced, edited-since-last-sync, sync-failed, in-conflict? A 5-state legend on Records would mirror what SyncCenter already exposes.
+
+4. **The Quick Actions grid on MainPage repeats targets that already exist as bottom tabs (Map, Records, Settings, Sync).** Is MainPage meant to be a true dashboard (KPIs + recent activity, no nav duplication), or a quick-launcher (current shape)? It is not registered in the Shell's `TabBar`, so today it is reachable only via deep-link / direct push - which is the intended role?
+
+5. **SettingsPage puts the "Developer Mode" toggle *underneath* the "Developer Options" card.** That means a user enabling dev mode for the first time sees an empty placeholder area, scrolls past it, finds the toggle, then scrolls back up. Should the toggle move above the options card, or should we collapse the dev-options card into an inline disclosure that lives next to the toggle?
+
+6. **The Danger Zone "Reset App" is a single full-width red button with no confirmation pattern in the XAML.** Do we want a 2-step confirm (slider, typed phrase, or modal with destructive action) baked into the UI rather than a follow-on alert? The current pattern is one tap to reach an irreversible action.
+
+7. **OfflineCacheDiagnostics shows six raw counters (Pending / Claimed / Succeeded / Failed / Retry / Conflict) as equal-weight tiles.** Field users have asked "is the sync healthy?" not "what is my retry count?" - should we collapse these into a single health indicator with an expandable details view, and reserve the raw counters for the developer-mode diagnostics page?
+
+8. **The template starter (`templates/honua-fieldcollector/MainPage.xaml`) uses `BackgroundColor="Green"` (the XAML named color, not our `#4CAF50` Success token) on the stats card and success toast.** Should we lock the template to the same tokens as the in-house app, or is the template intentionally permissive so partners can rebrand without touching `Colors.xaml`?
+
+9. **MapPage's `IsAddingFeature` overlay sits centered at the top with the "Cancel" button right beside the instruction.** On a 5"+ phone in landscape capture mode, the cancel target is far from the thumb. Should the overlay split into a top instruction band plus a bottom-anchored cancel/confirm pair?
+
+10. **There is no dark-mode `ResourceDictionary` - `App.xaml` only merges `Colors.xaml` and `Styles.xaml`.** The template uses `AppThemeBinding` in two places. Do we want a full dark-mode pass as part of the design review (dark tokens for every brand color, every gray), or is dark mode out of scope for this iteration?

--- a/docs/design-handoff/records/mock.html
+++ b/docs/design-handoff/records/mock.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>RecordsPage - Honua FieldCollection</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+  :root {
+    --color-primary: #2E8B57;
+    --color-primary-dark: #1F5F3F;
+    --color-secondary: #3F51B5;
+    --color-tertiary: #FF5722;
+    --color-info: #2196F3;
+    --color-warning: #FF9800;
+    --color-success: #4CAF50;
+    --color-white: #FFFFFF;
+    --color-gray-100: #F5F5F5;
+    --color-gray-200: #EEEEEE;
+    --color-gray-300: #E0E0E0;
+    --color-gray-400: #BDBDBD;
+    --color-gray-500: #9E9E9E;
+    --color-gray-600: #757575;
+    --color-on-surface: #212121;
+    --color-background: #FFFFFF;
+    --color-surface: #FAFAFA;
+    --color-status-bar: #1F5F3F;
+    --radius-sm: 8px;
+    --shadow-common: 0 2px 8px rgba(0,0,0,0.16);
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; background: var(--color-gray-200); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; color: var(--color-on-surface); }
+  body { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .device { width: 390px; height: 844px; background: var(--color-background); border-radius: 32px; box-shadow: 0 24px 64px rgba(0,0,0,0.25); overflow: hidden; display: grid; grid-template-rows: 28px 56px 1fr 64px; }
+  .status-bar { background: var(--color-status-bar); color: var(--color-white); font-size: 11px; display: flex; justify-content: space-between; align-items: center; padding: 0 18px; }
+  .nav-bar { background: var(--color-primary); color: var(--color-white); display: flex; align-items: center; justify-content: space-between; padding: 0 16px; font-size: 17px; font-weight: 700; }
+  .toolbar-actions { display: flex; gap: 14px; font-size: 13px; font-weight: 600; }
+  .toolbar-actions span { opacity: 0.92; }
+  main { position: relative; overflow-y: auto; padding: 10px; background: var(--color-background); }
+  .card { background: var(--color-white); border: 1px solid var(--color-gray-200); border-radius: var(--radius-sm); padding: 16px; box-shadow: var(--shadow-common); margin-bottom: 8px; }
+  .layer-row { display: grid; grid-template-columns: auto 1fr auto; gap: 10px; align-items: center; }
+  .layer-row label { font-weight: 700; font-size: 14px; }
+  .picker { background: var(--color-surface); border: 1px solid var(--color-gray-300); border-radius: var(--radius-sm); padding: 8px 12px; display: flex; align-items: center; justify-content: space-between; }
+  .picker .caret { color: var(--color-gray-600); }
+  .icon-btn { width: 50px; height: 36px; border: 0; border-radius: var(--radius-sm); color: var(--color-white); font-family: inherit; cursor: pointer; }
+  .icon-btn.secondary { background: var(--color-secondary); }
+  .stats-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 15px; margin-top: 10px; }
+  .stat .value { font-size: 18px; font-weight: 700; text-align: center; }
+  .stat .label { font-size: 12px; text-align: center; color: var(--color-gray-600); }
+  .stat.warn .value { color: var(--color-warning); }
+  .search-bar { display: grid; grid-template-columns: 1fr auto; gap: 10px; }
+  .search-input { background: var(--color-surface); border: 1px solid var(--color-gray-300); border-radius: var(--radius-sm); padding: 10px 12px; font-size: 16px; }
+  .filter-row { display: flex; flex-wrap: wrap; gap: 15px; margin-top: 10px; align-items: center; font-size: 13px; }
+  .checkbox { width: 18px; height: 18px; border: 2px solid var(--color-primary); border-radius: 3px; display: inline-block; vertical-align: middle; margin-right: 6px; }
+  .btn { border: 0; cursor: pointer; padding: 8px 12px; border-radius: var(--radius-sm); color: var(--color-white); font-size: 12px; font-family: inherit; }
+  .btn-secondary { background: var(--color-secondary); }
+  .btn-primary { background: var(--color-primary); }
+  .btn-danger { background: var(--color-tertiary); }
+  .record-card { background: var(--color-white); border: 1px solid var(--color-gray-200); border-radius: var(--radius-sm); box-shadow: var(--shadow-common); display: grid; grid-template-columns: 8px 1fr auto; gap: 10px; padding: 12px 12px 12px 0; margin: 10px 0; align-items: stretch; }
+  .record-status { width: 8px; border-radius: 4px; }
+  .status-pending { background: var(--color-warning); }
+  .status-synced { background: var(--color-success); }
+  .record-body { padding: 4px 0; }
+  .record-title { font-size: 16px; font-weight: 700; }
+  .record-meta { font-size: 12px; color: var(--color-gray-600); margin-top: 4px; }
+  .record-summary { font-size: 12px; color: var(--color-gray-600); margin-top: 4px; line-height: 1.4; max-height: 2.8em; overflow: hidden; }
+  .badges { display: flex; gap: 5px; margin-top: 6px; }
+  .badge { padding: 2px 6px; border-radius: 4px; color: var(--color-white); font-size: 10px; }
+  .badge-pending { background: var(--color-warning); }
+  .badge-info { background: var(--color-info); }
+  .record-actions { display: flex; flex-direction: column; gap: 5px; padding-right: 4px; }
+  .row-action { width: 40px; height: 32px; border: 0; border-radius: var(--radius-sm); color: var(--color-white); font-size: 14px; font-family: inherit; cursor: pointer; }
+  .row-view { background: var(--color-secondary); }
+  .row-edit { background: var(--color-primary); }
+  .row-delete { background: var(--color-tertiary); }
+  .fab {
+    position: absolute; bottom: 20px; right: 20px;
+    width: 60px; height: 60px; border-radius: 30px;
+    background: var(--color-primary); color: var(--color-white);
+    border: 0; cursor: pointer; font-size: 24px;
+    box-shadow: var(--shadow-common);
+    font-family: inherit;
+  }
+  .tab-bar { background: var(--color-primary); color: var(--color-white); display: grid; grid-template-columns: repeat(4,1fr); }
+  .tab-bar .tab { display: flex; flex-direction: column; align-items: center; justify-content: center; font-size: 11px; gap: 4px; color: var(--color-gray-300); }
+  .tab-bar .tab.active { color: var(--color-white); font-weight: 700; }
+  .tab-bar .glyph { width: 22px; height: 22px; border-radius: 6px; background: rgba(255,255,255,0.15); display: inline-flex; align-items: center; justify-content: center; font-size: 12px; }
+</style>
+</head>
+<body>
+  <div class="device">
+    <header class="status-bar"><span>9:41</span><span>FieldCollection</span><span>100%</span></header>
+    <nav class="nav-bar">
+      <span>Records</span>
+      <span class="toolbar-actions"><span>+ Create</span><span>↥ Export</span></span>
+    </nav>
+    <main>
+      <section class="card">
+        <div class="layer-row">
+          <label>Layer:</label>
+          <div class="picker"><span>Field Sites</span><span class="caret">v</span></div>
+          <button class="icon-btn secondary">📊</button>
+        </div>
+        <div class="stats-grid">
+          <div class="stat"><div class="value">128</div><div class="label">Total Records</div></div>
+          <div class="stat warn"><div class="value">7</div><div class="label">Pending Sync</div></div>
+          <div class="stat"><div class="value">24</div><div class="label">Filtered</div></div>
+        </div>
+      </section>
+
+      <section class="card">
+        <div class="search-bar">
+          <input class="search-input" type="search" placeholder="Search records..." value="culvert" />
+          <button class="btn btn-secondary">Clear</button>
+        </div>
+        <div class="filter-row">
+          <span><span class="checkbox"></span>Pending only</span>
+          <button class="btn btn-secondary">📅 Date Filter</button>
+          <button class="btn btn-secondary">🗺️ Location Filter</button>
+        </div>
+      </section>
+
+      <article class="record-card">
+        <div class="record-status status-pending"></div>
+        <div class="record-body">
+          <div class="record-title">Culvert #C-104</div>
+          <div class="record-meta">Created: 05/19/2026 14:22</div>
+          <div class="record-summary">Diameter: 36in - Material: HDPE - Condition: Fair - Sediment: 20% blockage along inlet.</div>
+          <div class="badges"><span class="badge badge-pending">Pending Sync</span><span class="badge badge-info">2 attachments</span></div>
+        </div>
+        <div class="record-actions">
+          <button class="row-action row-view">👁️</button>
+          <button class="row-action row-edit">✏️</button>
+          <button class="row-action row-delete">🗑️</button>
+        </div>
+      </article>
+
+      <article class="record-card">
+        <div class="record-status status-synced"></div>
+        <div class="record-body">
+          <div class="record-title">Culvert #C-103</div>
+          <div class="record-meta">Created: 05/18/2026 11:04</div>
+          <div class="record-summary">Diameter: 24in - Material: CMP - Condition: Good</div>
+          <div class="badges"><span class="badge badge-info">1 attachments</span></div>
+        </div>
+        <div class="record-actions">
+          <button class="row-action row-view">👁️</button>
+          <button class="row-action row-edit">✏️</button>
+          <button class="row-action row-delete">🗑️</button>
+        </div>
+      </article>
+
+      <article class="record-card">
+        <div class="record-status status-pending"></div>
+        <div class="record-body">
+          <div class="record-title">Culvert #C-102</div>
+          <div class="record-meta">Created: 05/18/2026 09:51</div>
+          <div class="record-summary">Diameter: 18in - Material: RCP - Condition: Poor. Cracked headwall noted, awaiting follow-up inspection.</div>
+          <div class="badges"><span class="badge badge-pending">Pending Sync</span></div>
+        </div>
+        <div class="record-actions">
+          <button class="row-action row-view">👁️</button>
+          <button class="row-action row-edit">✏️</button>
+          <button class="row-action row-delete">🗑️</button>
+        </div>
+      </article>
+
+      <button class="fab" aria-label="Create new record">+</button>
+    </main>
+    <nav class="tab-bar">
+      <div class="tab"><span class="glyph">M</span><span>Map</span></div>
+      <div class="tab active"><span class="glyph">R</span><span>Records</span></div>
+      <div class="tab"><span class="glyph">S</span><span>Sync</span></div>
+      <div class="tab"><span class="glyph">C</span><span>Settings</span></div>
+    </nav>
+  </div>
+</body>
+</html>

--- a/docs/design-handoff/records/notes.md
+++ b/docs/design-handoff/records/notes.md
@@ -1,0 +1,40 @@
+# RecordsPage
+
+**Source:** `apps/Honua.Mobile.FieldCollection/Views/RecordsPage.xaml`
+**ViewModel:** `RecordsViewModel` (Title: "Records")
+
+## Purpose
+List all features for the selected layer, filterable and searchable, with row-level actions and a floating create button.
+
+## Toolbar items
+- "Create" (`plus.png`) -> `CreateNewRecordCommand`.
+- "Export" (`export.png`) -> `ExportRecordsCommand`.
+
+## Layout (top to bottom)
+
+### 1. Statistics card
+- Layer picker (`AvailableLayers` / `SelectedLayer`).
+- 3-column counter row: `TotalRecordCount`, `PendingRecordCount` (Warning color), `Records.Count` ("Filtered").
+
+### 2. Search & filter card
+- `SearchBar` bound to `SearchText`; `Search` runs `SearchRecordsCommand`. Clear button visible when text is present (`ClearSearchCommand`).
+- Filter row: "Pending only" checkbox (`ShowPendingOnly`), "📅 Date Filter" + "🗺️ Location Filter" buttons (no command bindings present in XAML).
+
+### 3. Records list (`CollectionView`)
+- `EmptyView`: large 📝 icon, "No records found" + "Create your first record or adjust your filters".
+- Item template: `CardFrameStyle` row with three columns:
+  - **Status indicator**: 8x40dp vertical bar; orange when `IsPendingSync`, green otherwise (via `BoolToColorConverter`).
+  - **Content**: `DisplayTitle` (16sp bold), `CreatedAt`, `AttributeSummary` (2-line truncated), badge row with "Pending Sync" (`Warning`) and "{N} attachments" (`Info`).
+  - **Action buttons stack**: 👁️ View (`SecondaryButtonStyle`), ✏️ Edit (`BaseButtonStyle`), 🗑️ Delete (`DangerButtonStyle`). Whole row also gets a `TapGestureRecognizer` that triggers `ViewRecordCommand`.
+
+### 4. Floating Action Button
+- 60x60dp pill, `BaseButtonStyle` + `CommonShadow`, anchored bottom-right with 20dp margin, bound to `CreateNewRecordCommand`.
+
+## Bindings of note
+- `IsRefreshing` <-> `RefreshCommand`
+- `Records` is the filtered visible list; `TotalRecordCount` and `PendingRecordCount` are unfiltered.
+- Per-row commands use `RelativeSource AncestorType` to reach the page-level ViewModel.
+
+## Navigation in / out
+- **In:** Shell tab "Records".
+- **Out:** View / Edit / Delete commands and FAB-create push detail pages (handled in `RecordsViewModel`).

--- a/docs/design-handoff/records/xaml-source.md
+++ b/docs/design-handoff/records/xaml-source.md
@@ -1,0 +1,157 @@
+# RecordsPage - XAML source
+
+File: `apps/Honua.Mobile.FieldCollection/Views/RecordsPage.xaml`
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:models="clr-namespace:Honua.Mobile.FieldCollection.Models;assembly=Honua.Mobile.FieldCollection.Core"
+             xmlns:vm="clr-namespace:Honua.Mobile.FieldCollection.ViewModels"
+             x:Class="Honua.Mobile.FieldCollection.Views.RecordsPage"
+             Title="{Binding Title}"
+             x:DataType="vm:RecordsViewModel">
+
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Create" IconImageSource="plus.png" Command="{Binding CreateNewRecordCommand}" />
+        <ToolbarItem Text="Export" IconImageSource="export.png" Command="{Binding ExportRecordsCommand}" />
+    </ContentPage.ToolbarItems>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <!-- Layer Selection and Statistics -->
+        <Frame Grid.Row="0" Style="{StaticResource CardFrameStyle}" Margin="10,10,10,5">
+            <Grid RowDefinitions="Auto,Auto" RowSpacing="10">
+                <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
+                    <Label Grid.Column="0" Text="Layer:" FontAttributes="Bold" VerticalOptions="Center" />
+                    <Picker Grid.Column="1" ItemsSource="{Binding AvailableLayers}"
+                            SelectedItem="{Binding SelectedLayer}" ItemDisplayBinding="{Binding Name}"
+                            Title="Select Layer" />
+                    <Button Grid.Column="2" Text="📊" Style="{StaticResource SecondaryButtonStyle}" WidthRequest="50" />
+                </Grid>
+
+                <Grid Grid.Row="1" ColumnDefinitions="*,*,*" ColumnSpacing="15">
+                    <StackLayout Grid.Column="0">
+                        <Label Text="{Binding TotalRecordCount}" FontSize="18" FontAttributes="Bold"
+                               HorizontalOptions="Center" />
+                        <Label Text="Total Records" FontSize="12" HorizontalOptions="Center"
+                               TextColor="{StaticResource Gray600}" />
+                    </StackLayout>
+                    <StackLayout Grid.Column="1">
+                        <Label Text="{Binding PendingRecordCount}" FontSize="18" FontAttributes="Bold"
+                               HorizontalOptions="Center" TextColor="{StaticResource Warning}" />
+                        <Label Text="Pending Sync" FontSize="12" HorizontalOptions="Center"
+                               TextColor="{StaticResource Gray600}" />
+                    </StackLayout>
+                    <StackLayout Grid.Column="2">
+                        <Label Text="{Binding Records.Count}" FontSize="18" FontAttributes="Bold"
+                               HorizontalOptions="Center" />
+                        <Label Text="Filtered" FontSize="12" HorizontalOptions="Center"
+                               TextColor="{StaticResource Gray600}" />
+                    </StackLayout>
+                </Grid>
+            </Grid>
+        </Frame>
+
+        <!-- Search and Filter Controls -->
+        <Frame Grid.Row="1" Style="{StaticResource CardFrameStyle}" Margin="10,5,10,5">
+            <Grid RowDefinitions="Auto,Auto" RowSpacing="10">
+                <Grid Grid.Row="0" ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                    <SearchBar Grid.Column="0" Text="{Binding SearchText}" Placeholder="Search records..."
+                               SearchCommand="{Binding SearchRecordsCommand}"
+                               CancelButtonColor="{StaticResource Gray600}" />
+                    <Button Grid.Column="1" Text="Clear" Style="{StaticResource SecondaryButtonStyle}"
+                            Command="{Binding ClearSearchCommand}"
+                            IsVisible="{Binding SearchText, Converter={StaticResource IsNotNullOrEmptyConverter}}" />
+                </Grid>
+                <StackLayout Grid.Row="1" Orientation="Horizontal" Spacing="15">
+                    <StackLayout Orientation="Horizontal" Spacing="5">
+                        <CheckBox IsChecked="{Binding ShowPendingOnly}" />
+                        <Label Text="Pending only" VerticalOptions="Center" />
+                    </StackLayout>
+                    <Button Text="📅 Date Filter" Style="{StaticResource SecondaryButtonStyle}" FontSize="12" />
+                    <Button Text="🗺️ Location Filter" Style="{StaticResource SecondaryButtonStyle}" FontSize="12" />
+                </StackLayout>
+            </Grid>
+        </Frame>
+
+        <!-- Records List -->
+        <RefreshView Grid.Row="2" IsRefreshing="{Binding IsRefreshing}" Command="{Binding RefreshCommand}">
+            <CollectionView ItemsSource="{Binding Records}" Margin="10,0,10,10">
+                <CollectionView.EmptyView>
+                    <StackLayout Padding="50" VerticalOptions="Center">
+                        <Label Text="📝" FontSize="48" HorizontalOptions="Center"
+                               TextColor="{StaticResource Gray400}" />
+                        <Label Text="No records found" FontSize="18" HorizontalOptions="Center"
+                               TextColor="{StaticResource Gray600}" />
+                        <Label Text="Create your first record or adjust your filters"
+                               FontSize="14" HorizontalOptions="Center" TextColor="{StaticResource Gray500}" />
+                    </StackLayout>
+                </CollectionView.EmptyView>
+
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="models:Feature">
+                        <Frame Style="{StaticResource CardFrameStyle}" Margin="0,5">
+                            <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
+                                <Border Grid.Column="0" WidthRequest="8" HeightRequest="40"
+                                       BackgroundColor="{Binding IsPendingSync, Converter={StaticResource BoolToColorConverter}, ConverterParameter='Orange|Green'}"
+                                       StrokeThickness="0" />
+                                <StackLayout Grid.Column="1" Spacing="5">
+                                    <Label Text="{Binding DisplayTitle}" FontSize="16" FontAttributes="Bold" />
+                                    <Label Text="{Binding CreatedAt, StringFormat='Created: {0:MM/dd/yyyy HH:mm}'}"
+                                           FontSize="12" TextColor="{StaticResource Gray600}" />
+                                    <Label Text="{Binding AttributeSummary}" FontSize="12"
+                                           TextColor="{StaticResource Gray600}"
+                                           MaxLines="2" LineBreakMode="TailTruncation" />
+                                    <StackLayout Orientation="Horizontal" Spacing="5">
+                                        <Frame BackgroundColor="{StaticResource Warning}" Padding="5,2"
+                                               IsVisible="{Binding IsPendingSync}">
+                                            <Label Text="Pending Sync" FontSize="10" TextColor="{StaticResource White}" />
+                                        </Frame>
+                                        <Frame BackgroundColor="{StaticResource Info}" Padding="5,2"
+                                               IsVisible="{Binding HasAttachments}">
+                                            <Label Text="{Binding AttachmentsCount, StringFormat='{0} attachments'}"
+                                                   FontSize="10" TextColor="{StaticResource White}" />
+                                        </Frame>
+                                    </StackLayout>
+                                </StackLayout>
+                                <StackLayout Grid.Column="2" Spacing="5">
+                                    <Button Text="👁️" Style="{StaticResource SecondaryButtonStyle}"
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type vm:RecordsViewModel}}, Path=ViewRecordCommand}"
+                                            CommandParameter="{Binding .}" WidthRequest="40" />
+                                    <Button Text="✏️" Style="{StaticResource BaseButtonStyle}"
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type vm:RecordsViewModel}}, Path=EditRecordCommand}"
+                                            CommandParameter="{Binding .}" WidthRequest="40" />
+                                    <Button Text="🗑️" Style="{StaticResource DangerButtonStyle}"
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type vm:RecordsViewModel}}, Path=DeleteRecordCommand}"
+                                            CommandParameter="{Binding .}" WidthRequest="40" />
+                                </StackLayout>
+                            </Grid>
+                            <Frame.GestureRecognizers>
+                                <TapGestureRecognizer
+                                    Command="{Binding Source={RelativeSource AncestorType={x:Type vm:RecordsViewModel}}, Path=ViewRecordCommand}"
+                                    CommandParameter="{Binding .}" />
+                            </Frame.GestureRecognizers>
+                        </Frame>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </RefreshView>
+
+        <Button Grid.Row="2" Text="+" FontSize="24" WidthRequest="60" HeightRequest="60"
+                CornerRadius="30" Style="{StaticResource BaseButtonStyle}"
+                HorizontalOptions="End" VerticalOptions="End" Margin="20"
+                Command="{Binding CreateNewRecordCommand}"
+                Shadow="{StaticResource CommonShadow}" />
+
+        <ActivityIndicator Grid.RowSpan="3" IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}"
+                          Color="{StaticResource Primary}"
+                          HorizontalOptions="Center" VerticalOptions="Center" />
+    </Grid>
+</ContentPage>
+```

--- a/docs/design-handoff/settings/mock.html
+++ b/docs/design-handoff/settings/mock.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>SettingsPage - Honua FieldCollection</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+  :root {
+    --color-primary: #2E8B57;
+    --color-primary-dark: #1F5F3F;
+    --color-secondary: #3F51B5;
+    --color-tertiary: #FF5722;
+    --color-warning: #FF9800;
+    --color-danger: #F44336;
+    --color-danger-light: #FFEBEE;
+    --color-success: #4CAF50;
+    --color-white: #FFFFFF;
+    --color-gray-100: #F5F5F5;
+    --color-gray-200: #EEEEEE;
+    --color-gray-300: #E0E0E0;
+    --color-gray-600: #757575;
+    --color-on-surface: #212121;
+    --color-background: #FFFFFF;
+    --color-surface: #FAFAFA;
+    --color-status-bar: #1F5F3F;
+    --radius-sm: 8px;
+    --shadow-common: 0 2px 8px rgba(0,0,0,0.16);
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; background: var(--color-gray-200); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; color: var(--color-on-surface); }
+  body { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .device { width: 390px; height: 844px; background: var(--color-background); border-radius: 32px; box-shadow: 0 24px 64px rgba(0,0,0,0.25); overflow: hidden; display: grid; grid-template-rows: 28px 56px 1fr 64px; }
+  .status-bar { background: var(--color-status-bar); color: var(--color-white); font-size: 11px; display: flex; justify-content: space-between; align-items: center; padding: 0 18px; }
+  .nav-bar { background: var(--color-primary); color: var(--color-white); display: flex; align-items: center; padding: 0 16px; font-size: 17px; font-weight: 700; }
+  main { overflow-y: auto; padding: 20px; background: var(--color-background); display: flex; flex-direction: column; gap: 20px; }
+  .card { background: var(--color-white); border: 1px solid var(--color-gray-200); border-radius: var(--radius-sm); padding: 16px; box-shadow: var(--shadow-common); }
+  .card.danger { background: var(--color-danger-light); }
+  .section-header { font-size: 18px; font-weight: 700; color: var(--color-primary); margin: 0 0 12px 0; }
+  .section-header.warn { color: var(--color-warning); }
+  .section-header.danger { color: var(--color-danger); }
+  .account-row { display: grid; grid-template-columns: 24px 1fr auto; gap: 10px; align-items: center; padding: 6px 0; }
+  .label { font-size: 16px; }
+  .muted { color: var(--color-gray-600); font-size: 14px; }
+  .btn { border: 0; cursor: pointer; padding: 10px 14px; border-radius: var(--radius-sm); color: var(--color-white); font-size: 13px; font-family: inherit; }
+  .btn-primary { background: var(--color-primary); }
+  .btn-secondary { background: var(--color-secondary); }
+  .btn-danger { background: var(--color-tertiary); }
+  .pref-row { display: grid; grid-template-columns: 1fr auto; gap: 10px; align-items: center; padding: 10px 0; border-top: 1px solid var(--color-gray-200); }
+  .pref-row:first-of-type { border-top: 0; }
+  .pref-title { font-size: 16px; }
+  .pref-sub { font-size: 12px; color: var(--color-gray-600); margin-top: 2px; }
+  /* Switch */
+  .switch { width: 44px; height: 26px; background: var(--color-gray-300); border-radius: 13px; position: relative; cursor: pointer; }
+  .switch.on { background: var(--color-primary); }
+  .switch::after { content: ""; position: absolute; width: 22px; height: 22px; border-radius: 50%; background: var(--color-white); top: 2px; left: 2px; transition: transform 0.12s; box-shadow: 0 1px 2px rgba(0,0,0,0.2); }
+  .switch.on::after { transform: translateX(18px); }
+  /* Slider */
+  .slider-block { padding: 10px 0; border-top: 1px solid var(--color-gray-200); }
+  .slider-track { position: relative; height: 4px; background: var(--color-gray-300); border-radius: 2px; margin: 10px 0; }
+  .slider-track > .fill { position: absolute; top: 0; left: 0; height: 100%; background: var(--color-primary); border-radius: 2px; }
+  .slider-track > .thumb { position: absolute; width: 16px; height: 16px; border-radius: 50%; background: var(--color-primary); top: 50%; transform: translate(-50%, -50%); box-shadow: var(--shadow-common); }
+  .slider-scale { display: grid; grid-template-columns: 1fr 1fr 1fr; font-size: 10px; }
+  .slider-scale span:nth-child(2) { text-align: center; }
+  .slider-scale span:nth-child(3) { text-align: right; }
+  .entry { background: var(--color-surface); border: 1px solid var(--color-gray-300); border-radius: var(--radius-sm); padding: 10px 12px; font-size: 14px; width: 100%; }
+  .device-grid { display: grid; grid-template-columns: 24px 1fr; gap: 8px 10px; font-size: 14px; }
+  .device-grid .muted { font-size: 12px; }
+  .center { text-align: center; }
+  .dev-buttons { display: flex; flex-direction: column; gap: 10px; }
+  .tab-bar { background: var(--color-primary); color: var(--color-white); display: grid; grid-template-columns: repeat(4,1fr); }
+  .tab-bar .tab { display: flex; flex-direction: column; align-items: center; justify-content: center; font-size: 11px; gap: 4px; color: var(--color-gray-300); }
+  .tab-bar .tab.active { color: var(--color-white); font-weight: 700; }
+  .tab-bar .glyph { width: 22px; height: 22px; border-radius: 6px; background: rgba(255,255,255,0.15); display: inline-flex; align-items: center; justify-content: center; font-size: 12px; }
+</style>
+</head>
+<body>
+  <div class="device">
+    <header class="status-bar"><span>9:41</span><span>FieldCollection</span><span>100%</span></header>
+    <nav class="nav-bar">Settings</nav>
+    <main>
+      <section class="card">
+        <h2 class="section-header">Account</h2>
+        <div class="account-row"><span>👤</span><span class="label">mike@honua.io</span><button class="btn btn-secondary">Profile</button></div>
+        <div class="account-row"><span>🌐</span><span class="muted">https://api.honua.io</span><button class="btn btn-secondary">Configure</button></div>
+        <div class="account-row"><span>🔐</span><span class="label" style="color: var(--color-success);">Authenticated</span><button class="btn btn-danger">Sign Out</button></div>
+      </section>
+
+      <section class="card">
+        <h2 class="section-header">Preferences</h2>
+
+        <div class="pref-row">
+          <div><div class="pref-title">📍 Location Tracking</div><div class="pref-sub">Enable GPS tracking for field data collection</div></div>
+          <div class="switch on"></div>
+        </div>
+        <div class="pref-row">
+          <div><div class="pref-title">🔄 Background Sync</div><div class="pref-sub">Automatically sync when app is in background</div></div>
+          <div class="switch on"></div>
+        </div>
+        <div class="pref-row">
+          <div><div class="pref-title">🔔 Push Notifications</div><div class="pref-sub">Receive notifications for sync status and updates</div></div>
+          <div class="switch"></div>
+        </div>
+        <div class="pref-row">
+          <div><div class="pref-title">Exception Reporting</div><div class="pref-sub">Sanitized reports queued locally; upload disabled</div></div>
+          <div class="switch on"></div>
+        </div>
+
+        <div class="slider-block">
+          <div class="pref-title">Exception Upload Endpoint</div>
+          <input class="entry" type="url" placeholder="Local queue only" />
+          <div class="pref-sub" style="margin-top: 6px;">Leave blank to store sanitized reports locally until an approved ingestion endpoint is configured.</div>
+        </div>
+
+        <div class="slider-block">
+          <div class="pref-title">⏱️ Sync Interval</div>
+          <div class="pref-sub">Every 15 minutes</div>
+          <div class="slider-track"><div class="fill" style="width: 18%;"></div><div class="thumb" style="left: 18%;"></div></div>
+          <div class="slider-scale"><span>5 min</span><span>30 min</span><span>60 min</span></div>
+        </div>
+
+        <div class="slider-block">
+          <div class="pref-title">💾 Offline Storage Limit</div>
+          <div class="pref-sub">500 MB maximum</div>
+          <div class="slider-track"><div class="fill" style="width: 21%;"></div><div class="thumb" style="left: 21%;"></div></div>
+          <div class="slider-scale"><span>100 MB</span><span>1 GB</span><span>2 GB</span></div>
+        </div>
+
+        <button class="btn btn-primary" style="width: 100%; margin-top: 10px; padding: 12px;">💾 Save Settings</button>
+      </section>
+
+      <section class="card">
+        <h2 class="section-header">Device Information</h2>
+        <div class="device-grid">
+          <span>📱</span><span>Mike's Pixel 8</span>
+          <span>💻</span><span>Android</span>
+          <span>🔢</span><span>14 (UpsideDownCake)</span>
+          <span>📦</span><span>0.1.17-alpha.1</span>
+          <span>🆔</span><span class="muted">f1b2c3-9a8e-44d2-...</span>
+          <span>🏷️</span><span class="muted">main @ a8ab651</span>
+          <span>🏃</span><span class="muted">Workflow run #2418</span>
+          <span>🌐</span><span class="muted">https://api.honua.io</span>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2 class="section-header warn">🛠️ Developer Options</h2>
+        <div class="dev-buttons">
+          <button class="btn btn-secondary">🔍 View Diagnostics</button>
+          <button class="btn btn-secondary">🌐 Test Connection</button>
+          <button class="btn btn-secondary">🗑️ Clear Cache</button>
+          <button class="btn btn-secondary">📤 Export Data</button>
+        </div>
+      </section>
+
+      <section class="card">
+        <div class="pref-row" style="padding: 0; border: 0;">
+          <div><div class="pref-title">🛠️ Developer Mode</div><div class="pref-sub">Enable advanced developer options and diagnostics</div></div>
+          <div class="switch on"></div>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2 class="section-header">About</h2>
+        <button class="btn btn-secondary" style="width: 100%;">ℹ️ About Honua</button>
+        <div class="pref-sub center" style="margin-top: 10px;">Version 0.1.17-alpha.1</div>
+      </section>
+
+      <section class="card danger">
+        <h2 class="section-header danger">⚠️ Danger Zone</h2>
+        <button class="btn btn-danger" style="width: 100%;">🔄 Reset App</button>
+        <div class="pref-sub center" style="margin-top: 10px; color: var(--color-danger);">This will permanently delete all app data and settings</div>
+      </section>
+    </main>
+    <nav class="tab-bar">
+      <div class="tab"><span class="glyph">M</span><span>Map</span></div>
+      <div class="tab"><span class="glyph">R</span><span>Records</span></div>
+      <div class="tab"><span class="glyph">S</span><span>Sync</span></div>
+      <div class="tab active"><span class="glyph">C</span><span>Settings</span></div>
+    </nav>
+  </div>
+</body>
+</html>

--- a/docs/design-handoff/settings/notes.md
+++ b/docs/design-handoff/settings/notes.md
@@ -1,0 +1,52 @@
+# SettingsPage
+
+**Source:** `apps/Honua.Mobile.FieldCollection/Views/SettingsPage.xaml`
+**ViewModel:** `SettingsViewModel` (Title: "Settings")
+
+## Purpose
+Configure account, app preferences, see device/build metadata, toggle developer mode, and access destructive ("Danger Zone") actions.
+
+## Layout
+Vertical stack inside a `RefreshView` + `ScrollView`. 20dp outer padding, 20dp inter-card gap. All sections are `CardFrameStyle`.
+
+## Sections (top to bottom)
+
+### 1. Account
+3-row grid (icon | label | action):
+- 👤 `UserName` | Profile button (`ViewUserProfileCommand`, visible when authenticated).
+- 🌐 `ServerUrl` | Configure (`ConfigureServerCommand`).
+- 🔐 Authenticated / Not signed in (color-coded) | Sign Out (`DangerButtonStyle`, visible when authenticated).
+
+### 2. Preferences
+- **📍 Location Tracking** + caption, `Switch` -> `EnableLocationTracking`.
+- **🔄 Background Sync** + caption, `Switch` -> `EnableBackgroundSync`.
+- **🔔 Push Notifications** + caption, `Switch` -> `EnablePushNotifications`.
+- **Exception Reporting** + dynamic `ExceptionReportingStatus`, `Switch` (with `CanEnableExceptionReporting` gating).
+- **Exception Upload Endpoint** (`Entry` URL keyboard) + caption.
+- **⏱️ Sync Interval** label + dynamic minutes label + `Slider` (5-60, thumb `Primary`) + min/mid/max captions.
+- **💾 Offline Storage Limit** label + MB display + `Slider` (100-2000) + captions.
+- **💾 Save Settings** button (`BaseButtonStyle`).
+
+### 3. Device Information
+2-column grid with 8 rows: Device name, Platform, OS Version, App version, Device id, Build source display, Workflow run display, Service endpoint display. Right column is muted text for ids / metadata.
+
+### 4. Developer Options (visible when `EnableDeveloperMode`)
+Four `SecondaryButtonStyle` buttons:
+- 🔍 View Diagnostics (`ViewDiagnosticsCommand`)
+- 🌐 Test Connection (`TestConnectionCommand`)
+- 🗑️ Clear Cache (`ClearCacheCommand`)
+- 📤 Export Data (`ExportDataCommand`)
+Header is `SectionHeaderStyle` with `Warning` orange text.
+
+### 5. Developer Mode toggle
+"🛠️ Developer Mode" + caption, `Switch` -> `EnableDeveloperMode`. Sits *below* the developer options card so the user has to scroll past the dev tools to find the toggle that enables them.
+
+### 6. About
+"ℹ️ About Honua" button + centered version caption.
+
+### 7. Danger Zone
+Card background swapped to `DangerLight`. Header "⚠️ Danger Zone" in `Danger`. "🔄 Reset App" (`DangerButtonStyle`) plus a centered warning caption in `Danger`.
+
+## Navigation in / out
+- **In:** Shell tab "Settings".
+- **Out:** Profile, server config, about, diagnostics commands all push detail pages (not in this XAML).

--- a/docs/design-handoff/settings/xaml-source.md
+++ b/docs/design-handoff/settings/xaml-source.md
@@ -1,0 +1,67 @@
+# SettingsPage - XAML source
+
+File: `apps/Honua.Mobile.FieldCollection/Views/SettingsPage.xaml`
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:Honua.Mobile.FieldCollection.ViewModels"
+             x:Class="Honua.Mobile.FieldCollection.Views.SettingsPage"
+             Title="{Binding Title}"
+             x:DataType="vm:SettingsViewModel">
+
+    <RefreshView IsRefreshing="{Binding IsRefreshing}" Command="{Binding RefreshCommand}">
+        <ScrollView>
+            <VerticalStackLayout Spacing="20" Padding="20">
+
+                <!-- Account -->
+                <Frame Style="{StaticResource CardFrameStyle}">
+                    <VerticalStackLayout Spacing="15">
+                        <Label Text="Account" Style="{StaticResource SectionHeaderStyle}" />
+                        <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="Auto,*,Auto"
+                              RowSpacing="10" ColumnSpacing="10">
+                            <Label Grid.Row="0" Grid.Column="0" Text="👤" FontSize="16" />
+                            <Label Grid.Row="0" Grid.Column="1" Text="{Binding UserName}" FontSize="16" VerticalOptions="Center" />
+                            <Button Grid.Row="0" Grid.Column="2" Text="Profile"
+                                    Style="{StaticResource SecondaryButtonStyle}"
+                                    Command="{Binding ViewUserProfileCommand}"
+                                    IsVisible="{Binding IsAuthenticated}" />
+                            <Label Grid.Row="1" Grid.Column="0" Text="🌐" FontSize="16" />
+                            <Label Grid.Row="1" Grid.Column="1" Text="{Binding ServerUrl}"
+                                   FontSize="14" TextColor="{StaticResource Gray600}" VerticalOptions="Center" />
+                            <Button Grid.Row="1" Grid.Column="2" Text="Configure"
+                                    Style="{StaticResource SecondaryButtonStyle}"
+                                    Command="{Binding ConfigureServerCommand}" />
+                            <Label Grid.Row="2" Grid.Column="0" Text="🔐" FontSize="16" />
+                            <Label Grid.Row="2" Grid.Column="1"
+                                   Text="{Binding IsAuthenticated, Converter={StaticResource BoolToStringConverter}, ConverterParameter='Authenticated|Not signed in'}"
+                                   FontSize="14"
+                                   TextColor="{Binding IsAuthenticated, Converter={StaticResource BoolToColorConverter}, ConverterParameter='Green|Red'}"
+                                   VerticalOptions="Center" />
+                            <Button Grid.Row="2" Grid.Column="2" Text="Sign Out"
+                                    Style="{StaticResource DangerButtonStyle}"
+                                    Command="{Binding SignOutCommand}"
+                                    IsVisible="{Binding IsAuthenticated}" />
+                        </Grid>
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Preferences (toggles, exception reporting entry, sliders, Save) -->
+                <!-- Device Information (8-row grid of platform metadata) -->
+                <!-- Developer Options (visible when EnableDeveloperMode) -->
+                <!-- Developer Mode switch -->
+                <!-- About -->
+                <!-- Danger Zone (DangerLight background, Reset App) -->
+
+            </VerticalStackLayout>
+        </ScrollView>
+    </RefreshView>
+
+    <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}"
+                      Color="{StaticResource Primary}"
+                      HorizontalOptions="Center" VerticalOptions="Center" />
+</ContentPage>
+```
+
+> The Account card is shown in full. The remaining cards (Preferences, Device Information, Developer Options, Developer Mode toggle, About, Danger Zone) follow the same `CardFrameStyle` + `SectionHeaderStyle` pattern; see `apps/Honua.Mobile.FieldCollection/Views/SettingsPage.xaml` for the complete source.

--- a/docs/design-handoff/shell/mock.html
+++ b/docs/design-handoff/shell/mock.html
@@ -1,0 +1,217 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>AppShell - Honua FieldCollection</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+  :root {
+    --color-primary: #2E8B57;
+    --color-primary-dark: #1F5F3F;
+    --color-primary-light: #4CAF50;
+    --color-secondary: #3F51B5;
+    --color-tertiary: #FF5722;
+    --color-success: #4CAF50;
+    --color-info: #2196F3;
+    --color-warning: #FF9800;
+    --color-danger: #F44336;
+    --color-danger-light: #FFEBEE;
+    --color-white: #FFFFFF;
+    --color-black: #000000;
+    --color-gray-100: #F5F5F5;
+    --color-gray-200: #EEEEEE;
+    --color-gray-300: #E0E0E0;
+    --color-gray-400: #BDBDBD;
+    --color-gray-500: #9E9E9E;
+    --color-gray-600: #757575;
+    --color-gray-700: #616161;
+    --color-gray-800: #424242;
+    --color-gray-900: #212121;
+    --color-background: #FFFFFF;
+    --color-surface: #FAFAFA;
+    --color-on-surface: #212121;
+    --color-status-bar: #1F5F3F;
+    --radius-sm: 8px;
+    --radius-md: 10px;
+    --radius-lg: 12px;
+    --shadow-common: 0 2px 8px rgba(0, 0, 0, 0.16);
+    --space-xs: 5px;
+    --space-sm: 8px;
+    --space-md: 10px;
+    --space-lg: 15px;
+    --space-xl: 20px;
+    --space-2xl: 25px;
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0;
+    background: var(--color-gray-200);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    color: var(--color-on-surface);
+  }
+  body {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+  }
+  .device {
+    width: 390px;
+    height: 844px;
+    background: var(--color-background);
+    border-radius: 32px;
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.25);
+    overflow: hidden;
+    display: grid;
+    grid-template-rows: 28px 56px 1fr 64px;
+  }
+  .status-bar {
+    background: var(--color-status-bar);
+    color: var(--color-white);
+    font-size: 11px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 18px;
+  }
+  .nav-bar {
+    background: var(--color-primary);
+    color: var(--color-white);
+    display: flex;
+    align-items: center;
+    padding: 0 16px;
+    font-size: 17px;
+    font-weight: 700;
+  }
+  main {
+    background: var(--color-background);
+    padding: 16px;
+    overflow-y: auto;
+  }
+  .tab-bar {
+    background: var(--color-primary);
+    color: var(--color-white);
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    align-items: center;
+    border-top: 1px solid rgba(255,255,255,0.08);
+  }
+  .tab-bar .tab {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    height: 100%;
+    font-size: 11px;
+    color: var(--color-gray-300);
+    opacity: 0.95;
+  }
+  .tab-bar .tab.active {
+    color: var(--color-white);
+    font-weight: 700;
+  }
+  .tab-bar .glyph {
+    width: 22px; height: 22px;
+    border-radius: 6px;
+    background: rgba(255,255,255,0.15);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+  }
+  .tab-bar .tab.active .glyph {
+    background: var(--color-white);
+    color: var(--color-primary);
+  }
+  /* AppShell page contents (illustrative content) */
+  .shell-illustration {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  .card {
+    background: var(--color-white);
+    border: 1px solid var(--color-gray-200);
+    border-radius: var(--radius-sm);
+    padding: 16px;
+    box-shadow: var(--shadow-common);
+  }
+  .card h2 {
+    margin: 0 0 8px 0;
+    color: var(--color-primary);
+    font-size: 18px;
+  }
+  .card p {
+    margin: 0;
+    color: var(--color-gray-600);
+    font-size: 14px;
+    line-height: 1.4;
+  }
+  .item-row {
+    display: grid;
+    grid-template-columns: 50px 1fr;
+    align-items: center;
+    height: 50px;
+    gap: 5px;
+  }
+  .item-row .icon {
+    width: 45px; height: 45px;
+    background: var(--color-gray-100);
+    border-radius: var(--radius-sm);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    color: var(--color-primary);
+    margin: 5px;
+  }
+  .item-row .label {
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--color-on-surface);
+  }
+  .legend {
+    font-size: 12px;
+    color: var(--color-gray-600);
+  }
+</style>
+</head>
+<body>
+  <div class="device" role="application" aria-label="Honua FieldCollection AppShell">
+    <header class="status-bar">
+      <span>9:41</span>
+      <span>FieldCollection</span>
+      <span>100%</span>
+    </header>
+    <nav class="nav-bar">Honua Field Collection</nav>
+    <main>
+      <section class="shell-illustration">
+        <div class="card">
+          <h2>AppShell</h2>
+          <p>Root navigation host. The tab bar at the bottom routes between the four primary destinations. The body of the screen is whatever the active tab renders (see <code>map/</code>, <code>records/</code>, <code>sync-center/</code>, <code>settings/</code> mocks).</p>
+        </div>
+
+        <div class="card">
+          <h2>Flyout ItemTemplate</h2>
+          <p class="legend">Used only if a flyout item appears; tabs use platform defaults.</p>
+          <div style="margin-top: 12px; display: grid; gap: 4px;">
+            <div class="item-row"><span class="icon">M</span><span class="label">Map</span></div>
+            <div class="item-row"><span class="icon">R</span><span class="label">Records</span></div>
+            <div class="item-row"><span class="icon">S</span><span class="label">Sync</span></div>
+            <div class="item-row"><span class="icon">C</span><span class="label">Settings</span></div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <nav class="tab-bar" aria-label="Primary tabs">
+      <div class="tab active"><span class="glyph">M</span><span>Map</span></div>
+      <div class="tab"><span class="glyph">R</span><span>Records</span></div>
+      <div class="tab"><span class="glyph">S</span><span>Sync</span></div>
+      <div class="tab"><span class="glyph">C</span><span>Settings</span></div>
+    </nav>
+  </div>
+</body>
+</html>

--- a/docs/design-handoff/shell/notes.md
+++ b/docs/design-handoff/shell/notes.md
@@ -1,0 +1,32 @@
+# AppShell
+
+**Source:** `apps/Honua.Mobile.FieldCollection/AppShell.xaml`
+
+## Purpose
+Root navigation container. Provides a bottom `TabBar` with four destinations and a `Shell.ItemTemplate` for any flyout-style item rendering.
+
+## Primary tabs
+
+| Order | Route | Icon | Page |
+| --- | --- | --- | --- |
+| 1 | `map` | `map_icon.png` | `MapPage` |
+| 2 | `records` (inside a Tab named "Records") | `list_icon.png` | `RecordsPage` |
+| 3 | `sync` | `sync_icon.png` | `SyncCenterPage` |
+| 4 | `settings` | `settings_icon.png` | `SettingsPage` |
+
+The Records tab is wrapped in an explicit `<Tab>` element (the others are bare `<ShellContent>`), which on Android means Records gets a slightly different surface than its siblings.
+
+## Theming applied at Shell level (`BaseStyle`)
+
+- `Shell.BackgroundColor` -> `Primary` (`#2E8B57`)
+- `Shell.ForegroundColor` / `TitleColor` / `TabBarForegroundColor` / `TabBarTitleColor` -> `White`
+- `Shell.DisabledColor` -> `Gray200`
+- `Shell.UnselectedColor` / `Shell.TabBarUnselectedColor` -> `Gray300`
+- `Shell.TabBarBackgroundColor` -> `Primary`
+
+## ItemTemplate
+A 50dp tall grid with a 20%/80% column split: icon on the left (45dp), bold 18sp label on the right. Only fires for flyout-style items; the tab bar uses platform defaults.
+
+## Navigation in / out
+- Entry: `AppShell` is set as `MainPage` in `App.xaml.cs`.
+- No `MainPage` (dashboard) tab is registered; it is reachable only via deep-link / direct navigation.

--- a/docs/design-handoff/shell/xaml-source.md
+++ b/docs/design-handoff/shell/xaml-source.md
@@ -1,0 +1,59 @@
+# AppShell - XAML source
+
+File: `apps/Honua.Mobile.FieldCollection/AppShell.xaml`
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<Shell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+       xmlns:views="clr-namespace:Honua.Mobile.FieldCollection.Views"
+       x:Class="Honua.Mobile.FieldCollection.AppShell"
+       Title="Honua Field Collection">
+
+    <Shell.Resources>
+        <ResourceDictionary>
+            <Style x:Key="BaseStyle" TargetType="Element">
+                <Setter Property="Shell.BackgroundColor" Value="{StaticResource Primary}" />
+                <Setter Property="Shell.ForegroundColor" Value="{StaticResource White}" />
+                <Setter Property="Shell.TitleColor" Value="{StaticResource White}" />
+                <Setter Property="Shell.DisabledColor" Value="{StaticResource Gray200}" />
+                <Setter Property="Shell.UnselectedColor" Value="{StaticResource Gray300}" />
+                <Setter Property="Shell.TabBarBackgroundColor" Value="{StaticResource Primary}" />
+                <Setter Property="Shell.TabBarForegroundColor" Value="{StaticResource White}"/>
+                <Setter Property="Shell.TabBarUnselectedColor" Value="{StaticResource Gray300}"/>
+                <Setter Property="Shell.TabBarTitleColor" Value="{StaticResource White}"/>
+            </Style>
+        </ResourceDictionary>
+    </Shell.Resources>
+
+    <TabBar>
+        <ShellContent Title="Map" Icon="map_icon.png" Route="map"
+                      ContentTemplate="{DataTemplate views:MapPage}" />
+
+        <Tab Title="Records" Icon="list_icon.png">
+            <ShellContent Title="Records List" Route="records"
+                          ContentTemplate="{DataTemplate views:RecordsPage}" />
+        </Tab>
+
+        <ShellContent Title="Sync" Icon="sync_icon.png" Route="sync"
+                      ContentTemplate="{DataTemplate views:SyncCenterPage}" />
+
+        <ShellContent Title="Settings" Icon="settings_icon.png" Route="settings"
+                      ContentTemplate="{DataTemplate views:SettingsPage}" />
+    </TabBar>
+
+    <Shell.ItemTemplate>
+        <DataTemplate>
+            <Grid HeightRequest="50">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="0.2*" />
+                    <ColumnDefinition Width="0.8*" />
+                </Grid.ColumnDefinitions>
+                <Image Grid.Column="0" Source="{Binding Icon}" Margin="5" HeightRequest="45" />
+                <Label Grid.Column="1" Text="{Binding Title}" FontAttributes="Bold"
+                       FontSize="18" VerticalOptions="Center" />
+            </Grid>
+        </DataTemplate>
+    </Shell.ItemTemplate>
+</Shell>
+```

--- a/docs/design-handoff/sync-center/mock.html
+++ b/docs/design-handoff/sync-center/mock.html
@@ -1,0 +1,193 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>SyncCenterPage - Honua FieldCollection</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+  :root {
+    --color-primary: #2E8B57;
+    --color-primary-dark: #1F5F3F;
+    --color-secondary: #3F51B5;
+    --color-tertiary: #FF5722;
+    --color-warning: #FF9800;
+    --color-danger: #F44336;
+    --color-success: #4CAF50;
+    --color-info: #2196F3;
+    --color-white: #FFFFFF;
+    --color-gray-100: #F5F5F5;
+    --color-gray-200: #EEEEEE;
+    --color-gray-300: #E0E0E0;
+    --color-gray-600: #757575;
+    --color-on-surface: #212121;
+    --color-background: #FFFFFF;
+    --color-surface: #FAFAFA;
+    --color-status-bar: #1F5F3F;
+    --radius-sm: 8px;
+    --shadow-common: 0 2px 8px rgba(0,0,0,0.16);
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; background: var(--color-gray-200); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; color: var(--color-on-surface); }
+  body { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .device { width: 390px; height: 844px; background: var(--color-background); border-radius: 32px; box-shadow: 0 24px 64px rgba(0,0,0,0.25); overflow: hidden; display: grid; grid-template-rows: 28px 56px 1fr 64px; }
+  .status-bar { background: var(--color-status-bar); color: var(--color-white); font-size: 11px; display: flex; justify-content: space-between; align-items: center; padding: 0 18px; }
+  .nav-bar { background: var(--color-primary); color: var(--color-white); display: flex; align-items: center; padding: 0 16px; font-size: 17px; font-weight: 700; }
+  main { overflow-y: auto; padding: 20px; background: var(--color-background); display: flex; flex-direction: column; gap: 20px; }
+  .card { background: var(--color-white); border: 1px solid var(--color-gray-200); border-radius: var(--radius-sm); padding: 16px; box-shadow: var(--shadow-common); }
+  .section-header { font-size: 18px; font-weight: 700; color: var(--color-primary); margin: 0; }
+  .section-header.warn { color: var(--color-warning); }
+  .row-status { display: grid; grid-template-columns: 1fr auto; gap: 10px; align-items: start; margin-top: 10px; }
+  .status-msg { font-size: 16px; font-weight: 700; }
+  .info-line { display: flex; gap: 10px; font-size: 14px; align-items: center; margin-top: 6px; }
+  .online { color: var(--color-success); }
+  .actions { display: flex; flex-direction: column; gap: 5px; }
+  .icon-btn { width: 60px; height: 40px; border: 0; border-radius: var(--radius-sm); color: var(--color-white); font-size: 16px; font-family: inherit; cursor: pointer; }
+  .icon-btn.primary { background: var(--color-primary); }
+  .icon-btn.danger { background: var(--color-tertiary); }
+  .progress { margin-top: 10px; height: 4px; background: var(--color-gray-200); border-radius: 2px; overflow: hidden; }
+  .progress > span { display: block; height: 100%; background: var(--color-primary); width: 35%; }
+  .ops-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 15px; margin: 10px 0; }
+  .btn { border: 0; cursor: pointer; padding: 12px 16px; border-radius: var(--radius-sm); color: var(--color-white); font-size: 14px; font-family: inherit; }
+  .btn-secondary { background: var(--color-secondary); }
+  .btn-primary { background: var(--color-primary); }
+  .caption { font-size: 12px; color: var(--color-gray-600); }
+  .stats-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px; margin-top: 10px; }
+  .stat .value { font-size: 18px; font-weight: 700; text-align: center; }
+  .stat .label { font-size: 12px; text-align: center; color: var(--color-gray-600); }
+  .kv-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 12px; margin-top: 10px; font-size: 13px; }
+  .metrics-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; margin-top: 10px; }
+  .metric .value { font-size: 16px; font-weight: 700; text-align: center; }
+  .metric .label { font-size: 11px; text-align: center; }
+  .source-row { display: grid; grid-template-columns: 1fr auto; padding: 6px 0; border-top: 1px solid var(--color-gray-200); }
+  .conflict-row { display: grid; grid-template-columns: 1fr auto; padding: 10px 0; border-top: 1px solid var(--color-gray-200); align-items: center; }
+  .history-row { display: grid; grid-template-columns: auto 1fr auto; gap: 10px; padding: 8px 0; border-top: 1px solid var(--color-gray-200); align-items: center; }
+  .history-row .icon { font-size: 16px; }
+  .small-emph { font-size: 14px; font-weight: 700; }
+  .text-muted { font-size: 12px; color: var(--color-gray-600); }
+  .right-stack { text-align: right; font-size: 12px; }
+  .tab-bar { background: var(--color-primary); color: var(--color-white); display: grid; grid-template-columns: repeat(4,1fr); }
+  .tab-bar .tab { display: flex; flex-direction: column; align-items: center; justify-content: center; font-size: 11px; gap: 4px; color: var(--color-gray-300); }
+  .tab-bar .tab.active { color: var(--color-white); font-weight: 700; }
+  .tab-bar .glyph { width: 22px; height: 22px; border-radius: 6px; background: rgba(255,255,255,0.15); display: inline-flex; align-items: center; justify-content: center; font-size: 12px; }
+</style>
+</head>
+<body>
+  <div class="device">
+    <header class="status-bar"><span>9:41</span><span>FieldCollection</span><span>100%</span></header>
+    <nav class="nav-bar">Sync Center</nav>
+    <main>
+      <section class="card">
+        <h2 class="section-header">Sync Status</h2>
+        <div class="row-status">
+          <div>
+            <div class="status-msg">Syncing - 7 pending changes</div>
+            <div class="info-line">🌐 <span class="online">Online</span></div>
+            <div class="info-line">📝 7 pending changes</div>
+            <div class="info-line">🕒 Last sync: 05/20 09:14</div>
+          </div>
+          <div class="actions">
+            <button class="icon-btn primary">🔄</button>
+            <button class="icon-btn danger">⏹️</button>
+          </div>
+        </div>
+        <div class="progress"><span></span></div>
+      </section>
+
+      <section class="card">
+        <h2 class="section-header">Sync Operations</h2>
+        <div class="ops-grid">
+          <button class="btn btn-secondary">⬇️ Pull Only</button>
+          <button class="btn btn-secondary">⬆️ Push Only</button>
+        </div>
+        <div class="caption">⬇️ Pull: Download latest changes from server</div>
+        <div class="caption">⬆️ Push: Upload local changes to server</div>
+      </section>
+
+      <section class="card">
+        <h2 class="section-header">Last Sync Statistics</h2>
+        <div class="stats-3">
+          <div class="stat"><div class="value">42</div><div class="label">Downloaded</div></div>
+          <div class="stat"><div class="value">7</div><div class="label">Uploaded</div></div>
+          <div class="stat"><div class="value">01:18</div><div class="label">Duration</div></div>
+        </div>
+      </section>
+
+      <section class="card">
+        <div style="display:flex; justify-content: space-between; align-items: center;">
+          <h2 class="section-header">Offline Diagnostics</h2>
+          <button class="btn btn-secondary" style="font-size: 12px; padding: 8px 12px;">Refresh</button>
+        </div>
+        <div class="kv-grid">
+          <div><strong>Package: hwy-east-2026</strong></div>
+          <div>Size: 184 MB</div>
+          <div>Metadata: OK</div>
+          <div>Features: 1,204</div>
+          <div>Local gen: 88</div>
+          <div>Server gen: 91</div>
+        </div>
+        <div class="metrics-grid">
+          <div class="metric"><div class="value">7</div><div class="label">Pending</div></div>
+          <div class="metric"><div class="value">2</div><div class="label">Claimed</div></div>
+          <div class="metric"><div class="value">112</div><div class="label">Succeeded</div></div>
+          <div class="metric"><div class="value">1</div><div class="label">Failed</div></div>
+          <div class="metric"><div class="value">0</div><div class="label">Retry</div></div>
+          <div class="metric"><div class="value">2</div><div class="label">Conflict</div></div>
+        </div>
+        <div style="margin-top: 10px;">
+          <div class="source-row"><div><div class="small-emph">Culverts</div><div class="text-muted">Source 12</div></div><div>812 features</div></div>
+          <div class="source-row"><div><div class="small-emph">Headwalls</div><div class="text-muted">Source 13</div></div><div>312 features</div></div>
+          <div class="source-row"><div><div class="small-emph">Crews</div><div class="text-muted">Source 14</div></div><div>80 features</div></div>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2 class="section-header warn">⚠️ Sync Conflicts</h2>
+        <div class="conflict-row">
+          <div>
+            <div class="small-emph">Culverts</div>
+            <div class="text-muted">Local edit conflicts with server change on attribute "condition"</div>
+          </div>
+          <button class="btn btn-primary">Resolve</button>
+        </div>
+        <div class="conflict-row">
+          <div>
+            <div class="small-emph">Headwalls</div>
+            <div class="text-muted">Server-deleted feature was edited locally</div>
+          </div>
+          <button class="btn btn-primary">Resolve</button>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2 class="section-header warn">Conflict Review</h2>
+        <div style="margin-top: 10px;">
+          <div style="padding: 6px 0; border-top: 1px solid var(--color-gray-200);">
+            <div style="display: flex; justify-content: space-between;"><span class="small-emph">Feature 9871</span><span class="text-muted">version-mismatch</span></div>
+            <div class="text-muted">Source 12 - Operation 8c1...</div>
+            <div class="text-muted">Server generation moved ahead while edit was queued.</div>
+            <div class="text-muted">Local: condition="Poor"</div>
+            <div class="text-muted">Server: condition="Fair"</div>
+            <div style="text-align:right; margin-top: 6px;"><button class="btn btn-secondary" style="font-size: 12px; padding: 6px 12px;">Review</button></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="card">
+        <div style="display:flex; justify-content: space-between; align-items: center;">
+          <h2 class="section-header">Recent Sync History</h2>
+          <button class="btn btn-secondary" style="font-size: 12px; padding: 8px 12px;">View All</button>
+        </div>
+        <div class="history-row"><span class="icon">✅</span><div><div class="small-emph">Full Sync</div><div class="text-muted">05/20 09:14</div></div><div class="right-stack"><div>⬇️42</div><div>⬆️7</div></div></div>
+        <div class="history-row"><span class="icon">⚠️</span><div><div class="small-emph">Push Sync</div><div class="text-muted">05/19 18:02</div></div><div class="right-stack"><div>⬇️0</div><div>⬆️5</div></div></div>
+        <div class="history-row"><span class="icon">❌</span><div><div class="small-emph">Full Sync</div><div class="text-muted">05/19 07:48</div></div><div class="right-stack"><div>⬇️0</div><div>⬆️0</div></div></div>
+      </section>
+    </main>
+    <nav class="tab-bar">
+      <div class="tab"><span class="glyph">M</span><span>Map</span></div>
+      <div class="tab"><span class="glyph">R</span><span>Records</span></div>
+      <div class="tab active"><span class="glyph">S</span><span>Sync</span></div>
+      <div class="tab"><span class="glyph">C</span><span>Settings</span></div>
+    </nav>
+  </div>
+</body>
+</html>

--- a/docs/design-handoff/sync-center/notes.md
+++ b/docs/design-handoff/sync-center/notes.md
@@ -1,0 +1,57 @@
+# SyncCenterPage
+
+**Source:** `apps/Honua.Mobile.FieldCollection/Views/SyncCenterPage.xaml`
+**ViewModel:** `SyncCenterViewModel` (Title: "Sync Center")
+
+## Purpose
+Single screen that surfaces all sync state: current status, manual sync controls, last-sync stats, offline cache diagnostics, conflicts (two flavors), and recent history.
+
+## Layout
+Vertical scrollable stack inside a `RefreshView`. Outer padding 20dp, 20dp gap between cards.
+
+## Sections
+
+### 1. Sync Status card
+- Header `SyncStatusMessage` (16sp bold, dynamic).
+- 🌐 Online / Offline (`BoolToColorConverter`).
+- 📝 Pending changes count (hidden if zero).
+- 🕒 Last sync time (hidden if null).
+- Right column actions: 🔄 Start full sync (`BaseButtonStyle`, 60dp wide), ⏹️ Cancel (`DangerButtonStyle`, only while syncing).
+- Bottom row: `ProgressBar` (visible only while syncing, color `Primary`).
+
+### 2. Sync Operations card
+- 2-button grid: ⬇️ Pull Only (`PullChangesOnlyCommand`), ⬆️ Push Only (`PushChangesOnlyCommand`), both `SecondaryButtonStyle`.
+- Two caption labels explain what each does.
+
+### 3. Last Sync Statistics card (only when stats present)
+- 3 stat tiles: Downloaded (`FeaturesPulled`), Uploaded (`FeaturesPushed`), Duration (`mm:ss`).
+
+### 4. Offline Diagnostics card (only when `OfflineCacheDiagnostics` is non-null)
+- Section header + Refresh button (`LoadOfflineDiagnosticsCommand`).
+- 2-column key/value grid: Package id + size, Metadata status + Feature count, Local gen + Server gen.
+- 3-column metrics grid (2 rows): Pending / Claimed / Succeeded / Failed / Retry / Conflict.
+- Inline `CollectionView` of per-source diagnostics (capped 180dp height) showing name + source id + feature count.
+
+### 5. Active Conflicts card (only when `ActiveConflicts.Count > 0`)
+- "⚠️ Sync Conflicts" header (in `Warning` orange).
+- Flat list: layer name + description, with a `Resolve` button per row (`BaseButtonStyle`).
+
+### 6. Conflict Review card (only when `ConflictReviewItems.Count > 0`)
+- "Conflict Review" header (Warning orange), 260dp max height collection.
+- Each item: feature id, status, source id, operation id, reason, local/server state preview, and a per-row `Review` button (`SecondaryButtonStyle`).
+
+### 7. Recent Sync History card
+- Header + "View All" (`ViewSyncHistoryCommand`).
+- 200dp capped collection. Each row: status emoji (`SyncStatusToEmojiConverter`), "{Type} Sync", start time, and right-aligned ⬇️N / ⬆️N counters.
+
+### 8. Working Offline card (only when `IsOnline == false`)
+- Same orange warning card pattern as MainPage.
+
+## Bindings of note
+- `CanRunSyncOperations` gates Pull/Push/Full-sync buttons.
+- `IsSyncing` toggles Cancel button visibility and the progress bar.
+- All collections live on the VM (`SyncHistory`, `ActiveConflicts`, `ConflictReviewItems`, `OfflineSources`).
+
+## Navigation in / out
+- **In:** Shell tab "Sync".
+- **Out:** Resolve/Review commands and "View All" are expected to push detail pages; not present in this XAML.

--- a/docs/design-handoff/sync-center/xaml-source.md
+++ b/docs/design-handoff/sync-center/xaml-source.md
@@ -1,6 +1,8 @@
 # SyncCenterPage - XAML source
 
-File: `apps/Honua.Mobile.FieldCollection/Views/SyncCenterPage.xaml`
+Source path in repo: `apps/Honua.Mobile.FieldCollection/Views/SyncCenterPage.xaml`
+
+The full XAML for `SyncCenterPage` is reproduced below verbatim. Use it as the source of truth when proposing design changes that map back to MAUI; no sections are abbreviated.
 
 ```xml
 <?xml version="1.0" encoding="utf-8" ?>
@@ -13,65 +15,367 @@ File: `apps/Honua.Mobile.FieldCollection/Views/SyncCenterPage.xaml`
              Title="{Binding Title}"
              x:DataType="vm:SyncCenterViewModel">
 
-    <RefreshView IsRefreshing="{Binding IsRefreshing}" Command="{Binding RefreshCommand}">
+    <RefreshView IsRefreshing="{Binding IsRefreshing}"
+                 Command="{Binding RefreshCommand}">
         <ScrollView>
             <VerticalStackLayout Spacing="20" Padding="20">
 
                 <!-- Sync Status Card -->
                 <Frame Style="{StaticResource CardFrameStyle}">
                     <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="*,Auto" RowSpacing="10">
-                        <Label Grid.Row="0" Grid.ColumnSpan="2" Text="Sync Status"
+                        <!-- Status Header -->
+                        <Label Grid.Row="0" Grid.ColumnSpan="2"
+                               Text="Sync Status"
                                Style="{StaticResource SectionHeaderStyle}" />
 
+                        <!-- Status Information -->
                         <VerticalStackLayout Grid.Row="1" Grid.Column="0" Spacing="5">
-                            <Label Text="{Binding SyncStatusMessage}" FontSize="16" FontAttributes="Bold" />
+                            <Label Text="{Binding SyncStatusMessage}"
+                                   FontSize="16" FontAttributes="Bold" />
+
                             <StackLayout Orientation="Horizontal" Spacing="10">
                                 <Label Text="🌐" FontSize="14" />
                                 <Label Text="{Binding IsOnline, Converter={StaticResource BoolToStringConverter}, ConverterParameter='Online|Offline'}"
                                        FontSize="14"
                                        TextColor="{Binding IsOnline, Converter={StaticResource BoolToColorConverter}, ConverterParameter='Green|Red'}" />
                             </StackLayout>
+
                             <StackLayout Orientation="Horizontal" Spacing="10"
                                         IsVisible="{Binding PendingChangesCount, Converter={StaticResource IntToBoolConverter}}">
                                 <Label Text="📝" FontSize="14" />
-                                <Label Text="{Binding PendingChangesCount, StringFormat='{0} pending changes'}" FontSize="14" />
+                                <Label Text="{Binding PendingChangesCount, StringFormat='{0} pending changes'}"
+                                       FontSize="14" />
                             </StackLayout>
+
                             <StackLayout Orientation="Horizontal" Spacing="10"
                                         IsVisible="{Binding LastSyncTime, Converter={StaticResource IsNotNullConverter}}">
                                 <Label Text="🕒" FontSize="14" />
-                                <Label Text="{Binding LastSyncTime, StringFormat='Last sync: {0:MM/dd HH:mm}'}" FontSize="14" />
+                                <Label Text="{Binding LastSyncTime, StringFormat='Last sync: {0:MM/dd HH:mm}'}"
+                                       FontSize="14" />
                             </StackLayout>
                         </VerticalStackLayout>
 
+                        <!-- Sync Actions -->
                         <VerticalStackLayout Grid.Row="1" Grid.Column="1" Spacing="5">
-                            <Button Text="🔄" Style="{StaticResource BaseButtonStyle}"
+                            <Button Text="🔄"
+                                    Style="{StaticResource BaseButtonStyle}"
                                     Command="{Binding StartFullSyncCommand}"
-                                    IsEnabled="{Binding CanRunSyncOperations}" WidthRequest="60" />
-                            <Button Text="⏹️" Style="{StaticResource DangerButtonStyle}"
+                                    IsEnabled="{Binding CanRunSyncOperations}"
+                                    WidthRequest="60" />
+
+                            <Button Text="⏹️"
+                                    Style="{StaticResource DangerButtonStyle}"
                                     Command="{Binding CancelSyncCommand}"
-                                    IsVisible="{Binding IsSyncing}" WidthRequest="60" />
+                                    IsVisible="{Binding IsSyncing}"
+                                    WidthRequest="60" />
                         </VerticalStackLayout>
 
+                        <!-- Sync Progress -->
                         <ProgressBar Grid.Row="2" Grid.ColumnSpan="2"
-                                    Progress="{Binding SyncProgress}" IsVisible="{Binding IsSyncing}"
+                                    Progress="{Binding SyncProgress}"
+                                    IsVisible="{Binding IsSyncing}"
                                     ProgressColor="{StaticResource Primary}" />
                     </Grid>
                 </Frame>
 
-                <!-- Sync Operations -->
-                <!-- Pull Only / Push Only buttons + captions -->
+                <!-- Sync Actions -->
+                <Frame Style="{StaticResource CardFrameStyle}">
+                    <VerticalStackLayout Spacing="15">
+                        <Label Text="Sync Operations" Style="{StaticResource SectionHeaderStyle}" />
 
-                <!-- Sync Statistics, Offline Diagnostics, Active Conflicts, Conflict Review,
-                     Sync History, Offline banner. See file for full markup. -->
+                        <Grid ColumnDefinitions="*,*" ColumnSpacing="15" RowSpacing="10">
+                            <Button Grid.Column="0"
+                                    Text="⬇️ Pull Only"
+                                    Style="{StaticResource SecondaryButtonStyle}"
+                                    Command="{Binding PullChangesOnlyCommand}"
+                                    IsEnabled="{Binding CanRunSyncOperations}" />
+
+                            <Button Grid.Column="1"
+                                    Text="⬆️ Push Only"
+                                    Style="{StaticResource SecondaryButtonStyle}"
+                                    Command="{Binding PushChangesOnlyCommand}"
+                                    IsEnabled="{Binding CanRunSyncOperations}" />
+                        </Grid>
+
+                        <Label Text="⬇️ Pull: Download latest changes from server"
+                               FontSize="12" TextColor="{StaticResource Gray600}" />
+                        <Label Text="⬆️ Push: Upload local changes to server"
+                               FontSize="12" TextColor="{StaticResource Gray600}" />
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Sync Statistics -->
+                <Frame Style="{StaticResource CardFrameStyle}"
+                       IsVisible="{Binding LastSyncStatistics, Converter={StaticResource IsNotNullConverter}}">
+                    <VerticalStackLayout Spacing="10">
+                        <Label Text="Last Sync Statistics" Style="{StaticResource SectionHeaderStyle}" />
+
+                        <Grid ColumnDefinitions="*,*,*" ColumnSpacing="10">
+                            <StackLayout Grid.Column="0">
+                                <Label Text="{Binding LastSyncStatistics.FeaturesPulled}"
+                                       FontSize="18" FontAttributes="Bold"
+                                       HorizontalOptions="Center" />
+                                <Label Text="Downloaded"
+                                       FontSize="12" HorizontalOptions="Center"
+                                       TextColor="{StaticResource Gray600}" />
+                            </StackLayout>
+
+                            <StackLayout Grid.Column="1">
+                                <Label Text="{Binding LastSyncStatistics.FeaturesPushed}"
+                                       FontSize="18" FontAttributes="Bold"
+                                       HorizontalOptions="Center" />
+                                <Label Text="Uploaded"
+                                       FontSize="12" HorizontalOptions="Center"
+                                       TextColor="{StaticResource Gray600}" />
+                            </StackLayout>
+
+                            <StackLayout Grid.Column="2">
+                                <Label Text="{Binding LastSyncStatistics.LastSyncDuration, StringFormat='{0:mm}:{0:ss}'}"
+                                       FontSize="18" FontAttributes="Bold"
+                                       HorizontalOptions="Center" />
+                                <Label Text="Duration"
+                                       FontSize="12" HorizontalOptions="Center"
+                                       TextColor="{StaticResource Gray600}" />
+                            </StackLayout>
+                        </Grid>
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Offline Diagnostics -->
+                <Frame Style="{StaticResource CardFrameStyle}"
+                       IsVisible="{Binding OfflineCacheDiagnostics, Converter={StaticResource IsNotNullConverter}}">
+                    <VerticalStackLayout Spacing="12">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <Label Grid.Column="0"
+                                   Text="Offline Diagnostics"
+                                   Style="{StaticResource SectionHeaderStyle}" />
+                            <Button Grid.Column="1"
+                                    Text="Refresh"
+                                    Style="{StaticResource SecondaryButtonStyle}"
+                                    Command="{Binding LoadOfflineDiagnosticsCommand}" />
+                        </Grid>
+
+                        <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
+                            <Label Grid.Row="0" Grid.Column="0"
+                                   Text="{Binding OfflineCacheDiagnostics.PackageId, StringFormat='Package: {0}'}"
+                                   FontSize="13" FontAttributes="Bold"
+                                   LineBreakMode="TailTruncation" />
+                            <Label Grid.Row="0" Grid.Column="1"
+                                   Text="{Binding OfflineCacheDiagnostics.PackageSizeDisplay, StringFormat='Size: {0}'}"
+                                   FontSize="13" />
+                            <Label Grid.Row="1" Grid.Column="0"
+                                   Text="{Binding OfflineCacheDiagnostics.MetadataCache.Status, StringFormat='Metadata: {0}'}"
+                                   FontSize="13" />
+                            <Label Grid.Row="1" Grid.Column="1"
+                                   Text="{Binding OfflineCacheDiagnostics.FeatureCache.TotalFeatureCount, StringFormat='Features: {0}'}"
+                                   FontSize="13" />
+                            <Label Grid.Row="2" Grid.Column="0"
+                                   Text="{Binding OfflineCacheDiagnostics.LocalGeneration, StringFormat='Local gen: {0}'}"
+                                   FontSize="13" />
+                            <Label Grid.Row="2" Grid.Column="1"
+                                   Text="{Binding OfflineCacheDiagnostics.ServerGeneration, StringFormat='Server gen: {0}'}"
+                                   FontSize="13" />
+                        </Grid>
+
+                        <Grid ColumnDefinitions="*,*,*" RowDefinitions="Auto,Auto" ColumnSpacing="8" RowSpacing="8">
+                            <StackLayout Grid.Row="0" Grid.Column="0">
+                                <Label Text="{Binding OfflineCacheDiagnostics.Operations.PendingCount}"
+                                       FontSize="16" FontAttributes="Bold" HorizontalOptions="Center" />
+                                <Label Text="Pending" FontSize="11" HorizontalOptions="Center" />
+                            </StackLayout>
+                            <StackLayout Grid.Row="0" Grid.Column="1">
+                                <Label Text="{Binding OfflineCacheDiagnostics.Operations.ClaimedCount}"
+                                       FontSize="16" FontAttributes="Bold" HorizontalOptions="Center" />
+                                <Label Text="Claimed" FontSize="11" HorizontalOptions="Center" />
+                            </StackLayout>
+                            <StackLayout Grid.Row="0" Grid.Column="2">
+                                <Label Text="{Binding OfflineCacheDiagnostics.Operations.SucceededCount}"
+                                       FontSize="16" FontAttributes="Bold" HorizontalOptions="Center" />
+                                <Label Text="Succeeded" FontSize="11" HorizontalOptions="Center" />
+                            </StackLayout>
+                            <StackLayout Grid.Row="1" Grid.Column="0">
+                                <Label Text="{Binding OfflineCacheDiagnostics.Operations.FailedCount}"
+                                       FontSize="16" FontAttributes="Bold" HorizontalOptions="Center" />
+                                <Label Text="Failed" FontSize="11" HorizontalOptions="Center" />
+                            </StackLayout>
+                            <StackLayout Grid.Row="1" Grid.Column="1">
+                                <Label Text="{Binding OfflineCacheDiagnostics.Operations.RetryCount}"
+                                       FontSize="16" FontAttributes="Bold" HorizontalOptions="Center" />
+                                <Label Text="Retry" FontSize="11" HorizontalOptions="Center" />
+                            </StackLayout>
+                            <StackLayout Grid.Row="1" Grid.Column="2">
+                                <Label Text="{Binding OfflineCacheDiagnostics.Operations.ConflictCount}"
+                                       FontSize="16" FontAttributes="Bold" HorizontalOptions="Center" />
+                                <Label Text="Conflict" FontSize="11" HorizontalOptions="Center" />
+                            </StackLayout>
+                        </Grid>
+
+                        <CollectionView ItemsSource="{Binding OfflineSources}"
+                                        IsVisible="{Binding OfflineSources.Count, Converter={StaticResource IntToBoolConverter}}"
+                                        MaximumHeightRequest="180">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="diagnostics:OfflineSourceDiagnostics">
+                                    <Grid ColumnDefinitions="*,Auto" Padding="4" ColumnSpacing="8">
+                                        <StackLayout Grid.Column="0">
+                                            <Label Text="{Binding DisplayName}" FontSize="13" FontAttributes="Bold" />
+                                            <Label Text="{Binding SourceId, StringFormat='Source {0}'}"
+                                                   FontSize="11" TextColor="{StaticResource Gray600}" />
+                                        </StackLayout>
+                                        <Label Grid.Column="1"
+                                               Text="{Binding FeatureCount, StringFormat='{0} features'}"
+                                               FontSize="12"
+                                               VerticalOptions="Center" />
+                                    </Grid>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Active Conflicts -->
+                <Frame Style="{StaticResource CardFrameStyle}"
+                       IsVisible="{Binding ActiveConflicts.Count, Converter={StaticResource IntToBoolConverter}}">
+                    <VerticalStackLayout Spacing="10">
+                        <Label Text="⚠️ Sync Conflicts" Style="{StaticResource SectionHeaderStyle}"
+                               TextColor="{StaticResource Warning}" />
+
+                        <CollectionView ItemsSource="{Binding ActiveConflicts}">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="services:ConflictInfo">
+                                    <Grid ColumnDefinitions="*,Auto" Padding="10" ColumnSpacing="10">
+                                        <StackLayout Grid.Column="0">
+                                            <Label Text="{Binding LayerName}"
+                                                   FontAttributes="Bold" />
+                                            <Label Text="{Binding ConflictDescription}"
+                                                   FontSize="12"
+                                                   TextColor="{StaticResource Gray600}" />
+                                        </StackLayout>
+
+                                        <Button Grid.Column="1"
+                                                Text="Resolve"
+                                                Style="{StaticResource BaseButtonStyle}"
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type vm:SyncCenterViewModel}}, Path=ResolveConflictCommand}"
+                                                CommandParameter="{Binding .}" />
+                                    </Grid>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Conflict Review Diagnostics -->
+                <Frame Style="{StaticResource CardFrameStyle}"
+                       IsVisible="{Binding ConflictReviewItems.Count, Converter={StaticResource IntToBoolConverter}}">
+                    <VerticalStackLayout Spacing="10">
+                        <Label Text="Conflict Review" Style="{StaticResource SectionHeaderStyle}"
+                               TextColor="{StaticResource Warning}" />
+
+                        <CollectionView ItemsSource="{Binding ConflictReviewItems}"
+                                        MaximumHeightRequest="260">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="diagnostics:OfflineConflictReviewItem">
+                                    <VerticalStackLayout Padding="6" Spacing="4">
+                                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                                            <Label Grid.Column="0"
+                                                   Text="{Binding FeatureId, StringFormat='Feature {0}'}"
+                                                   FontSize="13" FontAttributes="Bold" />
+                                            <Label Grid.Column="1"
+                                                   Text="{Binding Status}"
+                                                   FontSize="12" />
+                                        </Grid>
+                                        <Label Text="{Binding SourceId, StringFormat='Source {0}'}"
+                                               FontSize="11"
+                                               TextColor="{StaticResource Gray600}" />
+                                        <Label Text="{Binding OperationId, StringFormat='Operation {0}'}"
+                                               FontSize="11"
+                                               TextColor="{StaticResource Gray600}"
+                                               LineBreakMode="TailTruncation" />
+                                        <Label Text="{Binding Reason}"
+                                               FontSize="12"
+                                               TextColor="{StaticResource Gray600}" />
+                                        <Label Text="{Binding LocalState, StringFormat='Local: {0}'}"
+                                               FontSize="11"
+                                               LineBreakMode="TailTruncation" />
+                                        <Label Text="{Binding ServerState, StringFormat='Server: {0}'}"
+                                               FontSize="11"
+                                               LineBreakMode="TailTruncation" />
+                                        <Button Text="Review"
+                                                Style="{StaticResource SecondaryButtonStyle}"
+                                                HorizontalOptions="End"
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type vm:SyncCenterViewModel}}, Path=ReviewConflictCommand}"
+                                                CommandParameter="{Binding .}" />
+                                    </VerticalStackLayout>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Sync History -->
+                <Frame Style="{StaticResource CardFrameStyle}">
+                    <VerticalStackLayout Spacing="10">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <Label Grid.Column="0"
+                                   Text="Recent Sync History"
+                                   Style="{StaticResource SectionHeaderStyle}" />
+                            <Button Grid.Column="1"
+                                    Text="View All"
+                                    Style="{StaticResource SecondaryButtonStyle}"
+                                    Command="{Binding ViewSyncHistoryCommand}" />
+                        </Grid>
+
+                        <CollectionView ItemsSource="{Binding SyncHistory}"
+                                       MaximumHeightRequest="200">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="vm:SyncHistoryItem">
+                                    <Grid ColumnDefinitions="Auto,*,Auto" Padding="5" ColumnSpacing="10">
+                                        <Label Grid.Column="0"
+                                               Text="{Binding Status, Converter={StaticResource SyncStatusToEmojiConverter}}"
+                                               FontSize="16" VerticalOptions="Center" />
+
+                                        <StackLayout Grid.Column="1">
+                                            <Label Text="{Binding Type, StringFormat='{0} Sync'}"
+                                                   FontSize="14" FontAttributes="Bold" />
+                                            <Label Text="{Binding StartTime, StringFormat='{0:MM/dd HH:mm}'}"
+                                                   FontSize="12" TextColor="{StaticResource Gray600}" />
+                                        </StackLayout>
+
+                                        <StackLayout Grid.Column="2" HorizontalOptions="End">
+                                            <Label Text="{Binding ChangesPulled, StringFormat='⬇️{0}'}"
+                                                   FontSize="12" HorizontalOptions="End" />
+                                            <Label Text="{Binding ChangesPushed, StringFormat='⬆️{0}'}"
+                                                   FontSize="12" HorizontalOptions="End" />
+                                        </StackLayout>
+                                    </Grid>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Offline Status -->
+                <Frame Style="{StaticResource CardFrameStyle}"
+                       IsVisible="{Binding IsOnline, Converter={StaticResource InvertedBoolConverter}}"
+                       BackgroundColor="{StaticResource Warning}">
+                    <StackLayout Spacing="10">
+                        <Label Text="📶 Working Offline"
+                               FontSize="16" FontAttributes="Bold"
+                               TextColor="{StaticResource White}" />
+                        <Label Text="Sync will resume automatically when connection is restored."
+                               FontSize="14" TextColor="{StaticResource White}" />
+                    </StackLayout>
+                </Frame>
 
             </VerticalStackLayout>
         </ScrollView>
     </RefreshView>
 
-    <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}"
+    <!-- Loading Indicator -->
+    <ActivityIndicator IsRunning="{Binding IsBusy}"
+                      IsVisible="{Binding IsBusy}"
                       Color="{StaticResource Primary}"
-                      HorizontalOptions="Center" VerticalOptions="Center" />
+                      HorizontalOptions="Center"
+                      VerticalOptions="Center" />
+
 </ContentPage>
 ```
-
-> The Sync Status card is reproduced in full above. The remaining sections (Sync Operations, Last Sync Statistics, Offline Diagnostics, Active Conflicts, Conflict Review, Recent Sync History, Offline banner) live in the same file; see `apps/Honua.Mobile.FieldCollection/Views/SyncCenterPage.xaml` for the complete markup. They share the same `CardFrameStyle` + `SectionHeaderStyle` pattern.

--- a/docs/design-handoff/sync-center/xaml-source.md
+++ b/docs/design-handoff/sync-center/xaml-source.md
@@ -1,0 +1,77 @@
+# SyncCenterPage - XAML source
+
+File: `apps/Honua.Mobile.FieldCollection/Views/SyncCenterPage.xaml`
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:diagnostics="clr-namespace:Honua.Mobile.FieldCollection.Services.Diagnostics;assembly=Honua.Mobile.FieldCollection.Core"
+             xmlns:services="clr-namespace:Honua.Mobile.FieldCollection.Services;assembly=Honua.Mobile.FieldCollection.Core"
+             xmlns:vm="clr-namespace:Honua.Mobile.FieldCollection.ViewModels"
+             x:Class="Honua.Mobile.FieldCollection.Views.SyncCenterPage"
+             Title="{Binding Title}"
+             x:DataType="vm:SyncCenterViewModel">
+
+    <RefreshView IsRefreshing="{Binding IsRefreshing}" Command="{Binding RefreshCommand}">
+        <ScrollView>
+            <VerticalStackLayout Spacing="20" Padding="20">
+
+                <!-- Sync Status Card -->
+                <Frame Style="{StaticResource CardFrameStyle}">
+                    <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="*,Auto" RowSpacing="10">
+                        <Label Grid.Row="0" Grid.ColumnSpan="2" Text="Sync Status"
+                               Style="{StaticResource SectionHeaderStyle}" />
+
+                        <VerticalStackLayout Grid.Row="1" Grid.Column="0" Spacing="5">
+                            <Label Text="{Binding SyncStatusMessage}" FontSize="16" FontAttributes="Bold" />
+                            <StackLayout Orientation="Horizontal" Spacing="10">
+                                <Label Text="🌐" FontSize="14" />
+                                <Label Text="{Binding IsOnline, Converter={StaticResource BoolToStringConverter}, ConverterParameter='Online|Offline'}"
+                                       FontSize="14"
+                                       TextColor="{Binding IsOnline, Converter={StaticResource BoolToColorConverter}, ConverterParameter='Green|Red'}" />
+                            </StackLayout>
+                            <StackLayout Orientation="Horizontal" Spacing="10"
+                                        IsVisible="{Binding PendingChangesCount, Converter={StaticResource IntToBoolConverter}}">
+                                <Label Text="📝" FontSize="14" />
+                                <Label Text="{Binding PendingChangesCount, StringFormat='{0} pending changes'}" FontSize="14" />
+                            </StackLayout>
+                            <StackLayout Orientation="Horizontal" Spacing="10"
+                                        IsVisible="{Binding LastSyncTime, Converter={StaticResource IsNotNullConverter}}">
+                                <Label Text="🕒" FontSize="14" />
+                                <Label Text="{Binding LastSyncTime, StringFormat='Last sync: {0:MM/dd HH:mm}'}" FontSize="14" />
+                            </StackLayout>
+                        </VerticalStackLayout>
+
+                        <VerticalStackLayout Grid.Row="1" Grid.Column="1" Spacing="5">
+                            <Button Text="🔄" Style="{StaticResource BaseButtonStyle}"
+                                    Command="{Binding StartFullSyncCommand}"
+                                    IsEnabled="{Binding CanRunSyncOperations}" WidthRequest="60" />
+                            <Button Text="⏹️" Style="{StaticResource DangerButtonStyle}"
+                                    Command="{Binding CancelSyncCommand}"
+                                    IsVisible="{Binding IsSyncing}" WidthRequest="60" />
+                        </VerticalStackLayout>
+
+                        <ProgressBar Grid.Row="2" Grid.ColumnSpan="2"
+                                    Progress="{Binding SyncProgress}" IsVisible="{Binding IsSyncing}"
+                                    ProgressColor="{StaticResource Primary}" />
+                    </Grid>
+                </Frame>
+
+                <!-- Sync Operations -->
+                <!-- Pull Only / Push Only buttons + captions -->
+
+                <!-- Sync Statistics, Offline Diagnostics, Active Conflicts, Conflict Review,
+                     Sync History, Offline banner. See file for full markup. -->
+
+            </VerticalStackLayout>
+        </ScrollView>
+    </RefreshView>
+
+    <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}"
+                      Color="{StaticResource Primary}"
+                      HorizontalOptions="Center" VerticalOptions="Center" />
+</ContentPage>
+```
+
+> The Sync Status card is reproduced in full above. The remaining sections (Sync Operations, Last Sync Statistics, Offline Diagnostics, Active Conflicts, Conflict Review, Recent Sync History, Offline banner) live in the same file; see `apps/Honua.Mobile.FieldCollection/Views/SyncCenterPage.xaml` for the complete markup. They share the same `CardFrameStyle` + `SectionHeaderStyle` pattern.

--- a/docs/design-handoff/template-starter/mock.html
+++ b/docs/design-handoff/template-starter/mock.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Template Starter MainPage - Honua FieldCollector</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+  :root {
+    --color-primary: #2E8B57;
+    --color-secondary: #3F51B5;
+    --color-gray-100: #F5F5F5;
+    --color-gray-200: #EEEEEE;
+    --color-gray-300: #E0E0E0;
+    --color-gray-500: #9E9E9E;
+    --color-gray-600: #757575;
+    --color-gray-800: #424242;
+    --color-on-surface: #212121;
+    --color-white: #FFFFFF;
+    --color-background: #FFFFFF;
+    --color-status-bar: #1F5F3F;
+    --color-loc-light: #E3F2FD;
+    --color-tab-strip: #F5F5F5;
+    --color-green-literal: #16A34A; /* corresponds to XAML "Green" literal in stats / toast */
+    --radius-sm: 8px;
+    --radius-md: 10px;
+    --shadow-common: 0 2px 8px rgba(0,0,0,0.16);
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; background: var(--color-gray-200); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; color: var(--color-on-surface); }
+  body { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .device { width: 390px; height: 844px; background: var(--color-background); border-radius: 32px; box-shadow: 0 24px 64px rgba(0,0,0,0.25); overflow: hidden; display: grid; grid-template-rows: 28px 56px 1fr; }
+  .status-bar { background: var(--color-status-bar); color: var(--color-white); font-size: 11px; display: flex; justify-content: space-between; align-items: center; padding: 0 18px; }
+  .nav-bar { background: var(--color-primary); color: var(--color-white); display: flex; align-items: center; padding: 0 16px; font-size: 17px; font-weight: 700; }
+  main { display: grid; grid-template-rows: auto 1fr auto; overflow: hidden; }
+  .gps-strip {
+    background: var(--color-loc-light);
+    padding: 10px 15px;
+    display: flex; justify-content: space-between; align-items: center;
+    font-size: 13px;
+  }
+  .gps-strip strong { color: var(--color-primary); }
+  .tab-strip {
+    background: var(--color-tab-strip);
+    height: 60px;
+    display: grid; grid-template-columns: 1fr 1fr 1fr;
+    align-items: center; text-align: center;
+    font-size: 14px; font-weight: 700;
+    border-bottom: 1px solid var(--color-gray-200);
+  }
+  .tab-strip .item { padding: 8px; color: var(--color-gray-600); }
+  .tab-strip .item.active { color: var(--color-primary); border-bottom: 3px solid var(--color-primary); }
+  .tab-strip .item.stats.active { color: var(--color-green-literal); border-bottom-color: var(--color-green-literal); }
+  .tab-body { overflow-y: auto; padding: 20px; display: flex; flex-direction: column; gap: 20px; }
+  .welcome {
+    background: var(--color-primary);
+    color: var(--color-white);
+    border-radius: var(--radius-md);
+    padding: 20px;
+    text-align: center;
+    box-shadow: var(--shadow-common);
+  }
+  .welcome h1 { margin: 0; font-size: 20px; }
+  .welcome p { margin: 5px 0 0 0; font-size: 14px; }
+  .form {
+    background: var(--color-gray-100);
+    border-radius: var(--radius-sm);
+    padding: 16px;
+    display: grid; gap: 12px;
+  }
+  .form .row { display: flex; flex-direction: column; gap: 4px; font-size: 13px; }
+  .form input, .form select, .form textarea { background: var(--color-white); border: 1px solid var(--color-gray-300); border-radius: var(--radius-sm); padding: 10px 12px; font-family: inherit; font-size: 14px; }
+  .form .progress { height: 4px; background: var(--color-gray-300); border-radius: 2px; overflow: hidden; margin-top: 4px; }
+  .form .progress > span { display: block; height: 100%; background: var(--color-primary); width: 40%; }
+  .quick-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+  .btn { border: 0; cursor: pointer; padding: 12px 14px; border-radius: var(--radius-sm); color: var(--color-white); font-size: 14px; font-family: inherit; }
+  .btn-secondary { background: var(--color-secondary); }
+  .btn-outline { background: transparent; color: var(--color-primary); border: 1px solid var(--color-primary); }
+  .sync-strip {
+    background: var(--color-tab-strip);
+    padding: 10px 15px;
+    display: flex; justify-content: space-between; align-items: center;
+    font-size: 13px;
+    border-top: 1px solid var(--color-gray-200);
+  }
+</style>
+</head>
+<body>
+  <div class="device">
+    <header class="status-bar"><span>9:41</span><span>FieldCollector</span><span>100%</span></header>
+    <nav class="nav-bar">YOUR_COMPANY_NAME Field Collection</nav>
+    <main>
+      <div class="gps-strip" role="status">
+        <span><strong>📍 GPS</strong> 3.2 m accuracy</span>
+        <span>40.7128, -74.0060</span>
+      </div>
+      <div>
+        <div class="tab-strip">
+          <div class="item active">📝 Collect</div>
+          <div class="item">🗺️ Map</div>
+          <div class="item stats">📊 Stats</div>
+        </div>
+        <div class="tab-body">
+          <section class="welcome">
+            <h1>🚀 Field Data Collection</h1>
+            <p>Professional data collection that competes with Fulcrum & Survey123</p>
+          </section>
+
+          <section class="form" aria-label="Field site inspection form">
+            <div class="row"><label>Site name</label><input type="text" value="Site 04 - Inlet" /></div>
+            <div class="row"><label>Inspector</label><input type="text" value="Mike McDougall" /></div>
+            <div class="row"><label>Condition</label>
+              <select><option>Good</option><option selected>Fair</option><option>Poor</option></select>
+            </div>
+            <div class="row"><label>Notes</label><textarea rows="3">Sediment buildup along inlet, sched. clean.</textarea></div>
+            <div>
+              <span style="font-size: 12px; color: var(--color-gray-600);">Form progress</span>
+              <div class="progress"><span></span></div>
+            </div>
+          </section>
+
+          <div class="quick-actions">
+            <button class="btn btn-secondary">📷 Quick Photo</button>
+            <button class="btn btn-outline">🗺️ View Map</button>
+          </div>
+        </div>
+      </div>
+      <div class="sync-strip" role="status">
+        <span>🔄 Synced 2 minutes ago</span>
+        <span style="color: var(--color-primary); font-weight: 700;">Sync now</span>
+      </div>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/design-handoff/template-starter/notes.md
+++ b/docs/design-handoff/template-starter/notes.md
@@ -1,0 +1,37 @@
+# Template starter - MainPage
+
+**Source:** `templates/honua-fieldcollector/MainPage.xaml`
+**Code-behind:** `templates/honua-fieldcollector/MainPage.xaml.cs`
+
+## Purpose
+Customer-facing scaffolding shown when a partner spins up a new FieldCollector app from the `honua-fieldcollector` template. It is intentionally separate from the in-house FieldCollection app and uses the Honua MAUI control suite (`honua:` namespace) at the top level.
+
+## Layout
+3-row grid:
+- Row 0: `HonuaLocationIndicator` (GPS strip).
+- Row 1: 3-tab `TabView` (Collect / Map / Stats) + a loading overlay.
+- Row 2: `HonuaSyncStatus` (sync strip).
+A success toast is overlaid at the top of the page when triggered.
+
+## Tabs
+
+### 📝 Collect
+- Welcome `Frame` with `Primary` background: "🚀 Field Data Collection" + tagline.
+- `HonuaFeatureForm` (FormId `field-site-inspection`, drafts on, progress on).
+- 2-column quick-action grid: "📷 Quick Photo" (`Secondary`) + outline "🗺️ View Map".
+
+### 🗺️ Map
+- Full-tab `HonuaMapView` with toolbar + overlays, spatial query off, shows collected features.
+
+### 📊 Stats
+- Green-background stats `Frame` with two columns: Records count + Photos count (32sp white numbers).
+- "📈 Recent Activity" header.
+- `CollectionView` of recent activity rows (icon | title + description | time).
+
+## Theming notes
+- This template references `Primary` / `Secondary` / `Gray500` / `Gray600` from `Colors.xaml` and uses two `AppThemeBinding` blocks for `HonuaLocationIndicator` (`#E3F2FD`/`#1565C0`) and the tab strip + `HonuaSyncStatus` (`#F5F5F5`/`#424242`). These dark-mode hex values are not present anywhere else in the codebase.
+- The stats `Frame` uses literal `BackgroundColor="Green"` (not a token) and the toast uses literal `BackgroundColor="Green"` - two of the few places in the bundle where colors bypass the tokens.
+
+## Navigation in / out
+- **In:** App entrypoint when the template is used.
+- **Out:** "🗺️ View Map" button via `OnViewMapClicked`; tab switching is in-page.

--- a/docs/design-handoff/template-starter/xaml-source.md
+++ b/docs/design-handoff/template-starter/xaml-source.md
@@ -1,0 +1,134 @@
+# Template starter MainPage - XAML source
+
+File: `templates/honua-fieldcollector/MainPage.xaml`
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage x:Class="HonuaFieldCollector.MainPage"
+             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:honua="http://schemas.honua.com/mobile/2024"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             Title="YOUR_COMPANY_NAME Field Collection">
+
+    <Grid RowDefinitions="Auto,*,Auto">
+
+        <!-- GPS Status & Accuracy -->
+        <honua:HonuaLocationIndicator Grid.Row="0"
+                                     x:Name="LocationIndicator"
+                                     ShowAccuracy="true"
+                                     RequiredAccuracy="5.0"
+                                     UpdateInterval="2000"
+                                     BackgroundColor="{AppThemeBinding Light=#E3F2FD, Dark=#1565C0}"
+                                     Padding="15,10"
+                                     LocationUpdated="OnLocationUpdated" />
+
+        <!-- Main Content -->
+        <Grid Grid.Row="1">
+            <TabView x:Name="MainTabs"
+                    TabStripBackgroundColor="{AppThemeBinding Light=#F5F5F5, Dark=#424242}"
+                    TabStripHeight="60">
+
+                <TabViewItem Text="📝 Collect" TextColor="{StaticResource Primary}" TextColorSelected="{StaticResource Primary}">
+                    <ScrollView>
+                        <StackLayout Spacing="0" Padding="20">
+                            <Frame BackgroundColor="{StaticResource Primary}" CornerRadius="10" Padding="20"
+                                  Margin="0,0,0,20" HasShadow="True">
+                                <StackLayout>
+                                    <Label Text="🚀 Field Data Collection" FontSize="20" FontAttributes="Bold"
+                                          TextColor="White" HorizontalOptions="Center" />
+                                    <Label Text="Professional data collection that competes with Fulcrum &amp; Survey123"
+                                          FontSize="14" TextColor="White" HorizontalOptions="Center" Margin="0,5,0,0" />
+                                </StackLayout>
+                            </Frame>
+
+                            <honua:HonuaFeatureForm x:Name="DataForm" FormId="field-site-inspection"
+                                                    AllowDrafts="true" ShowProgress="true" />
+
+                            <Grid ColumnDefinitions="*,*" ColumnSpacing="10" Margin="0,20,0,0">
+                                <Button Grid.Column="0" Text="📷 Quick Photo"
+                                       Command="{Binding QuickPhotoCommand}"
+                                       BackgroundColor="{StaticResource Secondary}" TextColor="White" CornerRadius="8" />
+                                <Button Grid.Column="1" Text="🗺️ View Map" Clicked="OnViewMapClicked"
+                                       BackgroundColor="Transparent" BorderColor="{StaticResource Primary}"
+                                       BorderWidth="1" TextColor="{StaticResource Primary}" CornerRadius="8" />
+                            </Grid>
+                        </StackLayout>
+                    </ScrollView>
+                </TabViewItem>
+
+                <TabViewItem Text="🗺️ Map" TextColor="{StaticResource Secondary}" TextColorSelected="{StaticResource Secondary}">
+                    <honua:HonuaMapView x:Name="MapView" ShowToolbar="true" ShowOverlays="true"
+                                       EnableSpatialQuery="false" ShowCollectedFeatures="true" />
+                </TabViewItem>
+
+                <TabViewItem Text="📊 Stats" TextColor="Green" TextColorSelected="Green">
+                    <ScrollView>
+                        <StackLayout Padding="20" Spacing="20">
+                            <Frame BackgroundColor="Green" CornerRadius="10" Padding="20" HasShadow="True">
+                                <StackLayout>
+                                    <Label Text="📊 Collection Statistics" FontSize="18" FontAttributes="Bold"
+                                          TextColor="White" HorizontalOptions="Center" />
+                                    <Grid ColumnDefinitions="*,*" ColumnSpacing="20" Margin="0,10,0,0">
+                                        <StackLayout Grid.Column="0">
+                                            <Label x:Name="RecordsCountLabel" Text="0" FontSize="32"
+                                                  FontAttributes="Bold" TextColor="White" HorizontalOptions="Center" />
+                                            <Label Text="Records" FontSize="14" TextColor="White" HorizontalOptions="Center" />
+                                        </StackLayout>
+                                        <StackLayout Grid.Column="1">
+                                            <Label x:Name="PhotosCountLabel" Text="0" FontSize="32"
+                                                  FontAttributes="Bold" TextColor="White" HorizontalOptions="Center" />
+                                            <Label Text="Photos" FontSize="14" TextColor="White" HorizontalOptions="Center" />
+                                        </StackLayout>
+                                    </Grid>
+                                </StackLayout>
+                            </Frame>
+
+                            <Label Text="📈 Recent Activity" FontSize="18" FontAttributes="Bold" />
+
+                            <CollectionView x:Name="RecentActivityList" HeightRequest="300">
+                                <CollectionView.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid ColumnDefinitions="Auto,*,Auto" Padding="15" RowSpacing="5">
+                                            <Label Grid.Column="0" Text="{Binding Icon}" FontSize="24" VerticalOptions="Center" />
+                                            <StackLayout Grid.Column="1" Margin="15,0,0,0" VerticalOptions="Center">
+                                                <Label Text="{Binding Title}" FontSize="16" FontAttributes="Bold" />
+                                                <Label Text="{Binding Description}" FontSize="14"
+                                                      TextColor="{StaticResource Gray600}" />
+                                            </StackLayout>
+                                            <Label Grid.Column="2" Text="{Binding Time}" FontSize="12"
+                                                  TextColor="{StaticResource Gray500}" VerticalOptions="Center" />
+                                        </Grid>
+                                    </DataTemplate>
+                                </CollectionView.ItemTemplate>
+                            </CollectionView>
+                        </StackLayout>
+                    </ScrollView>
+                </TabViewItem>
+            </TabView>
+
+            <!-- Loading overlay (hidden by default) -->
+            <Grid x:Name="LoadingOverlay" BackgroundColor="Black" Opacity="0.7" IsVisible="False">
+                <StackLayout VerticalOptions="Center" HorizontalOptions="Center">
+                    <ActivityIndicator x:Name="LoadingIndicator" IsRunning="False"
+                                       Color="{StaticResource Primary}" Scale="2" />
+                    <Label x:Name="LoadingMessage" Text="Loading..." TextColor="White" FontSize="16"
+                          HorizontalOptions="Center" Margin="0,20,0,0" />
+                </StackLayout>
+            </Grid>
+        </Grid>
+
+        <!-- Sync Status & Controls -->
+        <honua:HonuaSyncStatus Grid.Row="2" x:Name="SyncStatus" ShowDetails="false" EnableManualSync="true"
+                              BackgroundColor="{AppThemeBinding Light=#F5F5F5, Dark=#424242}"
+                              Padding="15,10" />
+    </Grid>
+
+    <!-- Success Toast (hidden by default) -->
+    <Grid x:Name="SuccessToast" BackgroundColor="Green" Opacity="0.9" Padding="20"
+         IsVisible="False" VerticalOptions="Start" HorizontalOptions="Fill">
+        <Label x:Name="SuccessMessage" Text="" TextColor="White" FontSize="16" FontAttributes="Bold"
+              HorizontalOptions="Center" VerticalOptions="Center" />
+    </Grid>
+</ContentPage>
+```

--- a/docs/design-handoff/template-starter/xaml-source.md
+++ b/docs/design-handoff/template-starter/xaml-source.md
@@ -1,6 +1,8 @@
 # Template starter MainPage - XAML source
 
-File: `templates/honua-fieldcollector/MainPage.xaml`
+Source path in repo: `templates/honua-fieldcollector/MainPage.xaml`
+
+The full XAML for the template's `MainPage` is reproduced below verbatim, including event handler wiring (`LocationUpdated`, `FormSubmitted`, `ValidationChanged`, `LoadingChanged`, `LayerClicked`, `FeatureSelected`, `ConflictDetected`, `SyncCompleted`) and the `TapGestureRecognizer` hooks on `HonuaLocationIndicator` and `HonuaSyncStatus`. Do not assume any element is self-closed or summarised in design proposals.
 
 ```xml
 <?xml version="1.0" encoding="utf-8" ?>
@@ -13,7 +15,7 @@ File: `templates/honua-fieldcollector/MainPage.xaml`
 
     <Grid RowDefinitions="Auto,*,Auto">
 
-        <!-- GPS Status & Accuracy -->
+        <!-- 📍 GPS Status & Accuracy -->
         <honua:HonuaLocationIndicator Grid.Row="0"
                                      x:Name="LocationIndicator"
                                      ShowAccuracy="true"
@@ -21,114 +23,237 @@ File: `templates/honua-fieldcollector/MainPage.xaml`
                                      UpdateInterval="2000"
                                      BackgroundColor="{AppThemeBinding Light=#E3F2FD, Dark=#1565C0}"
                                      Padding="15,10"
-                                     LocationUpdated="OnLocationUpdated" />
+                                     LocationUpdated="OnLocationUpdated">
+            <honua:HonuaLocationIndicator.GestureRecognizers>
+                <TapGestureRecognizer Tapped="OnLocationTapped" />
+            </honua:HonuaLocationIndicator.GestureRecognizers>
+        </honua:HonuaLocationIndicator>
 
-        <!-- Main Content -->
+        <!-- 📝 Main Content Area -->
         <Grid Grid.Row="1">
+            <!-- Tab Navigation -->
             <TabView x:Name="MainTabs"
                     TabStripBackgroundColor="{AppThemeBinding Light=#F5F5F5, Dark=#424242}"
                     TabStripHeight="60">
 
-                <TabViewItem Text="📝 Collect" TextColor="{StaticResource Primary}" TextColorSelected="{StaticResource Primary}">
+                <!-- Data Collection Tab -->
+                <TabViewItem Text="📝 Collect"
+                            TextColor="{StaticResource Primary}"
+                            TextColorSelected="{StaticResource Primary}">
                     <ScrollView>
                         <StackLayout Spacing="0" Padding="20">
-                            <Frame BackgroundColor="{StaticResource Primary}" CornerRadius="10" Padding="20"
-                                  Margin="0,0,0,20" HasShadow="True">
+
+                            <!-- Welcome Header -->
+                            <Frame BackgroundColor="{StaticResource Primary}"
+                                  CornerRadius="10"
+                                  Padding="20"
+                                  Margin="0,0,0,20"
+                                  HasShadow="True">
                                 <StackLayout>
-                                    <Label Text="🚀 Field Data Collection" FontSize="20" FontAttributes="Bold"
-                                          TextColor="White" HorizontalOptions="Center" />
+                                    <Label Text="🚀 Field Data Collection"
+                                          FontSize="20"
+                                          FontAttributes="Bold"
+                                          TextColor="White"
+                                          HorizontalOptions="Center" />
                                     <Label Text="Professional data collection that competes with Fulcrum &amp; Survey123"
-                                          FontSize="14" TextColor="White" HorizontalOptions="Center" Margin="0,5,0,0" />
+                                          FontSize="14"
+                                          TextColor="White"
+                                          HorizontalOptions="Center"
+                                          Margin="0,5,0,0" />
                                 </StackLayout>
                             </Frame>
 
-                            <honua:HonuaFeatureForm x:Name="DataForm" FormId="field-site-inspection"
-                                                    AllowDrafts="true" ShowProgress="true" />
+                            <!-- Dynamic Form -->
+                            <honua:HonuaFeatureForm x:Name="DataForm"
+                                                   FormId="field-site-inspection"
+                                                   AllowDrafts="true"
+                                                   ShowProgress="true"
+                                                   FormSubmitted="OnDataCollected"
+                                                   ValidationChanged="OnValidationChanged"
+                                                   LoadingChanged="OnFormLoadingChanged" />
 
-                            <Grid ColumnDefinitions="*,*" ColumnSpacing="10" Margin="0,20,0,0">
-                                <Button Grid.Column="0" Text="📷 Quick Photo"
+                            <!-- Quick Actions -->
+                            <Grid ColumnDefinitions="*,*"
+                                 ColumnSpacing="10"
+                                 Margin="0,20,0,0">
+                                <Button Grid.Column="0"
+                                       Text="📷 Quick Photo"
                                        Command="{Binding QuickPhotoCommand}"
-                                       BackgroundColor="{StaticResource Secondary}" TextColor="White" CornerRadius="8" />
-                                <Button Grid.Column="1" Text="🗺️ View Map" Clicked="OnViewMapClicked"
-                                       BackgroundColor="Transparent" BorderColor="{StaticResource Primary}"
-                                       BorderWidth="1" TextColor="{StaticResource Primary}" CornerRadius="8" />
+                                       BackgroundColor="{StaticResource Secondary}"
+                                       TextColor="White"
+                                       CornerRadius="8" />
+                                <Button Grid.Column="1"
+                                       Text="🗺️ View Map"
+                                       Clicked="OnViewMapClicked"
+                                       BackgroundColor="Transparent"
+                                       BorderColor="{StaticResource Primary}"
+                                       BorderWidth="1"
+                                       TextColor="{StaticResource Primary}"
+                                       CornerRadius="8" />
                             </Grid>
+
                         </StackLayout>
                     </ScrollView>
                 </TabViewItem>
 
-                <TabViewItem Text="🗺️ Map" TextColor="{StaticResource Secondary}" TextColorSelected="{StaticResource Secondary}">
-                    <honua:HonuaMapView x:Name="MapView" ShowToolbar="true" ShowOverlays="true"
-                                       EnableSpatialQuery="false" ShowCollectedFeatures="true" />
+                <!-- Map View Tab -->
+                <TabViewItem Text="🗺️ Map"
+                            TextColor="{StaticResource Secondary}"
+                            TextColorSelected="{StaticResource Secondary}">
+                    <honua:HonuaMapView x:Name="MapView"
+                                       ShowToolbar="true"
+                                       ShowOverlays="true"
+                                       EnableSpatialQuery="false"
+                                       ShowCollectedFeatures="true"
+                                       LayerClicked="OnMapLayerClicked"
+                                       FeatureSelected="OnMapFeatureSelected" />
                 </TabViewItem>
 
-                <TabViewItem Text="📊 Stats" TextColor="Green" TextColorSelected="Green">
+                <!-- Statistics Tab -->
+                <TabViewItem Text="📊 Stats"
+                            TextColor="Green"
+                            TextColorSelected="Green">
                     <ScrollView>
                         <StackLayout Padding="20" Spacing="20">
-                            <Frame BackgroundColor="Green" CornerRadius="10" Padding="20" HasShadow="True">
+
+                            <!-- Collection Statistics -->
+                            <Frame BackgroundColor="Green"
+                                  CornerRadius="10"
+                                  Padding="20"
+                                  HasShadow="True">
                                 <StackLayout>
-                                    <Label Text="📊 Collection Statistics" FontSize="18" FontAttributes="Bold"
-                                          TextColor="White" HorizontalOptions="Center" />
-                                    <Grid ColumnDefinitions="*,*" ColumnSpacing="20" Margin="0,10,0,0">
+                                    <Label Text="📊 Collection Statistics"
+                                          FontSize="18"
+                                          FontAttributes="Bold"
+                                          TextColor="White"
+                                          HorizontalOptions="Center" />
+                                    <Grid ColumnDefinitions="*,*"
+                                         ColumnSpacing="20"
+                                         Margin="0,10,0,0">
                                         <StackLayout Grid.Column="0">
-                                            <Label x:Name="RecordsCountLabel" Text="0" FontSize="32"
-                                                  FontAttributes="Bold" TextColor="White" HorizontalOptions="Center" />
-                                            <Label Text="Records" FontSize="14" TextColor="White" HorizontalOptions="Center" />
+                                            <Label x:Name="RecordsCountLabel"
+                                                  Text="0"
+                                                  FontSize="32"
+                                                  FontAttributes="Bold"
+                                                  TextColor="White"
+                                                  HorizontalOptions="Center" />
+                                            <Label Text="Records"
+                                                  FontSize="14"
+                                                  TextColor="White"
+                                                  HorizontalOptions="Center" />
                                         </StackLayout>
                                         <StackLayout Grid.Column="1">
-                                            <Label x:Name="PhotosCountLabel" Text="0" FontSize="32"
-                                                  FontAttributes="Bold" TextColor="White" HorizontalOptions="Center" />
-                                            <Label Text="Photos" FontSize="14" TextColor="White" HorizontalOptions="Center" />
+                                            <Label x:Name="PhotosCountLabel"
+                                                  Text="0"
+                                                  FontSize="32"
+                                                  FontAttributes="Bold"
+                                                  TextColor="White"
+                                                  HorizontalOptions="Center" />
+                                            <Label Text="Photos"
+                                                  FontSize="14"
+                                                  TextColor="White"
+                                                  HorizontalOptions="Center" />
                                         </StackLayout>
                                     </Grid>
                                 </StackLayout>
                             </Frame>
 
-                            <Label Text="📈 Recent Activity" FontSize="18" FontAttributes="Bold" />
+                            <!-- Recent Activity -->
+                            <Label Text="📈 Recent Activity"
+                                  FontSize="18"
+                                  FontAttributes="Bold" />
 
-                            <CollectionView x:Name="RecentActivityList" HeightRequest="300">
+                            <CollectionView x:Name="RecentActivityList"
+                                          HeightRequest="300">
                                 <CollectionView.ItemTemplate>
                                     <DataTemplate>
-                                        <Grid ColumnDefinitions="Auto,*,Auto" Padding="15" RowSpacing="5">
-                                            <Label Grid.Column="0" Text="{Binding Icon}" FontSize="24" VerticalOptions="Center" />
-                                            <StackLayout Grid.Column="1" Margin="15,0,0,0" VerticalOptions="Center">
-                                                <Label Text="{Binding Title}" FontSize="16" FontAttributes="Bold" />
-                                                <Label Text="{Binding Description}" FontSize="14"
+                                        <Grid ColumnDefinitions="Auto,*,Auto"
+                                             Padding="15"
+                                             RowSpacing="5">
+                                            <Label Grid.Column="0"
+                                                  Text="{Binding Icon}"
+                                                  FontSize="24"
+                                                  VerticalOptions="Center" />
+                                            <StackLayout Grid.Column="1"
+                                                       Margin="15,0,0,0"
+                                                       VerticalOptions="Center">
+                                                <Label Text="{Binding Title}"
+                                                      FontSize="16"
+                                                      FontAttributes="Bold" />
+                                                <Label Text="{Binding Description}"
+                                                      FontSize="14"
                                                       TextColor="{StaticResource Gray600}" />
                                             </StackLayout>
-                                            <Label Grid.Column="2" Text="{Binding Time}" FontSize="12"
-                                                  TextColor="{StaticResource Gray500}" VerticalOptions="Center" />
+                                            <Label Grid.Column="2"
+                                                  Text="{Binding Time}"
+                                                  FontSize="12"
+                                                  TextColor="{StaticResource Gray500}"
+                                                  VerticalOptions="Center" />
                                         </Grid>
                                     </DataTemplate>
                                 </CollectionView.ItemTemplate>
                             </CollectionView>
+
                         </StackLayout>
                     </ScrollView>
                 </TabViewItem>
+
             </TabView>
 
-            <!-- Loading overlay (hidden by default) -->
-            <Grid x:Name="LoadingOverlay" BackgroundColor="Black" Opacity="0.7" IsVisible="False">
-                <StackLayout VerticalOptions="Center" HorizontalOptions="Center">
-                    <ActivityIndicator x:Name="LoadingIndicator" IsRunning="False"
-                                       Color="{StaticResource Primary}" Scale="2" />
-                    <Label x:Name="LoadingMessage" Text="Loading..." TextColor="White" FontSize="16"
-                          HorizontalOptions="Center" Margin="0,20,0,0" />
+            <!-- Loading Overlay -->
+            <Grid x:Name="LoadingOverlay"
+                 BackgroundColor="Black"
+                 Opacity="0.7"
+                 IsVisible="False">
+                <StackLayout VerticalOptions="Center"
+                           HorizontalOptions="Center">
+                    <ActivityIndicator x:Name="LoadingIndicator"
+                                     IsRunning="False"
+                                     Color="{StaticResource Primary}"
+                                     Scale="2" />
+                    <Label x:Name="LoadingMessage"
+                          Text="Loading..."
+                          TextColor="White"
+                          FontSize="16"
+                          HorizontalOptions="Center"
+                          Margin="0,20,0,0" />
                 </StackLayout>
             </Grid>
+
         </Grid>
 
-        <!-- Sync Status & Controls -->
-        <honua:HonuaSyncStatus Grid.Row="2" x:Name="SyncStatus" ShowDetails="false" EnableManualSync="true"
+        <!-- 🔄 Sync Status & Controls -->
+        <honua:HonuaSyncStatus Grid.Row="2"
+                              x:Name="SyncStatus"
+                              ShowDetails="false"
+                              EnableManualSync="true"
+                              ConflictDetected="OnSyncConflict"
+                              SyncCompleted="OnSyncCompleted"
                               BackgroundColor="{AppThemeBinding Light=#F5F5F5, Dark=#424242}"
-                              Padding="15,10" />
+                              Padding="15,10">
+            <honua:HonuaSyncStatus.GestureRecognizers>
+                <TapGestureRecognizer Tapped="OnSyncStatusTapped" />
+            </honua:HonuaSyncStatus.GestureRecognizers>
+        </honua:HonuaSyncStatus>
+
     </Grid>
 
-    <!-- Success Toast (hidden by default) -->
-    <Grid x:Name="SuccessToast" BackgroundColor="Green" Opacity="0.9" Padding="20"
-         IsVisible="False" VerticalOptions="Start" HorizontalOptions="Fill">
-        <Label x:Name="SuccessMessage" Text="" TextColor="White" FontSize="16" FontAttributes="Bold"
-              HorizontalOptions="Center" VerticalOptions="Center" />
+    <!-- Success Toast -->
+    <Grid x:Name="SuccessToast"
+         BackgroundColor="Green"
+         Opacity="0.9"
+         Padding="20"
+         IsVisible="False"
+         VerticalOptions="Start"
+         HorizontalOptions="Fill">
+        <Label x:Name="SuccessMessage"
+              Text=""
+              TextColor="White"
+              FontSize="16"
+              FontAttributes="Bold"
+              HorizontalOptions="Center"
+              VerticalOptions="Center" />
     </Grid>
+
 </ContentPage>
 ```

--- a/docs/design-handoff/tokens.json
+++ b/docs/design-handoff/tokens.json
@@ -1,0 +1,106 @@
+{
+  "source": {
+    "colors": "apps/Honua.Mobile.FieldCollection/Resources/Styles/Colors.xaml",
+    "styles": "apps/Honua.Mobile.FieldCollection/Resources/Styles/Styles.xaml",
+    "appStyles": "apps/Honua.Mobile.FieldCollection/App.xaml"
+  },
+  "colors": {
+    "brand": {
+      "Primary": "#2E8B57",
+      "PrimaryDark": "#1F5F3F",
+      "PrimaryLight": "#4CAF50",
+      "Secondary": "#3F51B5",
+      "SecondaryDark": "#303F9F",
+      "SecondaryLight": "#7986CB",
+      "Tertiary": "#FF5722",
+      "TertiaryDark": "#D32F2F",
+      "TertiaryLight": "#FF9800"
+    },
+    "semantic": {
+      "Success": "#4CAF50",
+      "Info": "#2196F3",
+      "Warning": "#FF9800",
+      "Danger": "#F44336",
+      "DangerLight": "#FFEBEE"
+    },
+    "neutral": {
+      "White": "#FFFFFF",
+      "Black": "#000000",
+      "Gray100": "#F5F5F5",
+      "Gray200": "#EEEEEE",
+      "Gray300": "#E0E0E0",
+      "Gray400": "#BDBDBD",
+      "Gray500": "#9E9E9E",
+      "Gray600": "#757575",
+      "Gray700": "#616161",
+      "Gray800": "#424242",
+      "Gray900": "#212121"
+    },
+    "surface": {
+      "Background": "#FFFFFF",
+      "Surface": "#FAFAFA",
+      "OnPrimary": "#FFFFFF",
+      "OnSecondary": "#FFFFFF",
+      "OnSurface": "#212121",
+      "OnBackground": "#212121",
+      "StatusBarColor": "#1F5F3F",
+      "NavigationBarColor": "#2E8B57"
+    },
+    "templateOnly": {
+      "LocationIndicatorBg": { "light": "#E3F2FD", "dark": "#1565C0" },
+      "TabStripBg": { "light": "#F5F5F5", "dark": "#424242" }
+    }
+  },
+  "typography": {
+    "fontFamily": "system-default",
+    "ramp": [
+      { "role": "page-title", "styleKey": "PageTitleStyle", "size": 32, "weight": "bold", "color": "Primary" },
+      { "role": "title-alt", "styleKey": "TitleLabelStyle", "size": 28, "weight": "bold", "color": "OnSurface" },
+      { "role": "subtitle", "styleKey": "SubtitleLabelStyle", "size": 20, "weight": "bold", "color": "OnSurface" },
+      { "role": "section-header", "styleKey": "SectionHeaderStyle", "size": 18, "weight": "bold", "color": "Primary" },
+      { "role": "body", "styleKey": "BodyLabelStyle", "size": 16, "weight": "regular", "lineHeight": 1.4, "color": "OnSurface" },
+      { "role": "stat-number", "size": 18, "weight": "bold" },
+      { "role": "stat-label", "size": 12, "weight": "regular", "color": "Gray600" },
+      { "role": "caption", "styleKey": "CaptionLabelStyle", "size": 12, "weight": "regular", "color": "Gray600" },
+      { "role": "micro", "size": 10, "weight": "regular" },
+      { "role": "badge", "size": 10, "weight": "regular", "color": "White" }
+    ]
+  },
+  "spacing": {
+    "xs": 5,
+    "sm": 8,
+    "md": 10,
+    "lg": 15,
+    "xl": 20,
+    "2xl": 25,
+    "pageHorizontalPadding": 30,
+    "fabMargin": 20,
+    "tabBarHeight": 50,
+    "templateTabStripHeight": 60
+  },
+  "radius": {
+    "sm": 8,
+    "md": 10,
+    "lg": 12,
+    "iconButton": 25,
+    "fab": 30
+  },
+  "elevation": {
+    "CommonShadow": {
+      "color": "#000000",
+      "offsetX": 0,
+      "offsetY": 2,
+      "blur": 8,
+      "opacity": 0.16
+    }
+  },
+  "controls": {
+    "PrimaryButton": { "bg": "Primary", "fg": "White", "radius": 8, "padding": "16,12", "fontSize": 16 },
+    "SecondaryButton": { "bg": "Secondary", "fg": "White", "radius": 8, "padding": "16,12", "fontSize": 16 },
+    "DangerButton": { "bg": "Tertiary", "fg": "White", "radius": 8, "padding": "16,12", "fontSize": 16 },
+    "CardFrame": { "bg": "White", "border": "Gray200", "radius": 8, "padding": 16, "margin": "0,8", "shadow": "platform-default" },
+    "ElevatedFrame": { "bg": "Surface", "radius": 12, "padding": 16, "margin": 8, "shadow": "CommonShadow" },
+    "Switch": { "onColor": "Primary", "thumbColor": "White" },
+    "Slider": { "minTrack": "Primary", "maxTrack": "Gray300", "thumb": "Primary" }
+  }
+}

--- a/docs/design-handoff/tokens.md
+++ b/docs/design-handoff/tokens.md
@@ -1,0 +1,139 @@
+# Design Tokens
+
+Extracted verbatim from:
+
+- `apps/Honua.Mobile.FieldCollection/Resources/Styles/Colors.xaml` (colors)
+- `apps/Honua.Mobile.FieldCollection/Resources/Styles/Styles.xaml` (typography, control styles, shadow)
+- `apps/Honua.Mobile.FieldCollection/App.xaml` (app-wide button / frame / heading styles)
+
+The app does not currently ship a separate dark `ResourceDictionary` - `App.xaml` only merges `Colors.xaml` and `Styles.xaml`. `AppShell.xaml` adds Shell-level theming on top. Dark-mode hex values below are derived from the few `AppThemeBinding` usages in the template starter (`MainPage.xaml`) and are noted as "template only".
+
+## Colors
+
+### Brand
+
+| Token | Hex (light) | Notes |
+| --- | --- | --- |
+| `Primary` | `#2E8B57` | Sea-green; used for Shell background, primary buttons, page titles, section headers, slider thumb, progress, activity indicator. |
+| `PrimaryDark` | `#1F5F3F` | Also used as `StatusBarColor`. |
+| `PrimaryLight` | `#4CAF50` | Same hex as `Success`. |
+| `Secondary` | `#3F51B5` | Indigo; secondary button background. |
+| `SecondaryDark` | `#303F9F` | |
+| `SecondaryLight` | `#7986CB` | |
+| `Tertiary` | `#FF5722` | Deep orange; used as the danger button background (paired with `DangerButtonStyle`). |
+| `TertiaryDark` | `#D32F2F` | |
+| `TertiaryLight` | `#FF9800` | Same hex as `Warning`. |
+
+### Semantic
+
+| Token | Hex | Notes |
+| --- | --- | --- |
+| `Success` | `#4CAF50` | |
+| `Info` | `#2196F3` | Attachment count badge. |
+| `Warning` | `#FF9800` | Pending-sync badge, offline banner background, "Danger Zone" header text via `Danger`. |
+| `Danger` | `#F44336` | "Danger Zone" heading and caption color. |
+| `DangerLight` | `#FFEBEE` | Danger-zone card background. |
+
+### Neutrals
+
+| Token | Hex |
+| --- | --- |
+| `White` | `#FFFFFF` |
+| `Black` | `#000000` |
+| `Gray100` | `#F5F5F5` |
+| `Gray200` | `#EEEEEE` |
+| `Gray300` | `#E0E0E0` |
+| `Gray400` | `#BDBDBD` |
+| `Gray500` | `#9E9E9E` |
+| `Gray600` | `#757575` |
+| `Gray700` | `#616161` |
+| `Gray800` | `#424242` |
+| `Gray900` | `#212121` |
+
+### Surfaces / text
+
+| Token | Hex | Notes |
+| --- | --- | --- |
+| `Background` | `#FFFFFF` | Page background. |
+| `Surface` | `#FAFAFA` | Inputs, search, picker. |
+| `OnPrimary` | `#FFFFFF` | Text on Primary. |
+| `OnSecondary` | `#FFFFFF` | |
+| `OnSurface` | `#212121` | Body / title text. |
+| `OnBackground` | `#212121` | |
+| `StatusBarColor` | `#1F5F3F` | |
+| `NavigationBarColor` | `#2E8B57` | |
+
+### Template-only (AppThemeBinding hints, not in Colors.xaml)
+
+| Surface | Light | Dark |
+| --- | --- | --- |
+| `HonuaLocationIndicator` background | `#E3F2FD` | `#1565C0` |
+| `TabView` strip + `HonuaSyncStatus` background | `#F5F5F5` | `#424242` |
+
+## Typography ramp
+
+Sourced from `Styles.xaml` (named styles) plus inline `FontSize=` values found across the pages.
+
+| Role | Style key | Size (sp) | Weight | Color token |
+| --- | --- | --- | --- | --- |
+| Page title | `PageTitleStyle` (App.xaml) | 32 | Bold | `Primary` |
+| Title (alt) | `TitleLabelStyle` | 28 | Bold | `OnSurface` |
+| Subtitle | `SubtitleLabelStyle` | 20 | Bold | `OnSurface` |
+| Section header | `SectionHeaderStyle` (App.xaml) | 18 | Bold | `Primary` |
+| Body | `BodyLabelStyle` | 16 | Regular (line-height 1.4) | `OnSurface` |
+| Body emphasis | inline | 16 | Bold | `OnSurface` / `Warning` |
+| Stat number | inline (Records/Sync stats) | 18 | Bold | `OnSurface` / `Warning` |
+| Stat label | inline | 12 | Regular | `Gray600` |
+| Caption | `CaptionLabelStyle` | 12 | Regular | `Gray600` |
+| Micro label (range hint) | inline | 10 | Regular | `OnSurface` |
+| Badge text | inline (Sync / attachments badges) | 10 | Regular | `White` |
+| Emoji icon (card) | inline | 24 | n/a | n/a |
+| Empty-state icon | inline | 48 | n/a | `Gray400` |
+
+> The app uses the system font (no `FontFamily` override in `Styles.xaml`). Mocks fall back to the system stack.
+
+## Spacing
+
+Recurring numeric values in the XAML for `Padding`, `Margin`, `Spacing`, `ColumnSpacing`, `RowSpacing`.
+
+| Token | Value (dp) | Used by |
+| --- | --- | --- |
+| `space-xs` | 5 | Inline stack spacing inside cards |
+| `space-sm` | 8 | Card vertical margin, badge padding |
+| `space-md` | 10 | Card content spacing, picker column spacing |
+| `space-lg` | 15 | Quick-action grid spacing, settings stack |
+| `space-xl` | 20 | Sync Center outer padding, frame padding |
+| `space-2xl` | 25 | Main page stack spacing |
+| `page-h-padding` | 30 | Main page horizontal padding (`Padding="30,0"`) |
+| `fab-margin` | 20 | Records FAB margin |
+| `tab-bar-height` | 50 | Shell `Tab` item height; template tab strip is 60 |
+
+## Radius
+
+| Token | Value | Used by |
+| --- | --- | --- |
+| `radius-sm` | 8 | `BaseButtonStyle`, `CardFrameStyle`, outline frames |
+| `radius-md` | 10 | Template welcome frame |
+| `radius-lg` | 12 | `ElevatedFrameStyle` |
+| `radius-pill` | 25 / 30 | `IconButtonStyle` (50dp circle), Records FAB (60dp circle) |
+
+## Elevation / shadow
+
+The only named shadow is `CommonShadow` in `Styles.xaml`:
+
+| Token | Brush | Offset | Radius | Opacity |
+| --- | --- | --- | --- | --- |
+| `CommonShadow` | Black | `0,2` | 8 | 0.16 |
+
+`CardFrameStyle` in `App.xaml` uses MAUI's legacy `HasShadow=True` (platform default) rather than the named shadow; `ElevatedFrameStyle` and `PrimaryButtonStyle` use `CommonShadow` explicitly. The Records FAB pulls `CommonShadow` directly.
+
+## Control defaults worth knowing
+
+- Primary button (`BaseButtonStyle` in `App.xaml`): bg `Primary`, text `White`, radius 8, padding `16,12`, font 16.
+- Secondary button (`SecondaryButtonStyle`): inherits BaseButton, bg `Secondary` (indigo).
+- Danger button (`DangerButtonStyle`): inherits BaseButton, bg `Tertiary` (deep orange).
+- Card (`CardFrameStyle`): bg `White`, border `Gray200`, radius 8, padding 16, margin `0,8`, shadow on.
+- Switch (`BaseSwitchStyle`): on-color `Primary`, thumb `White`.
+- Slider (`BaseSliderStyle`): min track `Primary`, max track `Gray300`, thumb `Primary`.
+
+See `tokens.json` for the same values in machine-readable form.


### PR DESCRIPTION
## Summary

Closes #191. Adds `docs/design-handoff/` — a self-contained, framework-free snapshot of the FieldCollection mobile UI that can be uploaded directly to Claude Design for review.

## Contents

- `README.md` — bundle index + how to import into Claude Design
- `tokens.md` / `tokens.json` — color, type, spacing, radius, elevation tokens extracted from `Resources/Styles/Colors.xaml` + `Styles.xaml`
- 7 page subfolders (`shell/`, `main/`, `map/`, `records/`, `sync-center/`, `settings/`, `template-starter/`) each containing:
  - `notes.md` — purpose, actions, key bindings, navigation
  - `mock.html` — standalone HTML/CSS mock at 390×844 mobile viewport using the real design tokens
  - `xaml-source.md` — original XAML for reference
- `questions.md` — specific open UX questions for design review
- `feedback-loop.md` — how to flow Claude Design feedback back into XAML/styles

## Test plan

- [ ] Open each `*/mock.html` in a browser — they should render standalone (no JS, no external assets).
- [ ] Verify color tokens in `tokens.md` match `apps/Honua.Mobile.FieldCollection/Resources/Styles/Colors.xaml`.
- [ ] Upload `docs/design-handoff/` to Claude Design and confirm it's reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)