### PR TITLE
fix: restore mobile SDK converter compatibility

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      issues: read
+      issues: write
       statuses: write
     steps:
       - name: Check PR Requirements
@@ -169,18 +169,22 @@ jobs:
               });
             }
 
-            const statusState = issues.length > 0 ? 'failure' : 'success';
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.pull_request.head.sha,
-              state: statusState,
-              context: 'Validate Mobile SDK PR',
-              description: issues.length > 0
-                ? `Mobile SDK PR validation failed: ${issues.length} critical issue(s)`
-                : 'Mobile SDK PR validation passed',
-              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            });
+            try {
+              const statusState = issues.length > 0 ? 'failure' : 'success';
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: context.payload.pull_request.head.sha,
+                state: statusState,
+                context: 'Validate Mobile SDK PR',
+                description: issues.length > 0
+                  ? `Mobile SDK PR validation failed: ${issues.length} critical issue(s)`
+                  : 'Mobile SDK PR validation passed',
+                target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+              });
+            } catch (error) {
+              core.warning(`Unable to publish optional commit status: ${error.message}`);
+            }
 
             // Fail if critical issues found
             if (issues.length > 0) {

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Honua.Sdk.Abstractions.Features;
@@ -5,11 +6,6 @@ using Honua.Sdk.GeoServices.FeatureServer;
 using Honua.Sdk.GeoServices.FeatureServer.Exceptions;
 using Honua.Sdk.Grpc;
 using Honua.Sdk.OgcFeatures.Exceptions;
-
-// SDK-owned conversion shims (live in honua-sdk-dotnet train >= 0.1.17-alpha.1).
-// Aliased so the call-site identifiers stay close to the original local mappings.
-using FeatureServerRequestConverters = Honua.Sdk.GeoServices.FeatureServer.Conversion.RequestConverters;
-using GrpcRequestConverters = Honua.Sdk.Grpc.Conversion.MobileRequestConverters;
 
 namespace Honua.Mobile.Sdk;
 
@@ -218,9 +214,9 @@ public sealed partial class HonuaMobileClient
     private async Task<JsonDocument> QueryFeaturesGrpcAsync(QueryFeaturesRequest request, CancellationToken ct)
     {
         var response = await GetGrpcClient()
-            .QueryFeaturesAsync(GrpcRequestConverters.ToGrpcQueryRequest(request), ct)
+            .QueryAsync(ToSdkFeatureQueryRequest(request), ct)
             .ConfigureAwait(false);
-        return GrpcRequestConverters.ToJsonDocument(response);
+        return ToLegacyFeatureQueryJsonDocument(response);
     }
 
     private async IAsyncEnumerable<JsonDocument> QueryFeaturesGrpcPagesAsync(
@@ -228,60 +224,41 @@ public sealed partial class HonuaMobileClient
         [EnumeratorCancellation] CancellationToken ct)
     {
         await foreach (var page in GetGrpcClient()
-            .QueryFeaturesStreamAsync(GrpcRequestConverters.ToGrpcQueryRequest(request), ct)
+            .QueryPagesAsync(ToSdkFeatureQueryRequest(request), ct)
             .ConfigureAwait(false))
         {
-            yield return GrpcRequestConverters.ToJsonDocument(page);
+            yield return ToLegacyFeatureQueryJsonDocument(page);
         }
     }
 
     private async Task<JsonDocument> ApplyEditsGrpcAsync(ApplyEditsRequest request, CancellationToken ct)
     {
         var response = await GetGrpcClient()
-            .ApplyEditsAsync(GrpcRequestConverters.ToGrpcApplyEditsRequest(request), ct)
+            .ApplyEditsAsync(ToSdkFeatureEditRequest(request), ct)
             .ConfigureAwait(false);
-        return GrpcRequestConverters.ToJsonDocument(response);
+        return ToLegacyFeatureEditJsonDocument(response);
     }
 
     private async Task<JsonDocument> QueryFeaturesRestAsync(QueryFeaturesRequest request, CancellationToken ct)
     {
-        try
-        {
-            var response = await _featureServerClient
-                .QueryAsync(request.ServiceId, request.LayerId, FeatureServerRequestConverters.ToFeatureServerQueryParams(request), ct)
-                .ConfigureAwait(false);
-            return FeatureServerRequestConverters.ToJsonDocument(response);
-        }
-        catch (HonuaFeatureServerException ex)
-        {
-            throw ToMobileApiException("FeatureServer", ex);
-        }
+        var path = $"/rest/services/{Uri.EscapeDataString(request.ServiceId)}/FeatureServer/{request.LayerId}/query";
+        return await SendJsonAsync(
+            HttpMethod.Get,
+            path,
+            BuildFeatureServerQueryParameters(request),
+            content: null,
+            ct).ConfigureAwait(false);
     }
 
     private async Task<JsonDocument> ApplyEditsRestAsync(ApplyEditsRequest request, CancellationToken ct)
     {
-        if (!IsDefaultJsonResponseFormat(request.ResponseFormat))
-        {
-            var path = $"/rest/services/{Uri.EscapeDataString(request.ServiceId)}/FeatureServer/{request.LayerId}/applyEdits";
-            return await SendJsonAsync(
-                HttpMethod.Post,
-                path,
-                query: null,
-                new FormUrlEncodedContent(FeatureServerRequestConverters.ToFeatureServerEditFormParameters(request)),
-                ct).ConfigureAwait(false);
-        }
-
-        try
-        {
-            var response = await _featureServerClient
-                .ApplyEditsAsync(request.ServiceId, request.LayerId, FeatureServerRequestConverters.ToFeatureServerEditRequest(request), ct)
-                .ConfigureAwait(false);
-            return FeatureServerRequestConverters.ToJsonDocument(response);
-        }
-        catch (HonuaFeatureServerException ex)
-        {
-            throw ToMobileApiException("FeatureServer", ex);
-        }
+        var path = $"/rest/services/{Uri.EscapeDataString(request.ServiceId)}/FeatureServer/{request.LayerId}/applyEdits";
+        return await SendJsonAsync(
+            HttpMethod.Post,
+            path,
+            query: null,
+            new FormUrlEncodedContent(BuildFeatureServerEditFormParameters(request)),
+            ct).ConfigureAwait(false);
     }
 
     private async Task<FeatureQueryResult> QueryOgcFeaturesSdkAsync(FeatureQueryRequest request, CancellationToken ct)
@@ -444,17 +421,13 @@ public sealed partial class HonuaMobileClient
         var layerId = source.LayerId
             ?? throw new InvalidOperationException("FeatureServer feature edits require a layer ID.");
 
-        // The SDK's ApplyEditsRequest accepts FeatureEditFeature directly; the
-        // legacy mobile-side path that pre-converted to FeatureServerFeature is
-        // no longer required because Honua.Sdk.GeoServices owns the per-protocol
-        // conversion as part of ToFeatureServerEditFormParameters.
         var editRequest = new ApplyEditsRequest
         {
             ServiceId = serviceId,
             LayerId = layerId,
             Adds = request.Adds.Count > 0 ? [.. request.Adds] : null,
             Updates = request.Updates.Count > 0 ? [.. request.Updates] : null,
-            Deletes = FeatureServerRequestConverters.ToFeatureServerDeleteObjectIds(request),
+            Deletes = ResolveFeatureServerDeleteObjectIds(request),
             RollbackOnFailure = request.RollbackOnFailure,
             ForceWrite = request.ForceWrite,
         };
@@ -464,7 +437,7 @@ public sealed partial class HonuaMobileClient
             HttpMethod.Post,
             path,
             query: null,
-            new FormUrlEncodedContent(FeatureServerRequestConverters.ToFeatureServerEditFormParameters(editRequest)),
+            new FormUrlEncodedContent(BuildFeatureServerEditFormParameters(editRequest)),
             ct).ConfigureAwait(false);
     }
 
@@ -551,7 +524,369 @@ public sealed partial class HonuaMobileClient
                 : "Unknown FeatureServer edit error.",
         };
 
-    private static bool IsDefaultJsonResponseFormat(string? responseFormat)
-        => string.IsNullOrWhiteSpace(responseFormat) ||
-            string.Equals(responseFormat, "json", StringComparison.OrdinalIgnoreCase);
+    private static FeatureQueryRequest ToSdkFeatureQueryRequest(QueryFeaturesRequest request)
+        => new()
+        {
+            Source = new FeatureSource
+            {
+                ServiceId = request.ServiceId,
+                LayerId = request.LayerId,
+            },
+            Filter = request.Where,
+            ObjectIds = request.ObjectIds is { Count: > 0 } objectIds ? [.. objectIds] : [],
+            OutFields = request.OutFields is { Count: > 0 } outFields ? [.. outFields] : [],
+            ReturnGeometry = request.ReturnGeometry,
+            Offset = request.ResultOffset,
+            Limit = request.ResultRecordCount,
+            OrderBy = request.OrderBy,
+            ReturnDistinct = request.ReturnDistinct,
+            ReturnCountOnly = request.ReturnCountOnly,
+            ReturnIdsOnly = request.ReturnIdsOnly,
+            ReturnExtentOnly = request.ReturnExtentOnly,
+        };
+
+    private static FeatureEditRequest ToSdkFeatureEditRequest(ApplyEditsRequest request)
+        => new()
+        {
+            Source = new FeatureSource
+            {
+                ServiceId = request.ServiceId,
+                LayerId = request.LayerId,
+            },
+            Adds = request.Adds is { Count: > 0 } adds ? [.. adds] : [],
+            Updates = request.Updates is { Count: > 0 } updates ? [.. updates] : [],
+            DeleteObjectIds = ResolveFeatureServerDeleteObjectIds(request),
+            RollbackOnFailure = request.RollbackOnFailure,
+            ForceWrite = request.ForceWrite,
+        };
+
+    private static IReadOnlyDictionary<string, string?> BuildFeatureServerQueryParameters(QueryFeaturesRequest request)
+    {
+        var query = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["where"] = string.IsNullOrWhiteSpace(request.Where) ? "1=1" : request.Where,
+            ["outFields"] = request.OutFields is { Count: > 0 } outFields ? string.Join(',', outFields) : "*",
+            ["returnGeometry"] = request.ReturnGeometry.ToString().ToLowerInvariant(),
+            ["f"] = string.IsNullOrWhiteSpace(request.ResponseFormat) ? "json" : request.ResponseFormat,
+        };
+
+        if (request.ObjectIds is { Count: > 0 } objectIds)
+        {
+            query["objectIds"] = string.Join(',', objectIds);
+        }
+
+        if (request.ResultOffset is { } resultOffset)
+        {
+            query["resultOffset"] = resultOffset.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (request.ResultRecordCount is { } resultRecordCount)
+        {
+            query["resultRecordCount"] = resultRecordCount.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.OrderBy))
+        {
+            query["orderByFields"] = request.OrderBy;
+        }
+
+        if (request.ReturnDistinct)
+        {
+            query["returnDistinctValues"] = "true";
+        }
+
+        if (request.ReturnCountOnly)
+        {
+            query["returnCountOnly"] = "true";
+        }
+
+        if (request.ReturnIdsOnly)
+        {
+            query["returnIdsOnly"] = "true";
+        }
+
+        if (request.ReturnExtentOnly)
+        {
+            query["returnExtentOnly"] = "true";
+        }
+
+        return query;
+    }
+
+    private static IReadOnlyDictionary<string, string?> BuildFeatureServerEditFormParameters(ApplyEditsRequest request)
+    {
+        var form = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["rollbackOnFailure"] = request.RollbackOnFailure.ToString().ToLowerInvariant(),
+            ["forceWrite"] = request.ForceWrite.ToString().ToLowerInvariant(),
+            ["f"] = string.IsNullOrWhiteSpace(request.ResponseFormat) ? "json" : request.ResponseFormat,
+        };
+
+        if (!string.IsNullOrWhiteSpace(request.AddsJson))
+        {
+            form["adds"] = request.AddsJson;
+        }
+        else if (request.Adds is { Count: > 0 } adds)
+        {
+            form["adds"] = SerializeFeatureServerEditFeatures(adds);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.UpdatesJson))
+        {
+            form["updates"] = request.UpdatesJson;
+        }
+        else if (request.Updates is { Count: > 0 } updates)
+        {
+            form["updates"] = SerializeFeatureServerEditFeatures(updates);
+        }
+
+        if (request.Deletes is { Count: > 0 } deletes)
+        {
+            form["deletes"] = string.Join(',', deletes);
+        }
+        else if (!string.IsNullOrWhiteSpace(request.DeletesCsv))
+        {
+            form["deletes"] = request.DeletesCsv;
+        }
+
+        return form;
+    }
+
+    private static IReadOnlyList<long> ResolveFeatureServerDeleteObjectIds(FeatureEditRequest request)
+    {
+        if (request.DeleteObjectIds is { Count: > 0 } objectIds)
+        {
+            return objectIds;
+        }
+
+        if (request.DeleteIds is not { Count: > 0 } ids)
+        {
+            return [];
+        }
+
+        return ids
+            .Select(id => long.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId)
+                ? objectId
+                : (long?)null)
+            .Where(objectId => objectId.HasValue)
+            .Select(objectId => objectId!.Value)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<long> ResolveFeatureServerDeleteObjectIds(ApplyEditsRequest request)
+    {
+        if (request.Deletes is { Count: > 0 } deletes)
+        {
+            return deletes;
+        }
+
+        if (string.IsNullOrWhiteSpace(request.DeletesCsv))
+        {
+            return [];
+        }
+
+        return request.DeletesCsv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(value => long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId)
+                ? objectId
+                : (long?)null)
+            .Where(objectId => objectId.HasValue)
+            .Select(objectId => objectId!.Value)
+            .ToArray();
+    }
+
+    private static string SerializeFeatureServerEditFeatures(IReadOnlyList<FeatureEditFeature> features)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartArray();
+            foreach (var feature in features)
+            {
+                WriteFeatureServerEditFeature(writer, feature);
+            }
+
+            writer.WriteEndArray();
+        }
+
+        using var document = JsonDocument.Parse(stream.ToArray());
+        return document.RootElement.GetRawText();
+    }
+
+    private static void WriteFeatureServerEditFeature(Utf8JsonWriter writer, FeatureEditFeature feature)
+    {
+        writer.WriteStartObject();
+
+        writer.WritePropertyName("attributes");
+        WriteAttributesObject(writer, feature.Attributes, feature.ObjectId);
+
+        if (feature.Geometry is { } geometry && geometry.ValueKind != JsonValueKind.Undefined)
+        {
+            writer.WritePropertyName("geometry");
+            geometry.WriteTo(writer);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static JsonDocument ToLegacyFeatureQueryJsonDocument(FeatureQueryResult response)
+        => CreateJsonDocument(writer =>
+        {
+            writer.WriteStartObject();
+
+            if (!string.IsNullOrWhiteSpace(response.ObjectIdFieldName))
+            {
+                writer.WriteString("objectIdFieldName", response.ObjectIdFieldName);
+            }
+
+            if (response.NumberMatched is { } numberMatched)
+            {
+                writer.WriteNumber("count", numberMatched);
+            }
+
+            if (response.ObjectIds is { Count: > 0 } objectIds)
+            {
+                writer.WritePropertyName("objectIds");
+                writer.WriteStartArray();
+                foreach (var objectId in objectIds)
+                {
+                    writer.WriteNumberValue(objectId);
+                }
+
+                writer.WriteEndArray();
+            }
+
+            if (response.HasMoreResults is true)
+            {
+                writer.WriteBoolean("exceededTransferLimit", true);
+            }
+
+            writer.WritePropertyName("features");
+            writer.WriteStartArray();
+            foreach (var feature in response.Features)
+            {
+                writer.WriteStartObject();
+
+                if (!string.IsNullOrWhiteSpace(feature.Id))
+                {
+                    writer.WriteString("id", feature.Id);
+                }
+
+                writer.WritePropertyName("attributes");
+                WriteAttributesObject(writer, feature.Attributes);
+
+                if (feature.Geometry is { } geometry && geometry.ValueKind != JsonValueKind.Undefined)
+                {
+                    writer.WritePropertyName("geometry");
+                    geometry.WriteTo(writer);
+                }
+
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        });
+
+    private static JsonDocument ToLegacyFeatureEditJsonDocument(FeatureEditResponse response)
+        => CreateJsonDocument(writer =>
+        {
+            writer.WriteStartObject();
+
+            WriteFeatureEditResults(writer, "addResults", response.AddResults);
+            WriteFeatureEditResults(writer, "updateResults", response.UpdateResults);
+            WriteFeatureEditResults(writer, "deleteResults", response.DeleteResults);
+
+            if (response.PatchResults is { Count: > 0 } patchResults)
+            {
+                WriteFeatureEditResults(writer, "patchResults", patchResults);
+            }
+
+            if (response.Error is { } error)
+            {
+                writer.WritePropertyName("error");
+                WriteFeatureEditError(writer, error);
+            }
+
+            writer.WriteEndObject();
+        });
+
+    private static JsonDocument CreateJsonDocument(Action<Utf8JsonWriter> write)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            write(writer);
+        }
+
+        return JsonDocument.Parse(stream.ToArray());
+    }
+
+    private static void WriteAttributesObject(
+        Utf8JsonWriter writer,
+        IReadOnlyDictionary<string, JsonElement> attributes,
+        long? fallbackObjectId = null)
+    {
+        writer.WriteStartObject();
+        foreach (var attribute in attributes)
+        {
+            writer.WritePropertyName(attribute.Key);
+            attribute.Value.WriteTo(writer);
+        }
+
+        if (fallbackObjectId is { } objectId &&
+            !HasAttribute(attributes, "objectId", "objectid", "OBJECTID"))
+        {
+            writer.WriteNumber("objectId", objectId);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static bool HasAttribute(IReadOnlyDictionary<string, JsonElement> attributes, params string[] names)
+        => names.Any(attributes.ContainsKey);
+
+    private static void WriteFeatureEditResults(
+        Utf8JsonWriter writer,
+        string propertyName,
+        IReadOnlyList<FeatureEditResult> results)
+    {
+        writer.WritePropertyName(propertyName);
+        writer.WriteStartArray();
+        foreach (var result in results)
+        {
+            writer.WriteStartObject();
+            if (result.ObjectId is { } objectId)
+            {
+                writer.WriteNumber("objectId", objectId);
+            }
+
+            if (!string.IsNullOrWhiteSpace(result.Id))
+            {
+                writer.WriteString("globalId", result.Id);
+            }
+
+            writer.WriteBoolean("success", result.Succeeded);
+            if (result.Error is { } error)
+            {
+                writer.WritePropertyName("error");
+                WriteFeatureEditError(writer, error);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+    }
+
+    private static void WriteFeatureEditError(Utf8JsonWriter writer, FeatureEditError error)
+    {
+        writer.WriteStartObject();
+        if (error.Code is { } code)
+        {
+            writer.WriteNumber("code", code);
+        }
+
+        writer.WriteString("message", error.Message);
+        writer.WriteEndObject();
+    }
 }

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.OgcFeatures.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.OgcFeatures.cs
@@ -1,8 +1,7 @@
+using System.Globalization;
+using System.Text;
 using System.Text.Json;
 using Honua.Sdk.Abstractions.Features;
-using Honua.Sdk.OgcFeatures.Exceptions;
-
-using OgcRequestConverters = Honua.Sdk.OgcFeatures.Conversion.RequestConverters;
 
 namespace Honua.Mobile.Sdk;
 
@@ -16,15 +15,12 @@ public sealed partial class HonuaMobileClient
     /// <exception cref="HonuaMobileApiException">Thrown when the server returns a non-success HTTP status code.</exception>
     public async Task<JsonDocument> GetOgcCollectionsAsync(CancellationToken ct = default)
     {
-        try
-        {
-            var collections = await _ogcFeaturesClient.ListCollectionsAsync(ct).ConfigureAwait(false);
-            return OgcRequestConverters.ToJsonDocument(collections);
-        }
-        catch (HonuaOgcFeaturesException ex)
-        {
-            throw ToMobileApiException("OGC Features", ex);
-        }
+        return await SendJsonAsync(
+            HttpMethod.Get,
+            "/ogc/features/collections",
+            query: null,
+            content: null,
+            ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -39,17 +35,13 @@ public sealed partial class HonuaMobileClient
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        try
-        {
-            var response = await _ogcFeaturesClient
-                .GetItemsAsync(request.CollectionId, OgcRequestConverters.ToOgcItemsParams(request), ct)
-                .ConfigureAwait(false);
-            return OgcRequestConverters.ToJsonDocument(response);
-        }
-        catch (HonuaOgcFeaturesException ex)
-        {
-            throw ToMobileApiException("OGC Features", ex);
-        }
+        var path = $"/ogc/features/collections/{Uri.EscapeDataString(request.CollectionId)}/items";
+        return await SendJsonAsync(
+            HttpMethod.Get,
+            path,
+            BuildOgcItemsQueryParameters(request),
+            content: null,
+            ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -64,17 +56,13 @@ public sealed partial class HonuaMobileClient
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        try
-        {
-            var response = await _ogcFeaturesClient
-                .CreateItemAsync(request.CollectionId, OgcRequestConverters.ToOgcFeature(request.Feature), ct)
-                .ConfigureAwait(false);
-            return OgcRequestConverters.ToJsonDocument(response);
-        }
-        catch (HonuaOgcFeaturesException ex)
-        {
-            throw ToMobileApiException("OGC Features", ex);
-        }
+        var path = $"/ogc/features/collections/{Uri.EscapeDataString(request.CollectionId)}/items";
+        return await SendJsonAsync(
+            HttpMethod.Post,
+            path,
+            query: null,
+            CreateJsonContent(request.Feature, "application/geo+json"),
+            ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -89,17 +77,13 @@ public sealed partial class HonuaMobileClient
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        try
-        {
-            var response = await _ogcFeaturesClient
-                .UpdateItemAsync(request.CollectionId, request.FeatureId, OgcRequestConverters.ToOgcFeature(request.Feature), ct)
-                .ConfigureAwait(false);
-            return OgcRequestConverters.ToJsonDocument(response);
-        }
-        catch (HonuaOgcFeaturesException ex)
-        {
-            throw ToMobileApiException("OGC Features", ex);
-        }
+        var path = $"/ogc/features/collections/{Uri.EscapeDataString(request.CollectionId)}/items/{Uri.EscapeDataString(request.FeatureId)}";
+        return await SendJsonAsync(
+            HttpMethod.Put,
+            path,
+            query: null,
+            CreateJsonContent(request.Feature, "application/geo+json"),
+            ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -114,17 +98,13 @@ public sealed partial class HonuaMobileClient
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        try
-        {
-            var response = await _ogcFeaturesClient
-                .PatchItemAsync(request.CollectionId, request.FeatureId, OgcRequestConverters.ToJsonElement(request.Patch), ct)
-                .ConfigureAwait(false);
-            return OgcRequestConverters.ToJsonDocument(response);
-        }
-        catch (HonuaOgcFeaturesException ex)
-        {
-            throw ToMobileApiException("OGC Features", ex);
-        }
+        var path = $"/ogc/features/collections/{Uri.EscapeDataString(request.CollectionId)}/items/{Uri.EscapeDataString(request.FeatureId)}";
+        return await SendJsonAsync(
+            HttpMethod.Patch,
+            path,
+            query: null,
+            CreateJsonContent(request.Patch, "application/merge-patch+json"),
+            ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -142,4 +122,39 @@ public sealed partial class HonuaMobileClient
         var path = $"/ogc/features/collections/{Uri.EscapeDataString(request.CollectionId)}/items/{Uri.EscapeDataString(request.FeatureId)}";
         return await SendJsonAsync(HttpMethod.Delete, path, null, null, ct).ConfigureAwait(false);
     }
+
+    private static IReadOnlyDictionary<string, string?> BuildOgcItemsQueryParameters(OgcItemsRequest request)
+    {
+        var query = new Dictionary<string, string?>(StringComparer.Ordinal);
+
+        if (request.Limit is { } limit)
+        {
+            query["limit"] = limit.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (request.Offset is { } offset)
+        {
+            query["offset"] = offset.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (request.PropertyNames is { Count: > 0 } propertyNames)
+        {
+            query["properties"] = string.Join(',', propertyNames);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.CqlFilter))
+        {
+            query["filter"] = request.CqlFilter;
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.ResponseFormat))
+        {
+            query["f"] = request.ResponseFormat;
+        }
+
+        return query;
+    }
+
+    private static StringContent CreateJsonContent(JsonElement element, string mediaType)
+        => new(element.GetRawText(), Encoding.UTF8, mediaType);
 }


### PR DESCRIPTION
## Summary

Part of #208.

- removes mobile client references to SDK-internal FeatureServer, OGC, and gRPC converter classes
- keeps SDK-native provider-neutral query/edit paths on public Honua.Sdk clients
- preserves legacy mobile JSON APIs with thin raw HTTP/JSON compatibility adapters
- hardens PR validation so optional commit-status publication cannot fail an otherwise valid PR

## Testing

- dotnet build src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj --no-restore --configuration Release /p:TreatWarningsAsErrors=true --verbosity minimal
- dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --no-restore --configuration Release --verbosity minimal
- dotnet format src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj --no-restore --verify-no-changes --verbosity minimal
- npm ci --prefix src/Honua.Embed
- npm --prefix src/Honua.Embed test -- --run
- CI run 26326297913 passed, including Build & Format Check, Test Suite, gRPC Protocol Validation, Security Scan, MAUI Android Build & Trim Smoke, MAUI iOS Build & AOT Smoke, MAUI Windows Build, Quality Gates, and CI Gate

## Local validation note

Full solution restore/test is still blocked locally because the available gh token lacks read:packages for Honua.Sdk.Field and Honua.Sdk.Offline packages. CI workflows request packages: read and configure GITHUB_TOKEN for those restores, so this PR uses CI as the authoritative full validation gate.