### PR TITLE
docs: add local validation baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,32 @@ proto/
 
 ## Building
 
+Fresh checkouts need access to the private Honua GitHub Packages feed for
+`Honua.Sdk.*` packages. Use a GitHub token that can read packages in the
+`honua-io` organization:
+
 ```bash
+gh auth refresh -s read:packages
+export HONUA_GITHUB_PACKAGES_USER="$(gh api user --jq .login)"
+export HONUA_GITHUB_PACKAGES_TOKEN="$(gh auth token)"
+```
+
+Then run the local validation baseline:
+
+```bash
+scripts/validate-local.sh
+```
+
+The script restores, builds, runs .NET tests and smoke tests, verifies format
+for the core source projects, and runs the `@honua/embed` npm build/tests. It
+uses a temporary NuGet config for `HONUA_GITHUB_PACKAGES_TOKEN` and removes it
+on exit. Without those environment variables it falls back to any existing
+NuGet credentials already configured for the `github-honua` source.
+
+Equivalent manual commands:
+
+```bash
+dotnet restore Honua.Mobile.sln
 dotnet build Honua.Mobile.sln
 dotnet test Honua.Mobile.sln
 dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj

--- a/docs/guides/validation-strategy.md
+++ b/docs/guides/validation-strategy.md
@@ -154,6 +154,32 @@ Known coverage gaps, with the owner ticket where one exists:
 
 ## 4. How CI Surfaces Failures
 
+The local command that most closely mirrors the PR gate is:
+
+```bash
+scripts/validate-local.sh
+```
+
+For a fresh checkout, configure GitHub Packages credentials first. The mobile
+repo consumes versioned `Honua.Sdk.*` packages from the private
+`github-honua` NuGet source, so the token must have `read:packages` for the
+`honua-io` organization:
+
+```bash
+gh auth refresh -s read:packages
+export HONUA_GITHUB_PACKAGES_USER="$(gh api user --jq .login)"
+export HONUA_GITHUB_PACKAGES_TOKEN="$(gh auth token)"
+scripts/validate-local.sh
+```
+
+The script writes those credentials to a temporary NuGet config only for the
+duration of the run. It then restores and builds `Honua.Mobile.sln`, runs
+`dotnet test Honua.Mobile.sln`, runs `Honua.Mobile.Smoke.Tests`, verifies
+format for the core source projects, and runs `npm ci`, `npm run build`, and
+`npm test` for `src/Honua.Embed`. Live server, cloud, Android emulator, and iOS
+simulator coverage still use their existing environment variables and hosted
+runner workflows described below.
+
 The relevant workflows under `.github/workflows/`:
 
 - `ci.yml` -- the main PR and trunk gate. Jobs and the test buckets

--- a/scripts/validate-local.sh
+++ b/scripts/validate-local.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+configuration="${CONFIGURATION:-Release}"
+solution="${HONUA_MOBILE_VALIDATION_SOLUTION:-${repo_root}/Honua.Mobile.sln}"
+nuget_config="${repo_root}/NuGet.config"
+run_dotnet=true
+run_format=true
+run_npm=true
+run_npm_ci=true
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/validate-local.sh [options]
+
+Runs the local Honua Mobile validation baseline:
+  - dotnet restore/build/test Honua.Mobile.sln
+  - dotnet format checks for core source projects
+  - Honua.Mobile.Smoke.Tests
+  - npm ci/build/test for src/Honua.Embed
+
+Options:
+  --configuration <name>  Build configuration. Default: Release.
+  --skip-dotnet          Skip dotnet restore/build/test/format/smoke.
+  --skip-format          Skip dotnet format verification.
+  --skip-npm             Skip all npm embed validation.
+  --skip-npm-ci          Skip npm ci and use existing node_modules.
+  -h, --help             Show this help.
+
+GitHub Packages:
+  Fresh checkouts need a GitHub token with read:packages access to honua-io
+  packages. Set HONUA_GITHUB_PACKAGES_USER and HONUA_GITHUB_PACKAGES_TOKEN.
+  The script writes credentials only to a temporary NuGet.config and removes it
+  on exit.
+EOF
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+step() {
+  printf '\n==> %s\n' "$*"
+}
+
+run() {
+  printf '+'
+  printf ' %q' "$@"
+  printf '\n'
+  "$@"
+}
+
+xml_escape() {
+  local value="$1"
+  value=${value//&/&amp;}
+  value=${value//</&lt;}
+  value=${value//>/&gt;}
+  value=${value//\"/&quot;}
+  value=${value//\'/&apos;}
+  printf '%s' "${value}"
+}
+
+make_nuget_config() {
+  local token="${HONUA_GITHUB_PACKAGES_TOKEN:-}"
+  local user="${HONUA_GITHUB_PACKAGES_USER:-${GITHUB_ACTOR:-}}"
+
+  if [[ -z "${token}" ]]; then
+    printf '%s' "${nuget_config}"
+    return
+  fi
+
+  if [[ -z "${user}" ]]; then
+    fail "HONUA_GITHUB_PACKAGES_USER is required when HONUA_GITHUB_PACKAGES_TOKEN is set."
+  fi
+
+  local temp_dir
+  temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/honua-mobile-validation.XXXXXX")"
+  cleanup_paths+=("${temp_dir}")
+
+  local config_path="${temp_dir}/NuGet.config"
+  local escaped_user
+  local escaped_token
+  escaped_user="$(xml_escape "${user}")"
+  escaped_token="$(xml_escape "${token}")"
+
+  local old_umask
+  old_umask="$(umask)"
+  umask 077
+  cat >"${config_path}" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="github-honua" value="https://nuget.pkg.github.com/honua-io/index.json" />
+  </packageSources>
+  <packageSourceCredentials>
+    <github-honua>
+      <add key="Username" value="${escaped_user}" />
+      <add key="ClearTextPassword" value="${escaped_token}" />
+    </github-honua>
+  </packageSourceCredentials>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="github-honua">
+      <package pattern="Geospatial.Grpc" />
+      <package pattern="Honua.Core" />
+      <package pattern="Honua.Mobile.*" />
+      <package pattern="Honua.Sdk.*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>
+EOF
+  umask "${old_umask}"
+
+  printf '%s' "${config_path}"
+}
+
+cleanup_paths=()
+cleanup() {
+  local path
+  for path in "${cleanup_paths[@]:-}"; do
+    rm -rf "${path}"
+  done
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --configuration)
+      [[ $# -ge 2 ]] || fail "--configuration requires a value."
+      configuration="$2"
+      shift 2
+      ;;
+    --skip-dotnet)
+      run_dotnet=false
+      shift
+      ;;
+    --skip-format)
+      run_format=false
+      shift
+      ;;
+    --skip-npm)
+      run_npm=false
+      shift
+      ;;
+    --skip-npm-ci)
+      run_npm_ci=false
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown option: $1"
+      ;;
+  esac
+done
+
+cd "${repo_root}"
+
+if [[ "${run_dotnet}" == "true" ]]; then
+  restore_config="$(make_nuget_config)"
+
+  if [[ -z "${HONUA_GITHUB_PACKAGES_TOKEN:-}" ]]; then
+    step "Using existing NuGet credentials"
+    cat <<'EOF'
+No HONUA_GITHUB_PACKAGES_TOKEN is set. Restore will use any credentials already
+configured for the github-honua source. For a fresh checkout, set
+HONUA_GITHUB_PACKAGES_USER and HONUA_GITHUB_PACKAGES_TOKEN with read:packages.
+EOF
+  else
+    step "Using temporary GitHub Packages NuGet credentials"
+  fi
+
+  step "Restore solution"
+  if ! run dotnet restore "${solution}" --configfile "${restore_config}"; then
+    cat >&2 <<'EOF'
+error: dotnet restore failed.
+
+If the failure is NU1301/401/403 for https://nuget.pkg.github.com/honua-io,
+refresh the GitHub Packages token and rerun:
+
+  export HONUA_GITHUB_PACKAGES_USER=<github-user-or-bot>
+  export HONUA_GITHUB_PACKAGES_TOKEN=<token-with-read:packages>
+  scripts/validate-local.sh
+EOF
+    exit 1
+  fi
+
+  step "Build solution"
+  run dotnet build "${solution}" --no-restore --configuration "${configuration}"
+
+  step "Test solution"
+  run dotnet test "${solution}" --no-build --no-restore --configuration "${configuration}" --logger "console;verbosity=minimal"
+
+  step "Run smoke tests"
+  run dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj \
+    --no-build --no-restore --configuration "${configuration}" \
+    --logger "console;verbosity=minimal"
+
+  if [[ "${run_format}" == "true" ]]; then
+    step "Verify dotnet format"
+    run dotnet format src/Honua.Mobile.Sdk/Honua.Mobile.Sdk.csproj --no-restore --verify-no-changes --verbosity minimal
+    run dotnet format src/Honua.Mobile.Offline/Honua.Mobile.Offline.csproj --no-restore --verify-no-changes --verbosity minimal
+    run dotnet format src/Honua.Mobile.Field/Honua.Mobile.Field.csproj --no-restore --verify-no-changes --verbosity minimal
+  fi
+fi
+
+if [[ "${run_npm}" == "true" ]]; then
+  if [[ "${run_npm_ci}" == "true" ]]; then
+    step "Install embed dependencies"
+    run npm ci --prefix src/Honua.Embed
+  fi
+
+  step "Build embed package"
+  run npm run build --prefix src/Honua.Embed
+
+  step "Test embed package"
+  run npm test --prefix src/Honua.Embed
+fi
+
+step "Local validation completed"


### PR DESCRIPTION
## Summary

Part of #208.

- adds `scripts/validate-local.sh` as the documented local validation baseline
- documents GitHub Packages credentials for fresh restores of private `Honua.Sdk.*` packages
- updates validation docs so local restore/build/test/embed/smoke commands line up with the PR gates

## Testing

- bash -n scripts/validate-local.sh
- scripts/validate-local.sh --help
- scripts/validate-local.sh --skip-dotnet --skip-npm
- scripts/validate-local.sh --skip-dotnet --skip-npm-ci
- git diff --check

## Local validation note

The full dotnet path was intentionally exercised without a `read:packages` token and failed at restore with NU1301/401 for the private `github-honua` feed. The new script emitted the documented remediation text for `HONUA_GITHUB_PACKAGES_USER` and `HONUA_GITHUB_PACKAGES_TOKEN`. CI has `packages: read` and remains the authoritative full restore/build/test verification for this PR.