### PR TITLE
docs: reconcile mobile parity status

### DIFF
--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -1,6 +1,8 @@
 # 5-Minute Tutorial: Build Your First Field Data Collection App
 
-In just 5 minutes, you'll build a complete field data collection app that competes with expensive platforms like Fulcrum and Survey123 - completely free and open source!
+In just 5 minutes, you'll build an open-source field data collection app that
+demonstrates the same core workflow categories used by platforms like Fulcrum
+and Survey123.
 
 ## What You'll Build
 
@@ -11,7 +13,8 @@ A professional mobile app with:
 - ✅ Offline data storage and sync
 - ✅ Cross-platform (iOS, Android, Windows)
 
-**End Result**: A production-ready field data collection app in under 5 minutes!
+**End Result**: A field data collection app prototype you can extend and
+validate for your own workflow.
 
 ## Step 1: Create Project (30 seconds)
 
@@ -270,20 +273,26 @@ curl -H "X-API-Key: your-api-key" \
 
 ## Compare to Competition
 
-### What You Just Built vs. Fulcrum ($99/month)
+This table is a planning comparison for the template and SDK surface, not a
+claim that every item is fully shipped and validated in this repository. For
+source-backed status, use the [feature map](../features/README.md), the
+[validation strategy](../guides/validation-strategy.md), and the
+[mobile SDK backlog roadmap](../guides/mobile-sdk-backlog-roadmap.md).
 
-| Feature | Your App (Free) | Fulcrum ($99/mo) |
+### Template Direction vs. Fulcrum ($99/month)
+
+| Feature | Honua template direction | Fulcrum ($99/mo) |
 |---------|-----------------|------------------|
-| **Dynamic Forms** | ✅ Server-driven schemas | ✅ Web form builder |
-| **Offline Capability** | ✅ True offline-first | ⚠️ Limited offline |
-| **GPS Accuracy** | ✅ Real-time color-coded | ✅ Basic accuracy |
-| **Photo Management** | ✅ AI face blurring | ❌ Basic photos only |
-| **IoT Integration** | ✅ Bluetooth LE sensors | ❌ Not available |
-| **AR Visualization** | ✅ Native ARKit/ARCore | ❌ Not available |
-| **Customization** | ✅ Full source code access | ❌ Vendor lock-in |
-| **License Cost** | ✅ **$0 forever** | ❌ **$1,188/year** |
+| **Dynamic Forms** | SDK-backed schemas and rendering are active mobile scope | Web form builder |
+| **Offline Capability** | GeoPackage and sync runtime are implemented; app workflow parity is tracked in backlog | Offline field collection |
+| **GPS Accuracy** | Mobile location services and validation presentation are implemented; advanced field UX is backlog | Accuracy capture |
+| **Photo Management** | Media capture/local path handling is mobile scope; advanced AI hooks are backlog | Photo capture |
+| **IoT Integration** | Future extension track | Product-dependent |
+| **AR Visualization** | Future track after scene anchoring dependencies close | Not a core field form feature |
+| **Customization** | Source and template customization | Vendor-managed customization |
+| **License Cost** | Open-source client repository | Commercial subscription |
 
-**💰 Savings: $1,188/year per user**
+Commercial savings depend on hosting, support, and implementation choices.
 
 ## Next Steps (Choose Your Adventure)
 

--- a/docs/guides/migration-guide.md
+++ b/docs/guides/migration-guide.md
@@ -1,29 +1,35 @@
 # Migration Guide: From Proprietary Platforms to Honua
 
-**Break free from vendor lock-in and save thousands per year while gaining superior capabilities.**
+**Plan migrations away from proprietary field platforms using Honua's
+open-source mobile runtime and SDK-backed workflows.**
 
-This guide helps you migrate from expensive proprietary platforms to the open-source Honua Mobile SDK.
+This guide is a migration planning aid. It includes target-state examples and
+future roadmap items; it is not a guarantee that every compared capability is
+fully shipped and validated in this repository. For source-backed status, use
+[docs/features/README.md](../features/README.md),
+[docs/guides/validation-strategy.md](validation-strategy.md), and
+[docs/guides/mobile-sdk-backlog-roadmap.md](mobile-sdk-backlog-roadmap.md).
 
 ---
 
 ## 🎯 Migration Overview
 
-### Why Migrate to Honua?
+### Why Evaluate Honua?
 
 | Benefit | Savings/Improvement |
 |---------|-------------------|
-| **Cost Elimination** | Save $1,200-$3,600 per user per year |
+| **Cost Control** | Open-source client code can reduce per-seat licensing pressure depending on hosting and support choices |
 | **No Vendor Lock-in** | Full source code access and control |
 | **Superior Technology** | Native performance vs web wrappers |
-| **Advanced Features** | IoT integration and AR capabilities unavailable elsewhere |
+| **Advanced Features** | IoT and AR are roadmap tracks with mobile/server dependencies |
 | **Future-Proof** | Open standards and community-driven development |
 
 ### Migration Timeline
 
 - **🚀 Quick Start**: 1-2 hours to working prototype
-- **📱 Basic App**: 1-2 days to feature-complete app
+- **📱 Basic App**: 1-2 days to a field workflow prototype
 - **🎨 Customization**: 1 week to fully branded solution
-- **📊 Full Migration**: 2-4 weeks including data migration and training
+- **📊 Full Migration**: Plan as a project with data migration, acceptance testing, and training
 
 ---
 
@@ -37,9 +43,9 @@ Fulcrum is a popular field data collection platform charging $99-299/month per u
 |---------|-----------|-------------|
 | **Cost** | ✅ **$0** (open source) | ❌ **$99-299/month/user** |
 | **Performance** | ✅ **Native mobile** | ❌ Web wrapper |
-| **Offline Capability** | ✅ **True offline-first** | ⚠️ Limited offline |
-| **IoT Integration** | ✅ **Bluetooth LE, LoRa, WiFi** | ❌ Not available |
-| **AR Visualization** | ✅ **Native ARKit/ARCore** | ❌ Not available |
+| **Offline Capability** | ✅ **GeoPackage/sync runtime; app parity tracked in backlog** | Offline field collection |
+| **IoT Integration** | Roadmap extension track | Product-dependent |
+| **AR Visualization** | Roadmap after scene anchoring dependencies | Product-dependent |
 | **Custom Branding** | ✅ **Full customization** | ⚠️ Limited options |
 | **Data Ownership** | ✅ **Full control** | ❌ Vendor hosted |
 | **API Access** | ✅ **Full gRPC + REST APIs** | ⚠️ Limited REST API |
@@ -711,14 +717,15 @@ console.log(calculateROI('survey123', 100, 3));
 
 **[Contact Migration Services](mailto:migration@honua.com)**
 
-### Migration Guarantee
+### Migration Acceptance Checklist
 
-We're so confident in Honua's capabilities that we offer a **30-day migration guarantee**:
+Before replacing an existing field platform, validate the pilot against explicit
+acceptance criteria:
 
-✅ **Full feature parity** with your current platform
-✅ **Data migration accuracy** of 99.9%+
-✅ **Performance improvements** or money back
-✅ **Team training** until proficient
+- Define required feature parity against your current platform
+- Validate data migration accuracy with sample exports before production cutover
+- Measure performance on representative field workflows
+- Train the team until the pilot acceptance checklist passes
 
 ---
 

--- a/docs/guides/mobile-sdk-backlog-roadmap.md
+++ b/docs/guides/mobile-sdk-backlog-roadmap.md
@@ -7,21 +7,38 @@ epic. It covers open children #10, #12, #16, #23, #38, #42, #50, #51, and #57.
 It intentionally excludes #22, which owns Flutter and broader platform parity
 expansion.
 
-This page is a sequencing and closure matrix. It does not replace the detailed
-source-of-truth documents for contracts, 3D/AR, offline packaging, protected
-scene auth, or display implementation.
+This page is a sequencing and closure matrix. It also indexes the current
+Fulcrum/Survey123 parity backlog. It does not replace the detailed
+source-of-truth documents for implemented capabilities, validation coverage,
+contracts, 3D/AR, offline packaging, protected scene auth, or display
+implementation.
 
 ## Source Documents
 
 | Area | Source |
 |------|--------|
-| Phase 0 parity, innovation, and test baseline | [Phase 0 Summary](../phase-0/PHASE_0_SUMMARY.md) |
+| Current implemented capability map | [Feature Map](../features/README.md) |
+| Current validation and coverage map | [Validation Strategy](validation-strategy.md) |
+| Historical Phase 0 parity, innovation, and test baseline | [Phase 0 Summary](../phase-0/PHASE_0_SUMMARY.md) |
 | SDK/mobile contract ownership | [Mobile Contract Harmonization](mobile-contract-harmonization.md) |
 | 3D, scene, and AR dependency order | [Mobile 3D and AR Dependency Matrix](mobile-3d-ar-dependency-matrix.md) |
 | Offline 3D package policy | [Offline 3D Scene Packages](offline-3d-scene-packages.md) |
 | Protected scene auth handoff | [Protected 3D Scene Auth](protected-3d-scene-auth.md) |
 | Web scene rendering surface | [3D Scene Embed](3d-scene-embed.md) |
 | Web map embedding surface | [Embeddable Map](embeddable-map.md) |
+
+## Status Vocabulary
+
+Use these labels consistently when comparing Honua Mobile to Fulcrum,
+Survey123, or other field collection platforms:
+
+| Status | Meaning | Source of truth |
+|--------|---------|-----------------|
+| Implemented | Source exists in this repository and belongs in mobile. | [Feature Map](../features/README.md) plus `src/`, `apps/`, `examples/`, and `templates/`. |
+| Validated | Automated tests or CI jobs exercise the behavior. | [Validation Strategy](validation-strategy.md), `tests/`, `src/Honua.Embed/tests/`, and CI job status. |
+| Backlog | Product parity need is identified but not fully implemented or validated. | The backlog index below and linked GitHub issues. |
+| Cross-repo dependency | Required contracts or server behavior belong outside this repo. | Linked `honua-sdk-dotnet` or `honua-server` issues and dependency docs. |
+| Historical baseline | Phase 0 planning claim or target, not shipped status by itself. | `docs/phase-0/*` with the status notes at the top of each document. |
 
 ## Epic State
 
@@ -34,6 +51,18 @@ scene auth, or display implementation.
 | 3D, offline scene, and AR/VR | Policy and dependency order are documented; implementation depends on server, SDK, browser/WebView, and native platform decisions. | #12 remains the umbrella. #42 and #38 are immediate prerequisites for production offline scenes and native AR/VR work. |
 | Field location behavior | Geofencing acquisition remains a mobile-owned runtime slice once SDK evaluation contracts are available. | #51 should not define portable geofence rules; it should consume the SDK and own permissions, sensors, background behavior, and battery policy. |
 | Plugins | Mobile/web hosts own runtime loading and UI integration; non-UI manifests and permission contracts belong in shared SDK/server work. | #16 can consume SDK manifests from `Honua.Sdk.Abstractions`; server plugin APIs remain tracked in honua-io/honua-server#347. |
+
+## Fulcrum/Survey123 Parity Backlog Index
+
+These issues are the current execution backlog for closing the gap between the
+historical Phase 0 parity targets and source-backed shipped status.
+
+| Priority | Issues | Closure signal |
+|----------|--------|----------------|
+| P0 | [#208](https://github.com/honua-io/honua-mobile/issues/208) restore green validation; [#209](https://github.com/honua-io/honua-mobile/issues/209) reconcile parity docs. | Agents and reviewers can trust the local/CI baseline and source-backed docs. |
+| P1 | [#210](https://github.com/honua-io/honua-mobile/issues/210) functional FieldCollection workflows; [#211](https://github.com/honua-io/honua-mobile/issues/211) metadata-driven projects/layers/forms; [#212](https://github.com/honua-io/honua-mobile/issues/212) remote sync transports; [#213](https://github.com/honua-io/honua-mobile/issues/213) attachment storage/sync; [#214](https://github.com/honua-io/honua-mobile/issues/214) pilot field-type controls; [#215](https://github.com/honua-io/honua-mobile/issues/215) rules/calculations/conditional visibility/repeats; [#216](https://github.com/honua-io/honua-mobile/issues/216) real map workflow surface. | MVP field workflow is usable end to end from metadata load through capture, validation, map context, offline storage, and sync. |
+| P2 | [#217](https://github.com/honua-io/honua-mobile/issues/217) product acceptance suite; [#218](https://github.com/honua-io/honua-mobile/issues/218) auth/session hardening; [#219](https://github.com/honua-io/honua-mobile/issues/219) server/admin dependencies; [#220](https://github.com/honua-io/honua-mobile/issues/220) local record export; [#221](https://github.com/honua-io/honua-mobile/issues/221) diagnostics and sync health. | Beta hardening covers acceptance evidence, operational support, auth robustness, admin dependencies, and field troubleshooting. |
+| P3 | [#222](https://github.com/honua-io/honua-mobile/issues/222) external GNSS metadata; [#223](https://github.com/honua-io/honua-mobile/issues/223) geofence/proximity workflows; [#224](https://github.com/honua-io/honua-mobile/issues/224) AI-assisted capture hooks; [#225](https://github.com/honua-io/honua-mobile/issues/225) first AR/3D field workflow; [#226](https://github.com/honua-io/honua-mobile/issues/226) mobile/web plugin host hardening. | GA-oriented differentiators are implemented only after SDK/server dependencies and MVP/Beta workflow gaps are stable. |
 
 ## Acceptance Matrix
 

--- a/docs/phase-0/INNOVATION_SPEC.md
+++ b/docs/phase-0/INNOVATION_SPEC.md
@@ -1,5 +1,13 @@
 # Honua Mobile SDK - Innovation Specification
 
+> Status note, May 2026: this Phase 0 document is an innovation roadmap and
+> planning baseline, not shipped-product status. Use
+> [docs/features/README.md](../features/README.md) for source-backed current
+> capabilities, [docs/guides/validation-strategy.md](../guides/validation-strategy.md)
+> for validated coverage, and
+> [docs/guides/mobile-sdk-backlog-roadmap.md](../guides/mobile-sdk-backlog-roadmap.md)
+> for open parity backlog issues and dependencies.
+
 ## Executive Summary
 
 This document defines Honua's innovation roadmap beyond competitive parity, focusing on breakthrough capabilities that establish market leadership and create new industry standards. These innovations leverage our **open gRPC geospatial protocols** to democratize mobile field work while delivering superior performance and developer experience.

--- a/docs/phase-0/PARITY_SPEC.md
+++ b/docs/phase-0/PARITY_SPEC.md
@@ -1,14 +1,25 @@
 # Honua Mobile SDK - Competitive Parity Specification
 
+> Status note, May 2026: this Phase 0 document is a historical planning
+> baseline, not shipped-product status. Use
+> [docs/features/README.md](../features/README.md) for source-backed current
+> capabilities, [docs/guides/validation-strategy.md](../guides/validation-strategy.md)
+> for validated coverage, and
+> [docs/guides/mobile-sdk-backlog-roadmap.md](../guides/mobile-sdk-backlog-roadmap.md)
+> for open parity backlog issues and dependencies.
+
 ## Executive Summary
 
-This document defines Honua's competitive parity requirements against leading geospatial mobile platforms. The analysis demonstrates that Honua achieves **functional parity** with market leaders while introducing **innovative advantages** that position it as the next-generation platform.
+This document defines Honua's competitive parity requirements against leading
+geospatial mobile platforms. It records the Phase 0 target analysis for
+functional parity and innovation opportunities; shipped status must be verified
+against the feature map, validation strategy, and backlog issues linked above.
 
 **Key Findings:**
-- ✅ **Full parity** achieved with Survey123, Fulcrum, and Mapbox Mobile SDK
-- 🚀 **Innovation leadership** in gRPC protocols, real-time collaboration, and mobile optimization
-- 📱 **Superior mobile experience** with 60-70% bandwidth reduction and 5x faster form loading
-- 🌍 **Open source advantage** breaking vendor lock-in with Apache 2.0 client libraries
+- **Parity target** documented against Survey123, Fulcrum, and Mapbox Mobile SDK
+- **Innovation roadmap** identified around gRPC protocols, collaboration, and mobile optimization
+- **Performance targets** proposed for bandwidth and form loading
+- **Open source direction** recorded for Apache 2.0 client libraries
 
 ## Capability Matrix
 
@@ -264,16 +275,15 @@ This document defines Honua's competitive parity requirements against leading ge
 
 ## Conclusion
 
-Honua achieves **full competitive parity** with market leaders while introducing **breakthrough innovations** that position it for industry leadership:
+This Phase 0 specification defines the parity target and innovation thesis for
+later implementation:
 
-🎯 **Parity Achieved**: All essential capabilities match or exceed Survey123, Fulcrum, and Mapbox Mobile
+- **Parity target**: essential capabilities are mapped against Survey123,
+  Fulcrum, and Mapbox Mobile.
+- **Innovation roadmap**: open gRPC geospatial protocols, collaboration,
+  device-aware optimization, and performance targets are identified.
+- **Strategic advantage**: open-source client libraries are positioned as an
+  alternative to vendor lock-in.
 
-🚀 **Innovation Leadership**:
-- First open gRPC geospatial protocols
-- Real-time collaborative editing
-- Device-aware mobile optimization
-- Superior performance (5x faster, 68% bandwidth reduction)
-
-🌍 **Strategic Advantage**: Open source ecosystem disrupts vendor lock-in models while enabling rapid innovation
-
-**Phase 0 Exit Criteria Met**: Technical foundation ready for Phase 1 market deployment and standards leadership initiative.
+**Phase 0 Exit Criteria Met**: planning foundation ready for Phase 1
+implementation, validation, and standards exploration.

--- a/docs/phase-0/PHASE_0_SUMMARY.md
+++ b/docs/phase-0/PHASE_0_SUMMARY.md
@@ -1,15 +1,26 @@
 # Phase 0 Epic Summary - Mobile Parity & Innovation Baseline
 
+> Status note, May 2026: this Phase 0 summary records planning deliverables
+> and target parity assumptions. It is not a shipped-product status report. Use
+> [docs/features/README.md](../features/README.md) for current implementation,
+> [docs/guides/validation-strategy.md](../guides/validation-strategy.md) for
+> validated coverage, and
+> [docs/guides/mobile-sdk-backlog-roadmap.md](../guides/mobile-sdk-backlog-roadmap.md)
+> for open parity backlog issues and dependencies.
+
 ## Executive Summary
 
-Phase 0 of Honua's mobile initiative has successfully established the **technical and strategic foundation** for market entry with competitive parity and breakthrough innovations. All deliverables have been completed, providing a **contract-frozen baseline** for Phase 1 implementation.
+Phase 0 of Honua's mobile initiative established the **technical and strategic
+planning foundation** for market entry targets, competitive parity analysis,
+and innovation work. Its deliverables are planning artifacts for later
+implementation, validation, and dependency tracking.
 
 **Key Achievements:**
-- ✅ **Competitive parity** achieved across all domains vs Survey123, Fulcrum, Mapbox
-- 🚀 **Innovation leadership** in gRPC protocols, real-time collaboration, and mobile optimization
-- 📱 **Production-ready reference app** with comprehensive 4-screen implementation
-- 📋 **Complete specifications** for market entry and standards leadership
-- 🧪 **Comprehensive test strategy** ensuring production reliability
+- **Competitive parity targets** documented across domains vs Survey123, Fulcrum, and Mapbox
+- **Innovation roadmap** drafted for gRPC protocols, real-time collaboration, and mobile optimization
+- **Reference app direction** captured for field workflow implementation
+- **Specifications** drafted for market-entry and standards work
+- **Test strategy baseline** drafted for later production validation
 
 ## Epic Completion Status
 
@@ -29,7 +40,7 @@ Phase 0 of Honua's mobile initiative has successfully established the **technica
 
 **Comprehensive capability matrix** comparing Honua against market leaders:
 
-| Capability Domain | Survey123 | Fulcrum | Mapbox | **Honua Status** |
+| Capability Domain | Survey123 | Fulcrum | Mapbox | **Phase 0 Target** |
 |------------------|-----------|---------|---------|------------------|
 | **Form Definition** | ⚠️ XML-based | ✅ Advanced | ❌ Limited | ✅ **Best-in-class** |
 | **Mobile Performance** | ⚠️ Slow (XML) | ⚠️ Moderate | ⚠️ Good | ✅ **5x faster** |
@@ -38,10 +49,10 @@ Phase 0 of Honua's mobile initiative has successfully established the **technica
 | **Open Standards** | ❌ Closed | ❌ Closed | ❌ Closed | 🚀 **First open gRPC** |
 
 **Key Findings:**
-- **Full competitive parity** achieved across all essential capabilities
-- **Performance leadership**: 68% bandwidth reduction, 5x faster loading
-- **Innovation advantages**: Real-time collaboration, device-aware optimization
-- **Strategic position**: First open gRPC geospatial standard → OGC submission opportunity
+- **Competitive parity target** documented across essential capabilities
+- **Performance targets** proposed around bandwidth and form loading
+- **Innovation advantages** identified for real-time collaboration and device-aware optimization
+- **Strategic position** drafted around a possible open gRPC geospatial standards path
 
 ### 2. INNOVATION_SPEC.md - Beyond Parity Strategy ✅
 
@@ -317,7 +328,7 @@ message AuthenticationContext {
 
 **All Phase 0 deliverables have been completed successfully:**
 
-✅ **PARITY_SPEC.md**: Comprehensive competitive analysis demonstrating full parity and innovation advantages
+✅ **PARITY_SPEC.md**: Comprehensive competitive analysis documenting parity targets and innovation advantages
 
 ✅ **INNOVATION_SPEC.md**: Strategic roadmap for market leadership through open standards and breakthrough performance
 

--- a/docs/phase-0/TEST_STRATEGY.md
+++ b/docs/phase-0/TEST_STRATEGY.md
@@ -1,5 +1,13 @@
 # Honua Mobile SDK - Test Strategy
 
+> Status note, May 2026: this Phase 0 document is a proposed test strategy and
+> planning baseline. The source-backed validation map is
+> [docs/guides/validation-strategy.md](../guides/validation-strategy.md);
+> current implemented capability status is
+> [docs/features/README.md](../features/README.md), and open parity gaps are
+> tracked from
+> [docs/guides/mobile-sdk-backlog-roadmap.md](../guides/mobile-sdk-backlog-roadmap.md).
+
 ## Executive Summary
 
 This document defines the comprehensive testing strategy for Honua Mobile SDK, focusing on **golden dataset validation**, **replay testing**, and **fault injection** to ensure production reliability in challenging field conditions. The strategy emphasizes **real-world simulation** and **continuous validation** against competitive benchmarks.

--- a/tests/Honua.Mobile.Smoke.Tests/MobileParityBacklogDocsTests.cs
+++ b/tests/Honua.Mobile.Smoke.Tests/MobileParityBacklogDocsTests.cs
@@ -1,0 +1,63 @@
+namespace Honua.Mobile.Smoke.Tests;
+
+public sealed class MobileParityBacklogDocsTests
+{
+    [Fact]
+    public void PhaseZeroDocs_AreMarkedAsHistoricalPlanningBaselines()
+    {
+        var root = FindRepositoryRoot();
+        var phaseZeroDocs = new[]
+        {
+            Path.Combine(root, "docs", "phase-0", "PARITY_SPEC.md"),
+            Path.Combine(root, "docs", "phase-0", "PHASE_0_SUMMARY.md"),
+            Path.Combine(root, "docs", "phase-0", "INNOVATION_SPEC.md"),
+            Path.Combine(root, "docs", "phase-0", "TEST_STRATEGY.md"),
+        };
+
+        foreach (var path in phaseZeroDocs)
+        {
+            var contents = File.ReadAllText(path);
+
+            Assert.Contains("Status note, May 2026", contents);
+            Assert.Contains("docs/features/README.md", contents);
+            Assert.Contains("docs/guides/validation-strategy.md", contents);
+            Assert.Contains("docs/guides/mobile-sdk-backlog-roadmap.md", contents);
+        }
+    }
+
+    [Fact]
+    public void MobileSdkBacklogRoadmap_LinksCurrentParityBacklog()
+    {
+        var root = FindRepositoryRoot();
+        var roadmapPath = Path.Combine(root, "docs", "guides", "mobile-sdk-backlog-roadmap.md");
+        var roadmap = File.ReadAllText(roadmapPath);
+
+        Assert.Contains("## Status Vocabulary", roadmap);
+        Assert.Contains("## Fulcrum/Survey123 Parity Backlog Index", roadmap);
+
+        for (var issue = 208; issue <= 226; issue++)
+        {
+            Assert.Contains($"honua-io/honua-mobile/issues/{issue}", roadmap);
+        }
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            var agentsPath = Path.Combine(directory.FullName, "AGENTS.md");
+            var docsPath = Path.Combine(directory.FullName, "docs");
+
+            if (File.Exists(agentsPath) && Directory.Exists(docsPath))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root from test output directory.");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #209.

- marks Phase 0 parity/innovation/test docs as historical planning baselines instead of shipped-product status
- updates the backlog roadmap with source-of-truth status vocabulary and links to #208-#226
- softens current tutorial/migration guide competitive language so Fulcrum/Survey123 comparisons point readers to source-backed feature and validation maps
- adds a smoke test that guards the Phase 0 status notes and backlog issue links

## Testing

- git diff --check
- rg -n "Full competitive parity|Full parity|full competitive parity|full feature parity|parity achieved|Parity Achieved|money back|production-ready field data collection app|Honua achieves" docs/phase-0 docs/getting-started/tutorial.md docs/guides/migration-guide.md -S (no matches)

## Local validation note

`dotnet build tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --no-restore --configuration Release --verbosity minimal` is still blocked locally by the available token lacking read:packages for the private `github-honua` feed (`Honua.Sdk.Offline` returns 401). CI has packages: read and will be the authoritative .NET verification for the new smoke test.