### PR TITLE
mobile: load field metadata from Honua services

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Honua.Mobile.FieldCollection.Core.csproj
+++ b/apps/Honua.Mobile.FieldCollection.Core/Honua.Mobile.FieldCollection.Core.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="Honua.Sdk.Abstractions" Version="$(HonuaSdkDotNetTrainVersion)" />
     <PackageReference Include="Honua.Sdk.Field" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.GeoServices" Version="$(HonuaSdkDotNetTrainVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Maui.Essentials" Version="10.0.60" />
     <PackageReference Include="NetTopologySuite" Version="2.6.0" />

--- a/apps/Honua.Mobile.FieldCollection.Core/Models/CoreModels.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Models/CoreModels.cs
@@ -212,6 +212,8 @@ public enum AttachmentSyncStatus
 public class LayerInfo
 {
     public int Id { get; set; }
+    public string? ServiceId { get; set; }
+    public string? SourceId { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
     public GeometryType GeometryType { get; set; }
@@ -220,6 +222,16 @@ public class LayerInfo
     public FormDefinition? Form { get; set; }
     public List<FieldDefinition> Schema { get; set; } = new();
     public LayerStyle Style { get; set; } = new();
+}
+
+public class FieldProjectInfo
+{
+    public string ServiceId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public int LayerCount { get; set; }
+    public bool IsAvailableOffline { get; set; }
+    public List<LayerInfo> Layers { get; set; } = new();
 }
 
 public class LayerStyle

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/CoreServices.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/CoreServices.cs
@@ -28,11 +28,20 @@ public interface IStorageService
 
 public interface IFeatureService
 {
+    Task<IReadOnlyList<LayerInfo>> GetLayersAsync();
     Task<IEnumerable<Feature>> GetFeaturesAsync(int layerId, Polygon? spatialFilter = null);
     Task<Feature?> GetFeatureAsync(int layerId, string featureId);
     Task<Feature> CreateFeatureAsync(int layerId, Feature feature);
     Task<Feature> UpdateFeatureAsync(int layerId, Feature feature);
     Task DeleteFeatureAsync(int layerId, string featureId);
+}
+
+public interface IFieldCollectionMetadataService
+{
+    Task<IReadOnlyList<FieldProjectInfo>> GetProjectsAsync(bool refresh = false, CancellationToken cancellationToken = default);
+    Task<FieldProjectInfo?> GetSelectedProjectAsync(CancellationToken cancellationToken = default);
+    Task SelectProjectAsync(string serviceId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<LayerInfo>> GetLayersAsync(bool refresh = false, CancellationToken cancellationToken = default);
 }
 
 public interface IFormService
@@ -141,6 +150,11 @@ public class StorageService : IStorageService
 
 public class FeatureService : IFeatureService
 {
+    public Task<IReadOnlyList<LayerInfo>> GetLayersAsync()
+    {
+        return Task.FromResult<IReadOnlyList<LayerInfo>>(Array.Empty<LayerInfo>());
+    }
+
     public Task<IEnumerable<Feature>> GetFeaturesAsync(int layerId, Polygon? spatialFilter = null)
     {
         return Task.FromResult<IEnumerable<Feature>>(Array.Empty<Feature>());
@@ -169,9 +183,22 @@ public class FeatureService : IFeatureService
 
 public class FormService : IFormService
 {
-    public Task<FormDefinition?> GetFormDefinitionAsync(int layerId)
+    private readonly IFieldCollectionMetadataService? _metadataService;
+
+    public FormService(IFieldCollectionMetadataService? metadataService = null)
     {
-        return Task.FromResult<FormDefinition?>(null);
+        _metadataService = metadataService;
+    }
+
+    public async Task<FormDefinition?> GetFormDefinitionAsync(int layerId)
+    {
+        if (_metadataService == null)
+        {
+            return null;
+        }
+
+        var layers = await _metadataService.GetLayersAsync().ConfigureAwait(false);
+        return layers.FirstOrDefault(layer => layer.Id == layerId)?.Form;
     }
 
     public Task<bool> ValidateFormAsync(FormData formData, FormDefinition definition)

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Metadata/FieldCollectionMetadataMapper.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Metadata/FieldCollectionMetadataMapper.cs
@@ -1,0 +1,202 @@
+using System.Globalization;
+using System.Text.Json;
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Field.Forms;
+using Honua.Sdk.GeoServices.FeatureServer.Models;
+
+namespace Honua.Mobile.FieldCollection.Services.Metadata;
+
+internal static class FieldCollectionMetadataMapper
+{
+    public static LayerInfo ToLayerInfo(string serviceId, FeatureServerLayerInfo layer)
+    {
+        var schema = (layer.Fields ?? [])
+            .Where(IsFieldCollectionField)
+            .Select(ToFormField)
+            .ToList();
+
+        var layerInfo = new LayerInfo
+        {
+            Id = layer.Id,
+            ServiceId = serviceId,
+            SourceId = BuildSourceId(serviceId, layer.Id),
+            Name = string.IsNullOrWhiteSpace(layer.Name) ? $"Layer {layer.Id}" : layer.Name,
+            Description = layer.Description ?? string.Empty,
+            GeometryType = MapGeometryType(layer.GeometryType),
+            IsVisible = true,
+            IsEditable = AllowsEdits(layer.Capabilities),
+            Schema = schema
+        };
+
+        layerInfo.Form = CreateFormDefinition(layerInfo);
+        return layerInfo;
+    }
+
+    public static FormDefinition CreateFormDefinition(LayerInfo layer)
+    {
+        var formId = !string.IsNullOrWhiteSpace(layer.SourceId)
+            ? $"{layer.SourceId}:form"
+            : $"layer-{layer.Id}:form";
+
+        return new FormDefinition
+        {
+            FormId = formId,
+            Name = string.IsNullOrWhiteSpace(layer.Name) ? $"Layer {layer.Id}" : layer.Name,
+            Description = layer.Description,
+            Target = new FormTarget
+            {
+                SourceId = layer.SourceId,
+                ServiceId = layer.ServiceId,
+                LayerId = layer.Id
+            },
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "attributes",
+                    Label = "Attributes",
+                    Fields = layer.Schema
+                }
+            ],
+            Metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["geometryType"] = layer.GeometryType.ToString(),
+                ["editable"] = layer.IsEditable.ToString(CultureInfo.InvariantCulture)
+            }
+        };
+    }
+
+    public static FeatureSpatialGeometryType MapGeometryType(string? geometryType)
+    {
+        return geometryType?.Trim().ToLowerInvariant() switch
+        {
+            "esrigeometrypoint" or "point" => FeatureSpatialGeometryType.Point,
+            "esrigeometrymultipoint" or "multipoint" => FeatureSpatialGeometryType.MultiPoint,
+            "esrigeometrypolyline" or "polyline" or "linestring" or "multilinestring" => FeatureSpatialGeometryType.Polyline,
+            "esrigeometrypolygon" or "polygon" or "multipolygon" => FeatureSpatialGeometryType.Polygon,
+            "esrigeometryenvelope" or "envelope" => FeatureSpatialGeometryType.Envelope,
+            _ => FeatureSpatialGeometryType.Unspecified
+        };
+    }
+
+    public static string BuildSourceId(string serviceId, int layerId)
+    {
+        return $"{serviceId}/FeatureServer/{layerId}";
+    }
+
+    private static FormField ToFormField(FeatureServerField field)
+    {
+        var choices = ReadChoices(field.Domain);
+        var type = choices.Count > 0 ? FormFieldType.SingleChoice : MapFieldType(field.Type);
+
+        return new FormField
+        {
+            FieldId = field.Name,
+            SourceFieldName = field.Name,
+            Label = string.IsNullOrWhiteSpace(field.Alias) ? field.Name : field.Alias,
+            Type = type,
+            Required = !field.Nullable && field.DefaultValue is null,
+            Choices = choices,
+            Validation = new FieldValidationRule
+            {
+                MaxLength = type == FormFieldType.Text ? field.Length : null
+            }
+        };
+    }
+
+    private static bool IsFieldCollectionField(FeatureServerField field)
+    {
+        if (string.IsNullOrWhiteSpace(field.Name))
+        {
+            return false;
+        }
+
+        var type = field.Type.Trim();
+        if (type.Contains("OID", StringComparison.OrdinalIgnoreCase) ||
+            type.Contains("GlobalID", StringComparison.OrdinalIgnoreCase) ||
+            type.Contains("Geometry", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return !string.Equals(field.Name, "objectid", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(field.Name, "globalid", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(field.Name, "shape", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static FormFieldType MapFieldType(string? type)
+    {
+        return type?.Trim().ToLowerInvariant() switch
+        {
+            "esrifieldtypesmallinteger" or "esrifieldtypeinteger" or "esrifieldtypesingle" or "esrifieldtypedouble" => FormFieldType.Numeric,
+            "esrifieldtypedate" => FormFieldType.DateTime,
+            "esrifieldtypeblob" => FormFieldType.File,
+            "esrifieldtypeguid" => FormFieldType.Text,
+            _ => FormFieldType.Text
+        };
+    }
+
+    private static bool AllowsEdits(string? capabilities)
+    {
+        if (string.IsNullOrWhiteSpace(capabilities))
+        {
+            return false;
+        }
+
+        return capabilities
+            .Split([',', ';', ' '], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Any(capability =>
+                capability.Equals("Create", StringComparison.OrdinalIgnoreCase) ||
+                capability.Equals("Update", StringComparison.OrdinalIgnoreCase) ||
+                capability.Equals("Delete", StringComparison.OrdinalIgnoreCase) ||
+                capability.Equals("Editing", StringComparison.OrdinalIgnoreCase) ||
+                capability.Equals("Uploads", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static IReadOnlyList<FieldChoice> ReadChoices(JsonElement? domain)
+    {
+        if (domain is null ||
+            domain.Value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined ||
+            !domain.Value.TryGetProperty("codedValues", out var codedValues) ||
+            codedValues.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var choices = new List<FieldChoice>();
+        foreach (var codedValue in codedValues.EnumerateArray())
+        {
+            if (!codedValue.TryGetProperty("code", out var code))
+            {
+                continue;
+            }
+
+            var value = JsonScalarToString(code);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            var label = codedValue.TryGetProperty("name", out var name) && name.ValueKind == JsonValueKind.String
+                ? name.GetString()
+                : value;
+
+            choices.Add(new FieldChoice { Value = value, Label = label });
+        }
+
+        return choices;
+    }
+
+    private static string? JsonScalarToString(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number => element.GetRawText(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            _ => null
+        };
+    }
+}

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Metadata/FieldCollectionMetadataService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Metadata/FieldCollectionMetadataService.cs
@@ -1,0 +1,324 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Sdk.GeoServices.FeatureServer.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Mobile.FieldCollection.Services.Metadata;
+
+public sealed class FieldCollectionMetadataService : IFieldCollectionMetadataService
+{
+    public const string DefaultServiceId = "mobile_offline_demo";
+
+    private const string SelectedServiceIdKey = "field_collection.selected_service_id";
+
+    private readonly IAuthenticationService _authenticationService;
+    private readonly ISettingsService _settingsService;
+    private readonly GeoPackageStorageService _storageService;
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<FieldCollectionMetadataService>? _logger;
+
+    public FieldCollectionMetadataService(
+        IAuthenticationService authenticationService,
+        ISettingsService settingsService,
+        GeoPackageStorageService storageService,
+        HttpClient httpClient,
+        ILogger<FieldCollectionMetadataService>? logger = null)
+    {
+        _authenticationService = authenticationService;
+        _settingsService = settingsService;
+        _storageService = storageService;
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<FieldProjectInfo>> GetProjectsAsync(
+        bool refresh = false,
+        CancellationToken cancellationToken = default)
+    {
+        var cachedProjects = await GetCachedProjectsAsync(cancellationToken).ConfigureAwait(false);
+        if (!refresh && cachedProjects.Count > 0)
+        {
+            return cachedProjects;
+        }
+
+        if (CanLoadRemoteMetadata())
+        {
+            try
+            {
+                var remoteProjects = await LoadRemoteProjectsAsync(cancellationToken).ConfigureAwait(false);
+                if (remoteProjects.Count > 0)
+                {
+                    return MergeProjectOfflineState(remoteProjects, cachedProjects);
+                }
+            }
+            catch (Exception ex) when (ex is HttpRequestException or JsonException or TaskCanceledException or OperationCanceledException)
+            {
+                _logger?.LogWarning(ex, "Failed to load field collection project metadata from Honua server");
+            }
+        }
+
+        if (cachedProjects.Count > 0)
+        {
+            return cachedProjects;
+        }
+
+        var selectedServiceId = await GetSelectedServiceIdAsync(cancellationToken).ConfigureAwait(false);
+        return
+        [
+            new FieldProjectInfo
+            {
+                ServiceId = selectedServiceId,
+                Name = selectedServiceId,
+                Description = "Configured Honua feature service",
+                IsAvailableOffline = false
+            }
+        ];
+    }
+
+    public async Task<FieldProjectInfo?> GetSelectedProjectAsync(CancellationToken cancellationToken = default)
+    {
+        var selectedServiceId = await GetSelectedServiceIdAsync(cancellationToken).ConfigureAwait(false);
+        var projects = await GetProjectsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return projects.FirstOrDefault(project => string.Equals(project.ServiceId, selectedServiceId, StringComparison.OrdinalIgnoreCase)) ??
+            projects.FirstOrDefault();
+    }
+
+    public async Task SelectProjectAsync(string serviceId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(serviceId))
+        {
+            throw new ArgumentException("Service ID is required.", nameof(serviceId));
+        }
+
+        await _settingsService.SetSettingAsync(SelectedServiceIdKey, serviceId.Trim()).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<LayerInfo>> GetLayersAsync(
+        bool refresh = false,
+        CancellationToken cancellationToken = default)
+    {
+        var selectedServiceId = await GetSelectedServiceIdAsync(cancellationToken).ConfigureAwait(false);
+        var cachedLayers = await GetCachedLayersAsync(selectedServiceId, cancellationToken).ConfigureAwait(false);
+
+        if ((refresh || cachedLayers.Count == 0) && CanLoadRemoteMetadata())
+        {
+            try
+            {
+                var remoteLayers = await LoadRemoteLayersAsync(selectedServiceId, cancellationToken).ConfigureAwait(false);
+                foreach (var layer in remoteLayers)
+                {
+                    await _storageService.CreateLayerAsync(layer).ConfigureAwait(false);
+                }
+
+                return remoteLayers;
+            }
+            catch (Exception ex) when (ex is HttpRequestException or JsonException or TaskCanceledException or OperationCanceledException)
+            {
+                _logger?.LogWarning(ex, "Failed to load layer metadata for service {ServiceId}", selectedServiceId);
+            }
+        }
+
+        return cachedLayers;
+    }
+
+    private async Task<IReadOnlyList<FieldProjectInfo>> GetCachedProjectsAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var layers = await _storageService.GetLayersAsync().ConfigureAwait(false);
+        return layers
+            .GroupBy(layer => string.IsNullOrWhiteSpace(layer.ServiceId) ? DefaultServiceId : layer.ServiceId, StringComparer.OrdinalIgnoreCase)
+            .Select(group =>
+            {
+                var projectLayers = group.ToList();
+                return new FieldProjectInfo
+                {
+                    ServiceId = group.Key,
+                    Name = group.Key,
+                    Description = "Cached Honua feature service",
+                    LayerCount = projectLayers.Count,
+                    IsAvailableOffline = true,
+                    Layers = projectLayers
+                };
+            })
+            .OrderBy(project => project.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private async Task<IReadOnlyList<LayerInfo>> GetCachedLayersAsync(string selectedServiceId, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var layers = await _storageService.GetLayersAsync().ConfigureAwait(false);
+        var matchingLayers = layers
+            .Where(layer => string.Equals(layer.ServiceId, selectedServiceId, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (matchingLayers.Count > 0)
+        {
+            return matchingLayers;
+        }
+
+        return layers;
+    }
+
+    private async Task<IReadOnlyList<FieldProjectInfo>> LoadRemoteProjectsAsync(CancellationToken cancellationToken)
+    {
+        var uri = BuildUri("/rest/services?f=json");
+        using var request = CreateAuthenticatedRequest(HttpMethod.Get, uri);
+        using var response = await _httpClient.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken).ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        if (!document.RootElement.TryGetProperty("services", out var services) ||
+            services.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var projects = new List<FieldProjectInfo>();
+        foreach (var service in services.EnumerateArray())
+        {
+            var serviceId = ReadString(service, "name");
+            if (string.IsNullOrWhiteSpace(serviceId) || !IsFeatureServerService(service))
+            {
+                continue;
+            }
+
+            projects.Add(new FieldProjectInfo
+            {
+                ServiceId = serviceId,
+                Name = serviceId,
+                Description = ReadString(service, "description") ?? "Honua feature service",
+                IsAvailableOffline = false
+            });
+        }
+
+        return projects
+            .OrderBy(project => project.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private async Task<IReadOnlyList<LayerInfo>> LoadRemoteLayersAsync(
+        string serviceId,
+        CancellationToken cancellationToken)
+    {
+        var serviceInfo = await GetJsonAsync<FeatureServerServiceInfo>(
+            $"/rest/services/{Uri.EscapeDataString(serviceId)}/FeatureServer?f=json",
+            cancellationToken).ConfigureAwait(false);
+
+        var layerSummaries = serviceInfo.Layers ?? [];
+        var layers = new List<LayerInfo>(layerSummaries.Count);
+        foreach (var layerSummary in layerSummaries)
+        {
+            var layerInfo = await GetJsonAsync<FeatureServerLayerInfo>(
+                $"/rest/services/{Uri.EscapeDataString(serviceId)}/FeatureServer/{layerSummary.Id}?f=json",
+                cancellationToken).ConfigureAwait(false);
+
+            layers.Add(FieldCollectionMetadataMapper.ToLayerInfo(serviceId, layerInfo));
+        }
+
+        return layers;
+    }
+
+    private async Task<T> GetJsonAsync<T>(string pathAndQuery, CancellationToken cancellationToken)
+    {
+        var uri = BuildUri(pathAndQuery);
+        using var request = CreateAuthenticatedRequest(HttpMethod.Get, uri);
+        using var response = await _httpClient.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken).ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: cancellationToken).ConfigureAwait(false) ??
+            throw new JsonException($"Failed to deserialize {typeof(T).Name}.");
+    }
+
+    private async Task<string> GetSelectedServiceIdAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var selectedServiceId = await _settingsService.GetSettingAsync(SelectedServiceIdKey, DefaultServiceId).ConfigureAwait(false);
+        return string.IsNullOrWhiteSpace(selectedServiceId) ? DefaultServiceId : selectedServiceId.Trim();
+    }
+
+    private bool CanLoadRemoteMetadata()
+    {
+        return _authenticationService.IsAuthenticated &&
+            !string.IsNullOrWhiteSpace(_authenticationService.ServerUrl);
+    }
+
+    private Uri BuildUri(string pathAndQuery)
+    {
+        if (!Uri.TryCreate(_authenticationService.ServerUrl, UriKind.Absolute, out var serverUri))
+        {
+            throw new InvalidOperationException("A valid Honua server URL is required to load field metadata.");
+        }
+
+        return new Uri(serverUri, pathAndQuery);
+    }
+
+    private HttpRequestMessage CreateAuthenticatedRequest(HttpMethod method, Uri uri)
+    {
+        var request = new HttpRequestMessage(method, uri);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        if (!string.IsNullOrWhiteSpace(_authenticationService.ApiKey))
+        {
+            request.Headers.TryAddWithoutValidation("X-API-Key", _authenticationService.ApiKey);
+        }
+
+        return request;
+    }
+
+    private static IReadOnlyList<FieldProjectInfo> MergeProjectOfflineState(
+        IReadOnlyList<FieldProjectInfo> remoteProjects,
+        IReadOnlyList<FieldProjectInfo> cachedProjects)
+    {
+        var cachedByServiceId = cachedProjects.ToDictionary(
+            project => project.ServiceId,
+            StringComparer.OrdinalIgnoreCase);
+
+        return remoteProjects
+            .Select(project =>
+            {
+                if (!cachedByServiceId.TryGetValue(project.ServiceId, out var cachedProject))
+                {
+                    return project;
+                }
+
+                project.IsAvailableOffline = true;
+                project.LayerCount = cachedProject.LayerCount;
+                project.Layers = cachedProject.Layers;
+                return project;
+            })
+            .ToList();
+    }
+
+    private static bool IsFeatureServerService(JsonElement service)
+    {
+        var type = ReadString(service, "type") ?? ReadString(service, "serviceType");
+        return type is null ||
+            type.Contains("FeatureServer", StringComparison.OrdinalIgnoreCase) ||
+            type.Contains("Feature Service", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? ReadString(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+    }
+}

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Metadata/FieldCollectionMetadataService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Metadata/FieldCollectionMetadataService.cs
@@ -213,7 +213,7 @@ public sealed class FieldCollectionMetadataService : IFieldCollectionMetadataSer
         CancellationToken cancellationToken)
     {
         var serviceInfo = await GetJsonAsync<FeatureServerServiceInfo>(
-            $"/rest/services/{Uri.EscapeDataString(serviceId)}/FeatureServer?f=json",
+            $"/rest/services/{EscapeServicePath(serviceId)}/FeatureServer?f=json",
             cancellationToken).ConfigureAwait(false);
 
         var layerSummaries = serviceInfo.Layers ?? [];
@@ -221,7 +221,7 @@ public sealed class FieldCollectionMetadataService : IFieldCollectionMetadataSer
         foreach (var layerSummary in layerSummaries)
         {
             var layerInfo = await GetJsonAsync<FeatureServerLayerInfo>(
-                $"/rest/services/{Uri.EscapeDataString(serviceId)}/FeatureServer/{layerSummary.Id}?f=json",
+                $"/rest/services/{EscapeServicePath(serviceId)}/FeatureServer/{layerSummary.Id}?f=json",
                 cancellationToken).ConfigureAwait(false);
 
             layers.Add(FieldCollectionMetadataMapper.ToLayerInfo(serviceId, layerInfo));
@@ -320,5 +320,13 @@ public sealed class FieldCollectionMetadataService : IFieldCollectionMetadataSer
         return element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
             ? property.GetString()
             : null;
+    }
+
+    private static string EscapeServicePath(string serviceId)
+    {
+        return string.Join(
+            '/',
+            serviceId.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(Uri.EscapeDataString));
     }
 }

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
@@ -171,12 +171,80 @@ public class GeoPackageStorageService : IDisposable
         if (!columnNames.Contains("service_id"))
         {
             await _connection.ExecuteAsync("ALTER TABLE layer_metadata ADD COLUMN service_id TEXT");
+            columnNames.Add("service_id");
         }
 
         if (!columnNames.Contains("source_id"))
         {
             await _connection.ExecuteAsync("ALTER TABLE layer_metadata ADD COLUMN source_id TEXT");
+            columnNames.Add("source_id");
         }
+
+        if (!columnNames.Contains("storage_key"))
+        {
+            await MigrateLayerMetadataTableAsync();
+        }
+    }
+
+    private async Task MigrateLayerMetadataTableAsync()
+    {
+        const string migrationTable = "layer_metadata_migration";
+
+        await _connection.ExecuteAsync("BEGIN IMMEDIATE");
+        try
+        {
+            await _connection.ExecuteAsync($"DROP TABLE IF EXISTS {migrationTable}");
+            await CreateLayerMetadataTableAsync(migrationTable);
+            await _connection.ExecuteAsync($@"
+                INSERT OR REPLACE INTO {migrationTable}
+                    (storage_key, id, service_id, source_id, name, description, geometry_type, spatial_reference,
+                     is_editable, schema, server_url, created_at, last_sync, sync_enabled)
+                SELECT
+                    COALESCE(NULLIF(source_id, ''), COALESCE(NULLIF(service_id, ''), 'mobile_offline_demo') || '/FeatureServer/' || id),
+                    id,
+                    service_id,
+                    source_id,
+                    name,
+                    description,
+                    geometry_type,
+                    spatial_reference,
+                    is_editable,
+                    schema,
+                    server_url,
+                    created_at,
+                    last_sync,
+                    sync_enabled
+                FROM layer_metadata");
+            await _connection.ExecuteAsync("DROP TABLE layer_metadata");
+            await _connection.ExecuteAsync($"ALTER TABLE {migrationTable} RENAME TO layer_metadata");
+            await _connection.ExecuteAsync("COMMIT");
+        }
+        catch
+        {
+            await _connection.ExecuteAsync("ROLLBACK");
+            throw;
+        }
+    }
+
+    private Task CreateLayerMetadataTableAsync(string tableName)
+    {
+        return _connection.ExecuteAsync($@"
+            CREATE TABLE IF NOT EXISTS {tableName} (
+                storage_key TEXT NOT NULL PRIMARY KEY,
+                id INTEGER NOT NULL,
+                service_id TEXT,
+                source_id TEXT,
+                name TEXT NOT NULL,
+                description TEXT NOT NULL,
+                geometry_type TEXT NOT NULL,
+                spatial_reference TEXT NOT NULL,
+                is_editable INTEGER NOT NULL,
+                schema TEXT,
+                server_url TEXT,
+                created_at TEXT NOT NULL,
+                last_sync TEXT,
+                sync_enabled INTEGER NOT NULL DEFAULT 1
+            )");
     }
 
     private async Task MigrateLocalFeaturesTableAsync()
@@ -713,6 +781,7 @@ public class GeoPackageStorageService : IDisposable
         {
             var metadata = new LayerMetadata
             {
+                StorageKey = GetLayerMetadataStorageKey(layer),
                 Id = layer.Id,
                 ServiceId = layer.ServiceId,
                 SourceId = layer.SourceId,
@@ -801,6 +870,20 @@ public class GeoPackageStorageService : IDisposable
 
         layer.Form = FieldCollectionMetadataMapper.CreateFormDefinition(layer);
         return layer;
+    }
+
+    private static string GetLayerMetadataStorageKey(LayerInfo layer)
+    {
+        if (!string.IsNullOrWhiteSpace(layer.SourceId))
+        {
+            return layer.SourceId;
+        }
+
+        var serviceId = string.IsNullOrWhiteSpace(layer.ServiceId)
+            ? "mobile_offline_demo"
+            : layer.ServiceId.Trim();
+
+        return FieldCollectionMetadataMapper.BuildSourceId(serviceId, layer.Id);
     }
 
     private static GeometryType ParseGeometryType(string? value)

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Serialization;
 using NetTopologySuite.IO;
 using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services.Diagnostics;
+using Honua.Mobile.FieldCollection.Services.Metadata;
 using Honua.Mobile.FieldCollection.Services.Storage.Models;
 using ChangeOperation = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeOperation;
 using CoreModels = Honua.Mobile.FieldCollection.Models;
@@ -129,6 +130,7 @@ public class GeoPackageStorageService : IDisposable
         await _connection.CreateTableAsync<SyncSession>();
         await _connection.CreateTableAsync<ConflictRecord>();
         await _connection.CreateTableAsync<LayerMetadata>();
+        await EnsureLayerMetadataTableAsync();
     }
 
     private async Task EnsureLocalFeaturesTableAsync()
@@ -157,6 +159,24 @@ public class GeoPackageStorageService : IDisposable
         return columns.Any(column =>
             string.Equals(column.Name, "storage_key", StringComparison.OrdinalIgnoreCase) &&
             column.PrimaryKey > 0);
+    }
+
+    private async Task EnsureLayerMetadataTableAsync()
+    {
+        var columns = await _connection.QueryAsync<TableColumnInfo>("PRAGMA table_info(layer_metadata)");
+        var columnNames = columns
+            .Select(column => column.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        if (!columnNames.Contains("service_id"))
+        {
+            await _connection.ExecuteAsync("ALTER TABLE layer_metadata ADD COLUMN service_id TEXT");
+        }
+
+        if (!columnNames.Contains("source_id"))
+        {
+            await _connection.ExecuteAsync("ALTER TABLE layer_metadata ADD COLUMN source_id TEXT");
+        }
     }
 
     private async Task MigrateLocalFeaturesTableAsync()
@@ -694,13 +714,16 @@ public class GeoPackageStorageService : IDisposable
             var metadata = new LayerMetadata
             {
                 Id = layer.Id,
+                ServiceId = layer.ServiceId,
+                SourceId = layer.SourceId,
                 Name = layer.Name,
                 Description = layer.Description,
                 GeometryType = layer.GeometryType.ToString(),
                 SpatialReference = "EPSG:4326",
                 IsEditable = layer.IsEditable,
                 Schema = JsonSerializer.Serialize(layer.Schema, SchemaJsonOptions),
-                CreatedAt = DateTime.UtcNow
+                CreatedAt = DateTime.UtcNow,
+                LastSync = DateTime.UtcNow
             };
 
             await _connection.InsertOrReplaceAsync(metadata);
@@ -763,9 +786,11 @@ public class GeoPackageStorageService : IDisposable
 
     private LayerInfo ConvertToLayerInfo(LayerMetadata metadata)
     {
-        return new LayerInfo
+        var layer = new LayerInfo
         {
             Id = metadata.Id,
+            ServiceId = metadata.ServiceId,
+            SourceId = metadata.SourceId,
             Name = metadata.Name,
             Description = metadata.Description,
             GeometryType = ParseGeometryType(metadata.GeometryType),
@@ -773,6 +798,9 @@ public class GeoPackageStorageService : IDisposable
             IsVisible = true,
             Schema = DeserializeLayerSchema(metadata.Schema)
         };
+
+        layer.Form = FieldCollectionMetadataMapper.CreateFormDefinition(layer);
+        return layer;
     }
 
     private static GeometryType ParseGeometryType(string? value)

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/Models/StorageModels.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/Models/StorageModels.cs
@@ -179,6 +179,12 @@ public class LayerMetadata
     [Column("id")]
     public int Id { get; set; }
 
+    [Column("service_id")]
+    public string? ServiceId { get; set; }
+
+    [Column("source_id")]
+    public string? SourceId { get; set; }
+
     [Column("name")]
     public string Name { get; set; } = string.Empty;
 

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/Models/StorageModels.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/Models/StorageModels.cs
@@ -176,6 +176,9 @@ public class ConflictRecord
 public class LayerMetadata
 {
     [PrimaryKey]
+    [Column("storage_key")]
+    public string StorageKey { get; set; } = string.Empty;
+
     [Column("id")]
     public int Id { get; set; }
 

--- a/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
+++ b/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
@@ -3,6 +3,7 @@ using Honua.Mobile.FieldCollection.Services;
 using Honua.Mobile.FieldCollection.Services.Configuration;
 using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using Honua.Mobile.FieldCollection.Services.Features;
+using Honua.Mobile.FieldCollection.Services.Metadata;
 using Honua.Mobile.FieldCollection.Services.Storage;
 using Honua.Mobile.FieldCollection.Services.Sync;
 using Honua.Mobile.Maui;
@@ -80,6 +81,7 @@ public static class MauiProgram
         services.AddSingleton<INavigationService, NavigationService>();
         services.AddSingleton<ILocationService, LocationService>();
         services.AddHttpClient("HonuaFieldAuthentication");
+        services.AddHttpClient("HonuaFieldMetadata");
         services.AddSingleton<IAuthenticationService>(provider =>
         {
             var httpClientFactory = provider.GetRequiredService<IHttpClientFactory>();
@@ -98,9 +100,22 @@ public static class MauiProgram
             var logger = provider.GetRequiredService<ILogger<GeoPackageFeatureService>>();
             return new GeoPackageFeatureService(storageService, syncService, logger);
         });
+        services.AddSingleton<IFieldCollectionMetadataService>(provider =>
+        {
+            var databaseService = provider.GetRequiredService<DatabaseService>();
+            var httpClientFactory = provider.GetRequiredService<IHttpClientFactory>();
+            var logger = provider.GetService<ILogger<FieldCollectionMetadataService>>();
+            return new FieldCollectionMetadataService(
+                provider.GetRequiredService<IAuthenticationService>(),
+                provider.GetRequiredService<ISettingsService>(),
+                databaseService.GetStorageService(),
+                httpClientFactory.CreateClient("HonuaFieldMetadata"),
+                logger);
+        });
 
         // Other feature services
-        services.AddSingleton<IFormService, FormService>();
+        services.AddSingleton<IFormService>(provider =>
+            new FormService(provider.GetRequiredService<IFieldCollectionMetadataService>()));
         services.AddSingleton<IAttachmentService, AttachmentService>();
 
         // Configuration services

--- a/apps/Honua.Mobile.FieldCollection/Services/Features/GeoPackageFeatureService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Features/GeoPackageFeatureService.cs
@@ -333,7 +333,7 @@ public class GeoPackageFeatureService : IFeatureService
         }
     }
 
-    public async Task<List<LayerInfo>> GetLayersAsync()
+    public async Task<IReadOnlyList<LayerInfo>> GetLayersAsync()
     {
         try
         {

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/MapViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/MapViewModel.cs
@@ -4,7 +4,6 @@ using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services;
 using System.Collections.ObjectModel;
 using FieldPoint = Honua.Mobile.FieldCollection.Models.Point;
-using GeometryType = Honua.Sdk.Abstractions.Features.FeatureSpatialGeometryType;
 
 namespace Honua.Mobile.FieldCollection.ViewModels;
 
@@ -13,6 +12,8 @@ public partial class MapViewModel : BaseViewModel
     private readonly ILocationService _locationService;
     private readonly IFeatureService _featureService;
     private readonly IFormService _formService;
+    private readonly IFieldCollectionMetadataService _metadataService;
+    private bool _updatingSelection;
 
     [ObservableProperty]
     private Location? currentLocation;
@@ -24,6 +25,9 @@ public partial class MapViewModel : BaseViewModel
     private LayerInfo? selectedLayer;
 
     [ObservableProperty]
+    private FieldProjectInfo? selectedProject;
+
+    [ObservableProperty]
     private Feature? selectedFeature;
 
     [ObservableProperty]
@@ -32,6 +36,7 @@ public partial class MapViewModel : BaseViewModel
     [ObservableProperty]
     private FieldPoint? newFeatureLocation;
 
+    public ObservableCollection<FieldProjectInfo> AvailableProjects { get; } = new();
     public ObservableCollection<LayerInfo> AvailableLayers { get; } = new();
     public ObservableCollection<Feature> MapFeatures { get; } = new();
 
@@ -39,64 +44,99 @@ public partial class MapViewModel : BaseViewModel
         INavigationService navigationService,
         ILocationService locationService,
         IFeatureService featureService,
-        IFormService formService)
+        IFormService formService,
+        IFieldCollectionMetadataService metadataService)
         : base(navigationService)
     {
         _locationService = locationService;
         _featureService = featureService;
         _formService = formService;
+        _metadataService = metadataService;
 
         Title = "Map";
         IsLocationEnabled = _locationService.IsLocationEnabled;
-
-        // Initialize with default layers until server-provided metadata is available.
-        InitializeLayers();
     }
 
-    private void InitializeLayers()
+    partial void OnSelectedLayerChanged(LayerInfo? value)
     {
-        AvailableLayers.Add(new LayerInfo
+        if (_updatingSelection || value == null)
         {
-            Id = 1,
-            Name = "Points of Interest",
-            Description = "Point feature layer",
-            GeometryType = GeometryType.Point,
-            IsVisible = true,
-            IsEditable = true,
-            Style = new LayerStyle
-            {
-                FillColor = "#FF0000",
-                StrokeColor = "#000000",
-                MarkerSize = 12
-            }
-        });
-
-        AvailableLayers.Add(new LayerInfo
-        {
-            Id = 2,
-            Name = "Inspection Routes",
-            Description = "Line features for route planning",
-            GeometryType = GeometryType.Polyline,
-            IsVisible = false,
-            IsEditable = true,
-            Style = new LayerStyle
-            {
-                StrokeColor = "#0000FF",
-                StrokeWidth = 3
-            }
-        });
-
-        // Select the first layer by default
-        if (AvailableLayers.Count > 0)
-        {
-            SelectedLayer = AvailableLayers[0];
+            return;
         }
+
+        _ = LoadMapFeatures();
+    }
+
+    partial void OnSelectedProjectChanged(FieldProjectInfo? value)
+    {
+        if (_updatingSelection || value == null)
+        {
+            return;
+        }
+
+        _ = SelectProject(value);
     }
 
     protected override async Task OnRefresh()
     {
+        await LoadMetadataAsync(refresh: true);
         await LoadCurrentLocation();
+    }
+
+    [RelayCommand]
+    private Task LoadMetadata()
+    {
+        return LoadMetadataAsync();
+    }
+
+    private async Task LoadMetadataAsync(bool refresh = false)
+    {
+        await ExecuteAsync(async () =>
+        {
+            var projects = await _metadataService.GetProjectsAsync(refresh);
+            var selectedProject = await _metadataService.GetSelectedProjectAsync();
+            var layers = await _metadataService.GetLayersAsync(refresh);
+
+            ApplyMetadata(projects, selectedProject, layers);
+        });
+
         await LoadMapFeatures();
+    }
+
+    private void ApplyMetadata(
+        IReadOnlyList<FieldProjectInfo> projects,
+        FieldProjectInfo? selectedProject,
+        IReadOnlyList<LayerInfo> layers)
+    {
+        var selectedLayerId = SelectedLayer?.Id;
+
+        _updatingSelection = true;
+        try
+        {
+            AvailableProjects.Clear();
+            foreach (var project in projects)
+            {
+                AvailableProjects.Add(project);
+            }
+
+            SelectedProject = selectedProject is null
+                ? AvailableProjects.FirstOrDefault()
+                : AvailableProjects.FirstOrDefault(project =>
+                    string.Equals(project.ServiceId, selectedProject.ServiceId, StringComparison.OrdinalIgnoreCase)) ?? selectedProject;
+
+            AvailableLayers.Clear();
+            foreach (var layer in layers)
+            {
+                AvailableLayers.Add(layer);
+            }
+
+            SelectedLayer = AvailableLayers.FirstOrDefault(layer => layer.Id == selectedLayerId) ??
+                AvailableLayers.FirstOrDefault();
+        }
+        finally
+        {
+            _updatingSelection = false;
+        }
     }
 
     [RelayCommand]
@@ -111,7 +151,11 @@ public partial class MapViewModel : BaseViewModel
     [RelayCommand]
     private async Task LoadMapFeatures()
     {
-        if (SelectedLayer == null) return;
+        if (SelectedLayer == null)
+        {
+            MapFeatures.Clear();
+            return;
+        }
 
         await ExecuteAsync(async () =>
         {
@@ -132,6 +176,18 @@ public partial class MapViewModel : BaseViewModel
 
         SelectedLayer = layer;
         await LoadMapFeatures();
+    }
+
+    [RelayCommand]
+    private async Task SelectProject(FieldProjectInfo project)
+    {
+        if (SelectedProject != project)
+        {
+            SelectedProject = project;
+        }
+
+        await _metadataService.SelectProjectAsync(project.ServiceId);
+        await LoadMetadataAsync(refresh: true);
     }
 
     [RelayCommand]

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/RecordsViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/RecordsViewModel.cs
@@ -3,7 +3,6 @@ using CommunityToolkit.Mvvm.Input;
 using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services;
 using System.Collections.ObjectModel;
-using GeometryType = Honua.Sdk.Abstractions.Features.FeatureSpatialGeometryType;
 
 namespace Honua.Mobile.FieldCollection.ViewModels;
 
@@ -11,9 +10,14 @@ public partial class RecordsViewModel : BaseViewModel
 {
     private readonly IFeatureService _featureService;
     private readonly IFormService _formService;
+    private readonly IFieldCollectionMetadataService _metadataService;
+    private bool _updatingSelection;
 
     [ObservableProperty]
     private LayerInfo? selectedLayer;
+
+    [ObservableProperty]
+    private FieldProjectInfo? selectedProject;
 
     [ObservableProperty]
     private string searchText = string.Empty;
@@ -27,62 +31,115 @@ public partial class RecordsViewModel : BaseViewModel
     [ObservableProperty]
     private int pendingRecordCount;
 
+    public ObservableCollection<FieldProjectInfo> AvailableProjects { get; } = new();
     public ObservableCollection<LayerInfo> AvailableLayers { get; } = new();
     public ObservableCollection<Feature> Records { get; } = new();
 
     public RecordsViewModel(
         INavigationService navigationService,
         IFeatureService featureService,
-        IFormService formService)
+        IFormService formService,
+        IFieldCollectionMetadataService metadataService)
         : base(navigationService)
     {
         _featureService = featureService;
         _formService = formService;
+        _metadataService = metadataService;
 
         Title = "Records";
-
-        // Initialize with default layers until server-provided metadata is available.
-        InitializeLayers();
     }
 
-    private void InitializeLayers()
+    partial void OnSelectedLayerChanged(LayerInfo? value)
     {
-        AvailableLayers.Add(new LayerInfo
+        if (_updatingSelection || value == null)
         {
-            Id = 1,
-            Name = "Points of Interest",
-            Description = "Point feature layer",
-            GeometryType = GeometryType.Point,
-            IsVisible = true,
-            IsEditable = true
-        });
-
-        AvailableLayers.Add(new LayerInfo
-        {
-            Id = 2,
-            Name = "Inspection Routes",
-            Description = "Line features for route planning",
-            GeometryType = GeometryType.Polyline,
-            IsVisible = false,
-            IsEditable = true
-        });
-
-        // Select the first layer by default
-        if (AvailableLayers.Count > 0)
-        {
-            SelectedLayer = AvailableLayers[0];
+            return;
         }
+
+        _ = LoadRecords();
+    }
+
+    partial void OnSelectedProjectChanged(FieldProjectInfo? value)
+    {
+        if (_updatingSelection || value == null)
+        {
+            return;
+        }
+
+        _ = SelectProject(value);
     }
 
     protected override async Task OnRefresh()
     {
+        await LoadMetadataAsync(refresh: true);
+    }
+
+    [RelayCommand]
+    private Task LoadMetadata()
+    {
+        return LoadMetadataAsync();
+    }
+
+    private async Task LoadMetadataAsync(bool refresh = false)
+    {
+        await ExecuteAsync(async () =>
+        {
+            var projects = await _metadataService.GetProjectsAsync(refresh);
+            var selectedProject = await _metadataService.GetSelectedProjectAsync();
+            var layers = await _metadataService.GetLayersAsync(refresh);
+
+            ApplyMetadata(projects, selectedProject, layers);
+        });
+
         await LoadRecords();
+    }
+
+    private void ApplyMetadata(
+        IReadOnlyList<FieldProjectInfo> projects,
+        FieldProjectInfo? selectedProject,
+        IReadOnlyList<LayerInfo> layers)
+    {
+        var selectedLayerId = SelectedLayer?.Id;
+
+        _updatingSelection = true;
+        try
+        {
+            AvailableProjects.Clear();
+            foreach (var project in projects)
+            {
+                AvailableProjects.Add(project);
+            }
+
+            SelectedProject = selectedProject is null
+                ? AvailableProjects.FirstOrDefault()
+                : AvailableProjects.FirstOrDefault(project =>
+                    string.Equals(project.ServiceId, selectedProject.ServiceId, StringComparison.OrdinalIgnoreCase)) ?? selectedProject;
+
+            AvailableLayers.Clear();
+            foreach (var layer in layers)
+            {
+                AvailableLayers.Add(layer);
+            }
+
+            SelectedLayer = AvailableLayers.FirstOrDefault(layer => layer.Id == selectedLayerId) ??
+                AvailableLayers.FirstOrDefault();
+        }
+        finally
+        {
+            _updatingSelection = false;
+        }
     }
 
     [RelayCommand]
     private async Task LoadRecords()
     {
-        if (SelectedLayer == null) return;
+        if (SelectedLayer == null)
+        {
+            Records.Clear();
+            TotalRecordCount = 0;
+            PendingRecordCount = 0;
+            return;
+        }
 
         await ExecuteAsync(async () =>
         {
@@ -120,6 +177,18 @@ public partial class RecordsViewModel : BaseViewModel
 
         SelectedLayer = layer;
         await LoadRecords();
+    }
+
+    [RelayCommand]
+    private async Task SelectProject(FieldProjectInfo project)
+    {
+        if (SelectedProject != project)
+        {
+            SelectedProject = project;
+        }
+
+        await _metadataService.SelectProjectAsync(project.ServiceId);
+        await LoadMetadataAsync(refresh: true);
     }
 
     [RelayCommand]

--- a/apps/Honua.Mobile.FieldCollection/Views/MapPage.xaml
+++ b/apps/Honua.Mobile.FieldCollection/Views/MapPage.xaml
@@ -69,10 +69,22 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
-                <!-- Layer Selection -->
+                <!-- Project Selection -->
                 <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto">
+                    <Label Grid.Column="0" Text="Project:" FontAttributes="Bold" VerticalOptions="Center" />
+
+                    <Picker Grid.Column="1"
+                            ItemsSource="{Binding AvailableProjects}"
+                            SelectedItem="{Binding SelectedProject}"
+                            ItemDisplayBinding="{Binding Name}"
+                            Title="Select Project" />
+                </Grid>
+
+                <!-- Layer Selection -->
+                <Grid Grid.Row="1" ColumnDefinitions="Auto,*,Auto" Margin="0,10,0,0">
                     <Label Grid.Column="0" Text="Layer:" FontAttributes="Bold" VerticalOptions="Center" />
 
                     <Picker Grid.Column="1"
@@ -89,7 +101,7 @@
                 </Grid>
 
                 <!-- Layer Info -->
-                <StackLayout Grid.Row="1"
+                <StackLayout Grid.Row="2"
                              Orientation="Horizontal"
                              Spacing="20"
                              Margin="0,10,0,0"

--- a/apps/Honua.Mobile.FieldCollection/Views/MapPage.xaml.cs
+++ b/apps/Honua.Mobile.FieldCollection/Views/MapPage.xaml.cs
@@ -23,9 +23,9 @@ public partial class MapPage : ContentPage
     {
         base.OnAppearing();
 
-        // Load current location and features when page appears
+        // Load metadata, current location, and features when page appears
+        await _viewModel.LoadMetadataCommand.ExecuteAsync(null);
         await _viewModel.LoadCurrentLocationCommand.ExecuteAsync(null);
-        await _viewModel.LoadMapFeaturesCommand.ExecuteAsync(null);
 
         // Center map on current location if available
         if (_viewModel.CurrentLocation != null)

--- a/apps/Honua.Mobile.FieldCollection/Views/RecordsPage.xaml
+++ b/apps/Honua.Mobile.FieldCollection/Views/RecordsPage.xaml
@@ -23,9 +23,20 @@
 
         <!-- Layer Selection and Statistics -->
         <Frame Grid.Row="0" Style="{StaticResource CardFrameStyle}" Margin="10,10,10,5">
-            <Grid RowDefinitions="Auto,Auto" RowSpacing="10">
-                <!-- Layer Picker -->
+            <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="10">
+                <!-- Project Picker -->
                 <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
+                    <Label Grid.Column="0" Text="Project:" FontAttributes="Bold" VerticalOptions="Center" />
+
+                    <Picker Grid.Column="1"
+                            ItemsSource="{Binding AvailableProjects}"
+                            SelectedItem="{Binding SelectedProject}"
+                            ItemDisplayBinding="{Binding Name}"
+                            Title="Select Project" />
+                </Grid>
+
+                <!-- Layer Picker -->
+                <Grid Grid.Row="1" ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
                     <Label Grid.Column="0" Text="Layer:" FontAttributes="Bold" VerticalOptions="Center" />
 
                     <Picker Grid.Column="1"
@@ -41,7 +52,7 @@
                 </Grid>
 
                 <!-- Record Statistics -->
-                <Grid Grid.Row="1" ColumnDefinitions="*,*,*" ColumnSpacing="15">
+                <Grid Grid.Row="2" ColumnDefinitions="*,*,*" ColumnSpacing="15">
                     <StackLayout Grid.Column="0">
                         <Label Text="{Binding TotalRecordCount}"
                                FontSize="18" FontAttributes="Bold"

--- a/apps/Honua.Mobile.FieldCollection/Views/RecordsPage.xaml.cs
+++ b/apps/Honua.Mobile.FieldCollection/Views/RecordsPage.xaml.cs
@@ -17,7 +17,7 @@ public partial class RecordsPage : ContentPage
     {
         base.OnAppearing();
 
-        // Load records when page appears
-        await _viewModel.LoadRecordsCommand.ExecuteAsync(null);
+        // Load metadata and records when page appears
+        await _viewModel.LoadMetadataCommand.ExecuteAsync(null);
     }
 }

--- a/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionMetadataServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionMetadataServiceTests.cs
@@ -131,6 +131,49 @@ public sealed class FieldCollectionMetadataServiceTests
     }
 
     [Fact]
+    public async Task GetLayersAsync_WithFolderedServiceId_PreservesServicePathSeparators()
+    {
+        var requestedPaths = new List<string>();
+        using var http = new HttpClient(new StubHttpMessageHandler(request =>
+        {
+            requestedPaths.Add(request.RequestUri!.PathAndQuery);
+            return request.RequestUri!.PathAndQuery switch
+            {
+                "/rest/services/Utilities/Assets/FeatureServer?f=json" => JsonResponse("""
+                    {
+                      "layers": [
+                        { "id": 0, "name": "Meters" }
+                      ]
+                    }
+                    """),
+                "/rest/services/Utilities/Assets/FeatureServer/0?f=json" => JsonResponse("""
+                    {
+                      "id": 0,
+                      "name": "Meters",
+                      "geometryType": "esriGeometryPoint",
+                      "capabilities": "Query",
+                      "fields": []
+                    }
+                    """),
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound)
+            };
+        }));
+
+        var databasePath = Path.Combine(Path.GetTempPath(), $"honua-field-metadata-foldered-{Guid.NewGuid():N}.gpkg");
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var service = CreateService(storage, http);
+
+        await service.SelectProjectAsync("Utilities/Assets");
+        var layers = await service.GetLayersAsync(refresh: true);
+
+        Assert.Single(layers);
+        Assert.Contains("/rest/services/Utilities/Assets/FeatureServer?f=json", requestedPaths);
+        Assert.Contains("/rest/services/Utilities/Assets/FeatureServer/0?f=json", requestedPaths);
+        Assert.DoesNotContain(requestedPaths, path => path.Contains("Utilities%2FAssets", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task GetLayersAsync_WhenOffline_ReturnsCachedLayerMetadata()
     {
         var databasePath = Path.Combine(Path.GetTempPath(), $"honua-field-metadata-offline-{Guid.NewGuid():N}.gpkg");
@@ -184,6 +227,45 @@ public sealed class FieldCollectionMetadataServiceTests
 
         Assert.NotNull(cachedForm);
         Assert.Equal("assets/FeatureServer/42", cachedForm.Target?.SourceId);
+    }
+
+    [Fact]
+    public async Task GeoPackageStorageService_CreateLayerAsync_KeysMetadataByServiceAndLayerId()
+    {
+        var databasePath = Path.Combine(Path.GetTempPath(), $"honua-field-metadata-service-key-{Guid.NewGuid():N}.gpkg");
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+
+        await storage.CreateLayerAsync(new LayerInfo
+        {
+            Id = 0,
+            ServiceId = "Utilities/Assets",
+            SourceId = "Utilities/Assets/FeatureServer/0",
+            Name = "Utility Assets",
+            GeometryType = FeatureSpatialGeometryType.Point
+        });
+        await storage.CreateLayerAsync(new LayerInfo
+        {
+            Id = 0,
+            ServiceId = "Parks/Assets",
+            SourceId = "Parks/Assets/FeatureServer/0",
+            Name = "Park Assets",
+            GeometryType = FeatureSpatialGeometryType.Polygon
+        });
+
+        var layers = await storage.GetLayersAsync();
+
+        Assert.Equal(2, layers.Count);
+        Assert.Contains(layers, layer =>
+            layer.Id == 0 &&
+            layer.ServiceId == "Utilities/Assets" &&
+            layer.Name == "Utility Assets" &&
+            layer.GeometryType == FeatureSpatialGeometryType.Point);
+        Assert.Contains(layers, layer =>
+            layer.Id == 0 &&
+            layer.ServiceId == "Parks/Assets" &&
+            layer.Name == "Park Assets" &&
+            layer.GeometryType == FeatureSpatialGeometryType.Polygon);
     }
 
     private static FieldCollectionMetadataService CreateService(

--- a/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionMetadataServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionMetadataServiceTests.cs
@@ -1,0 +1,251 @@
+using System.Net;
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.FieldCollection.Services.Metadata;
+using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Field.Forms;
+
+namespace Honua.Mobile.FieldCollection.Tests;
+
+public sealed class FieldCollectionMetadataServiceTests
+{
+    public FieldCollectionMetadataServiceTests()
+    {
+        SQLitePCL.Batteries_V2.Init();
+    }
+
+    [Fact]
+    public async Task GetProjectsAsync_WithServerCatalog_ListsFeatureServerProjects()
+    {
+        var requests = new List<HttpRequestMessage>();
+        using var http = new HttpClient(new StubHttpMessageHandler(request =>
+        {
+            requests.Add(request);
+            Assert.Equal("/rest/services?f=json", request.RequestUri!.PathAndQuery);
+
+            return JsonResponse("""
+                {
+                  "services": [
+                    { "name": "assets", "type": "FeatureServer" },
+                    { "name": "Routing", "type": "NAServer" }
+                  ]
+                }
+                """);
+        }));
+
+        var databasePath = Path.Combine(Path.GetTempPath(), $"honua-field-metadata-projects-{Guid.NewGuid():N}.gpkg");
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var service = CreateService(storage, http);
+
+        var projects = await service.GetProjectsAsync(refresh: true);
+
+        var project = Assert.Single(projects);
+        Assert.Equal("assets", project.ServiceId);
+        Assert.False(project.IsAvailableOffline);
+        Assert.True(requests.Single().Headers.TryGetValues("X-API-Key", out var values));
+        Assert.Equal("test-api-key", Assert.Single(values));
+    }
+
+    [Fact]
+    public async Task GetLayersAsync_WithRemoteMetadata_CachesLayerSchemaAndForm()
+    {
+        using var http = new HttpClient(new StubHttpMessageHandler(request =>
+        {
+            return request.RequestUri!.PathAndQuery switch
+            {
+                "/rest/services/assets/FeatureServer?f=json" => JsonResponse("""
+                    {
+                      "serviceDescription": "Asset inspections",
+                      "capabilities": "Query",
+                      "layers": [
+                        { "id": 7, "name": "Inspection Sites" }
+                      ]
+                    }
+                    """),
+                "/rest/services/assets/FeatureServer/7?f=json" => JsonResponse("""
+                    {
+                      "id": 7,
+                      "name": "Inspection Sites",
+                      "description": "Pilot inspection layer",
+                      "geometryType": "esriGeometryPoint",
+                      "capabilities": "Query,Create,Update,Delete",
+                      "fields": [
+                        { "name": "OBJECTID", "type": "esriFieldTypeOID", "alias": "Object ID", "nullable": false, "editable": false },
+                        { "name": "site_name", "type": "esriFieldTypeString", "alias": "Site name", "nullable": false, "editable": true, "length": 80 },
+                        {
+                          "name": "status",
+                          "type": "esriFieldTypeString",
+                          "alias": "Status",
+                          "nullable": true,
+                          "editable": true,
+                          "domain": {
+                            "type": "codedValue",
+                            "codedValues": [
+                              { "name": "Open", "code": "open" },
+                              { "name": "Closed", "code": "closed" }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                    """),
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound)
+            };
+        }));
+
+        var databasePath = Path.Combine(Path.GetTempPath(), $"honua-field-metadata-layers-{Guid.NewGuid():N}.gpkg");
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var service = CreateService(storage, http);
+
+        await service.SelectProjectAsync("assets");
+        var layers = await service.GetLayersAsync(refresh: true);
+
+        var layer = Assert.Single(layers);
+        Assert.Equal(7, layer.Id);
+        Assert.Equal("assets", layer.ServiceId);
+        Assert.Equal("assets/FeatureServer/7", layer.SourceId);
+        Assert.Equal(FeatureSpatialGeometryType.Point, layer.GeometryType);
+        Assert.True(layer.IsEditable);
+
+        Assert.Equal(2, layer.Schema.Count);
+        var siteName = layer.Schema.Single(field => field.FieldId == "site_name");
+        Assert.Equal(FormFieldType.Text, siteName.Type);
+        Assert.True(siteName.Required);
+        Assert.Equal(80, siteName.Validation.MaxLength);
+
+        var status = layer.Schema.Single(field => field.FieldId == "status");
+        Assert.Equal(FormFieldType.SingleChoice, status.Type);
+        Assert.Equal(["open", "closed"], status.Choices.Select(choice => choice.Value).ToArray());
+
+        Assert.NotNull(layer.Form);
+        Assert.Equal("assets", layer.Form.Target?.ServiceId);
+        Assert.Equal(7, layer.Form.Target?.LayerId);
+
+        var cachedLayer = Assert.Single(await storage.GetLayersAsync());
+        Assert.Equal("assets", cachedLayer.ServiceId);
+        Assert.Equal("assets", cachedLayer.Form?.Target?.ServiceId);
+        Assert.Equal(2, cachedLayer.Schema.Count);
+    }
+
+    [Fact]
+    public async Task GetLayersAsync_WhenOffline_ReturnsCachedLayerMetadata()
+    {
+        var databasePath = Path.Combine(Path.GetTempPath(), $"honua-field-metadata-offline-{Guid.NewGuid():N}.gpkg");
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.CreateLayerAsync(new LayerInfo
+        {
+            Id = 42,
+            ServiceId = "assets",
+            SourceId = "assets/FeatureServer/42",
+            Name = "Cached Assets",
+            Description = "Previously loaded metadata",
+            GeometryType = FeatureSpatialGeometryType.Polygon,
+            IsEditable = false,
+            Schema =
+            [
+                new FormField
+                {
+                    FieldId = "asset_id",
+                    SourceFieldName = "asset_id",
+                    Label = "Asset ID",
+                    Type = FormFieldType.Text,
+                    Required = true
+                }
+            ]
+        });
+
+        using var http = new HttpClient(new StubHttpMessageHandler(_ =>
+            throw new InvalidOperationException("Offline service must not call the network.")));
+        var service = CreateService(
+            storage,
+            http,
+            new TestAuthenticationService
+            {
+                IsAuthenticated = false,
+                ServerUrl = null,
+                ApiKey = null
+            });
+
+        var layers = await service.GetLayersAsync();
+
+        var layer = Assert.Single(layers);
+        Assert.Equal("Cached Assets", layer.Name);
+        Assert.Equal("assets", layer.ServiceId);
+        Assert.Equal(FeatureSpatialGeometryType.Polygon, layer.GeometryType);
+        Assert.NotNull(layer.Form);
+        Assert.Equal("assets/FeatureServer/42", layer.Form.Target?.SourceId);
+
+        var formService = new FormService(service);
+        var cachedForm = await formService.GetFormDefinitionAsync(42);
+
+        Assert.NotNull(cachedForm);
+        Assert.Equal("assets/FeatureServer/42", cachedForm.Target?.SourceId);
+    }
+
+    private static FieldCollectionMetadataService CreateService(
+        GeoPackageStorageService storage,
+        HttpClient http,
+        IAuthenticationService? authenticationService = null)
+    {
+        return new FieldCollectionMetadataService(
+            authenticationService ?? new TestAuthenticationService { ServerUrl = "https://api.honua.test" },
+            new InMemorySettingsService(),
+            storage,
+            http);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class DatabaseCleanup : IAsyncDisposable
+    {
+        private readonly string _databasePath;
+
+        public DatabaseCleanup(string databasePath)
+        {
+            _databasePath = databasePath;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (File.Exists(_databasePath))
+            {
+                File.Delete(_databasePath);
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class InMemorySettingsService : ISettingsService
+    {
+        private readonly Dictionary<string, object?> _settings = new(StringComparer.Ordinal);
+
+        public Task<T> GetSettingAsync<T>(string key, T defaultValue = default!)
+        {
+            return Task.FromResult(_settings.TryGetValue(key, out var value) && value is T typedValue
+                ? typedValue
+                : defaultValue);
+        }
+
+        public Task SetSettingAsync<T>(string key, T value)
+        {
+            _settings[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> HasSettingAsync(string key)
+        {
+            return Task.FromResult(_settings.ContainsKey(key));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- adds a FieldCollection metadata adapter that discovers Honua FeatureServer services/layers through SDK GeoServices metadata models
- caches service/source IDs, layer schema, editability, geometry type, and generated form targets in the GeoPackage layer metadata table
- replaces hardcoded Map/Records layer initialization with project and layer pickers backed by cached or remote metadata
- wires `FormService.GetFormDefinitionAsync` to resolve metadata-backed forms from the layer cache

Closes #211.

## Validation
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore --verbosity minimal` (51 passed)
- `git diff --check`

## Notes
- Local Android MAUI build could not run to compilation because this machine has no Android SDK (`XA5300`). CI remains the MAUI app compile gate.
