### PR TITLE
mobile: wire field collection remote sync

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Honua.Mobile.FieldCollection.Core.csproj
+++ b/apps/Honua.Mobile.FieldCollection.Core/Honua.Mobile.FieldCollection.Core.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Honua.Sdk.Abstractions" Version="$(HonuaSdkDotNetTrainVersion)" />
     <PackageReference Include="Honua.Sdk.Field" Version="$(HonuaSdkDotNetTrainVersion)" />
     <PackageReference Include="Honua.Sdk.GeoServices" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Maui.Essentials" Version="10.0.60" />
     <PackageReference Include="NetTopologySuite" Version="2.6.0" />

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
@@ -401,12 +401,41 @@ public class GeoPackageStorageService : IDisposable
             var deleted = 0;
             await ExecuteInImmediateTransactionAsync(async () =>
             {
+                var existing = await _connection.Table<LocalFeature>()
+                    .FirstOrDefaultAsync(f => f.Id == featureId && f.LayerId == layerId);
+                var existingFeature = existing == null ? null : ConvertToFeature(existing);
+                var changeData = existing == null
+                    ? null
+                    : CreateChangeData(existingFeature!, ChangeOperation.Delete);
+                var pendingFeatureChanges = await _connection.Table<ChangeRecord>()
+                    .Where(c =>
+                        c.FeatureId == featureId &&
+                        c.LayerId == layerId &&
+                        c.SyncStatus == StorageSyncStatus.PendingUpload)
+                    .ToListAsync();
+                var collapseLocalOnlyLifecycle = existingFeature != null &&
+                    pendingFeatureChanges.Any(change => change.Operation == ChangeOperation.Insert) &&
+                    !TryReadObjectId(existingFeature.Attributes, out _);
+
                 deleted = await _connection.Table<LocalFeature>()
                     .DeleteAsync(f => f.Id == featureId && f.LayerId == layerId);
 
                 if (deleted > 0)
                 {
-                    await RecordChange(featureId, layerId, ChangeOperation.Delete);
+                    if (collapseLocalOnlyLifecycle)
+                    {
+                        foreach (var change in pendingFeatureChanges)
+                        {
+                            await _connection.ExecuteAsync(
+                                "UPDATE change_records SET sync_status = ? WHERE id = ?",
+                                StorageSyncStatus.Synced,
+                                change.Id);
+                        }
+                    }
+                    else
+                    {
+                        await RecordChange(featureId, layerId, ChangeOperation.Delete, changeData);
+                    }
                 }
             });
 
@@ -490,10 +519,11 @@ public class GeoPackageStorageService : IDisposable
 
         if (trackChange)
         {
+            var changeData = CreateChangeData(feature, operation);
             await ExecuteInImmediateTransactionAsync(async () =>
             {
                 await _connection.InsertOrReplaceAsync(localFeature);
-                await RecordChange(feature.Id, feature.LayerId, operation);
+                await RecordChange(feature.Id, feature.LayerId, operation, changeData);
             });
         }
         else
@@ -531,7 +561,11 @@ public class GeoPackageStorageService : IDisposable
 
     #region Change Tracking
 
-    private async Task RecordChange(string featureId, int layerId, ChangeOperation operation)
+    private async Task RecordChange(
+        string featureId,
+        int layerId,
+        ChangeOperation operation,
+        string? changeData = null)
     {
         var changeRecord = new ChangeRecord
         {
@@ -540,10 +574,76 @@ public class GeoPackageStorageService : IDisposable
             LayerId = layerId,
             Operation = operation,
             Timestamp = DateTime.UtcNow,
-            SyncStatus = StorageSyncStatus.PendingUpload
+            SyncStatus = StorageSyncStatus.PendingUpload,
+            ChangeData = changeData
         };
 
         await _connection.InsertAsync(changeRecord);
+    }
+
+    private static string CreateChangeData(Feature feature, ChangeOperation operation)
+    {
+        JsonElement? geometry = feature.Geometry == null
+            ? null
+            : GeometryJson.ToJsonElement(feature.Geometry);
+
+        var payload = new
+        {
+            featureId = feature.Id,
+            layerId = feature.LayerId,
+            operation = operation.ToString(),
+            version = feature.Version,
+            objectId = TryReadObjectId(feature.Attributes, out var objectId) ? objectId : (long?)null,
+            attributes = feature.Attributes,
+            geometry,
+            timestamp = DateTime.UtcNow
+        };
+
+        return JsonSerializer.Serialize(payload);
+    }
+
+    private static bool TryReadObjectId(IReadOnlyDictionary<string, object?> attributes, out long objectId)
+    {
+        objectId = 0;
+        foreach (var attribute in attributes)
+        {
+            if (!attribute.Key.Equals("objectid", StringComparison.OrdinalIgnoreCase) &&
+                !attribute.Key.Equals("objectId", StringComparison.OrdinalIgnoreCase) &&
+                !attribute.Key.Equals("OBJECTID", StringComparison.OrdinalIgnoreCase) &&
+                !attribute.Key.Equals("FID", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (TryConvertInt64(attribute.Value, out objectId))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryConvertInt64(object? value, out long objectId)
+    {
+        objectId = 0;
+        return value switch
+        {
+            long longValue => Set(longValue, out objectId),
+            int intValue => Set(intValue, out objectId),
+            double doubleValue when Math.Abs(doubleValue % 1) < double.Epsilon => Set((long)doubleValue, out objectId),
+            decimal decimalValue when decimalValue == Math.Truncate(decimalValue) => Set((long)decimalValue, out objectId),
+            string stringValue => long.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out objectId),
+            JsonElement { ValueKind: JsonValueKind.Number } element => element.TryGetInt64(out objectId),
+            JsonElement { ValueKind: JsonValueKind.String } element => long.TryParse(element.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out objectId),
+            _ => false
+        };
+
+        static bool Set(long value, out long target)
+        {
+            target = value;
+            return true;
+        }
     }
 
     public async Task<List<ChangeRecord>> GetPendingChangesAsync(int? layerId = null)

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs
@@ -1,7 +1,834 @@
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Mobile.Sdk;
+using Honua.Mobile.Sdk.Auth;
+using Honua.Sdk.Abstractions.Features;
 using Microsoft.Extensions.Logging;
 using StorageChangeRecord = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeRecord;
+using StorageChangeOperation = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeOperation;
+using StorageConflictRecord = Honua.Mobile.FieldCollection.Services.Storage.Models.ConflictRecord;
+using StorageConflictType = Honua.Mobile.FieldCollection.Services.Storage.Models.ConflictType;
 
 namespace Honua.Mobile.FieldCollection.Services.Sync;
+
+public interface IFieldCollectionFeatureSyncClient
+{
+    bool IsConfigured { get; }
+    Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken cancellationToken = default);
+    Task<FeatureQueryResult> QueryAsync(FeatureQueryRequest request, CancellationToken cancellationToken = default);
+}
+
+public sealed class HonuaSdkFieldCollectionFeatureSyncClient : IFieldCollectionFeatureSyncClient
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IAuthenticationService _authenticationService;
+    private readonly ILogger<HonuaSdkFieldCollectionFeatureSyncClient>? _logger;
+
+    public HonuaSdkFieldCollectionFeatureSyncClient(
+        IHttpClientFactory httpClientFactory,
+        IAuthenticationService authenticationService,
+        ILogger<HonuaSdkFieldCollectionFeatureSyncClient>? logger = null)
+    {
+        _httpClientFactory = httpClientFactory;
+        _authenticationService = authenticationService;
+        _logger = logger;
+    }
+
+    public bool IsConfigured => TryCreateOptions(out _);
+
+    public async Task<FeatureEditResponse> ApplyEditsAsync(
+        FeatureEditRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        using var client = CreateClient();
+        return await client.ApplyEditsAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<FeatureQueryResult> QueryAsync(
+        FeatureQueryRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        using var client = CreateClient();
+        return await client.QueryAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private HonuaMobileClient CreateClient()
+    {
+        if (!TryCreateOptions(out var options))
+        {
+            throw new InvalidOperationException("Honua server URL and API key are required for field sync.");
+        }
+
+        var httpClient = _httpClientFactory.CreateClient("HonuaFieldSync");
+        return new HonuaMobileClient(
+            httpClient,
+            options,
+            new FieldCollectionApiKeyTokenProvider(_authenticationService));
+    }
+
+    private bool TryCreateOptions(out HonuaMobileClientOptions options)
+    {
+        options = null!;
+
+        if (string.IsNullOrWhiteSpace(_authenticationService.ServerUrl) ||
+            string.IsNullOrWhiteSpace(_authenticationService.ApiKey) ||
+            !Uri.TryCreate(_authenticationService.ServerUrl.Trim(), UriKind.Absolute, out var baseUri))
+        {
+            return false;
+        }
+
+        if (baseUri.Scheme != Uri.UriSchemeHttps && !(baseUri.Scheme == Uri.UriSchemeHttp && baseUri.IsLoopback))
+        {
+            _logger?.LogWarning(
+                "Field sync refused non-HTTPS Honua endpoint {Endpoint}",
+                baseUri.GetLeftPart(UriPartial.Authority));
+            return false;
+        }
+
+        options = new HonuaMobileClientOptions
+        {
+            BaseUri = baseUri,
+            ApiKey = _authenticationService.ApiKey,
+            AllowInsecureTransportForDevelopment = baseUri.Scheme == Uri.UriSchemeHttp && baseUri.IsLoopback,
+            PreferGrpcForFeatureQueries = false,
+            PreferGrpcForFeatureEdits = false,
+            AllowRestFallbackOnGrpcFailure = true
+        };
+
+        return true;
+    }
+}
+
+public sealed class HonuaFieldCollectionChangeUploader :
+    IFieldCollectionChangeUploader,
+    IFieldCollectionRemoteSyncCapability
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly GeoPackageStorageService _storage;
+    private readonly IFieldCollectionMetadataService _metadataService;
+    private readonly IFieldCollectionFeatureSyncClient _featureClient;
+    private readonly ILogger<HonuaFieldCollectionChangeUploader>? _logger;
+
+    public HonuaFieldCollectionChangeUploader(
+        GeoPackageStorageService storage,
+        IFieldCollectionMetadataService metadataService,
+        IFieldCollectionFeatureSyncClient featureClient,
+        ILogger<HonuaFieldCollectionChangeUploader>? logger = null)
+    {
+        _storage = storage;
+        _metadataService = metadataService;
+        _featureClient = featureClient;
+        _logger = logger;
+    }
+
+    public bool IsRemoteSyncConfigured => _featureClient.IsConfigured;
+
+    public async Task<bool> UploadChangeAsync(
+        StorageChangeRecord change,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!IsRemoteSyncConfigured)
+        {
+            return false;
+        }
+
+        var layer = await ResolveLayerAsync(change.LayerId, cancellationToken).ConfigureAwait(false);
+        var serviceId = ResolveServiceId(layer);
+        if (string.IsNullOrWhiteSpace(serviceId))
+        {
+            _logger?.LogWarning("Cannot upload change {ChangeId}; layer {LayerId} has no service id", change.Id, change.LayerId);
+            return false;
+        }
+
+        Feature? localFeature = null;
+        IReadOnlyList<FeatureEditFeature> adds = [];
+        IReadOnlyList<FeatureEditFeature> updates = [];
+        IReadOnlyList<long> deleteObjectIds = [];
+        switch (change.Operation)
+        {
+            case StorageChangeOperation.Insert:
+                localFeature = await _storage.GetFeatureAsync(change.FeatureId, change.LayerId).ConfigureAwait(false);
+                if (localFeature == null)
+                {
+                    return false;
+                }
+
+                adds = [ToEditFeature(localFeature)];
+                break;
+
+            case StorageChangeOperation.Update:
+                localFeature = await _storage.GetFeatureAsync(change.FeatureId, change.LayerId).ConfigureAwait(false);
+                if (localFeature == null)
+                {
+                    return false;
+                }
+
+                updates = [ToEditFeature(localFeature)];
+                break;
+
+            case StorageChangeOperation.Delete:
+                if (!TryResolveDeleteObjectId(change, out var objectId))
+                {
+                    localFeature = await _storage.GetFeatureAsync(change.FeatureId, change.LayerId).ConfigureAwait(false);
+                    if (localFeature == null || !TryReadObjectId(localFeature, out objectId))
+                    {
+                        _logger?.LogWarning(
+                            "Cannot upload delete change {ChangeId}; no FeatureServer object id was available for feature {FeatureId}",
+                            change.Id,
+                            change.FeatureId);
+                        return false;
+                    }
+                }
+
+                deleteObjectIds = [objectId];
+                break;
+        }
+
+        var request = new FeatureEditRequest
+        {
+            Source = new FeatureSource { ServiceId = serviceId, LayerId = change.LayerId },
+            Adds = adds,
+            Updates = updates,
+            DeleteObjectIds = deleteObjectIds,
+            RollbackOnFailure = false,
+            ForceWrite = false
+        };
+
+        var response = await _featureClient.ApplyEditsAsync(request, cancellationToken).ConfigureAwait(false);
+        if (response.Succeeded)
+        {
+            await UpdateLocalFeatureAfterSuccessfulAddAsync(change, localFeature, response).ConfigureAwait(false);
+            return true;
+        }
+
+        if (IsConflict(response))
+        {
+            await StoreConflictAsync(change, localFeature, response).ConfigureAwait(false);
+        }
+
+        _logger?.LogWarning(
+            "Field sync upload failed for change {ChangeId}: {Message}",
+            change.Id,
+            GetFailureMessage(response));
+        return false;
+    }
+
+    private async Task<LayerInfo> ResolveLayerAsync(int layerId, CancellationToken cancellationToken)
+    {
+        var layers = await _metadataService.GetLayersAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        return layers.FirstOrDefault(layer => layer.Id == layerId)
+            ?? throw new InvalidOperationException($"Layer {layerId} is not available in field metadata.");
+    }
+
+    private async Task UpdateLocalFeatureAfterSuccessfulAddAsync(
+        StorageChangeRecord change,
+        Feature? localFeature,
+        FeatureEditResponse response)
+    {
+        if (change.Operation != StorageChangeOperation.Insert || localFeature == null)
+        {
+            return;
+        }
+
+        var addResult = response.AddResults.FirstOrDefault(result => result.Succeeded);
+        if (addResult?.ObjectId is not { } objectId)
+        {
+            return;
+        }
+
+        localFeature.Attributes["objectid"] = objectId;
+        localFeature.Attributes["OBJECTID"] = objectId;
+        await _storage.ApplyRemoteFeatureAsync(localFeature).ConfigureAwait(false);
+    }
+
+    private async Task StoreConflictAsync(
+        StorageChangeRecord change,
+        Feature? localFeature,
+        FeatureEditResponse response)
+    {
+        var conflict = new StorageConflictRecord
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            FeatureId = change.FeatureId,
+            LayerId = change.LayerId,
+            ConflictType = change.Operation == StorageChangeOperation.Delete
+                ? StorageConflictType.DeleteUpdate
+                : StorageConflictType.UpdateUpdate,
+            LocalVersion = localFeature?.Version ?? 0,
+            ServerVersion = localFeature?.Version + 1 ?? 1,
+            LocalData = change.ChangeData ?? (localFeature == null ? "{}" : JsonSerializer.Serialize(localFeature, JsonOptions)),
+            ServerData = JsonSerializer.Serialize(
+                new
+                {
+                    error = response.Error,
+                    addResults = response.AddResults,
+                    updateResults = response.UpdateResults,
+                    deleteResults = response.DeleteResults
+                },
+                JsonOptions),
+            CreatedAt = DateTime.UtcNow
+        };
+
+        await _storage.StoreConflictAsync(conflict).ConfigureAwait(false);
+    }
+
+    private static bool IsConflict(FeatureEditResponse response)
+    {
+        if (IsConflictError(response.Error))
+        {
+            return true;
+        }
+
+        return response.AddResults
+            .Concat(response.UpdateResults)
+            .Concat(response.DeleteResults)
+            .Any(result => IsConflictError(result.Error));
+    }
+
+    private static bool IsConflictError(FeatureEditError? error)
+    {
+        if (error == null)
+        {
+            return false;
+        }
+
+        return error.Code is 409 or 1000 or 1003 ||
+            (!string.IsNullOrWhiteSpace(error.Message) &&
+             error.Message.Contains("conflict", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string GetFailureMessage(FeatureEditResponse response)
+    {
+        if (!string.IsNullOrWhiteSpace(response.Error?.Message))
+        {
+            return response.Error.Message;
+        }
+
+        var resultError = response.AddResults
+            .Concat(response.UpdateResults)
+            .Concat(response.DeleteResults)
+            .Select(result => result.Error?.Message)
+            .FirstOrDefault(message => !string.IsNullOrWhiteSpace(message));
+
+        return resultError ?? "Feature edit response did not report success.";
+    }
+
+    private static FeatureEditFeature ToEditFeature(Feature feature)
+    {
+        TryReadObjectId(feature, out var objectId);
+
+        return new FeatureEditFeature
+        {
+            Id = feature.Id,
+            ObjectId = objectId <= 0 ? null : objectId,
+            Attributes = feature.Attributes.ToDictionary(
+                attribute => attribute.Key,
+                attribute => JsonSerializer.SerializeToElement(attribute.Value, JsonOptions),
+                StringComparer.OrdinalIgnoreCase),
+            Geometry = feature.Geometry == null ? null : ToFeatureServerGeometry(feature.Geometry)
+        };
+    }
+
+    private static JsonElement ToFeatureServerGeometry(Geometry geometry)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            switch (geometry)
+            {
+                case Point point:
+                    writer.WriteNumber("x", point.Longitude);
+                    writer.WriteNumber("y", point.Latitude);
+                    if (point.Altitude.HasValue)
+                    {
+                        writer.WriteNumber("z", point.Altitude.Value);
+                    }
+                    break;
+
+                case LineString line:
+                    writer.WritePropertyName("paths");
+                    writer.WriteStartArray();
+                    WriteCoordinateArray(writer, line.Coordinates);
+                    writer.WriteEndArray();
+                    break;
+
+                case Polygon polygon:
+                    writer.WritePropertyName("rings");
+                    writer.WriteStartArray();
+                    foreach (var ring in polygon.Coordinates)
+                    {
+                        WriteCoordinateArray(writer, ring);
+                    }
+                    writer.WriteEndArray();
+                    break;
+
+                default:
+                    throw new NotSupportedException($"Geometry type {geometry.Type} is not supported by FeatureServer sync.");
+            }
+
+            writer.WritePropertyName("spatialReference");
+            writer.WriteStartObject();
+            writer.WriteNumber("wkid", geometry.SRID <= 0 ? 4326 : geometry.SRID);
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
+
+        using var document = JsonDocument.Parse(stream.ToArray());
+        return document.RootElement.Clone();
+    }
+
+    private static void WriteCoordinateArray(Utf8JsonWriter writer, IEnumerable<Point> points)
+    {
+        writer.WriteStartArray();
+        foreach (var point in points)
+        {
+            writer.WriteStartArray();
+            writer.WriteNumberValue(point.Longitude);
+            writer.WriteNumberValue(point.Latitude);
+            if (point.Altitude.HasValue)
+            {
+                writer.WriteNumberValue(point.Altitude.Value);
+            }
+            writer.WriteEndArray();
+        }
+        writer.WriteEndArray();
+    }
+
+    private static bool TryResolveDeleteObjectId(StorageChangeRecord change, out long objectId)
+    {
+        objectId = 0;
+        if (!string.IsNullOrWhiteSpace(change.ChangeData))
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(change.ChangeData);
+                if (TryReadInt64(document.RootElement, "objectId", out objectId) ||
+                    TryReadInt64(document.RootElement, "objectid", out objectId) ||
+                    TryReadInt64(document.RootElement, "OBJECTID", out objectId))
+                {
+                    return true;
+                }
+
+                if (document.RootElement.TryGetProperty("attributes", out var attributes) &&
+                    (TryReadInt64(attributes, "objectId", out objectId) ||
+                     TryReadInt64(attributes, "objectid", out objectId) ||
+                     TryReadInt64(attributes, "OBJECTID", out objectId)))
+                {
+                    return true;
+                }
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        return long.TryParse(change.FeatureId, NumberStyles.Integer, CultureInfo.InvariantCulture, out objectId);
+    }
+
+    private static bool TryReadObjectId(Feature feature, out long objectId)
+    {
+        objectId = 0;
+        foreach (var attribute in feature.Attributes)
+        {
+            if (!attribute.Key.Equals("objectid", StringComparison.OrdinalIgnoreCase) &&
+                !attribute.Key.Equals("objectId", StringComparison.OrdinalIgnoreCase) &&
+                !attribute.Key.Equals("OBJECTID", StringComparison.OrdinalIgnoreCase) &&
+                !attribute.Key.Equals("FID", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (TryConvertInt64(attribute.Value, out objectId))
+            {
+                return true;
+            }
+        }
+
+        return long.TryParse(feature.Id, NumberStyles.Integer, CultureInfo.InvariantCulture, out objectId);
+    }
+
+    private static bool TryReadInt64(JsonElement element, string propertyName, out long value)
+    {
+        value = 0;
+        if (!element.TryGetProperty(propertyName, out var property))
+        {
+            return false;
+        }
+
+        return property.ValueKind switch
+        {
+            JsonValueKind.Number => property.TryGetInt64(out value),
+            JsonValueKind.String => long.TryParse(property.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out value),
+            _ => false
+        };
+    }
+
+    internal static bool TryConvertInt64(object? value, out long objectId)
+    {
+        objectId = 0;
+        return value switch
+        {
+            long longValue => Set(longValue, out objectId),
+            int intValue => Set(intValue, out objectId),
+            double doubleValue when Math.Abs(doubleValue % 1) < double.Epsilon => Set((long)doubleValue, out objectId),
+            decimal decimalValue when decimalValue == Math.Truncate(decimalValue) => Set((long)decimalValue, out objectId),
+            string stringValue => long.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out objectId),
+            JsonElement { ValueKind: JsonValueKind.Number } element => element.TryGetInt64(out objectId),
+            JsonElement { ValueKind: JsonValueKind.String } element => long.TryParse(element.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out objectId),
+            _ => false
+        };
+
+        static bool Set(long value, out long target)
+        {
+            target = value;
+            return true;
+        }
+    }
+
+    private static string? ResolveServiceId(LayerInfo layer)
+    {
+        if (!string.IsNullOrWhiteSpace(layer.ServiceId))
+        {
+            return layer.ServiceId;
+        }
+
+        const string separator = "/FeatureServer/";
+        if (!string.IsNullOrWhiteSpace(layer.SourceId) &&
+            layer.SourceId.IndexOf(separator, StringComparison.OrdinalIgnoreCase) is var index and >= 0)
+        {
+            return layer.SourceId[..index];
+        }
+
+        return null;
+    }
+}
+
+public sealed class HonuaFieldCollectionChangePuller :
+    IFieldCollectionChangePuller,
+    IFieldCollectionRemoteSyncCapability
+{
+    private const string CursorKeyPrefix = "fieldcollection.sync.serverGeneration";
+
+    private readonly IFieldCollectionMetadataService _metadataService;
+    private readonly IFieldCollectionFeatureSyncClient _featureClient;
+    private readonly ISettingsService _settingsService;
+    private readonly ILogger<HonuaFieldCollectionChangePuller>? _logger;
+    private long? _pendingObservedGeneration;
+
+    public HonuaFieldCollectionChangePuller(
+        IFieldCollectionMetadataService metadataService,
+        IFieldCollectionFeatureSyncClient featureClient,
+        ISettingsService settingsService,
+        ILogger<HonuaFieldCollectionChangePuller>? logger = null)
+    {
+        _metadataService = metadataService;
+        _featureClient = featureClient;
+        _settingsService = settingsService;
+        _logger = logger;
+    }
+
+    public bool IsRemoteSyncConfigured => _featureClient.IsConfigured;
+
+    public async Task<IReadOnlyList<ServerChange>> GetChangesAsync(
+        long sinceGeneration,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!IsRemoteSyncConfigured)
+        {
+            return [];
+        }
+
+        var layers = await _metadataService.GetLayersAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        var changes = new List<ServerChange>();
+        var maxGeneration = sinceGeneration;
+
+        foreach (var layer in layers.Where(layer => layer.IsEditable))
+        {
+            var serviceId = ResolveServiceId(layer);
+            if (string.IsNullOrWhiteSpace(serviceId))
+            {
+                continue;
+            }
+
+            var result = await _featureClient.QueryAsync(
+                new FeatureQueryRequest
+                {
+                    Source = new FeatureSource { ServiceId = serviceId, LayerId = layer.Id },
+                    Filter = "1=1",
+                    OutFields = ["*"],
+                    ReturnGeometry = true
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            foreach (var record in result.Features)
+            {
+                var feature = Feature.FromSdkFeatureRecord(record, layer.Id);
+                feature.Id = ResolveFeatureId(record, result.ObjectIdFieldName);
+                feature.Version = ResolveFeatureVersion(feature, record);
+                feature.UpdatedAt = ResolveFeatureTimestamp(feature, record) ?? DateTime.UtcNow;
+                feature.ModifiedAt = feature.UpdatedAt;
+
+                maxGeneration = Math.Max(maxGeneration, feature.Version);
+                if (feature.Version <= sinceGeneration)
+                {
+                    continue;
+                }
+
+                changes.Add(new ServerChange
+                {
+                    FeatureId = feature.Id,
+                    LayerId = layer.Id,
+                    Operation = IsDeletedFeature(feature) ? StorageChangeOperation.Delete : StorageChangeOperation.Update,
+                    Version = feature.Version,
+                    Feature = feature,
+                    Timestamp = feature.UpdatedAt ?? DateTime.UtcNow
+                });
+            }
+        }
+
+        _pendingObservedGeneration = Math.Max(_pendingObservedGeneration ?? sinceGeneration, maxGeneration);
+        return changes;
+    }
+
+    public async Task<long> GetLatestServerGenerationAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var cursorKey = await GetCursorKeyAsync(cancellationToken).ConfigureAwait(false);
+
+        if (_pendingObservedGeneration.HasValue)
+        {
+            var observed = _pendingObservedGeneration.Value;
+            await _settingsService.SetSettingAsync(cursorKey, observed).ConfigureAwait(false);
+            _pendingObservedGeneration = null;
+            return observed;
+        }
+
+        return await _settingsService.GetSettingAsync<long>(cursorKey, 0L).ConfigureAwait(false);
+    }
+
+    public async Task<long> GetLastSyncedGenerationAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var cursorKey = await GetCursorKeyAsync(cancellationToken).ConfigureAwait(false);
+        return await _settingsService.GetSettingAsync<long>(cursorKey, 0L).ConfigureAwait(false);
+    }
+
+    private async Task<string> GetCursorKeyAsync(CancellationToken cancellationToken)
+    {
+        var selectedProject = await _metadataService.GetSelectedProjectAsync(cancellationToken).ConfigureAwait(false);
+        var serviceId = string.IsNullOrWhiteSpace(selectedProject?.ServiceId)
+            ? "default"
+            : selectedProject.ServiceId.Trim();
+        return $"{CursorKeyPrefix}:{serviceId}";
+    }
+
+    private static string ResolveFeatureId(FeatureRecord record, string? objectIdFieldName)
+    {
+        if (!string.IsNullOrWhiteSpace(record.Id))
+        {
+            return record.Id;
+        }
+
+        foreach (var fieldName in CandidateObjectIdFields(objectIdFieldName))
+        {
+            if (record.Attributes.TryGetValue(fieldName, out var value))
+            {
+                if (value.ValueKind == JsonValueKind.String)
+                {
+                    return value.GetString() ?? string.Empty;
+                }
+
+                return value.GetRawText();
+            }
+        }
+
+        return Guid.NewGuid().ToString("N");
+    }
+
+    private static long ResolveFeatureVersion(Feature feature, FeatureRecord record)
+    {
+        foreach (var fieldName in new[] { "sync_version", "version", "server_version", "edit_version" })
+        {
+            if (TryReadInt64(feature.Attributes, fieldName, out var version) ||
+                (record.Attributes.TryGetValue(fieldName, out var value) && TryReadInt64(value, out version)))
+            {
+                return Math.Max(1, version);
+            }
+        }
+
+        if (ResolveFeatureTimestamp(feature, record) is { } timestamp)
+        {
+            return Math.Max(1, timestamp.Ticks);
+        }
+
+        return 1;
+    }
+
+    private static DateTime? ResolveFeatureTimestamp(Feature feature, FeatureRecord record)
+    {
+        foreach (var fieldName in new[] { "updated_at", "modified_at", "last_edited_date", "editdate" })
+        {
+            if (TryReadDateTime(feature.Attributes, fieldName, out var timestamp) ||
+                (record.Attributes.TryGetValue(fieldName, out var value) && TryReadDateTime(value, out timestamp)))
+            {
+                return timestamp;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsDeletedFeature(Feature feature)
+    {
+        foreach (var fieldName in new[] { "deleted", "is_deleted", "honua_deleted" })
+        {
+            if (feature.Attributes.TryGetValue(fieldName, out var value) && TryReadBoolean(value, out var deleted))
+            {
+                return deleted;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<string> CandidateObjectIdFields(string? objectIdFieldName)
+    {
+        if (!string.IsNullOrWhiteSpace(objectIdFieldName))
+        {
+            yield return objectIdFieldName;
+        }
+
+        yield return "objectid";
+        yield return "OBJECTID";
+        yield return "objectId";
+        yield return "FID";
+    }
+
+    private static bool TryReadInt64(IReadOnlyDictionary<string, object?> attributes, string fieldName, out long value)
+    {
+        value = 0;
+        foreach (var attribute in attributes)
+        {
+            if (attribute.Key.Equals(fieldName, StringComparison.OrdinalIgnoreCase) &&
+                HonuaFieldCollectionChangeUploader.TryConvertInt64(attribute.Value, out value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryReadInt64(JsonElement element, out long value)
+    {
+        value = 0;
+        return element.ValueKind switch
+        {
+            JsonValueKind.Number => element.TryGetInt64(out value),
+            JsonValueKind.String => long.TryParse(element.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out value),
+            _ => false
+        };
+    }
+
+    private static bool TryReadDateTime(IReadOnlyDictionary<string, object?> attributes, string fieldName, out DateTime value)
+    {
+        value = default;
+        foreach (var attribute in attributes)
+        {
+            if (!attribute.Key.Equals(fieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (attribute.Value is DateTime dateTime)
+            {
+                value = dateTime.Kind == DateTimeKind.Unspecified
+                    ? DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)
+                    : dateTime.ToUniversalTime();
+                return true;
+            }
+
+            if (attribute.Value is string stringValue &&
+                DateTime.TryParse(stringValue, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out value))
+            {
+                value = value.ToUniversalTime();
+                return true;
+            }
+
+            if (attribute.Value is JsonElement json && TryReadDateTime(json, out value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryReadDateTime(JsonElement element, out DateTime value)
+    {
+        value = default;
+        if (element.ValueKind == JsonValueKind.String &&
+            DateTime.TryParse(element.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out value))
+        {
+            value = value.ToUniversalTime();
+            return true;
+        }
+
+        if (element.ValueKind == JsonValueKind.Number && element.TryGetInt64(out var epochMillis))
+        {
+            value = DateTimeOffset.FromUnixTimeMilliseconds(epochMillis).UtcDateTime;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryReadBoolean(object? value, out bool result)
+    {
+        result = false;
+        return value switch
+        {
+            bool boolValue => Set(boolValue, out result),
+            string stringValue => bool.TryParse(stringValue, out result),
+            JsonElement { ValueKind: JsonValueKind.True } => Set(true, out result),
+            JsonElement { ValueKind: JsonValueKind.False } => Set(false, out result),
+            _ => false
+        };
+
+        static bool Set(bool value, out bool target)
+        {
+            target = value;
+            return true;
+        }
+    }
+
+    private static string? ResolveServiceId(LayerInfo layer)
+    {
+        if (!string.IsNullOrWhiteSpace(layer.ServiceId))
+        {
+            return layer.ServiceId;
+        }
+
+        const string separator = "/FeatureServer/";
+        if (!string.IsNullOrWhiteSpace(layer.SourceId) &&
+            layer.SourceId.IndexOf(separator, StringComparison.OrdinalIgnoreCase) is var index and >= 0)
+        {
+            return layer.SourceId[..index];
+        }
+
+        return null;
+    }
+}
 
 public sealed class QueuedFieldCollectionChangeUploader :
     IFieldCollectionChangeUploader,
@@ -28,6 +855,33 @@ public sealed class QueuedFieldCollectionChangeUploader :
 
         return Task.FromResult(false);
     }
+}
+
+internal sealed class FieldCollectionApiKeyTokenProvider : IAuthTokenProvider
+{
+    private readonly IAuthenticationService _authenticationService;
+
+    public FieldCollectionApiKeyTokenProvider(IAuthenticationService authenticationService)
+    {
+        _authenticationService = authenticationService;
+    }
+
+    public ValueTask<HonuaAuthToken?> GetTokenAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return string.IsNullOrWhiteSpace(_authenticationService.ApiKey)
+            ? ValueTask.FromResult<HonuaAuthToken?>(null)
+            : ValueTask.FromResult<HonuaAuthToken?>(new HonuaAuthToken(HonuaAuthScheme.ApiKey, _authenticationService.ApiKey));
+    }
+
+    public ValueTask<HonuaAuthToken?> RefreshTokenAsync(CancellationToken ct = default)
+        => GetTokenAsync(ct);
+
+    public ValueTask StoreTokenAsync(HonuaAuthToken token, CancellationToken ct = default)
+        => ValueTask.CompletedTask;
+
+    public ValueTask ClearTokenAsync(CancellationToken ct = default)
+        => ValueTask.CompletedTask;
 }
 
 public sealed class LocalOnlyFieldCollectionChangePuller :

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/GeoPackageSyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/GeoPackageSyncService.cs
@@ -83,7 +83,9 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
     [ObservableProperty]
     private string? syncMessage;
 
-    public bool IsRemoteSyncConfigured { get; }
+    public bool IsRemoteSyncConfigured =>
+        IsConfiguredRemoteTransport(_changeUploader) &&
+        IsConfiguredRemoteTransport(_changePuller);
 
     public GeoPackageSyncService(
         GeoPackageStorageService storage,
@@ -101,10 +103,6 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         _changePuller = changePuller ?? new UnconfiguredFieldCollectionChangePuller();
         _exceptionReporter = exceptionReporter ?? new NoOpMobileExceptionReporter();
         _logger = logger;
-        IsRemoteSyncConfigured =
-            IsConfiguredRemoteTransport(_changeUploader) &&
-            IsConfiguredRemoteTransport(_changePuller);
-
         // Update pending changes count periodically
         _pendingChangesTask = Task.Run(() => UpdatePendingChangesAsync(_pendingChangesCancellation.Token));
     }

--- a/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
+++ b/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
@@ -57,8 +57,18 @@ public static class MauiProgram
         services.AddSingleton<IStorageService, StorageService>();
 
         // Register sync service factory
-        services.AddSingleton<IFieldCollectionChangeUploader, QueuedFieldCollectionChangeUploader>();
-        services.AddSingleton<IFieldCollectionChangePuller, LocalOnlyFieldCollectionChangePuller>();
+        services.AddHttpClient("HonuaFieldSync");
+        services.AddSingleton<IFieldCollectionFeatureSyncClient, HonuaSdkFieldCollectionFeatureSyncClient>();
+        services.AddSingleton<IFieldCollectionChangeUploader>(provider =>
+        {
+            var databaseService = provider.GetRequiredService<DatabaseService>();
+            return new HonuaFieldCollectionChangeUploader(
+                databaseService.GetStorageService(),
+                provider.GetRequiredService<IFieldCollectionMetadataService>(),
+                provider.GetRequiredService<IFieldCollectionFeatureSyncClient>(),
+                provider.GetService<ILogger<HonuaFieldCollectionChangeUploader>>());
+        });
+        services.AddSingleton<IFieldCollectionChangePuller, HonuaFieldCollectionChangePuller>();
         services.AddSingleton<ISyncService>(provider =>
         {
             var databaseService = provider.GetRequiredService<DatabaseService>();

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/SyncCenterViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/SyncCenterViewModel.cs
@@ -95,8 +95,7 @@ public partial class SyncCenterViewModel : BaseViewModel
     {
         if (e.PropertyName == nameof(IAuthenticationService.IsAuthenticated))
         {
-            UpdateSyncActionState();
-            UpdateSyncStatusMessage();
+            UpdateFromSyncService();
         }
     }
 

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.Attachments.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.Attachments.cs
@@ -130,7 +130,7 @@ public sealed partial class HonuaMobileClient
             ?? throw new InvalidOperationException("FeatureServer attachments require a service ID.");
         var layerId = request.Source.LayerId
             ?? throw new InvalidOperationException("FeatureServer attachments require a layer ID.");
-        var path = $"/rest/services/{Uri.EscapeDataString(serviceId)}/FeatureServer/{layerId}/queryAttachments";
+        var path = $"/rest/services/{EscapePathSegments(serviceId)}/FeatureServer/{layerId}/queryAttachments";
 
         using var response = await SendJsonAsync(
             HttpMethod.Get,

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs
@@ -241,7 +241,7 @@ public sealed partial class HonuaMobileClient
 
     private async Task<JsonDocument> QueryFeaturesRestAsync(QueryFeaturesRequest request, CancellationToken ct)
     {
-        var path = $"/rest/services/{Uri.EscapeDataString(request.ServiceId)}/FeatureServer/{request.LayerId}/query";
+        var path = $"/rest/services/{EscapePathSegments(request.ServiceId)}/FeatureServer/{request.LayerId}/query";
         return await SendJsonAsync(
             HttpMethod.Get,
             path,
@@ -252,7 +252,7 @@ public sealed partial class HonuaMobileClient
 
     private async Task<JsonDocument> ApplyEditsRestAsync(ApplyEditsRequest request, CancellationToken ct)
     {
-        var path = $"/rest/services/{Uri.EscapeDataString(request.ServiceId)}/FeatureServer/{request.LayerId}/applyEdits";
+        var path = $"/rest/services/{EscapePathSegments(request.ServiceId)}/FeatureServer/{request.LayerId}/applyEdits";
         return await SendJsonAsync(
             HttpMethod.Post,
             path,
@@ -432,7 +432,7 @@ public sealed partial class HonuaMobileClient
             ForceWrite = request.ForceWrite,
         };
 
-        var path = $"/rest/services/{Uri.EscapeDataString(serviceId)}/FeatureServer/{layerId}/applyEdits";
+        var path = $"/rest/services/{EscapePathSegments(serviceId)}/FeatureServer/{layerId}/applyEdits";
         return await SendJsonAsync(
             HttpMethod.Post,
             path,

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.Internals.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.Internals.cs
@@ -183,6 +183,14 @@ public sealed partial class HonuaMobileClient
         return new Uri($"{relativePath}?{queryText}", UriKind.Relative);
     }
 
+    private static string EscapePathSegments(string path)
+    {
+        return string.Join(
+            '/',
+            path.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(Uri.EscapeDataString));
+    }
+
     private Uri BuildAbsoluteUri(string relativePath, IReadOnlyDictionary<string, string?>? query)
     {
         var relative = BuildUri(relativePath, query);

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -4,8 +4,10 @@ using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using Honua.Mobile.FieldCollection.Services.Sync;
 using Honua.Mobile.FieldCollection.Services.Storage;
 using Honua.Mobile.Maui.Diagnostics;
+using Honua.Sdk.Abstractions.Features;
 using Microsoft.Extensions.Logging.Abstractions;
 using SQLite;
+using System.Text.Json;
 using StorageChangeRecord = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeRecord;
 using StorageChangeOperation = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeOperation;
 using StorageConflictRecord = Honua.Mobile.FieldCollection.Services.Storage.Models.ConflictRecord;
@@ -135,6 +137,144 @@ public sealed class GeoPackageSyncServiceTests
     }
 
     [Fact]
+    public async Task PushChangesAsync_WithHonuaUploader_UploadsSdkFeatureEditAndMarksChangeSynced()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var layer = CreateLayer();
+        await storage.CreateLayerAsync(layer);
+        var feature = CreateFeature("asset-1", version: 1);
+        feature.Attributes["objectid"] = 42;
+        await storage.StoreFeatureAsync(feature);
+        var metadata = new FixedMetadataService([layer]);
+        var client = new RecordingFeatureSyncClient
+        {
+            EditResponse = new FeatureEditResponse
+            {
+                ProviderName = "test",
+                AddResults = [new FeatureEditResult { Succeeded = true, ObjectId = 42 }]
+            }
+        };
+        using var sync = CreateSyncService(
+            storage,
+            uploader: new HonuaFieldCollectionChangeUploader(storage, metadata, client));
+
+        var result = await sync.PushChangesAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(await storage.GetPendingChangesAsync());
+        var request = Assert.Single(client.EditRequests);
+        Assert.Equal("assets", request.Source.ServiceId);
+        Assert.Equal(1, request.Source.LayerId);
+        var add = Assert.Single(request.Adds);
+        Assert.Equal(42, add.ObjectId);
+        Assert.Equal(-157.8, add.Geometry!.Value.GetProperty("x").GetDouble());
+        Assert.Equal(21.3, add.Geometry!.Value.GetProperty("y").GetDouble());
+    }
+
+    [Fact]
+    public async Task PushChangesAsync_WithHonuaUploaderDelete_UsesStoredObjectIdAfterLocalDelete()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var layer = CreateLayer();
+        await storage.CreateLayerAsync(layer);
+        var feature = CreateFeature("asset-1", version: 1);
+        feature.Attributes["objectid"] = 42;
+        await storage.StoreFeatureAsync(feature);
+        var initialChanges = await storage.GetPendingChangesAsync();
+        await storage.MarkChangesAsSynced(initialChanges.Select(change => change.Id).ToList());
+        await storage.DeleteFeatureAsync("asset-1", 1);
+        var metadata = new FixedMetadataService([layer]);
+        var client = new RecordingFeatureSyncClient
+        {
+            EditResponse = new FeatureEditResponse
+            {
+                ProviderName = "test",
+                DeleteResults = [new FeatureEditResult { Succeeded = true, ObjectId = 42 }]
+            }
+        };
+        using var sync = CreateSyncService(
+            storage,
+            uploader: new HonuaFieldCollectionChangeUploader(storage, metadata, client));
+
+        var result = await sync.PushChangesAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(await storage.GetPendingChangesAsync());
+        var request = Assert.Single(client.EditRequests);
+        Assert.Empty(request.Adds);
+        Assert.Empty(request.Updates);
+        Assert.Equal([42], request.DeleteObjectIds);
+    }
+
+    [Fact]
+    public async Task DeleteFeatureAsync_WhenOfflineInsertNeverSynced_CollapsesLocalOnlyLifecycle()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var layer = CreateLayer();
+        await storage.CreateLayerAsync(layer);
+        await storage.StoreFeatureAsync(CreateFeature("local-only", version: 1));
+        var metadata = new FixedMetadataService([layer]);
+        var client = new RecordingFeatureSyncClient();
+        using var sync = CreateSyncService(
+            storage,
+            uploader: new HonuaFieldCollectionChangeUploader(storage, metadata, client));
+
+        await storage.DeleteFeatureAsync("local-only", 1);
+        var result = await sync.PushChangesAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, result.ChangesPushed);
+        Assert.Empty(await storage.GetPendingChangesAsync());
+        Assert.Empty(client.EditRequests);
+    }
+
+    [Fact]
+    public async Task PushChangesAsync_WithHonuaUploaderConflict_StoresConflictForReview()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var layer = CreateLayer();
+        await storage.CreateLayerAsync(layer);
+        var feature = CreateFeature("asset-1", version: 2);
+        feature.Attributes["objectid"] = 42;
+        await storage.StoreFeatureAsync(feature);
+        var metadata = new FixedMetadataService([layer]);
+        var client = new RecordingFeatureSyncClient
+        {
+            EditResponse = new FeatureEditResponse
+            {
+                ProviderName = "test",
+                AddResults =
+                [
+                    new FeatureEditResult
+                    {
+                        Succeeded = false,
+                        Error = new FeatureEditError { Code = 409, Message = "Version conflict" }
+                    }
+                ]
+            }
+        };
+        using var sync = CreateSyncService(
+            storage,
+            uploader: new HonuaFieldCollectionChangeUploader(storage, metadata, client));
+
+        var result = await sync.PushChangesAsync();
+
+        Assert.False(result.IsSuccess);
+        Assert.Single(await storage.GetPendingChangesAsync());
+        var conflict = Assert.Single(await sync.GetConflictsAsync());
+        Assert.Equal("asset-1", conflict.FeatureId);
+        Assert.Contains("Version conflict", conflict.RedactedServerVersion);
+    }
+
+    [Fact]
     public async Task PushChangesAsync_WhenCompleted_PersistsSyncHistory()
     {
         var databasePath = CreateDatabasePath();
@@ -172,6 +312,71 @@ public sealed class GeoPackageSyncServiceTests
 
         Assert.False(result.IsSuccess);
         Assert.Equal(0, result.ChangesPulled);
+    }
+
+    [Fact]
+    public async Task PullChangesAsync_WithHonuaPuller_AppliesServerFeatureAndPersistsCursor()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var layer = CreateLayer();
+        await storage.CreateLayerAsync(layer);
+        var metadata = new FixedMetadataService([layer]);
+        var settings = new InMemorySettingsService();
+        var client = new RecordingFeatureSyncClient
+        {
+            QueryResponse = new FeatureQueryResult
+            {
+                ProviderName = "test",
+                ObjectIdFieldName = "objectid",
+                Features =
+                [
+                    new FeatureRecord
+                    {
+                        Id = "42",
+                        Attributes = new Dictionary<string, JsonElement>
+                        {
+                            ["objectid"] = JsonSerializer.SerializeToElement(42),
+                            ["sync_version"] = JsonSerializer.SerializeToElement(5L),
+                            ["name"] = JsonSerializer.SerializeToElement("server")
+                        },
+                        Geometry = JsonSerializer.SerializeToElement(new { x = -157.8, y = 21.3 })
+                    }
+                ]
+            }
+        };
+        var puller = new HonuaFieldCollectionChangePuller(metadata, client, settings);
+        using var sync = CreateSyncService(storage, puller: puller);
+
+        var result = await sync.PullChangesAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.ChangesPulled);
+        Assert.Equal(5, await puller.GetLastSyncedGenerationAsync());
+        var feature = await storage.GetFeatureAsync("42", 1);
+        Assert.NotNull(feature);
+        Assert.Equal("server", feature.Attributes["name"]?.ToString());
+    }
+
+    [Fact]
+    public void IsRemoteSyncConfigured_ReflectsDynamicTransportConfiguration()
+    {
+        var databasePath = CreateDatabasePath();
+        using var storage = new GeoPackageStorageService(databasePath);
+        var client = new RecordingFeatureSyncClient { IsConfigured = false };
+        var metadata = new FixedMetadataService([CreateLayer()]);
+        var settings = new InMemorySettingsService();
+        using var sync = CreateSyncService(
+            storage,
+            uploader: new HonuaFieldCollectionChangeUploader(storage, metadata, client),
+            puller: new HonuaFieldCollectionChangePuller(metadata, client, settings));
+
+        Assert.False(sync.IsRemoteSyncConfigured);
+
+        client.IsConfigured = true;
+
+        Assert.True(sync.IsRemoteSyncConfigured);
     }
 
     [Fact]
@@ -431,6 +636,19 @@ public sealed class GeoPackageSyncServiceTests
         return context;
     }
 
+    private static LayerInfo CreateLayer()
+    {
+        return new LayerInfo
+        {
+            Id = 1,
+            ServiceId = "assets",
+            SourceId = "assets/FeatureServer/1",
+            Name = "Assets",
+            GeometryType = GeometryType.Point,
+            IsEditable = true
+        };
+    }
+
     private static Feature CreateFeature(
         string id,
         long version,
@@ -540,6 +758,115 @@ public sealed class GeoPackageSyncServiceTests
         public Task<long> GetLastSyncedGenerationAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult(0L);
+        }
+    }
+
+    private sealed class RecordingFeatureSyncClient : IFieldCollectionFeatureSyncClient
+    {
+        public bool IsConfigured { get; set; } = true;
+        public FeatureEditResponse? EditResponse { get; set; }
+        public FeatureQueryResult? QueryResponse { get; set; }
+        public List<FeatureEditRequest> EditRequests { get; } = [];
+        public List<FeatureQueryRequest> QueryRequests { get; } = [];
+
+        public Task<FeatureEditResponse> ApplyEditsAsync(
+            FeatureEditRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            EditRequests.Add(request);
+            return Task.FromResult(EditResponse ?? new FeatureEditResponse
+            {
+                ProviderName = "test",
+                UpdateResults = [new FeatureEditResult { Succeeded = true }]
+            });
+        }
+
+        public Task<FeatureQueryResult> QueryAsync(
+            FeatureQueryRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            QueryRequests.Add(request);
+            return Task.FromResult(QueryResponse ?? new FeatureQueryResult
+            {
+                ProviderName = "test",
+                Features = []
+            });
+        }
+    }
+
+    private sealed class FixedMetadataService : IFieldCollectionMetadataService
+    {
+        private readonly IReadOnlyList<LayerInfo> _layers;
+        private string _selectedServiceId;
+
+        public FixedMetadataService(IReadOnlyList<LayerInfo> layers)
+        {
+            _layers = layers;
+            _selectedServiceId = layers.FirstOrDefault()?.ServiceId ?? "assets";
+        }
+
+        public Task<IReadOnlyList<FieldProjectInfo>> GetProjectsAsync(
+            bool refresh = false,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<FieldProjectInfo>>(
+            [
+                new FieldProjectInfo
+                {
+                    ServiceId = _selectedServiceId,
+                    Name = _selectedServiceId,
+                    LayerCount = _layers.Count,
+                    Layers = _layers.ToList()
+                }
+            ]);
+        }
+
+        public Task<FieldProjectInfo?> GetSelectedProjectAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<FieldProjectInfo?>(new FieldProjectInfo
+            {
+                ServiceId = _selectedServiceId,
+                Name = _selectedServiceId,
+                LayerCount = _layers.Count,
+                Layers = _layers.ToList()
+            });
+        }
+
+        public Task SelectProjectAsync(string serviceId, CancellationToken cancellationToken = default)
+        {
+            _selectedServiceId = serviceId;
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<LayerInfo>> GetLayersAsync(
+            bool refresh = false,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_layers);
+        }
+    }
+
+    private sealed class InMemorySettingsService : ISettingsService
+    {
+        private readonly Dictionary<string, object?> _values = new(StringComparer.Ordinal);
+
+        public Task<T> GetSettingAsync<T>(string key, T defaultValue = default!)
+        {
+            return Task.FromResult(
+                _values.TryGetValue(key, out var value) && value is T typed
+                    ? typed
+                    : defaultValue);
+        }
+
+        public Task SetSettingAsync<T>(string key, T value)
+        {
+            _values[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> HasSettingAsync(string key)
+        {
+            return Task.FromResult(_values.ContainsKey(key));
         }
     }
 

--- a/tests/Honua.Mobile.Sdk.Tests/HonuaMobileClientHttpTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/HonuaMobileClientHttpTests.cs
@@ -92,6 +92,62 @@ public sealed class HonuaMobileClientHttpTests
     }
 
     [Fact]
+    public async Task FeatureServerRestAsync_WithFolderedServiceId_PreservesFolderPath()
+    {
+        var capturedPaths = new List<string>();
+        var handler = new StubHttpMessageHandler((request, _) =>
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            capturedPaths.Add(path);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    path.EndsWith("/query", StringComparison.Ordinal)
+                        ? """{"features":[]}"""
+                        : """{"addResults":[{"objectId":42,"success":true}],"updateResults":[],"deleteResults":[]}""",
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+        });
+
+        var client = CreateClient(handler);
+
+        using var queryResult = await client.QueryFeaturesAsync(new QueryFeaturesRequest
+        {
+            ServiceId = "Utilities/Assets",
+            LayerId = 2,
+        });
+
+        using var editResult = await client.ApplyEditsAsync(new ApplyEditsRequest
+        {
+            ServiceId = "Utilities/Assets",
+            LayerId = 2,
+            AddsJson = """[{"attributes":{"name":"Test"}}]""",
+        });
+
+        var sdkEditResult = await client.ApplyEditsAsync(new FeatureEditRequest
+        {
+            Source = new FeatureSource { ServiceId = "Utilities/Assets", LayerId = 2 },
+            Adds =
+            [
+                new FeatureEditFeature
+                {
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["name"] = JsonSerializer.SerializeToElement("Test"),
+                    },
+                },
+            ],
+        });
+
+        Assert.Contains("/rest/services/Utilities/Assets/FeatureServer/2/query", capturedPaths);
+        Assert.Equal(
+            2,
+            capturedPaths.Count(path => path == "/rest/services/Utilities/Assets/FeatureServer/2/applyEdits"));
+        Assert.True(sdkEditResult.Succeeded);
+    }
+
+    [Fact]
     public async Task ApplyEditsAsync_WithSdkFeatureServerModels_SerializesEditForm()
     {
         string? capturedBody = null;

--- a/tests/Honua.Mobile.Sdk.Tests/HonuaMobileSdkFeatureClientTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/HonuaMobileSdkFeatureClientTests.cs
@@ -381,7 +381,7 @@ public sealed class HonuaMobileSdkFeatureClientTests
         var handler = new StubHttpMessageHandler((request, _) =>
         {
             requestedPaths.Add(request.RequestUri!.PathAndQuery);
-            if (request.RequestUri!.AbsolutePath == "/rest/services/assets/FeatureServer/0/queryAttachments")
+            if (request.RequestUri!.AbsolutePath == "/rest/services/Utilities/Assets/FeatureServer/0/queryAttachments")
             {
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
@@ -420,11 +420,11 @@ public sealed class HonuaMobileSdkFeatureClientTests
 
         var listed = await attachments.ListAttachmentsAsync(new FeatureAttachmentListRequest
         {
-            Source = new FeatureSource { ServiceId = "assets", LayerId = 0 },
+            Source = new FeatureSource { ServiceId = "Utilities/Assets", LayerId = 0 },
             ObjectId = 42,
         });
 
-        Assert.Contains(requestedPaths, path => path.Contains("/rest/services/assets/FeatureServer/0/queryAttachments", StringComparison.Ordinal));
+        Assert.Contains(requestedPaths, path => path.Contains("/rest/services/Utilities/Assets/FeatureServer/0/queryAttachments", StringComparison.Ordinal));
         var attachment = Assert.Single(listed);
         Assert.Equal(42, attachment.ParentObjectId);
         Assert.Equal(7, attachment.AttachmentId);


### PR DESCRIPTION
## Summary
- Replace FieldCollection local-only sync transports with Honua SDK-backed push/pull transports using the configured server URL and API key.
- Preserve durable local change payloads for upload, including deleted feature object IDs, and collapse local-only create/delete lifecycles that never reached the server.
- Refresh Sync Center configured-state from authentication changes and preserve foldered FeatureServer service paths in mobile SDK REST fallbacks.

## Validation
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore --verbosity minimal`
- `dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --no-restore --verbosity minimal`
- `git diff --check`

## Notes
- Full `dotnet test Honua.Mobile.sln --no-restore --verbosity minimal` is blocked locally by missing Android SDK for `Honua.Mobile.PlatformSmoke` (`XA5300`).

Closes #212