### PR TITLE
mobile: implement FieldCollection attachment storage and sync

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Models/CoreModels.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Models/CoreModels.cs
@@ -189,13 +189,26 @@ public class FormData
 public class AttachmentInfo
 {
     public string Id { get; set; } = string.Empty;
+    public int LayerId { get; set; }
+    public string FeatureId { get; set; } = string.Empty;
+    public long? RemoteAttachmentId { get; set; }
+    public string? RemoteGlobalId { get; set; }
     public string FileName { get; set; } = string.Empty;
     public string ContentType { get; set; } = string.Empty;
+    public AttachmentPayloadKind PayloadKind { get; set; } = AttachmentPayloadKind.File;
     public long SizeBytes { get; set; }
+    public string? LocalPath { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
     public DateTime UploadedAt { get; set; }
+    public DateTime? LastSyncedAt { get; set; }
     public string? Description { get; set; }
     public string? ThumbnailUrl { get; set; }
     public AttachmentSyncStatus SyncStatus { get; set; } = AttachmentSyncStatus.Synced;
+    public int RetryCount { get; set; }
+    public string? LastError { get; set; }
+    public bool IsDeleted { get; set; }
+    public DateTime? DeletedAt { get; set; }
 }
 
 public enum AttachmentSyncStatus
@@ -206,7 +219,17 @@ public enum AttachmentSyncStatus
     UploadFailed,
     PendingDownload,
     Downloading,
-    DownloadFailed
+    DownloadFailed,
+    PendingDelete,
+    Deleting,
+    DeleteFailed
+}
+
+public enum AttachmentPayloadKind
+{
+    File,
+    Photo,
+    Signature
 }
 
 public class LayerInfo

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/CoreServices.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/CoreServices.cs
@@ -1,6 +1,9 @@
 using System.ComponentModel;
 using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Field.Forms;
+using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Devices.Sensors;
 using Microsoft.Maui.Networking;
 using Microsoft.Maui.Storage;
@@ -54,9 +57,26 @@ public interface IFormService
 public interface IAttachmentService
 {
     Task<string> SaveAttachmentAsync(Stream fileStream, string fileName, string contentType);
+    Task<AttachmentInfo> SaveAttachmentAsync(
+        int layerId,
+        string featureId,
+        Stream fileStream,
+        string fileName,
+        string contentType,
+        AttachmentPayloadKind payloadKind = AttachmentPayloadKind.File,
+        string? description = null,
+        CancellationToken cancellationToken = default);
+    Task<AttachmentInfo> SaveDownloadedAttachmentAsync(
+        int layerId,
+        string featureId,
+        FeatureAttachmentInfo remoteAttachment,
+        Stream content,
+        CancellationToken cancellationToken = default);
     Task<Stream> GetAttachmentAsync(string attachmentId);
     Task DeleteAttachmentAsync(string attachmentId);
     Task<IEnumerable<AttachmentInfo>> GetAttachmentsAsync(string featureId);
+    Task<IReadOnlyList<AttachmentInfo>> GetPendingAttachmentsAsync(CancellationToken cancellationToken = default);
+    Task<bool> AttachmentContentExistsAsync(string attachmentId);
 }
 
 public interface ISettingsService
@@ -228,24 +248,363 @@ public class FormService : IFormService
 
 public class AttachmentService : IAttachmentService
 {
-    public Task<string> SaveAttachmentAsync(Stream fileStream, string fileName, string contentType)
+    private const long DefaultQuotaBytes = 250L * 1024L * 1024L;
+
+    private readonly GeoPackageStorageService? _storage;
+    private readonly string _rootDirectory;
+    private readonly long _quotaBytes;
+    private readonly ILogger<AttachmentService>? _logger;
+
+    public AttachmentService()
+        : this(storage: null)
     {
-        throw new InvalidOperationException("Attachment storage is not configured.");
     }
 
-    public Task<Stream> GetAttachmentAsync(string attachmentId)
+    public AttachmentService(
+        GeoPackageStorageService? storage,
+        string? rootDirectory = null,
+        long quotaBytes = DefaultQuotaBytes,
+        ILogger<AttachmentService>? logger = null)
     {
-        throw new InvalidOperationException("Attachment storage is not configured.");
+        _storage = storage;
+        _rootDirectory = rootDirectory ?? GetDefaultAttachmentRoot();
+        _quotaBytes = quotaBytes;
+        _logger = logger;
     }
 
-    public Task DeleteAttachmentAsync(string attachmentId)
+    public async Task<string> SaveAttachmentAsync(Stream fileStream, string fileName, string contentType)
     {
-        throw new InvalidOperationException("Attachment storage is not configured.");
+        var attachment = await SaveAttachmentAsync(
+            layerId: 0,
+            featureId: string.Empty,
+            fileStream,
+            fileName,
+            contentType,
+            InferPayloadKind(fileName, contentType),
+            cancellationToken: default).ConfigureAwait(false);
+        return attachment.Id;
     }
 
-    public Task<IEnumerable<AttachmentInfo>> GetAttachmentsAsync(string featureId)
+    public async Task<AttachmentInfo> SaveAttachmentAsync(
+        int layerId,
+        string featureId,
+        Stream fileStream,
+        string fileName,
+        string contentType,
+        AttachmentPayloadKind payloadKind = AttachmentPayloadKind.File,
+        string? description = null,
+        CancellationToken cancellationToken = default)
     {
-        return Task.FromResult<IEnumerable<AttachmentInfo>>(Array.Empty<AttachmentInfo>());
+        var storage = EnsureStorageConfigured();
+        ArgumentNullException.ThrowIfNull(fileStream);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var attachmentId = Guid.NewGuid().ToString("N");
+        var safeFileName = SanitizeFileName(fileName);
+        var safeContentType = string.IsNullOrWhiteSpace(contentType)
+            ? "application/octet-stream"
+            : contentType.Trim();
+        var kind = payloadKind == AttachmentPayloadKind.File
+            ? InferPayloadKind(safeFileName, safeContentType)
+            : payloadKind;
+        var now = DateTime.UtcNow;
+        var finalPath = BuildAttachmentPath(layerId, featureId, attachmentId, safeFileName);
+        var tempPath = Path.Combine(_rootDirectory, ".tmp", $"{attachmentId}.tmp");
+        Directory.CreateDirectory(Path.GetDirectoryName(tempPath)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(finalPath)!);
+
+        var sizeBytes = await CopyToFileWithQuotaAsync(fileStream, tempPath, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            File.Move(tempPath, finalPath, overwrite: true);
+            var attachment = new AttachmentInfo
+            {
+                Id = attachmentId,
+                LayerId = layerId,
+                FeatureId = featureId,
+                FileName = safeFileName,
+                ContentType = safeContentType,
+                PayloadKind = kind,
+                SizeBytes = sizeBytes,
+                LocalPath = finalPath,
+                CreatedAt = now,
+                UpdatedAt = now,
+                Description = description,
+                SyncStatus = AttachmentSyncStatus.PendingUpload
+            };
+
+            await storage.StoreAttachmentMetadataAsync(attachment).ConfigureAwait(false);
+            return attachment;
+        }
+        catch
+        {
+            DeleteFileIfExists(tempPath);
+            DeleteFileIfExists(finalPath);
+            throw;
+        }
+    }
+
+    public async Task<AttachmentInfo> SaveDownloadedAttachmentAsync(
+        int layerId,
+        string featureId,
+        FeatureAttachmentInfo remoteAttachment,
+        Stream content,
+        CancellationToken cancellationToken = default)
+    {
+        var storage = EnsureStorageConfigured();
+        ArgumentNullException.ThrowIfNull(content);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var remoteAttachmentId = remoteAttachment.AttachmentId.GetValueOrDefault();
+        var existing = remoteAttachmentId > 0
+            ? await storage.GetAttachmentByRemoteIdAsync(layerId, featureId, remoteAttachmentId).ConfigureAwait(false)
+            : null;
+        var attachmentId = existing?.Id ?? Guid.NewGuid().ToString("N");
+        var fileName = SanitizeFileName(remoteAttachment.Name ?? "attachment.bin");
+        var contentType = string.IsNullOrWhiteSpace(remoteAttachment.ContentType)
+            ? "application/octet-stream"
+            : remoteAttachment.ContentType;
+        var finalPath = BuildAttachmentPath(layerId, featureId, attachmentId, fileName);
+        var tempPath = Path.Combine(_rootDirectory, ".tmp", $"{attachmentId}.download");
+        Directory.CreateDirectory(Path.GetDirectoryName(tempPath)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(finalPath)!);
+
+        var sizeBytes = await CopyToFileWithQuotaAsync(content, tempPath, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            File.Move(tempPath, finalPath, overwrite: true);
+            var now = DateTime.UtcNow;
+            var attachment = new AttachmentInfo
+            {
+                Id = attachmentId,
+                LayerId = layerId,
+                FeatureId = featureId,
+                RemoteAttachmentId = remoteAttachmentId <= 0 ? null : remoteAttachmentId,
+                RemoteGlobalId = remoteAttachment.GlobalId,
+                FileName = fileName,
+                ContentType = contentType,
+                PayloadKind = InferPayloadKind(fileName, contentType),
+                SizeBytes = remoteAttachment.Size.GetValueOrDefault() > 0
+                    ? remoteAttachment.Size.GetValueOrDefault()
+                    : sizeBytes,
+                LocalPath = finalPath,
+                CreatedAt = existing?.CreatedAt == default ? now : existing?.CreatedAt ?? now,
+                UpdatedAt = now,
+                UploadedAt = now,
+                LastSyncedAt = now,
+                Description = remoteAttachment.Keywords,
+                ThumbnailUrl = remoteAttachment.Url?.ToString(),
+                SyncStatus = AttachmentSyncStatus.Synced,
+                RetryCount = 0,
+                LastError = null,
+                IsDeleted = false,
+                DeletedAt = null
+            };
+
+            await storage.StoreAttachmentMetadataAsync(attachment).ConfigureAwait(false);
+            return attachment;
+        }
+        catch
+        {
+            DeleteFileIfExists(tempPath);
+            DeleteFileIfExists(finalPath);
+            throw;
+        }
+    }
+
+    public async Task<Stream> GetAttachmentAsync(string attachmentId)
+    {
+        var storage = EnsureStorageConfigured();
+        var attachment = await storage.GetAttachmentMetadataAsync(attachmentId).ConfigureAwait(false)
+            ?? throw new FileNotFoundException("Attachment metadata was not found.", attachmentId);
+        if (attachment.IsDeleted || string.IsNullOrWhiteSpace(attachment.LocalPath) || !File.Exists(attachment.LocalPath))
+        {
+            throw new FileNotFoundException("Attachment content was not found.", attachment.LocalPath);
+        }
+
+        return File.OpenRead(attachment.LocalPath);
+    }
+
+    public async Task DeleteAttachmentAsync(string attachmentId)
+    {
+        var storage = EnsureStorageConfigured();
+        var attachment = await storage.GetAttachmentMetadataAsync(attachmentId).ConfigureAwait(false);
+        if (attachment == null)
+        {
+            return;
+        }
+
+        DeleteFileIfExists(attachment.LocalPath);
+        if (attachment.RemoteAttachmentId.HasValue)
+        {
+            await storage.MarkAttachmentPendingDeleteAsync(attachmentId).ConfigureAwait(false);
+        }
+        else
+        {
+            await storage.MarkAttachmentDeletedSyncedAsync(attachmentId).ConfigureAwait(false);
+        }
+    }
+
+    public async Task<IEnumerable<AttachmentInfo>> GetAttachmentsAsync(string featureId)
+    {
+        var storage = EnsureStorageConfigured();
+        return await storage.GetAttachmentsForFeatureAsync(featureId).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<AttachmentInfo>> GetPendingAttachmentsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var storage = EnsureStorageConfigured();
+        return await storage.GetPendingAttachmentChangesAsync().ConfigureAwait(false);
+    }
+
+    public async Task<bool> AttachmentContentExistsAsync(string attachmentId)
+    {
+        var storage = EnsureStorageConfigured();
+        var attachment = await storage.GetAttachmentMetadataAsync(attachmentId).ConfigureAwait(false);
+        return attachment is { IsDeleted: false } &&
+            !string.IsNullOrWhiteSpace(attachment.LocalPath) &&
+            File.Exists(attachment.LocalPath);
+    }
+
+    private GeoPackageStorageService EnsureStorageConfigured()
+    {
+        return _storage ?? throw new InvalidOperationException("Attachment storage is not configured.");
+    }
+
+    private string BuildAttachmentPath(int layerId, string featureId, string attachmentId, string fileName)
+    {
+        var extension = Path.GetExtension(fileName);
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            extension = ".bin";
+        }
+
+        return Path.Combine(
+            _rootDirectory,
+            "features",
+            SanitizePathSegment(layerId.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+            SanitizePathSegment(string.IsNullOrWhiteSpace(featureId) ? "unassigned" : featureId),
+            $"{attachmentId}{extension}");
+    }
+
+    private async Task<long> CopyToFileWithQuotaAsync(
+        Stream source,
+        string destinationPath,
+        CancellationToken cancellationToken)
+    {
+        var existingBytes = GetDirectorySizeBytes(_rootDirectory);
+        var writtenBytes = 0L;
+        try
+        {
+            await using var output = File.Create(destinationPath);
+            var buffer = new byte[64 * 1024];
+            int read;
+            while ((read = await source.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false)) > 0)
+            {
+                writtenBytes += read;
+                if (_quotaBytes > 0 && existingBytes + writtenBytes > _quotaBytes)
+                {
+                    _logger?.LogWarning(
+                        "Attachment quota exceeded while writing {DestinationPath}; quota {QuotaBytes} bytes",
+                        destinationPath,
+                        _quotaBytes);
+                    throw new InvalidOperationException("Attachment storage quota exceeded.");
+                }
+
+                await output.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch
+        {
+            DeleteFileIfExists(destinationPath);
+            throw;
+        }
+
+        return writtenBytes;
+    }
+
+    private static long GetDirectorySizeBytes(string directory)
+    {
+        if (!Directory.Exists(directory))
+        {
+            return 0;
+        }
+
+        return Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories)
+            .Sum(path => new FileInfo(path).Length);
+    }
+
+    private static string GetDefaultAttachmentRoot()
+    {
+        var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        return Path.Combine(appDataPath, "Honua", "FieldCollection", "attachments");
+    }
+
+    private static string SanitizeFileName(string fileName)
+    {
+        var safe = Path.GetFileName(fileName);
+        if (string.IsNullOrWhiteSpace(safe))
+        {
+            safe = "attachment.bin";
+        }
+
+        foreach (var invalid in Path.GetInvalidFileNameChars())
+        {
+            safe = safe.Replace(invalid, '_');
+        }
+
+        return safe;
+    }
+
+    private static string SanitizePathSegment(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "blank";
+        }
+
+        var safe = value.Trim();
+        foreach (var invalid in Path.GetInvalidFileNameChars().Concat(Path.GetInvalidPathChars()).Distinct())
+        {
+            safe = safe.Replace(invalid, '_');
+        }
+
+        return safe.Replace(Path.DirectorySeparatorChar, '_').Replace(Path.AltDirectorySeparatorChar, '_');
+    }
+
+    private static AttachmentPayloadKind InferPayloadKind(string fileName, string contentType)
+    {
+        if (fileName.Contains("signature", StringComparison.OrdinalIgnoreCase) ||
+            contentType.Equals("image/svg+xml", StringComparison.OrdinalIgnoreCase))
+        {
+            return AttachmentPayloadKind.Signature;
+        }
+
+        return contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
+            ? AttachmentPayloadKind.Photo
+            : AttachmentPayloadKind.File;
+    }
+
+    private static void DeleteFileIfExists(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // Local cleanup is best effort; sync state keeps the operation retryable.
+        }
     }
 }
 

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Diagnostics/OfflineCacheDiagnostics.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Diagnostics/OfflineCacheDiagnostics.cs
@@ -69,6 +69,12 @@ public sealed class OfflineOperationDiagnostics
     public int FailedCount { get; set; }
     public int RetryCount { get; set; }
     public int ConflictCount { get; set; }
+    public int AttachmentPendingCount { get; set; }
+    public int AttachmentSucceededCount { get; set; }
+    public int AttachmentFailedCount { get; set; }
+    public int AttachmentUploadFailedCount { get; set; }
+    public int AttachmentDownloadFailedCount { get; set; }
+    public int AttachmentDeleteFailedCount { get; set; }
 }
 
 public sealed class OfflineConflictReviewItem

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/ISyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/ISyncService.cs
@@ -36,6 +36,9 @@ public class SyncResult
     public string? ErrorMessage { get; set; }
     public int ChangesPulled { get; set; }
     public int ChangesPushed { get; set; }
+    public int AttachmentsPulled { get; set; }
+    public int AttachmentsPushed { get; set; }
+    public int AttachmentsFailed { get; set; }
     public int ConflictsDetected { get; set; }
     public TimeSpan Duration { get; set; }
     public DateTime CompletedAt { get; set; }

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
@@ -131,6 +131,7 @@ public class GeoPackageStorageService : IDisposable
         await _connection.CreateTableAsync<ConflictRecord>();
         await _connection.CreateTableAsync<LayerMetadata>();
         await EnsureLayerMetadataTableAsync();
+        await EnsureLocalAttachmentsTableAsync();
     }
 
     private async Task EnsureLocalFeaturesTableAsync()
@@ -184,6 +185,20 @@ public class GeoPackageStorageService : IDisposable
         {
             await MigrateLayerMetadataTableAsync();
         }
+    }
+
+    private async Task EnsureLocalAttachmentsTableAsync()
+    {
+        await _connection.CreateTableAsync<LocalAttachment>();
+
+        await _connection.ExecuteAsync(
+            "CREATE INDEX IF NOT EXISTS idx_local_attachments_feature_layer ON local_attachments(feature_id, layer_id)");
+        await _connection.ExecuteAsync(
+            "CREATE INDEX IF NOT EXISTS idx_local_attachments_remote ON local_attachments(layer_id, feature_id, remote_attachment_id)");
+        await _connection.ExecuteAsync(
+            "CREATE INDEX IF NOT EXISTS idx_local_attachments_sync_status ON local_attachments(sync_status)");
+        await _connection.ExecuteAsync(
+            "CREATE INDEX IF NOT EXISTS idx_local_attachments_deleted ON local_attachments(is_deleted)");
     }
 
     private async Task MigrateLayerMetadataTableAsync()
@@ -685,6 +700,375 @@ public class GeoPackageStorageService : IDisposable
         {
             _dbLock.Release();
         }
+    }
+
+    #endregion
+
+    #region Attachment Storage
+
+    public async Task StoreAttachmentMetadataAsync(AttachmentInfo attachment)
+    {
+        ArgumentNullException.ThrowIfNull(attachment);
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            var now = DateTime.UtcNow;
+            if (string.IsNullOrWhiteSpace(attachment.Id))
+            {
+                attachment.Id = Guid.NewGuid().ToString("N");
+            }
+
+            if (attachment.CreatedAt == default)
+            {
+                attachment.CreatedAt = now;
+            }
+
+            attachment.UpdatedAt = now;
+            await _connection.InsertOrReplaceAsync(ToLocalAttachment(attachment));
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    public async Task<AttachmentInfo?> GetAttachmentMetadataAsync(string attachmentId)
+    {
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            var attachment = await _connection.Table<LocalAttachment>()
+                .FirstOrDefaultAsync(row => row.Id == attachmentId);
+            return attachment == null ? null : ToAttachmentInfo(attachment);
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    public async Task<AttachmentInfo?> GetAttachmentByRemoteIdAsync(
+        int layerId,
+        string featureId,
+        long remoteAttachmentId)
+    {
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            var attachment = await _connection.Table<LocalAttachment>()
+                .FirstOrDefaultAsync(row =>
+                    row.LayerId == layerId &&
+                    row.FeatureId == featureId &&
+                    row.RemoteAttachmentId == remoteAttachmentId);
+            return attachment == null ? null : ToAttachmentInfo(attachment);
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    public async Task<List<AttachmentInfo>> GetAttachmentsForFeatureAsync(
+        string featureId,
+        int? layerId = null,
+        bool includeDeleted = false)
+    {
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            var query = _connection.Table<LocalAttachment>()
+                .Where(row => row.FeatureId == featureId);
+
+            if (layerId.HasValue)
+            {
+                query = query.Where(row => row.LayerId == layerId.Value);
+            }
+
+            var rows = await query.ToListAsync();
+            return rows
+                .Where(row => includeDeleted || !row.IsDeleted)
+                .OrderBy(row => row.CreatedAt)
+                .Select(ToAttachmentInfo)
+                .ToList();
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    public async Task<List<AttachmentInfo>> GetPendingAttachmentChangesAsync()
+    {
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            var rows = await _connection.Table<LocalAttachment>().ToListAsync();
+            return rows
+                .Where(row => IsPendingAttachmentStatus(row.SyncStatus))
+                .OrderBy(row => row.UpdatedAt ?? row.CreatedAt)
+                .Select(ToAttachmentInfo)
+                .ToList();
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    public async Task MarkAttachmentUploadedAsync(
+        string attachmentId,
+        long remoteAttachmentId,
+        string? remoteGlobalId,
+        DateTime uploadedAt)
+    {
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            await _connection.ExecuteAsync(
+                """
+                UPDATE local_attachments
+                SET remote_attachment_id = ?,
+                    remote_global_id = ?,
+                    uploaded_at = ?,
+                    last_synced_at = ?,
+                    updated_at = ?,
+                    sync_status = ?,
+                    retry_count = 0,
+                    last_error = NULL,
+                    is_deleted = 0,
+                    deleted_at = NULL
+                WHERE id = ?
+                """,
+                remoteAttachmentId,
+                remoteGlobalId,
+                uploadedAt,
+                uploadedAt,
+                DateTime.UtcNow,
+                AttachmentSyncStatus.Synced,
+                attachmentId);
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    public async Task MarkAttachmentSyncedAsync(string attachmentId)
+    {
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            var now = DateTime.UtcNow;
+            await _connection.ExecuteAsync(
+                """
+                UPDATE local_attachments
+                SET last_synced_at = ?,
+                    updated_at = ?,
+                    sync_status = ?,
+                    retry_count = 0,
+                    last_error = NULL
+                WHERE id = ?
+                """,
+                now,
+                now,
+                AttachmentSyncStatus.Synced,
+                attachmentId);
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    public async Task MarkAttachmentPendingDeleteAsync(string attachmentId)
+    {
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            var now = DateTime.UtcNow;
+            await _connection.ExecuteAsync(
+                """
+                UPDATE local_attachments
+                SET sync_status = ?,
+                    is_deleted = 1,
+                    deleted_at = ?,
+                    updated_at = ?,
+                    last_error = NULL
+                WHERE id = ?
+                """,
+                AttachmentSyncStatus.PendingDelete,
+                now,
+                now,
+                attachmentId);
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    public async Task MarkAttachmentDeletedSyncedAsync(string attachmentId)
+    {
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            var now = DateTime.UtcNow;
+            await _connection.ExecuteAsync(
+                """
+                UPDATE local_attachments
+                SET sync_status = ?,
+                    is_deleted = 1,
+                    deleted_at = COALESCE(deleted_at, ?),
+                    last_synced_at = ?,
+                    updated_at = ?,
+                    retry_count = 0,
+                    last_error = NULL
+                WHERE id = ?
+                """,
+                AttachmentSyncStatus.Synced,
+                now,
+                now,
+                now,
+                attachmentId);
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    public async Task MarkAttachmentSyncFailedAsync(
+        string attachmentId,
+        AttachmentSyncStatus failedStatus,
+        string errorMessage)
+    {
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            await _connection.ExecuteAsync(
+                """
+                UPDATE local_attachments
+                SET sync_status = ?,
+                    retry_count = retry_count + 1,
+                    last_error = ?,
+                    updated_at = ?
+                WHERE id = ?
+                """,
+                failedStatus,
+                errorMessage,
+                DateTime.UtcNow,
+                attachmentId);
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    public async Task<int> GetPendingAttachmentChangesCountAsync()
+    {
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            var rows = await _connection.Table<LocalAttachment>().ToListAsync();
+            return rows.Count(row => IsPendingAttachmentStatus(row.SyncStatus));
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    internal async Task<IReadOnlyList<AttachmentStatusCount>> GetAttachmentStatusCountsAsync()
+    {
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            return await _connection.QueryAsync<AttachmentStatusCount>(
+                "SELECT sync_status AS sync_status, COUNT(*) AS item_count FROM local_attachments GROUP BY sync_status");
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    private static bool IsPendingAttachmentStatus(AttachmentSyncStatus status)
+    {
+        return status is AttachmentSyncStatus.PendingUpload
+            or AttachmentSyncStatus.UploadFailed
+            or AttachmentSyncStatus.PendingDownload
+            or AttachmentSyncStatus.DownloadFailed
+            or AttachmentSyncStatus.PendingDelete
+            or AttachmentSyncStatus.DeleteFailed;
+    }
+
+    private static LocalAttachment ToLocalAttachment(AttachmentInfo attachment)
+    {
+        return new LocalAttachment
+        {
+            Id = attachment.Id,
+            FeatureId = attachment.FeatureId,
+            LayerId = attachment.LayerId,
+            RemoteAttachmentId = attachment.RemoteAttachmentId,
+            RemoteGlobalId = attachment.RemoteGlobalId,
+            FileName = attachment.FileName,
+            ContentType = attachment.ContentType,
+            PayloadKind = attachment.PayloadKind,
+            SizeBytes = attachment.SizeBytes,
+            LocalPath = attachment.LocalPath,
+            CreatedAt = attachment.CreatedAt,
+            UpdatedAt = attachment.UpdatedAt,
+            UploadedAt = attachment.UploadedAt,
+            LastSyncedAt = attachment.LastSyncedAt,
+            Description = attachment.Description,
+            ThumbnailUrl = attachment.ThumbnailUrl,
+            SyncStatus = attachment.SyncStatus,
+            RetryCount = attachment.RetryCount,
+            LastError = attachment.LastError,
+            IsDeleted = attachment.IsDeleted,
+            DeletedAt = attachment.DeletedAt
+        };
+    }
+
+    private static AttachmentInfo ToAttachmentInfo(LocalAttachment attachment)
+    {
+        return new AttachmentInfo
+        {
+            Id = attachment.Id,
+            FeatureId = attachment.FeatureId,
+            LayerId = attachment.LayerId,
+            RemoteAttachmentId = attachment.RemoteAttachmentId,
+            RemoteGlobalId = attachment.RemoteGlobalId,
+            FileName = attachment.FileName,
+            ContentType = attachment.ContentType,
+            PayloadKind = attachment.PayloadKind,
+            SizeBytes = attachment.SizeBytes,
+            LocalPath = attachment.LocalPath,
+            CreatedAt = attachment.CreatedAt,
+            UpdatedAt = attachment.UpdatedAt,
+            UploadedAt = attachment.UploadedAt,
+            LastSyncedAt = attachment.LastSyncedAt,
+            Description = attachment.Description,
+            ThumbnailUrl = attachment.ThumbnailUrl,
+            SyncStatus = attachment.SyncStatus,
+            RetryCount = attachment.RetryCount,
+            LastError = attachment.LastError,
+            IsDeleted = attachment.IsDeleted,
+            DeletedAt = attachment.DeletedAt
+        };
     }
 
     #endregion
@@ -1238,6 +1622,8 @@ public class GeoPackageStorageService : IDisposable
                 "SELECT layer_id AS layer_id, COUNT(*) AS feature_count FROM local_features GROUP BY layer_id ORDER BY layer_id");
             var operationCounts = await _connection.QueryAsync<OperationStatusCount>(
                 "SELECT sync_status AS sync_status, COUNT(*) AS item_count FROM change_records GROUP BY sync_status");
+            var attachmentCounts = await _connection.QueryAsync<AttachmentStatusCount>(
+                "SELECT sync_status AS sync_status, COUNT(*) AS item_count FROM local_attachments GROUP BY sync_status");
             var unresolvedConflictCount = await _connection.ExecuteScalarAsync<int>(
                 "SELECT COUNT(*) FROM conflict_records WHERE resolved_at IS NULL");
             var conflicts = await _connection.QueryAsync<ConflictRecord>(
@@ -1276,7 +1662,7 @@ public class GeoPackageStorageService : IDisposable
                 })
                 .ToList();
 
-            var operations = MapOperationCounts(operationCounts, unresolvedConflictCount);
+            var operations = MapOperationCounts(operationCounts, attachmentCounts, unresolvedConflictCount);
             var session = latestSession.FirstOrDefault();
             var lastSyncTimes = metadataRows
                 .Select(row => row.LastSync)
@@ -1321,18 +1707,38 @@ public class GeoPackageStorageService : IDisposable
 
     private static OfflineOperationDiagnostics MapOperationCounts(
         IEnumerable<OperationStatusCount> counts,
+        IEnumerable<AttachmentStatusCount> attachmentCounts,
         int unresolvedConflictCount)
     {
         var byStatus = counts.ToDictionary(row => row.SyncStatus, row => row.ItemCount);
+        var attachmentsByStatus = attachmentCounts.ToDictionary(row => row.SyncStatus, row => row.ItemCount);
+        var attachmentPending =
+            attachmentsByStatus.GetValueOrDefault(AttachmentSyncStatus.PendingUpload) +
+            attachmentsByStatus.GetValueOrDefault(AttachmentSyncStatus.UploadFailed) +
+            attachmentsByStatus.GetValueOrDefault(AttachmentSyncStatus.PendingDownload) +
+            attachmentsByStatus.GetValueOrDefault(AttachmentSyncStatus.DownloadFailed) +
+            attachmentsByStatus.GetValueOrDefault(AttachmentSyncStatus.PendingDelete) +
+            attachmentsByStatus.GetValueOrDefault(AttachmentSyncStatus.DeleteFailed);
+
         return new OfflineOperationDiagnostics
         {
             PendingCount = byStatus.GetValueOrDefault(StorageSyncStatus.PendingUpload) +
-                byStatus.GetValueOrDefault(StorageSyncStatus.PendingDownload),
+                byStatus.GetValueOrDefault(StorageSyncStatus.PendingDownload) +
+                attachmentPending,
             ClaimedCount = 0,
             SucceededCount = byStatus.GetValueOrDefault(StorageSyncStatus.Synced),
             FailedCount = byStatus.GetValueOrDefault(StorageSyncStatus.Error),
             RetryCount = 0,
-            ConflictCount = unresolvedConflictCount + byStatus.GetValueOrDefault(StorageSyncStatus.Conflict)
+            ConflictCount = unresolvedConflictCount + byStatus.GetValueOrDefault(StorageSyncStatus.Conflict),
+            AttachmentPendingCount = attachmentPending,
+            AttachmentSucceededCount = attachmentsByStatus.GetValueOrDefault(AttachmentSyncStatus.Synced),
+            AttachmentFailedCount =
+                attachmentsByStatus.GetValueOrDefault(AttachmentSyncStatus.UploadFailed) +
+                attachmentsByStatus.GetValueOrDefault(AttachmentSyncStatus.DownloadFailed) +
+                attachmentsByStatus.GetValueOrDefault(AttachmentSyncStatus.DeleteFailed),
+            AttachmentUploadFailedCount = attachmentsByStatus.GetValueOrDefault(AttachmentSyncStatus.UploadFailed),
+            AttachmentDownloadFailedCount = attachmentsByStatus.GetValueOrDefault(AttachmentSyncStatus.DownloadFailed),
+            AttachmentDeleteFailedCount = attachmentsByStatus.GetValueOrDefault(AttachmentSyncStatus.DeleteFailed)
         };
     }
 
@@ -1419,6 +1825,15 @@ internal sealed class OperationStatusCount
 {
     [Column("sync_status")]
     public StorageSyncStatus SyncStatus { get; set; }
+
+    [Column("item_count")]
+    public int ItemCount { get; set; }
+}
+
+internal sealed class AttachmentStatusCount
+{
+    [Column("sync_status")]
+    public AttachmentSyncStatus SyncStatus { get; set; }
 
     [Column("item_count")]
     public int ItemCount { get; set; }

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/Models/StorageModels.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/Models/StorageModels.cs
@@ -51,6 +51,82 @@ public class LocalFeature
 }
 
 /// <summary>
+/// Locally stored feature attachment metadata and sync state.
+/// </summary>
+[Table("local_attachments")]
+public class LocalAttachment
+{
+    [PrimaryKey]
+    [Column("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [Column("feature_id")]
+    [Indexed]
+    public string FeatureId { get; set; } = string.Empty;
+
+    [Column("layer_id")]
+    [Indexed]
+    public int LayerId { get; set; }
+
+    [Column("remote_attachment_id")]
+    [Indexed]
+    public long? RemoteAttachmentId { get; set; }
+
+    [Column("remote_global_id")]
+    public string? RemoteGlobalId { get; set; }
+
+    [Column("file_name")]
+    public string FileName { get; set; } = string.Empty;
+
+    [Column("content_type")]
+    public string ContentType { get; set; } = "application/octet-stream";
+
+    [Column("payload_kind")]
+    public AttachmentPayloadKind PayloadKind { get; set; } = AttachmentPayloadKind.File;
+
+    [Column("size_bytes")]
+    public long SizeBytes { get; set; }
+
+    [Column("local_path")]
+    public string? LocalPath { get; set; }
+
+    [Column("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    [Column("updated_at")]
+    public DateTime? UpdatedAt { get; set; }
+
+    [Column("uploaded_at")]
+    public DateTime UploadedAt { get; set; }
+
+    [Column("last_synced_at")]
+    public DateTime? LastSyncedAt { get; set; }
+
+    [Column("description")]
+    public string? Description { get; set; }
+
+    [Column("thumbnail_url")]
+    public string? ThumbnailUrl { get; set; }
+
+    [Column("sync_status")]
+    [Indexed]
+    public AttachmentSyncStatus SyncStatus { get; set; } = AttachmentSyncStatus.Synced;
+
+    [Column("retry_count")]
+    public int RetryCount { get; set; }
+
+    [Column("last_error")]
+    public string? LastError { get; set; }
+
+    [Column("is_deleted")]
+    [Indexed]
+    public bool IsDeleted { get; set; }
+
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
+}
+
+/// <summary>
 /// Change tracking record for delta sync
 /// </summary>
 [Table("change_records")]

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs
@@ -21,7 +21,26 @@ public interface IFieldCollectionFeatureSyncClient
     Task<FeatureQueryResult> QueryAsync(FeatureQueryRequest request, CancellationToken cancellationToken = default);
 }
 
-public sealed class HonuaSdkFieldCollectionFeatureSyncClient : IFieldCollectionFeatureSyncClient
+public interface IFieldCollectionAttachmentSyncClient
+{
+    bool IsConfigured { get; }
+    Task<IReadOnlyList<FeatureAttachmentInfo>> ListAttachmentsAsync(
+        FeatureAttachmentListRequest request,
+        CancellationToken cancellationToken = default);
+    Task<FeatureAttachmentContent> DownloadAttachmentAsync(
+        FeatureAttachmentDownloadRequest request,
+        CancellationToken cancellationToken = default);
+    Task<FeatureAttachmentResult> AddAttachmentAsync(
+        FeatureAttachmentAddRequest request,
+        CancellationToken cancellationToken = default);
+    Task<FeatureAttachmentResult> DeleteAttachmentAsync(
+        FeatureAttachmentDeleteRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class HonuaSdkFieldCollectionFeatureSyncClient :
+    IFieldCollectionFeatureSyncClient,
+    IFieldCollectionAttachmentSyncClient
 {
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IAuthenticationService _authenticationService;
@@ -53,6 +72,38 @@ public sealed class HonuaSdkFieldCollectionFeatureSyncClient : IFieldCollectionF
     {
         using var client = CreateClient();
         return await client.QueryAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<FeatureAttachmentInfo>> ListAttachmentsAsync(
+        FeatureAttachmentListRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        using var client = CreateClient();
+        return await client.ListAttachmentsAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<FeatureAttachmentContent> DownloadAttachmentAsync(
+        FeatureAttachmentDownloadRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        using var client = CreateClient();
+        return await client.DownloadAttachmentAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<FeatureAttachmentResult> AddAttachmentAsync(
+        FeatureAttachmentAddRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        using var client = CreateClient();
+        return await client.AddAttachmentAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<FeatureAttachmentResult> DeleteAttachmentAsync(
+        FeatureAttachmentDeleteRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        using var client = CreateClient();
+        return await client.DeleteAttachmentAsync(request, cancellationToken).ConfigureAwait(false);
     }
 
     private HonuaMobileClient CreateClient()
@@ -810,6 +861,439 @@ public sealed class HonuaFieldCollectionChangePuller :
             target = value;
             return true;
         }
+    }
+
+    private static string? ResolveServiceId(LayerInfo layer)
+    {
+        if (!string.IsNullOrWhiteSpace(layer.ServiceId))
+        {
+            return layer.ServiceId;
+        }
+
+        const string separator = "/FeatureServer/";
+        if (!string.IsNullOrWhiteSpace(layer.SourceId) &&
+            layer.SourceId.IndexOf(separator, StringComparison.OrdinalIgnoreCase) is var index and >= 0)
+        {
+            return layer.SourceId[..index];
+        }
+
+        return null;
+    }
+}
+
+public sealed class HonuaFieldCollectionAttachmentSynchronizer :
+    IFieldCollectionAttachmentSynchronizer,
+    IFieldCollectionRemoteSyncCapability
+{
+    private readonly GeoPackageStorageService _storage;
+    private readonly IAttachmentService _attachmentService;
+    private readonly IFieldCollectionMetadataService _metadataService;
+    private readonly IFieldCollectionAttachmentSyncClient _attachmentClient;
+    private readonly ILogger<HonuaFieldCollectionAttachmentSynchronizer>? _logger;
+
+    public HonuaFieldCollectionAttachmentSynchronizer(
+        GeoPackageStorageService storage,
+        IAttachmentService attachmentService,
+        IFieldCollectionMetadataService metadataService,
+        IFieldCollectionAttachmentSyncClient attachmentClient,
+        ILogger<HonuaFieldCollectionAttachmentSynchronizer>? logger = null)
+    {
+        _storage = storage;
+        _attachmentService = attachmentService;
+        _metadataService = metadataService;
+        _attachmentClient = attachmentClient;
+        _logger = logger;
+    }
+
+    public bool IsRemoteSyncConfigured => _attachmentClient.IsConfigured;
+
+    public async Task<AttachmentSyncResult> PushPendingAttachmentsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!IsRemoteSyncConfigured)
+        {
+            return new AttachmentSyncResult();
+        }
+
+        var result = new AttachmentSyncResult();
+        var layers = await _metadataService.GetLayersAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        var pendingAttachments = await _storage.GetPendingAttachmentChangesAsync().ConfigureAwait(false);
+
+        foreach (var attachment in pendingAttachments)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (attachment.SyncStatus is AttachmentSyncStatus.PendingDownload or AttachmentSyncStatus.DownloadFailed)
+            {
+                continue;
+            }
+
+            var layer = layers.FirstOrDefault(layer => layer.Id == attachment.LayerId);
+            var serviceId = layer == null ? null : ResolveServiceId(layer);
+            if (string.IsNullOrWhiteSpace(serviceId))
+            {
+                await MarkAttachmentFailureAsync(
+                    attachment,
+                    attachment.IsDeleted ? AttachmentSyncStatus.DeleteFailed : AttachmentSyncStatus.UploadFailed,
+                    $"Layer {attachment.LayerId} has no FeatureServer service id.").ConfigureAwait(false);
+                result.Failed++;
+                continue;
+            }
+
+            var objectId = await ResolveObjectIdAsync(attachment).ConfigureAwait(false);
+            if (!objectId.HasValue)
+            {
+                await MarkAttachmentFailureAsync(
+                    attachment,
+                    attachment.IsDeleted ? AttachmentSyncStatus.DeleteFailed : AttachmentSyncStatus.UploadFailed,
+                    $"Feature {attachment.FeatureId} does not have a server object id yet.").ConfigureAwait(false);
+                result.Failed++;
+                continue;
+            }
+
+            try
+            {
+                if (attachment.IsDeleted ||
+                    attachment.SyncStatus is AttachmentSyncStatus.PendingDelete or AttachmentSyncStatus.DeleteFailed)
+                {
+                    if (await PushAttachmentDeleteAsync(attachment, serviceId, objectId.Value, cancellationToken)
+                            .ConfigureAwait(false))
+                    {
+                        result.Deleted++;
+                    }
+                    else
+                    {
+                        result.Failed++;
+                    }
+                }
+                else if (await PushAttachmentUploadAsync(attachment, serviceId, objectId.Value, cancellationToken)
+                             .ConfigureAwait(false))
+                {
+                    result.Uploaded++;
+                }
+                else
+                {
+                    result.Failed++;
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                await MarkAttachmentFailureAsync(
+                    attachment,
+                    attachment.IsDeleted ? AttachmentSyncStatus.DeleteFailed : AttachmentSyncStatus.UploadFailed,
+                    ex.Message).ConfigureAwait(false);
+                _logger?.LogWarning(
+                    ex,
+                    "Attachment sync failed for local attachment {AttachmentId}",
+                    attachment.Id);
+                result.Failed++;
+            }
+        }
+
+        return result;
+    }
+
+    public async Task<AttachmentSyncResult> PullRemoteAttachmentsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!IsRemoteSyncConfigured)
+        {
+            return new AttachmentSyncResult();
+        }
+
+        var result = new AttachmentSyncResult();
+        var layers = await _metadataService.GetLayersAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        foreach (var layer in layers.Where(layer => layer.IsEditable))
+        {
+            var serviceId = ResolveServiceId(layer);
+            if (string.IsNullOrWhiteSpace(serviceId))
+            {
+                continue;
+            }
+
+            var features = await _storage.QueryFeaturesAsync(layer.Id).ConfigureAwait(false);
+            foreach (var feature in features)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!TryReadObjectId(feature, out var objectId))
+                {
+                    continue;
+                }
+
+                IReadOnlyList<FeatureAttachmentInfo> remoteAttachments;
+                try
+                {
+                    remoteAttachments = await _attachmentClient.ListAttachmentsAsync(
+                        new FeatureAttachmentListRequest
+                        {
+                            Source = new FeatureSource { ServiceId = serviceId, LayerId = layer.Id },
+                            ObjectId = objectId
+                        },
+                        cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger?.LogWarning(
+                        ex,
+                        "Failed to list attachments for feature {FeatureId} in layer {LayerId}",
+                        feature.Id,
+                        layer.Id);
+                    result.Failed++;
+                    continue;
+                }
+
+                foreach (var remoteAttachment in remoteAttachments)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var remoteAttachmentId = remoteAttachment.AttachmentId.GetValueOrDefault();
+                    if (remoteAttachmentId <= 0)
+                    {
+                        continue;
+                    }
+
+                    var existing = await _storage.GetAttachmentByRemoteIdAsync(layer.Id, feature.Id, remoteAttachmentId)
+                        .ConfigureAwait(false);
+
+                    if (existing is { IsDeleted: true } &&
+                        existing.SyncStatus is AttachmentSyncStatus.PendingDelete or AttachmentSyncStatus.DeleteFailed)
+                    {
+                        continue;
+                    }
+
+                    if (existing is { IsDeleted: false } &&
+                        await _attachmentService.AttachmentContentExistsAsync(existing.Id).ConfigureAwait(false))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        var content = await _attachmentClient.DownloadAttachmentAsync(
+                            new FeatureAttachmentDownloadRequest
+                            {
+                                Source = new FeatureSource { ServiceId = serviceId, LayerId = layer.Id },
+                                ObjectId = objectId,
+                                AttachmentId = remoteAttachmentId
+                            },
+                            cancellationToken).ConfigureAwait(false);
+                        using var contentStream = content.Content;
+
+                        var info = content.Info.AttachmentId > 0
+                            ? content.Info
+                            : remoteAttachment;
+                        await _attachmentService.SaveDownloadedAttachmentAsync(
+                            layer.Id,
+                            feature.Id,
+                            info,
+                            contentStream,
+                            cancellationToken).ConfigureAwait(false);
+                        result.Downloaded++;
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        await StoreDownloadFailureAsync(layer.Id, feature.Id, remoteAttachment, ex.Message)
+                            .ConfigureAwait(false);
+                        _logger?.LogWarning(
+                            ex,
+                            "Attachment download failed for remote attachment {AttachmentId} on feature {FeatureId}",
+                            remoteAttachment.AttachmentId,
+                            feature.Id);
+                        result.Failed++;
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private async Task<bool> PushAttachmentUploadAsync(
+        AttachmentInfo attachment,
+        string serviceId,
+        long objectId,
+        CancellationToken cancellationToken)
+    {
+        if (!await _attachmentService.AttachmentContentExistsAsync(attachment.Id).ConfigureAwait(false))
+        {
+            await MarkAttachmentFailureAsync(
+                attachment,
+                AttachmentSyncStatus.UploadFailed,
+                "Attachment content file is missing.").ConfigureAwait(false);
+            return false;
+        }
+
+        using var content = await _attachmentService.GetAttachmentAsync(attachment.Id).ConfigureAwait(false);
+        var response = await _attachmentClient.AddAttachmentAsync(
+            new FeatureAttachmentAddRequest
+            {
+                Source = new FeatureSource { ServiceId = serviceId, LayerId = attachment.LayerId },
+                ObjectId = objectId,
+                Name = attachment.FileName,
+                ContentType = string.IsNullOrWhiteSpace(attachment.ContentType)
+                    ? "application/octet-stream"
+                    : attachment.ContentType,
+                Content = content,
+                Keywords = attachment.Description
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (response.Succeeded)
+        {
+            var remoteAttachmentId = response.AttachmentId.GetValueOrDefault();
+            if (remoteAttachmentId <= 0)
+            {
+                await MarkAttachmentFailureAsync(
+                    attachment,
+                    AttachmentSyncStatus.UploadFailed,
+                    "Attachment upload response did not include a remote attachment id.").ConfigureAwait(false);
+                return false;
+            }
+
+            await _storage.MarkAttachmentUploadedAsync(
+                attachment.Id,
+                remoteAttachmentId,
+                response.GlobalId,
+                DateTime.UtcNow).ConfigureAwait(false);
+            return true;
+        }
+
+        await MarkAttachmentFailureAsync(
+            attachment,
+            AttachmentSyncStatus.UploadFailed,
+            GetFailureMessage(response, "Attachment upload failed.")).ConfigureAwait(false);
+        return false;
+    }
+
+    private async Task<bool> PushAttachmentDeleteAsync(
+        AttachmentInfo attachment,
+        string serviceId,
+        long objectId,
+        CancellationToken cancellationToken)
+    {
+        if (!attachment.RemoteAttachmentId.HasValue || attachment.RemoteAttachmentId.Value <= 0)
+        {
+            await _storage.MarkAttachmentDeletedSyncedAsync(attachment.Id).ConfigureAwait(false);
+            return true;
+        }
+
+        var response = await _attachmentClient.DeleteAttachmentAsync(
+            new FeatureAttachmentDeleteRequest
+            {
+                Source = new FeatureSource { ServiceId = serviceId, LayerId = attachment.LayerId },
+                ObjectId = objectId,
+                AttachmentId = attachment.RemoteAttachmentId.Value
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (response.Succeeded)
+        {
+            await _storage.MarkAttachmentDeletedSyncedAsync(attachment.Id).ConfigureAwait(false);
+            return true;
+        }
+
+        await MarkAttachmentFailureAsync(
+            attachment,
+            AttachmentSyncStatus.DeleteFailed,
+            GetFailureMessage(response, "Attachment delete failed.")).ConfigureAwait(false);
+        return false;
+    }
+
+    private async Task StoreDownloadFailureAsync(
+        int layerId,
+        string featureId,
+        FeatureAttachmentInfo remoteAttachment,
+        string errorMessage)
+    {
+        var remoteAttachmentId = remoteAttachment.AttachmentId.GetValueOrDefault();
+        var existing = remoteAttachmentId > 0
+            ? await _storage.GetAttachmentByRemoteIdAsync(layerId, featureId, remoteAttachmentId)
+                .ConfigureAwait(false)
+            : null;
+        if (existing == null)
+        {
+            var now = DateTime.UtcNow;
+            existing = new AttachmentInfo
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                LayerId = layerId,
+                FeatureId = featureId,
+                RemoteAttachmentId = remoteAttachmentId <= 0 ? null : remoteAttachmentId,
+                RemoteGlobalId = remoteAttachment.GlobalId,
+                FileName = string.IsNullOrWhiteSpace(remoteAttachment.Name)
+                    ? "attachment.bin"
+                    : remoteAttachment.Name,
+                ContentType = string.IsNullOrWhiteSpace(remoteAttachment.ContentType)
+                    ? "application/octet-stream"
+                    : remoteAttachment.ContentType,
+                PayloadKind = !string.IsNullOrWhiteSpace(remoteAttachment.ContentType) &&
+                    remoteAttachment.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
+                    ? AttachmentPayloadKind.Photo
+                    : AttachmentPayloadKind.File,
+                SizeBytes = remoteAttachment.Size.GetValueOrDefault(),
+                CreatedAt = now,
+                UpdatedAt = now,
+                UploadedAt = now,
+                SyncStatus = AttachmentSyncStatus.PendingDownload
+            };
+            await _storage.StoreAttachmentMetadataAsync(existing).ConfigureAwait(false);
+        }
+
+        await _storage.MarkAttachmentSyncFailedAsync(
+            existing.Id,
+            AttachmentSyncStatus.DownloadFailed,
+            errorMessage).ConfigureAwait(false);
+    }
+
+    private Task MarkAttachmentFailureAsync(
+        AttachmentInfo attachment,
+        AttachmentSyncStatus failedStatus,
+        string errorMessage)
+    {
+        return _storage.MarkAttachmentSyncFailedAsync(attachment.Id, failedStatus, errorMessage);
+    }
+
+    private async Task<long?> ResolveObjectIdAsync(AttachmentInfo attachment)
+    {
+        var feature = await _storage.GetFeatureAsync(attachment.FeatureId, attachment.LayerId).ConfigureAwait(false);
+        if (feature != null && TryReadObjectId(feature, out var objectId))
+        {
+            return objectId;
+        }
+
+        return long.TryParse(attachment.FeatureId, NumberStyles.Integer, CultureInfo.InvariantCulture, out objectId)
+            ? objectId
+            : null;
+    }
+
+    private static bool TryReadObjectId(Feature feature, out long objectId)
+    {
+        objectId = 0;
+        foreach (var attribute in feature.Attributes)
+        {
+            if (!attribute.Key.Equals("objectid", StringComparison.OrdinalIgnoreCase) &&
+                !attribute.Key.Equals("objectId", StringComparison.OrdinalIgnoreCase) &&
+                !attribute.Key.Equals("OBJECTID", StringComparison.OrdinalIgnoreCase) &&
+                !attribute.Key.Equals("FID", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (HonuaFieldCollectionChangeUploader.TryConvertInt64(attribute.Value, out objectId))
+            {
+                return true;
+            }
+        }
+
+        return long.TryParse(feature.Id, NumberStyles.Integer, CultureInfo.InvariantCulture, out objectId);
+    }
+
+    private static string GetFailureMessage(FeatureAttachmentResult response, string fallback)
+    {
+        return string.IsNullOrWhiteSpace(response.Error?.Message)
+            ? fallback
+            : response.Error.Message;
     }
 
     private static string? ResolveServiceId(LayerInfo layer)

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/GeoPackageSyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/GeoPackageSyncService.cs
@@ -37,6 +37,24 @@ public interface IFieldCollectionChangePuller
 }
 
 /// <summary>
+/// Uploads and downloads feature attachments through the configured remote sync transport.
+/// </summary>
+public interface IFieldCollectionAttachmentSynchronizer
+{
+    Task<AttachmentSyncResult> PushPendingAttachmentsAsync(CancellationToken cancellationToken = default);
+    Task<AttachmentSyncResult> PullRemoteAttachmentsAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed class AttachmentSyncResult
+{
+    public int Uploaded { get; set; }
+    public int Downloaded { get; set; }
+    public int Deleted { get; set; }
+    public int Failed { get; set; }
+    public bool Succeeded => Failed == 0;
+}
+
+/// <summary>
 /// Marks sync transports that intentionally do not connect to a remote field sync endpoint.
 /// </summary>
 public interface IFieldCollectionRemoteSyncCapability
@@ -57,6 +75,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
     private readonly IConnectivityService _connectivityService;
     private readonly IFieldCollectionChangeUploader _changeUploader;
     private readonly IFieldCollectionChangePuller _changePuller;
+    private readonly IFieldCollectionAttachmentSynchronizer _attachmentSynchronizer;
     private readonly IMobileExceptionReporter _exceptionReporter;
     private readonly ILogger<GeoPackageSyncService>? _logger;
     private readonly SemaphoreSlim _syncLock = new(1, 1);
@@ -93,6 +112,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         IConnectivityService connectivityService,
         IFieldCollectionChangeUploader? changeUploader = null,
         IFieldCollectionChangePuller? changePuller = null,
+        IFieldCollectionAttachmentSynchronizer? attachmentSynchronizer = null,
         ILogger<GeoPackageSyncService>? logger = null,
         IMobileExceptionReporter? exceptionReporter = null)
     {
@@ -101,6 +121,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         _connectivityService = connectivityService;
         _changeUploader = changeUploader ?? new UnconfiguredFieldCollectionChangeUploader();
         _changePuller = changePuller ?? new UnconfiguredFieldCollectionChangePuller();
+        _attachmentSynchronizer = attachmentSynchronizer ?? new NoOpFieldCollectionAttachmentSynchronizer();
         _exceptionReporter = exceptionReporter ?? new NoOpMobileExceptionReporter();
         _logger = logger;
         // Update pending changes count periodically
@@ -114,7 +135,8 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
             try
             {
                 var changes = await _storage.GetPendingChangesAsync();
-                PendingChangesCount = changes.Count;
+                var pendingAttachments = await _storage.GetPendingAttachmentChangesCountAsync();
+                PendingChangesCount = changes.Count + pendingAttachments;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -163,6 +185,8 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
             SyncMessage = "Starting sync session...";
 
             StorageSyncSession? session = null;
+            AttachmentSyncResult pulledAttachments = new();
+            AttachmentSyncResult pushedAttachments = new();
             try
             {
                 session = await CreateSyncSessionAsync(sessionId, includeRemoteGeneration: true);
@@ -171,6 +195,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
                 Status = SyncStatus.PullingChanges;
                 SyncMessage = "Downloading changes from server...";
                 await PullChangesInternalAsync(session, _syncCancellation.Token);
+                pulledAttachments = await PullAttachmentsInternalAsync(_syncCancellation.Token);
 
                 SyncProgress = 0.5;
 
@@ -178,6 +203,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
                 Status = SyncStatus.PushingChanges;
                 SyncMessage = "Uploading changes to server...";
                 await PushChangesInternalAsync(session, _syncCancellation.Token);
+                pushedAttachments = await PushAttachmentsInternalAsync(_syncCancellation.Token);
 
                 SyncProgress = 0.8;
 
@@ -202,6 +228,9 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
                     Duration = duration,
                     ChangesPulled = session.ChangesPulled,
                     ChangesPushed = session.ChangesPushed,
+                    AttachmentsPulled = pulledAttachments.Downloaded,
+                    AttachmentsPushed = pushedAttachments.Uploaded + pushedAttachments.Deleted,
+                    AttachmentsFailed = pulledAttachments.Failed + pushedAttachments.Failed,
                     ConflictsDetected = session.ConflictsDetected
                 };
             }
@@ -278,6 +307,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
             Status = SyncStatus.PullingChanges;
 
             await PullChangesInternalAsync(session, _syncCancellation.Token);
+            var pulledAttachments = await PullAttachmentsInternalAsync(_syncCancellation.Token);
             await CompleteSyncSessionAsync(session, StorageSyncSessionStatus.Completed);
 
             LastSyncTime = DateTime.UtcNow;
@@ -286,7 +316,9 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
             {
                 IsSuccess = true,
                 CompletedAt = DateTime.UtcNow,
-                ChangesPulled = session.ChangesPulled
+                ChangesPulled = session.ChangesPulled,
+                AttachmentsPulled = pulledAttachments.Downloaded,
+                AttachmentsFailed = pulledAttachments.Failed
             };
         }
         catch (OperationCanceledException)
@@ -350,6 +382,13 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         }
     }
 
+    private async Task<AttachmentSyncResult> PullAttachmentsInternalAsync(CancellationToken cancellationToken)
+    {
+        var result = await _attachmentSynchronizer.PullRemoteAttachmentsAsync(cancellationToken).ConfigureAwait(false);
+        ThrowIfAttachmentFailures(result, "download");
+        return result;
+    }
+
     #endregion
 
     #region Push Changes
@@ -368,7 +407,11 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         try
         {
             var pendingChanges = await _storage.GetPendingChangesAsync();
-            if (pendingChanges.Count == 0)
+            var pendingAttachmentUploads = (await _storage.GetPendingAttachmentChangesAsync())
+                .Where(attachment =>
+                    attachment.SyncStatus is not AttachmentSyncStatus.PendingDownload and not AttachmentSyncStatus.DownloadFailed)
+                .ToList();
+            if (pendingChanges.Count == 0 && pendingAttachmentUploads.Count == 0)
             {
                 return new SyncResult
                 {
@@ -386,13 +429,16 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
             Status = SyncStatus.PushingChanges;
 
             await PushChangesInternalAsync(session, _syncCancellation.Token);
+            var pushedAttachments = await PushAttachmentsInternalAsync(_syncCancellation.Token);
             await CompleteSyncSessionAsync(session, StorageSyncSessionStatus.Completed);
 
             return new SyncResult
             {
                 IsSuccess = true,
                 CompletedAt = DateTime.UtcNow,
-                ChangesPushed = session.ChangesPushed
+                ChangesPushed = session.ChangesPushed,
+                AttachmentsPushed = pushedAttachments.Uploaded + pushedAttachments.Deleted,
+                AttachmentsFailed = pushedAttachments.Failed
             };
         }
         catch (OperationCanceledException)
@@ -471,6 +517,22 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         catch (Exception)
         {
             throw;
+        }
+    }
+
+    private async Task<AttachmentSyncResult> PushAttachmentsInternalAsync(CancellationToken cancellationToken)
+    {
+        var result = await _attachmentSynchronizer.PushPendingAttachmentsAsync(cancellationToken).ConfigureAwait(false);
+        ThrowIfAttachmentFailures(result, "upload");
+        return result;
+    }
+
+    private static void ThrowIfAttachmentFailures(AttachmentSyncResult result, string operation)
+    {
+        if (result.Failed > 0)
+        {
+            throw new InvalidOperationException(
+                $"{result.Failed} attachment(s) failed to {operation} and remain queued for retry.");
         }
     }
 
@@ -1022,6 +1084,21 @@ internal sealed class UnconfiguredFieldCollectionChangePuller :
     {
         throw new InvalidOperationException(
             "Field collection local sync generation lookup is not configured.");
+    }
+}
+
+internal sealed class NoOpFieldCollectionAttachmentSynchronizer : IFieldCollectionAttachmentSynchronizer
+{
+    public Task<AttachmentSyncResult> PushPendingAttachmentsAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(new AttachmentSyncResult());
+    }
+
+    public Task<AttachmentSyncResult> PullRemoteAttachmentsAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(new AttachmentSyncResult());
     }
 }
 

--- a/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
+++ b/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
@@ -58,7 +58,11 @@ public static class MauiProgram
 
         // Register sync service factory
         services.AddHttpClient("HonuaFieldSync");
-        services.AddSingleton<IFieldCollectionFeatureSyncClient, HonuaSdkFieldCollectionFeatureSyncClient>();
+        services.AddSingleton<HonuaSdkFieldCollectionFeatureSyncClient>();
+        services.AddSingleton<IFieldCollectionFeatureSyncClient>(provider =>
+            provider.GetRequiredService<HonuaSdkFieldCollectionFeatureSyncClient>());
+        services.AddSingleton<IFieldCollectionAttachmentSyncClient>(provider =>
+            provider.GetRequiredService<HonuaSdkFieldCollectionFeatureSyncClient>());
         services.AddSingleton<IFieldCollectionChangeUploader>(provider =>
         {
             var databaseService = provider.GetRequiredService<DatabaseService>();
@@ -69,6 +73,16 @@ public static class MauiProgram
                 provider.GetService<ILogger<HonuaFieldCollectionChangeUploader>>());
         });
         services.AddSingleton<IFieldCollectionChangePuller, HonuaFieldCollectionChangePuller>();
+        services.AddSingleton<IFieldCollectionAttachmentSynchronizer>(provider =>
+        {
+            var databaseService = provider.GetRequiredService<DatabaseService>();
+            return new HonuaFieldCollectionAttachmentSynchronizer(
+                databaseService.GetStorageService(),
+                provider.GetRequiredService<IAttachmentService>(),
+                provider.GetRequiredService<IFieldCollectionMetadataService>(),
+                provider.GetRequiredService<IFieldCollectionAttachmentSyncClient>(),
+                provider.GetService<ILogger<HonuaFieldCollectionAttachmentSynchronizer>>());
+        });
         services.AddSingleton<ISyncService>(provider =>
         {
             var databaseService = provider.GetRequiredService<DatabaseService>();
@@ -76,6 +90,7 @@ public static class MauiProgram
             var connectivityService = provider.GetRequiredService<IConnectivityService>();
             var changeUploader = provider.GetRequiredService<IFieldCollectionChangeUploader>();
             var changePuller = provider.GetRequiredService<IFieldCollectionChangePuller>();
+            var attachmentSynchronizer = provider.GetRequiredService<IFieldCollectionAttachmentSynchronizer>();
             var logger = provider.GetRequiredService<ILogger<GeoPackageSyncService>>();
             var exceptionReporter = provider.GetRequiredService<IMobileExceptionReporter>();
             return databaseService.GetSyncService(
@@ -83,6 +98,7 @@ public static class MauiProgram
                 connectivityService,
                 changeUploader,
                 changePuller,
+                attachmentSynchronizer,
                 logger: logger,
                 exceptionReporter: exceptionReporter);
         });
@@ -126,7 +142,13 @@ public static class MauiProgram
         // Other feature services
         services.AddSingleton<IFormService>(provider =>
             new FormService(provider.GetRequiredService<IFieldCollectionMetadataService>()));
-        services.AddSingleton<IAttachmentService, AttachmentService>();
+        services.AddSingleton<IAttachmentService>(provider =>
+        {
+            var databaseService = provider.GetRequiredService<DatabaseService>();
+            return new AttachmentService(
+                databaseService.GetStorageService(),
+                logger: provider.GetService<ILogger<AttachmentService>>());
+        });
 
         // Configuration services
         var buildConfiguration = MobileBuildConfiguration.FromAssembly(

--- a/apps/Honua.Mobile.FieldCollection/Services/Features/GeoPackageFeatureService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Features/GeoPackageFeatureService.cs
@@ -46,16 +46,20 @@ public class GeoPackageFeatureService : IFeatureService
         {
             if (spatialFilter != null)
             {
-                return await _storage.QueryFeaturesAsync(
+                var filtered = await _storage.QueryFeaturesAsync(
                     layerId,
                     new StorageSpatialQuery
                 {
                     Bounds = ConvertToBoundingBox(spatialFilter),
                     Relationship = StorageSpatialRelationship.Intersects
                 });
+                await PopulateAttachmentsAsync(filtered);
+                return filtered;
             }
 
-            return await _storage.QueryFeaturesAsync(layerId);
+            var features = await _storage.QueryFeaturesAsync(layerId);
+            await PopulateAttachmentsAsync(features);
+            return features;
         }
         catch (Exception ex)
         {
@@ -68,7 +72,13 @@ public class GeoPackageFeatureService : IFeatureService
     {
         try
         {
-            return await _storage.GetFeatureAsync(featureId, layerId);
+            var feature = await _storage.GetFeatureAsync(featureId, layerId);
+            if (feature != null)
+            {
+                await PopulateAttachmentsAsync([feature]);
+            }
+
+            return feature;
         }
         catch (Exception ex)
         {
@@ -128,6 +138,7 @@ public class GeoPackageFeatureService : IFeatureService
                 features = features.Take(query.Limit.Value).ToList();
             }
 
+            await PopulateAttachmentsAsync(features);
             return features;
         }
         catch (Exception ex) when (ex is not NotSupportedException and not ArgumentException)
@@ -138,6 +149,14 @@ public class GeoPackageFeatureService : IFeatureService
     }
 
     #endregion
+
+    private async Task PopulateAttachmentsAsync(IEnumerable<Feature> features)
+    {
+        foreach (var feature in features)
+        {
+            feature.Attachments = await _storage.GetAttachmentsForFeatureAsync(feature.Id, feature.LayerId);
+        }
+    }
 
     #region Feature Modification
 

--- a/apps/Honua.Mobile.FieldCollection/Services/Storage/DatabaseService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Storage/DatabaseService.cs
@@ -58,6 +58,7 @@ public class DatabaseService : IDisposable
         IConnectivityService connectivityService,
         IFieldCollectionChangeUploader? changeUploader = null,
         IFieldCollectionChangePuller? changePuller = null,
+        IFieldCollectionAttachmentSynchronizer? attachmentSynchronizer = null,
         ILogger<GeoPackageSyncService>? logger = null,
         IMobileExceptionReporter? exceptionReporter = null)
     {
@@ -69,6 +70,7 @@ public class DatabaseService : IDisposable
                 connectivityService,
                 changeUploader,
                 changePuller,
+                attachmentSynchronizer,
                 logger,
                 exceptionReporter);
             if (_storageService != null && !await _storageService.InitializeAsync())
@@ -90,6 +92,7 @@ public class DatabaseService : IDisposable
         IConnectivityService connectivityService,
         IFieldCollectionChangeUploader? changeUploader = null,
         IFieldCollectionChangePuller? changePuller = null,
+        IFieldCollectionAttachmentSynchronizer? attachmentSynchronizer = null,
         ILogger<GeoPackageSyncService>? logger = null,
         IMobileExceptionReporter? exceptionReporter = null)
     {
@@ -104,6 +107,7 @@ public class DatabaseService : IDisposable
                     connectivityService,
                     changeUploader,
                     changePuller,
+                    attachmentSynchronizer,
                     logger,
                     exceptionReporter);
             }
@@ -208,6 +212,12 @@ public class DatabaseService : IDisposable
             if (File.Exists(_databasePath))
             {
                 File.Delete(_databasePath);
+            }
+
+            var attachmentDirectory = Path.Combine(Path.GetDirectoryName(_databasePath)!, "attachments");
+            if (Directory.Exists(attachmentDirectory))
+            {
+                Directory.Delete(attachmentDirectory, recursive: true);
             }
 
             _initialized = false;

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/SyncCenterViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/SyncCenterViewModel.cs
@@ -198,6 +198,8 @@ public partial class SyncCenterViewModel : BaseViewModel
                     LastSyncTime = result.CompletedAt,
                     FeaturesPulled = result.ChangesPulled,
                     FeaturesPushed = result.ChangesPushed,
+                    AttachmentsDownloaded = result.AttachmentsPulled,
+                    AttachmentsUploaded = result.AttachmentsPushed,
                     ConflictsDetected = result.ConflictsDetected,
                     LastSyncDuration = result.Duration
                 };
@@ -219,6 +221,8 @@ public partial class SyncCenterViewModel : BaseViewModel
                     $"Sync completed successfully!\n" +
                     $"Downloaded: {result.ChangesPulled} changes\n" +
                     $"Uploaded: {result.ChangesPushed} changes\n" +
+                    $"Attachments downloaded: {result.AttachmentsPulled}\n" +
+                    $"Attachments uploaded/deleted: {result.AttachmentsPushed}\n" +
                     $"Duration: {result.Duration:mm\\:ss}");
 
                 // Refresh conflicts if any were detected
@@ -267,7 +271,9 @@ public partial class SyncCenterViewModel : BaseViewModel
             var result = await _syncService.PullChangesAsync();
             if (result.IsSuccess)
             {
-                await ShowMessage("Pull Complete", $"Downloaded {result.ChangesPulled} changes from server.");
+                await ShowMessage(
+                    "Pull Complete",
+                    $"Downloaded {result.ChangesPulled} changes and {result.AttachmentsPulled} attachments from server.");
             }
             else
             {
@@ -302,7 +308,9 @@ public partial class SyncCenterViewModel : BaseViewModel
             var result = await _syncService.PushChangesAsync();
             if (result.IsSuccess)
             {
-                await ShowMessage("Push Complete", $"Uploaded {result.ChangesPushed} changes to server.");
+                await ShowMessage(
+                    "Push Complete",
+                    $"Uploaded {result.ChangesPushed} changes and {result.AttachmentsPushed} attachments to server.");
             }
             else
             {

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/WorkflowViewModels.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/WorkflowViewModels.cs
@@ -35,6 +35,7 @@ public sealed partial class EditableAttributeItem : ObservableObject
 public partial class RecordDetailViewModel : BaseViewModel, IRouteAwareViewModel
 {
     private readonly IFeatureService _featureService;
+    private readonly IAttachmentService _attachmentService;
 
     [ObservableProperty]
     private string featureId = string.Empty;
@@ -49,11 +50,16 @@ public partial class RecordDetailViewModel : BaseViewModel, IRouteAwareViewModel
     private string geometrySummary = "No geometry";
 
     public ObservableCollection<AttributeDisplayItem> Attributes { get; } = [];
+    public ObservableCollection<AttachmentInfo> Attachments { get; } = [];
 
-    public RecordDetailViewModel(INavigationService navigationService, IFeatureService featureService)
+    public RecordDetailViewModel(
+        INavigationService navigationService,
+        IFeatureService featureService,
+        IAttachmentService attachmentService)
         : base(navigationService)
     {
         _featureService = featureService;
+        _attachmentService = attachmentService;
         Title = "Record Detail";
     }
 
@@ -77,6 +83,7 @@ public partial class RecordDetailViewModel : BaseViewModel, IRouteAwareViewModel
         {
             Feature = await _featureService.GetFeatureAsync(LayerId, FeatureId);
             Attributes.Clear();
+            Attachments.Clear();
 
             if (Feature == null)
             {
@@ -94,6 +101,11 @@ public partial class RecordDetailViewModel : BaseViewModel, IRouteAwareViewModel
             }
 
             GeometrySummary = FormatGeometry(Feature.Geometry);
+
+            foreach (var attachment in await _attachmentService.GetAttachmentsAsync(Feature.Id))
+            {
+                Attachments.Add(attachment);
+            }
         });
     }
 
@@ -141,6 +153,22 @@ public partial class RecordDetailViewModel : BaseViewModel, IRouteAwareViewModel
         });
     }
 
+    [RelayCommand]
+    private async Task OpenAttachment(AttachmentInfo attachment)
+    {
+        if (string.IsNullOrWhiteSpace(attachment.LocalPath) || !File.Exists(attachment.LocalPath))
+        {
+            using var _ = await _attachmentService.GetAttachmentAsync(attachment.Id);
+            await ShowMessage("Attachment", attachment.FileName);
+            return;
+        }
+
+        await Microsoft.Maui.ApplicationModel.Launcher.Default.OpenAsync(
+            new Microsoft.Maui.ApplicationModel.OpenFileRequest(
+                attachment.FileName,
+                new Microsoft.Maui.Storage.ReadOnlyFile(attachment.LocalPath, attachment.ContentType)));
+    }
+
     private static string FormatGeometry(Geometry? geometry)
     {
         return geometry switch
@@ -168,8 +196,11 @@ public partial class RecordDetailViewModel : BaseViewModel, IRouteAwareViewModel
 
 public sealed partial class FeatureDetailViewModel : RecordDetailViewModel
 {
-    public FeatureDetailViewModel(INavigationService navigationService, IFeatureService featureService)
-        : base(navigationService, featureService)
+    public FeatureDetailViewModel(
+        INavigationService navigationService,
+        IFeatureService featureService,
+        IAttachmentService attachmentService)
+        : base(navigationService, featureService, attachmentService)
     {
         Title = "Feature Detail";
     }
@@ -178,6 +209,7 @@ public sealed partial class FeatureDetailViewModel : RecordDetailViewModel
 public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareViewModel
 {
     private readonly IFeatureService _featureService;
+    private readonly IAttachmentService _attachmentService;
 
     [ObservableProperty]
     private int layerId = 1;
@@ -198,11 +230,16 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
     private Feature? _existingFeature;
 
     public ObservableCollection<EditableAttributeItem> Attributes { get; } = [];
+    public ObservableCollection<AttachmentInfo> Attachments { get; } = [];
 
-    public RecordEditViewModel(INavigationService navigationService, IFeatureService featureService)
+    public RecordEditViewModel(
+        INavigationService navigationService,
+        IFeatureService featureService,
+        IAttachmentService attachmentService)
         : base(navigationService)
     {
         _featureService = featureService;
+        _attachmentService = attachmentService;
         Title = "Create Record";
     }
 
@@ -227,8 +264,14 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
         await ExecuteAsync(async () =>
         {
             Attributes.Clear();
+            Attachments.Clear();
             PageTitle = IsNew ? "Create Record" : "Edit Record";
             Title = PageTitle;
+
+            if (IsNew && string.IsNullOrWhiteSpace(FeatureId))
+            {
+                FeatureId = Guid.NewGuid().ToString("N");
+            }
 
             if (!IsNew && !string.IsNullOrWhiteSpace(FeatureId))
             {
@@ -246,6 +289,14 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
             }
 
             GeometrySummary = FormatGeometry(_existingFeature?.Geometry ?? _location);
+
+            if (!string.IsNullOrWhiteSpace(FeatureId))
+            {
+                foreach (var attachment in await _attachmentService.GetAttachmentsAsync(FeatureId))
+                {
+                    Attachments.Add(attachment);
+                }
+            }
         });
     }
 
@@ -264,6 +315,74 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
     private void RemoveAttribute(EditableAttributeItem item)
     {
         Attributes.Remove(item);
+    }
+
+    [RelayCommand]
+    private async Task AddFileAttachment()
+    {
+        var picked = await Microsoft.Maui.Storage.FilePicker.Default.PickAsync();
+        if (picked == null)
+        {
+            return;
+        }
+
+        await AddAttachmentFromFileResultAsync(picked, AttachmentPayloadKind.File);
+    }
+
+    [RelayCommand]
+    private async Task AddPhotoAttachment()
+    {
+        Microsoft.Maui.Storage.FileResult? photo = null;
+        if (Microsoft.Maui.Media.MediaPicker.Default.IsCaptureSupported)
+        {
+            photo = await Microsoft.Maui.Media.MediaPicker.Default.CapturePhotoAsync();
+        }
+
+        photo ??= await Microsoft.Maui.Storage.FilePicker.Default.PickAsync(new Microsoft.Maui.Storage.PickOptions
+        {
+            FileTypes = Microsoft.Maui.Storage.FilePickerFileType.Images
+        });
+        if (photo == null)
+        {
+            return;
+        }
+
+        await AddAttachmentFromFileResultAsync(photo, AttachmentPayloadKind.Photo);
+    }
+
+    [RelayCommand]
+    private async Task RemoveAttachment(AttachmentInfo attachment)
+    {
+        await ExecuteAsync(async () =>
+        {
+            await _attachmentService.DeleteAttachmentAsync(attachment.Id);
+            Attachments.Remove(attachment);
+        });
+    }
+
+    private async Task AddAttachmentFromFileResultAsync(
+        Microsoft.Maui.Storage.FileResult file,
+        AttachmentPayloadKind payloadKind)
+    {
+        await ExecuteAsync(async () =>
+        {
+            if (string.IsNullOrWhiteSpace(FeatureId))
+            {
+                FeatureId = Guid.NewGuid().ToString("N");
+            }
+
+            await using var stream = await file.OpenReadAsync();
+            var attachment = await _attachmentService.SaveAttachmentAsync(
+                LayerId,
+                FeatureId,
+                stream,
+                file.FileName,
+                string.IsNullOrWhiteSpace(file.ContentType)
+                    ? "application/octet-stream"
+                    : file.ContentType,
+                payloadKind);
+            Attachments.Add(attachment);
+        });
     }
 
     [RelayCommand]
@@ -309,7 +428,18 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
     }
 
     [RelayCommand]
-    private Task Cancel() => NavigationService.GoBackAsync();
+    private async Task Cancel()
+    {
+        if (IsNew && !string.IsNullOrWhiteSpace(FeatureId))
+        {
+            foreach (var attachment in Attachments.ToList())
+            {
+                await _attachmentService.DeleteAttachmentAsync(attachment.Id);
+            }
+        }
+
+        await NavigationService.GoBackAsync();
+    }
 
     private static Dictionary<string, object?> CreateDefaultAttributes() =>
         new(StringComparer.OrdinalIgnoreCase)
@@ -486,6 +616,8 @@ public sealed partial class DiagnosticsViewModel : BaseViewModel, IRouteAwareVie
             $"Online {report.Connectivity.IsConnected}\n" +
             $"Remote sync configured {report.Sync.IsRemoteSyncConfigured}\n" +
             $"Pending changes {report.Sync.PendingChanges}\n" +
+            $"Pending attachments {report.OfflineCache.Operations.AttachmentPendingCount}\n" +
+            $"Attachment failures {report.OfflineCache.Operations.AttachmentFailedCount}\n" +
             $"Conflicts {report.Sync.ConflictCount}\n" +
             $"Database {report.Database.DatabaseSize}\n" +
             $"Offline cache {report.OfflineCache.PackageSizeDisplay}";

--- a/apps/Honua.Mobile.FieldCollection/Views/WorkflowPages.cs
+++ b/apps/Honua.Mobile.FieldCollection/Views/WorkflowPages.cs
@@ -1,3 +1,4 @@
+using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -228,6 +229,8 @@ internal static class WorkflowPageContent
             })
         };
         attributes.SetBinding(ItemsView.ItemsSourceProperty, new Binding("Attributes"));
+        var attachments = AttachmentList("OpenAttachmentCommand");
+        attachments.SetBinding(ItemsView.ItemsSourceProperty, new Binding("Attachments"));
 
         return PageScroll(
             BoundHeader("Feature.DisplayTitle", "Record"),
@@ -235,6 +238,8 @@ internal static class WorkflowPageContent
             BoundLabel("GeometrySummary", "Geometry"),
             SectionTitle("Attributes"),
             attributes,
+            SectionTitle("Attachments"),
+            attachments,
             ButtonRow(
                 CommandButton("Edit", "EditRecordCommand"),
                 CommandButton("Delete", "DeleteRecordCommand")));
@@ -270,14 +275,20 @@ internal static class WorkflowPageContent
             })
         };
         attributes.SetBinding(ItemsView.ItemsSourceProperty, new Binding("Attributes"));
+        var attachments = AttachmentList("RemoveAttachmentCommand");
+        attachments.SetBinding(ItemsView.ItemsSourceProperty, new Binding("Attachments"));
 
         return PageScroll(
             BoundHeader("PageTitle", "Record"),
             BoundLabel("GeometrySummary", "Geometry"),
             SectionTitle("Attributes"),
             attributes,
+            SectionTitle("Attachments"),
+            attachments,
             ButtonRow(
                 CommandButton("Add field", "AddAttributeCommand"),
+                CommandButton("Add file", "AddFileAttachmentCommand"),
+                CommandButton("Add photo", "AddPhotoAttachmentCommand"),
                 CommandButton("Save", "SaveRecordCommand"),
                 CommandButton("Cancel", "CancelCommand")));
     }
@@ -454,6 +465,55 @@ internal static class WorkflowPageContent
         var label = new Label { LineBreakMode = LineBreakMode.WordWrap };
         label.SetBinding(Label.TextProperty, new Binding(path));
         return label;
+    }
+
+    private static CollectionView AttachmentList(string commandPath)
+    {
+        return new CollectionView
+        {
+            EmptyView = new Label { Text = "No attachments" },
+            ItemTemplate = new DataTemplate(() =>
+            {
+                var fileName = new Label { FontAttributes = FontAttributes.Bold };
+                fileName.SetBinding(Label.TextProperty, new Binding(nameof(AttachmentInfo.FileName)));
+
+                var details = new Label { FontSize = 12, TextColor = Colors.Gray };
+                details.SetBinding(
+                    Label.TextProperty,
+                    new Binding(nameof(AttachmentInfo.SyncStatus), stringFormat: "{0}"));
+
+                var action = new Button { Text = commandPath.StartsWith("Open", StringComparison.Ordinal) ? "Open" : "Remove" };
+                action.SetBinding(
+                    Button.CommandProperty,
+                    new Binding(
+                        $"BindingContext.{commandPath}",
+                        source: new RelativeBindingSource(
+                            RelativeBindingSourceMode.FindAncestor,
+                            typeof(ContentPage))));
+                action.SetBinding(Button.CommandParameterProperty, new Binding("."));
+
+                var info = new VerticalStackLayout
+                {
+                    Spacing = 2,
+                    Children = { fileName, details }
+                };
+
+                var grid = new Grid
+                {
+                    Padding = new Thickness(0, 6),
+                    ColumnDefinitions =
+                    {
+                        new ColumnDefinition { Width = GridLength.Star },
+                        new ColumnDefinition { Width = GridLength.Auto }
+                    }
+                };
+                Grid.SetColumn(info, 0);
+                Grid.SetColumn(action, 1);
+                grid.Children.Add(info);
+                grid.Children.Add(action);
+                return grid;
+            })
+        };
     }
 
     private static Entry BoundEntry(string path, string placeholder)

--- a/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionAttachmentServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionAttachmentServiceTests.cs
@@ -1,0 +1,496 @@
+using System.Text;
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Mobile.FieldCollection.Services.Sync;
+using Honua.Sdk.Abstractions.Features;
+using StorageChangeRecord = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeRecord;
+
+namespace Honua.Mobile.FieldCollection.Tests;
+
+public sealed class FieldCollectionAttachmentServiceTests
+{
+    public FieldCollectionAttachmentServiceTests()
+    {
+        SQLitePCL.Batteries_V2.Init();
+    }
+
+    [Fact]
+    public async Task SaveAttachmentAsync_PersistsContentMetadataAndQueueAcrossRestart()
+    {
+        var databasePath = CreateDatabasePath();
+        var attachmentRoot = CreateAttachmentRoot();
+        await using var cleanup = new FileCleanup(databasePath, attachmentRoot);
+
+        using (var storage = new GeoPackageStorageService(databasePath))
+        {
+            var service = new AttachmentService(storage, attachmentRoot);
+            await using var content = new MemoryStream(Encoding.UTF8.GetBytes("photo"));
+
+            var attachment = await service.SaveAttachmentAsync(
+                layerId: 1,
+                featureId: "asset-1",
+                content,
+                "asset.jpg",
+                "image/jpeg",
+                AttachmentPayloadKind.Photo);
+
+            Assert.Equal(AttachmentSyncStatus.PendingUpload, attachment.SyncStatus);
+            Assert.Equal(AttachmentPayloadKind.Photo, attachment.PayloadKind);
+            Assert.True(File.Exists(attachment.LocalPath));
+            Assert.Single(await storage.GetPendingAttachmentChangesAsync());
+        }
+
+        using (var restartedStorage = new GeoPackageStorageService(databasePath))
+        {
+            var restartedService = new AttachmentService(restartedStorage, attachmentRoot);
+            var attachments = (await restartedService.GetAttachmentsAsync("asset-1")).ToList();
+
+            var attachment = Assert.Single(attachments);
+            Assert.Equal("asset.jpg", attachment.FileName);
+            await using var savedContent = await restartedService.GetAttachmentAsync(attachment.Id);
+            using var reader = new StreamReader(savedContent, Encoding.UTF8);
+            Assert.Equal("photo", await reader.ReadToEndAsync());
+        }
+    }
+
+    [Fact]
+    public async Task DeleteAttachmentAsync_WhenUnsynced_RemovesContentAndClearsPendingQueue()
+    {
+        var databasePath = CreateDatabasePath();
+        var attachmentRoot = CreateAttachmentRoot();
+        await using var cleanup = new FileCleanup(databasePath, attachmentRoot);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var service = new AttachmentService(storage, attachmentRoot);
+        await using var content = new MemoryStream(Encoding.UTF8.GetBytes("draft"));
+        var attachment = await service.SaveAttachmentAsync(1, "asset-1", content, "draft.txt", "text/plain");
+
+        await service.DeleteAttachmentAsync(attachment.Id);
+
+        Assert.Empty(await service.GetAttachmentsAsync("asset-1"));
+        Assert.Empty(await storage.GetPendingAttachmentChangesAsync());
+        Assert.False(File.Exists(attachment.LocalPath));
+        var metadata = await storage.GetAttachmentMetadataAsync(attachment.Id);
+        Assert.True(metadata?.IsDeleted);
+        Assert.Equal(AttachmentSyncStatus.Synced, metadata?.SyncStatus);
+    }
+
+    [Fact]
+    public async Task SaveAttachmentAsync_WhenQuotaExceeded_DoesNotPersistMetadataOrFile()
+    {
+        var databasePath = CreateDatabasePath();
+        var attachmentRoot = CreateAttachmentRoot();
+        await using var cleanup = new FileCleanup(databasePath, attachmentRoot);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var service = new AttachmentService(storage, attachmentRoot, quotaBytes: 4);
+        await using var content = new MemoryStream(Encoding.UTF8.GetBytes("too-large"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.SaveAttachmentAsync(1, "asset-1", content, "large.bin", "application/octet-stream"));
+
+        Assert.Empty(await service.GetAttachmentsAsync("asset-1"));
+        Assert.Empty(Directory.Exists(attachmentRoot)
+            ? Directory.EnumerateFiles(attachmentRoot, "*", SearchOption.AllDirectories)
+            : []);
+    }
+
+    [Fact]
+    public async Task GetOfflineCacheDiagnosticsAsync_ReportsAttachmentPendingAndFailures()
+    {
+        var databasePath = CreateDatabasePath();
+        var attachmentRoot = CreateAttachmentRoot();
+        await using var cleanup = new FileCleanup(databasePath, attachmentRoot);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var service = new AttachmentService(storage, attachmentRoot);
+        await using var content = new MemoryStream(Encoding.UTF8.GetBytes("photo"));
+        var attachment = await service.SaveAttachmentAsync(1, "asset-1", content, "asset.jpg", "image/jpeg");
+
+        await storage.MarkAttachmentSyncFailedAsync(
+            attachment.Id,
+            AttachmentSyncStatus.UploadFailed,
+            "upload failed");
+
+        var diagnostics = await storage.GetOfflineCacheDiagnosticsAsync();
+
+        Assert.Equal(1, diagnostics.Operations.AttachmentPendingCount);
+        Assert.Equal(1, diagnostics.Operations.AttachmentFailedCount);
+        Assert.Equal(1, diagnostics.Operations.AttachmentUploadFailedCount);
+        Assert.Equal(0, diagnostics.Operations.AttachmentDownloadFailedCount);
+    }
+
+    [Fact]
+    public async Task PushChangesAsync_UploadsPendingAttachmentsAndRetriesFailures()
+    {
+        var databasePath = CreateDatabasePath();
+        var attachmentRoot = CreateAttachmentRoot();
+        await using var cleanup = new FileCleanup(databasePath, attachmentRoot);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.StoreFeatureAsync(CreateFeature("asset-1", objectId: 42));
+        await storage.MarkChangesAsSynced((await storage.GetPendingChangesAsync()).Select(change => change.Id).ToList());
+
+        var service = new AttachmentService(storage, attachmentRoot);
+        await using var content = new MemoryStream(Encoding.UTF8.GetBytes("photo"));
+        var attachment = await service.SaveAttachmentAsync(
+            1,
+            "asset-1",
+            content,
+            "asset.jpg",
+            "image/jpeg",
+            AttachmentPayloadKind.Photo);
+
+        var attachmentClient = new RecordingAttachmentSyncClient
+        {
+            AddResult = new FeatureAttachmentResult
+            {
+                Succeeded = false,
+                Error = new FeatureEditError { Code = 503, Message = "temporary outage" }
+            }
+        };
+        using var sync = CreateSyncService(storage, service, attachmentClient);
+
+        var failed = await sync.PushChangesAsync();
+
+        Assert.False(failed.IsSuccess);
+        var failedMetadata = await storage.GetAttachmentMetadataAsync(attachment.Id);
+        Assert.Equal(AttachmentSyncStatus.UploadFailed, failedMetadata?.SyncStatus);
+        Assert.Equal(1, failedMetadata?.RetryCount);
+        Assert.Contains("temporary outage", failedMetadata?.LastError);
+
+        attachmentClient.AddResult = new FeatureAttachmentResult { Succeeded = true, AttachmentId = 7 };
+        var retried = await sync.PushChangesAsync();
+
+        Assert.True(retried.IsSuccess);
+        Assert.Equal(1, retried.AttachmentsPushed);
+        Assert.Equal(2, attachmentClient.AddRequests.Count);
+        var request = attachmentClient.AddRequests.Last();
+        Assert.Equal(42, request.ObjectId);
+        Assert.Equal("asset.jpg", request.Name);
+
+        var syncedMetadata = await storage.GetAttachmentMetadataAsync(attachment.Id);
+        Assert.Equal(AttachmentSyncStatus.Synced, syncedMetadata?.SyncStatus);
+        Assert.Equal(7, syncedMetadata?.RemoteAttachmentId);
+        Assert.Equal(0, syncedMetadata?.RetryCount);
+    }
+
+    [Fact]
+    public async Task PullChangesAsync_DownloadsRemoteAttachmentsForLocalFeatures()
+    {
+        var databasePath = CreateDatabasePath();
+        var attachmentRoot = CreateAttachmentRoot();
+        await using var cleanup = new FileCleanup(databasePath, attachmentRoot);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.ApplyRemoteFeatureAsync(CreateFeature("asset-1", objectId: 42));
+
+        var service = new AttachmentService(storage, attachmentRoot);
+        var attachmentClient = new RecordingAttachmentSyncClient
+        {
+            ListResponse =
+            [
+                new FeatureAttachmentInfo
+                {
+                    Source = new FeatureSource { ServiceId = "assets", LayerId = 1 },
+                    ParentObjectId = 42,
+                    AttachmentId = 7,
+                    Name = "server.txt",
+                    ContentType = "text/plain",
+                    Size = 6
+                }
+            ],
+            DownloadFactory = _ => new FeatureAttachmentContent
+            {
+                Info = new FeatureAttachmentInfo
+                {
+                    Source = new FeatureSource { ServiceId = "assets", LayerId = 1 },
+                    ParentObjectId = 42,
+                    AttachmentId = 7,
+                    Name = "server.txt",
+                    ContentType = "text/plain",
+                    Size = 6
+                },
+                Content = new MemoryStream(Encoding.UTF8.GetBytes("server"))
+            }
+        };
+        using var sync = CreateSyncService(storage, service, attachmentClient);
+
+        var result = await sync.PullChangesAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.AttachmentsPulled);
+        var attachment = Assert.Single(await service.GetAttachmentsAsync("asset-1"));
+        Assert.Equal(AttachmentSyncStatus.Synced, attachment.SyncStatus);
+        Assert.Equal(7, attachment.RemoteAttachmentId);
+        await using var downloaded = await service.GetAttachmentAsync(attachment.Id);
+        using var reader = new StreamReader(downloaded, Encoding.UTF8);
+        Assert.Equal("server", await reader.ReadToEndAsync());
+    }
+
+    [Fact]
+    public async Task PushChangesAsync_DeletesRemoteAttachmentsAfterOfflineRemoval()
+    {
+        var databasePath = CreateDatabasePath();
+        var attachmentRoot = CreateAttachmentRoot();
+        await using var cleanup = new FileCleanup(databasePath, attachmentRoot);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.StoreFeatureAsync(CreateFeature("asset-1", objectId: 42));
+        await storage.MarkChangesAsSynced((await storage.GetPendingChangesAsync()).Select(change => change.Id).ToList());
+
+        var service = new AttachmentService(storage, attachmentRoot);
+        await using var content = new MemoryStream(Encoding.UTF8.GetBytes("remote"));
+        var attachment = await service.SaveDownloadedAttachmentAsync(
+            1,
+            "asset-1",
+            new FeatureAttachmentInfo
+            {
+                Source = new FeatureSource { ServiceId = "assets", LayerId = 1 },
+                ParentObjectId = 42,
+                AttachmentId = 7,
+                Name = "remote.txt",
+                ContentType = "text/plain",
+                Size = 6
+            },
+            content);
+        await service.DeleteAttachmentAsync(attachment.Id);
+
+        var attachmentClient = new RecordingAttachmentSyncClient();
+        using var sync = CreateSyncService(storage, service, attachmentClient);
+        var result = await sync.PushChangesAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.AttachmentsPushed);
+        var deleteRequest = Assert.Single(attachmentClient.DeleteRequests);
+        Assert.Equal(42, deleteRequest.ObjectId);
+        Assert.Equal(7, deleteRequest.AttachmentId);
+
+        var metadata = await storage.GetAttachmentMetadataAsync(attachment.Id);
+        Assert.True(metadata?.IsDeleted);
+        Assert.Equal(AttachmentSyncStatus.Synced, metadata?.SyncStatus);
+        Assert.Empty(await storage.GetPendingAttachmentChangesAsync());
+    }
+
+    private static GeoPackageSyncService CreateSyncService(
+        GeoPackageStorageService storage,
+        IAttachmentService attachmentService,
+        RecordingAttachmentSyncClient attachmentClient)
+    {
+        var metadata = new FixedMetadataService([CreateLayer()]);
+        var synchronizer = new HonuaFieldCollectionAttachmentSynchronizer(
+            storage,
+            attachmentService,
+            metadata,
+            attachmentClient);
+
+        return new GeoPackageSyncService(
+            storage,
+            new TestAuthenticationService(),
+            new TestConnectivityService(),
+            new FixedResultUploader(true),
+            new FixedPuller([]),
+            synchronizer);
+    }
+
+    private static LayerInfo CreateLayer()
+    {
+        return new LayerInfo
+        {
+            Id = 1,
+            ServiceId = "assets",
+            SourceId = "assets/FeatureServer/1",
+            Name = "Assets",
+            GeometryType = GeometryType.Point,
+            IsEditable = true
+        };
+    }
+
+    private static Feature CreateFeature(string id, long objectId)
+    {
+        return new Feature
+        {
+            Id = id,
+            LayerId = 1,
+            Version = 1,
+            CreatedAt = DateTime.UtcNow,
+            ModifiedAt = DateTime.UtcNow,
+            Attributes = new Dictionary<string, object?>
+            {
+                ["objectid"] = objectId,
+                ["name"] = id
+            },
+            Geometry = new Point(21.3, -157.8)
+        };
+    }
+
+    private static string CreateDatabasePath()
+    {
+        return Path.Combine(Path.GetTempPath(), $"honua-field-attachments-{Guid.NewGuid():N}.gpkg");
+    }
+
+    private static string CreateAttachmentRoot()
+    {
+        return Path.Combine(Path.GetTempPath(), $"honua-field-attachments-{Guid.NewGuid():N}");
+    }
+
+    private sealed class RecordingAttachmentSyncClient : IFieldCollectionAttachmentSyncClient
+    {
+        public bool IsConfigured { get; set; } = true;
+        public FeatureAttachmentResult AddResult { get; set; } = new() { Succeeded = true, AttachmentId = 7 };
+        public FeatureAttachmentResult DeleteResult { get; set; } = new() { Succeeded = true, AttachmentId = 7 };
+        public IReadOnlyList<FeatureAttachmentInfo> ListResponse { get; set; } = [];
+        public Func<FeatureAttachmentDownloadRequest, FeatureAttachmentContent>? DownloadFactory { get; set; }
+        public List<FeatureAttachmentAddRequest> AddRequests { get; } = [];
+        public List<FeatureAttachmentDeleteRequest> DeleteRequests { get; } = [];
+        public List<FeatureAttachmentListRequest> ListRequests { get; } = [];
+        public List<FeatureAttachmentDownloadRequest> DownloadRequests { get; } = [];
+
+        public Task<IReadOnlyList<FeatureAttachmentInfo>> ListAttachmentsAsync(
+            FeatureAttachmentListRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            ListRequests.Add(request);
+            return Task.FromResult(ListResponse);
+        }
+
+        public Task<FeatureAttachmentContent> DownloadAttachmentAsync(
+            FeatureAttachmentDownloadRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            DownloadRequests.Add(request);
+            return Task.FromResult(DownloadFactory?.Invoke(request) ?? new FeatureAttachmentContent
+            {
+                Info = new FeatureAttachmentInfo
+                {
+                    Source = request.Source,
+                    ParentObjectId = request.ObjectId,
+                    AttachmentId = request.AttachmentId,
+                    Name = "attachment.bin",
+                    ContentType = "application/octet-stream"
+                },
+                Content = new MemoryStream()
+            });
+        }
+
+        public Task<FeatureAttachmentResult> AddAttachmentAsync(
+            FeatureAttachmentAddRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            AddRequests.Add(request);
+            return Task.FromResult(AddResult);
+        }
+
+        public Task<FeatureAttachmentResult> DeleteAttachmentAsync(
+            FeatureAttachmentDeleteRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            DeleteRequests.Add(request);
+            return Task.FromResult(DeleteResult);
+        }
+    }
+
+    private sealed class FixedResultUploader : IFieldCollectionChangeUploader
+    {
+        private readonly bool _result;
+
+        public FixedResultUploader(bool result)
+        {
+            _result = result;
+        }
+
+        public Task<bool> UploadChangeAsync(
+            StorageChangeRecord change,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_result);
+        }
+    }
+
+    private sealed class FixedPuller : IFieldCollectionChangePuller
+    {
+        private readonly IReadOnlyList<ServerChange> _changes;
+
+        public FixedPuller(IReadOnlyList<ServerChange> changes)
+        {
+            _changes = changes;
+        }
+
+        public Task<IReadOnlyList<ServerChange>> GetChangesAsync(
+            long sinceGeneration,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_changes);
+        }
+
+        public Task<long> GetLatestServerGenerationAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(1L);
+        }
+
+        public Task<long> GetLastSyncedGenerationAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(0L);
+        }
+    }
+
+    private sealed class FixedMetadataService : IFieldCollectionMetadataService
+    {
+        private readonly IReadOnlyList<LayerInfo> _layers;
+
+        public FixedMetadataService(IReadOnlyList<LayerInfo> layers)
+        {
+            _layers = layers;
+        }
+
+        public Task<IReadOnlyList<FieldProjectInfo>> GetProjectsAsync(
+            bool refresh = false,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<FieldProjectInfo>>([]);
+        }
+
+        public Task<FieldProjectInfo?> GetSelectedProjectAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<FieldProjectInfo?>(new FieldProjectInfo
+            {
+                ServiceId = _layers.FirstOrDefault()?.ServiceId ?? "assets",
+                Layers = _layers.ToList()
+            });
+        }
+
+        public Task SelectProjectAsync(string serviceId, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<LayerInfo>> GetLayersAsync(
+            bool refresh = false,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_layers);
+        }
+    }
+
+    private sealed class FileCleanup : IAsyncDisposable
+    {
+        private readonly string _databasePath;
+        private readonly string _attachmentRoot;
+
+        public FileCleanup(string databasePath, string attachmentRoot)
+        {
+            _databasePath = databasePath;
+            _attachmentRoot = attachmentRoot;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (File.Exists(_databasePath))
+            {
+                File.Delete(_databasePath);
+            }
+
+            if (Directory.Exists(_attachmentRoot))
+            {
+                Directory.Delete(_attachmentRoot, recursive: true);
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add mobile-owned local attachment metadata/file storage for photos, files, and signatures with quota, delete cleanup, persisted queue state, and diagnostics counts
- wire attachment upload, download, retry, and delete handling into the FieldCollection GeoPackage sync path using SDK FeatureServer attachment contracts
- expose attachments in record detail/edit workflows and register the real attachment service/synchronizer in MAUI DI

Closes #213

## Offline Impact
- attachments are stored under the mobile app data directory and indexed in GeoPackage-backed metadata
- pending upload, download, delete, retry, and failure states are counted with offline diagnostics and Sync Center state
- attachment sync uses existing SDK FeatureServer attachment contracts and leaves failed items queued for retry

## Platform Testing
- local MAUI app target build is blocked in this environment by missing Android SDK (XA5300)
- forced non-platform compile reaches only expected CS5001 for no platform Main after compiling app code
- GitHub Actions remains the authoritative Android/iOS/Windows validation

## Testing
- dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore --verbosity minimal
- dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --no-restore --verbosity minimal
- git diff --check
- dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj --no-restore --verbosity minimal (blocked locally: XA5300 missing Android SDK)
- dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0 --no-restore --verbosity minimal (expected CS5001 because this forced non-MAUI target has no platform Main; project code compiles first)