### PR TITLE
mobile: expand FieldCollection form control parity

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Models/CoreModels.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Models/CoreModels.cs
@@ -145,6 +145,8 @@ public class FormData
     public int LayerId { get; set; }
     public string? FeatureId { get; set; }
     public Dictionary<string, object?> Values { get; set; } = new();
+    public List<FieldMediaAttachment> Media { get; set; } = new();
+    public FieldGeoPoint? Location { get; set; }
     public Dictionary<string, string> ValidationErrors { get; set; } = new();
     public bool IsValid => ValidationErrors.Count == 0;
     public DateTime CreatedAt { get; set; }
@@ -157,6 +159,8 @@ public class FormData
             RecordId = FeatureId ?? string.Empty,
             FormId = definition?.FormId ?? LayerId.ToString(CultureInfo.InvariantCulture),
             Values = new Dictionary<string, object?>(Values),
+            Media = new System.Collections.ObjectModel.Collection<FieldMediaAttachment>(Media),
+            Location = Location,
             CreatedAtUtc = ToDateTimeOffset(CreatedAt),
         };
     }
@@ -168,6 +172,8 @@ public class FormData
             LayerId = layerId,
             FeatureId = record.RecordId,
             Values = new Dictionary<string, object?>(record.Values),
+            Media = record.Media.ToList(),
+            Location = record.Location,
             CreatedAt = record.CreatedAtUtc.UtcDateTime,
             UpdatedAt = record.SubmittedAtUtc?.UtcDateTime ?? record.CompletedAtUtc?.UtcDateTime
         };

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/CoreServices.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/CoreServices.cs
@@ -83,6 +83,7 @@ public interface ISettingsService
 {
     Task<T> GetSettingAsync<T>(string key, T defaultValue = default!);
     Task SetSettingAsync<T>(string key, T value);
+    Task RemoveSettingAsync(string key);
     Task<bool> HasSettingAsync(string key);
 }
 
@@ -223,7 +224,8 @@ public class FormService : IFormService
 
     public Task<bool> ValidateFormAsync(FormData formData, FormDefinition definition)
     {
-        var result = FormValidator.Validate(definition, formData.ToSdkFieldRecord(definition));
+        var validationDefinition = EnsureValidationRules(definition);
+        var result = FormValidator.Validate(validationDefinition, formData.ToSdkFieldRecord(validationDefinition));
 
         formData.ValidationErrors.Clear();
         foreach (var error in result.Errors)
@@ -232,6 +234,43 @@ public class FormService : IFormService
         }
 
         return Task.FromResult(result.IsValid);
+    }
+
+    private static FormDefinition EnsureValidationRules(FormDefinition definition)
+    {
+        return new FormDefinition
+        {
+            FormId = definition.FormId,
+            Name = definition.Name,
+            Description = definition.Description,
+            Target = definition.Target,
+            Sections = definition.Sections
+                .Select(section => new FormSection
+                {
+                    SectionId = section.SectionId,
+                    Label = section.Label,
+                    Fields = section.Fields.Select(CloneField).ToList()
+                })
+                .ToList(),
+            Metadata = new Dictionary<string, string>(definition.Metadata, StringComparer.OrdinalIgnoreCase)
+        };
+    }
+
+    private static FormField CloneField(FormField field)
+    {
+        return new FormField
+        {
+            FieldId = field.FieldId,
+            Label = field.Label,
+            Type = field.Type,
+            SourceFieldName = field.SourceFieldName,
+            Required = field.Required,
+            Choices = field.Choices,
+            Validation = field.Validation ?? new FieldValidationRule(),
+            VisibilityRule = field.VisibilityRule,
+            CalculatedExpression = field.CalculatedExpression,
+            HelpText = field.HelpText
+        };
     }
 
     public async Task<FormData> CreateEmptyFormAsync(int layerId)
@@ -630,6 +669,12 @@ public class SettingsService : ISettingsService
     {
         var json = System.Text.Json.JsonSerializer.Serialize(value);
         await SecureStorage.SetAsync(key, json);
+    }
+
+    public Task RemoveSettingAsync(string key)
+    {
+        SecureStorage.Remove(key);
+        return Task.CompletedTask;
     }
 
     public async Task<bool> HasSettingAsync(string key)

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Forms/MobileFormRuntime.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Forms/MobileFormRuntime.cs
@@ -1,0 +1,642 @@
+using System.Globalization;
+using System.Text.Json;
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services;
+using Honua.Sdk.Field.Forms;
+using Honua.Sdk.Field.Records;
+
+namespace Honua.Mobile.FieldCollection.Services.Forms;
+
+public enum MobileFormControlKind
+{
+    SingleLineText,
+    MultilineText,
+    Numeric,
+    Date,
+    DateTime,
+    YesNo,
+    SingleChoice,
+    Dropdown,
+    MultipleChoice,
+    Location,
+    Photo,
+    File,
+    Signature,
+    Barcode,
+    Unsupported
+}
+
+public static class MobileFormControlSelector
+{
+    public static MobileFormControlKind Select(FormField field)
+    {
+        ArgumentNullException.ThrowIfNull(field);
+
+        return field.Type switch
+        {
+            FormFieldType.Text => IsLikelyMultiline(field)
+                ? MobileFormControlKind.MultilineText
+                : MobileFormControlKind.SingleLineText,
+            FormFieldType.Numeric => MobileFormControlKind.Numeric,
+            FormFieldType.Date => MobileFormControlKind.Date,
+            FormFieldType.DateTime => MobileFormControlKind.DateTime,
+            FormFieldType.YesNo => MobileFormControlKind.YesNo,
+            FormFieldType.SingleChoice => field.Choices.Count > 5
+                ? MobileFormControlKind.Dropdown
+                : MobileFormControlKind.SingleChoice,
+            FormFieldType.MultipleChoice => MobileFormControlKind.MultipleChoice,
+            FormFieldType.Location => MobileFormControlKind.Location,
+            FormFieldType.Photo => MobileFormControlKind.Photo,
+            FormFieldType.File => MobileFormControlKind.File,
+            FormFieldType.Signature => MobileFormControlKind.Signature,
+            FormFieldType.Barcode => MobileFormControlKind.Barcode,
+            FormFieldType.Hyperlink or
+            FormFieldType.Address or
+            FormFieldType.Classification or
+            FormFieldType.RecordLink or
+            FormFieldType.Calculated => MobileFormControlKind.SingleLineText,
+            _ => MobileFormControlKind.Unsupported
+        };
+    }
+
+    private static bool IsLikelyMultiline(FormField field)
+    {
+        if (field.Validation?.MaxLength > 255)
+        {
+            return true;
+        }
+
+        var name = $"{field.FieldId} {field.Label}".ToLowerInvariant();
+        return name.Contains("note", StringComparison.Ordinal) ||
+            name.Contains("comment", StringComparison.Ordinal) ||
+            name.Contains("description", StringComparison.Ordinal);
+    }
+}
+
+public static class MobileFormValueConverter
+{
+    public static object? NormalizeValue(FormField field, object? value)
+    {
+        ArgumentNullException.ThrowIfNull(field);
+
+        if (IsBlank(value))
+        {
+            return null;
+        }
+
+        return field.Type switch
+        {
+            FormFieldType.Numeric => NormalizeNumeric(value),
+            FormFieldType.Date => NormalizeDate(value),
+            FormFieldType.DateTime => NormalizeDateTime(value),
+            FormFieldType.Time => NormalizeTime(value),
+            FormFieldType.YesNo => NormalizeBoolean(value),
+            FormFieldType.SingleChoice => ToScalarText(value),
+            FormFieldType.MultipleChoice => ToChoiceValues(value),
+            FormFieldType.Location => NormalizeLocation(value),
+            FormFieldType.Photo or
+            FormFieldType.File or
+            FormFieldType.Signature or
+            FormFieldType.Video or
+            FormFieldType.Audio or
+            FormFieldType.Sketch => ToChoiceValues(value),
+            _ => ToScalarText(value)
+        };
+    }
+
+    public static object? FromText(FormField field, string? text)
+        => NormalizeValue(field, text);
+
+    public static object? FromBoolean(FormField field, bool value)
+        => field.Type == FormFieldType.YesNo ? value : NormalizeValue(field, value);
+
+    public static object? FromDate(FormField field, DateTime date)
+    {
+        if (field.Type == FormFieldType.Date)
+        {
+            return DateOnly.FromDateTime(date);
+        }
+
+        return NormalizeValue(field, date);
+    }
+
+    public static object? FromDateTime(FormField field, DateTime date, TimeSpan time)
+    {
+        var value = date.Date.Add(time);
+        return field.Type == FormFieldType.DateTime
+            ? value
+            : NormalizeValue(field, value);
+    }
+
+    public static object? FromChoiceValues(FormField field, IEnumerable<string> values)
+    {
+        var selected = values
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        return field.Type == FormFieldType.MultipleChoice ? selected : selected.FirstOrDefault();
+    }
+
+    public static object FromLocation(double latitude, double longitude, double? accuracyMeters = null)
+        => new FieldGeoPoint(latitude, longitude, accuracyMeters);
+
+    public static string ToDisplayText(FormField field, object? value)
+    {
+        var normalized = NormalizeValue(field, value);
+        return normalized switch
+        {
+            null => string.Empty,
+            DateOnly date => date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            DateTime dateTime => dateTime.ToString("u", CultureInfo.InvariantCulture),
+            DateTimeOffset dateTimeOffset => dateTimeOffset.ToString("u", CultureInfo.InvariantCulture),
+            TimeSpan time => time.ToString(@"hh\:mm", CultureInfo.InvariantCulture),
+            FieldGeoPoint point => FormatLocation(point),
+            string[] values => string.Join(", ", values),
+            IEnumerable<string> values => string.Join(", ", values),
+            bool boolean => boolean ? "Yes" : "No",
+            _ => Convert.ToString(normalized, CultureInfo.InvariantCulture) ?? string.Empty
+        };
+    }
+
+    public static IReadOnlyList<string> ToChoiceValues(object? value)
+    {
+        if (IsBlank(value))
+        {
+            return [];
+        }
+
+        if (value is JsonElement json)
+        {
+            return JsonToStrings(json);
+        }
+
+        if (value is string text)
+        {
+            return text
+                .Split([','], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(part => !string.IsNullOrWhiteSpace(part))
+                .ToArray();
+        }
+
+        if (value is IEnumerable<string> strings)
+        {
+            return strings.Where(item => !string.IsNullOrWhiteSpace(item)).ToArray();
+        }
+
+        if (value is System.Collections.IEnumerable enumerable)
+        {
+            return enumerable
+                .Cast<object?>()
+                .Select(ToScalarText)
+                .Where(item => !string.IsNullOrWhiteSpace(item))
+                .Select(item => item!)
+                .ToArray();
+        }
+
+        var scalar = ToScalarText(value);
+        return string.IsNullOrWhiteSpace(scalar) ? [] : [scalar];
+    }
+
+    public static bool TryGetBoolean(object? value, out bool boolean)
+    {
+        var normalized = NormalizeBoolean(value);
+        if (normalized is bool typed)
+        {
+            boolean = typed;
+            return true;
+        }
+
+        boolean = false;
+        return false;
+    }
+
+    public static bool TryGetDate(object? value, out DateTime date)
+    {
+        var normalized = NormalizeDate(value);
+        if (normalized is DateOnly dateOnly)
+        {
+            date = dateOnly.ToDateTime(TimeOnly.MinValue);
+            return true;
+        }
+
+        if (normalized is DateTime dateTime)
+        {
+            date = dateTime.Date;
+            return true;
+        }
+
+        date = DateTime.Today;
+        return false;
+    }
+
+    public static bool TryGetDateTime(object? value, out DateTime dateTime)
+    {
+        var normalized = NormalizeDateTime(value);
+        if (normalized is DateTime typed)
+        {
+            dateTime = typed;
+            return true;
+        }
+
+        if (normalized is DateTimeOffset offset)
+        {
+            dateTime = offset.DateTime;
+            return true;
+        }
+
+        dateTime = DateTime.Now;
+        return false;
+    }
+
+    public static bool TryGetLocation(object? value, out FieldGeoPoint point)
+    {
+        var normalized = NormalizeLocation(value);
+        if (normalized is FieldGeoPoint typed)
+        {
+            point = typed;
+            return true;
+        }
+
+        point = default!;
+        return false;
+    }
+
+    public static IReadOnlyList<FieldMediaAttachment> BuildMediaAttachments(
+        IEnumerable<FormField> fields,
+        IReadOnlyDictionary<string, object?> values,
+        IReadOnlyDictionary<string, AttachmentInfo> attachmentsById)
+    {
+        var media = new List<FieldMediaAttachment>();
+        foreach (var field in fields.Where(IsMediaField))
+        {
+            if (!values.TryGetValue(field.FieldId, out var rawValue))
+            {
+                continue;
+            }
+
+            foreach (var attachmentId in ToChoiceValues(rawValue))
+            {
+                if (!attachmentsById.TryGetValue(attachmentId, out var attachment))
+                {
+                    continue;
+                }
+
+                media.Add(new FieldMediaAttachment
+                {
+                    AttachmentId = attachment.Id,
+                    FieldId = field.FieldId,
+                    FileName = attachment.FileName,
+                    ContentType = attachment.ContentType,
+                    SizeBytes = attachment.SizeBytes,
+                    CapturedAtUtc = new DateTimeOffset(attachment.CreatedAt == default ? DateTime.UtcNow : attachment.CreatedAt),
+                    MediaType = ToSdkMediaType(field.Type, attachment.PayloadKind)
+                });
+            }
+        }
+
+        return media;
+    }
+
+    public static bool IsMediaField(FormField field)
+        => field.Type is FormFieldType.Photo or
+            FormFieldType.Video or
+            FormFieldType.Audio or
+            FormFieldType.Signature or
+            FormFieldType.Sketch or
+            FormFieldType.File;
+
+    public static FieldMediaType ToSdkMediaType(FormFieldType fieldType, AttachmentPayloadKind payloadKind)
+    {
+        return fieldType switch
+        {
+            FormFieldType.Photo => FieldMediaType.Photo,
+            FormFieldType.Video => FieldMediaType.Video,
+            FormFieldType.Audio => FieldMediaType.Audio,
+            FormFieldType.Signature => FieldMediaType.Signature,
+            FormFieldType.Sketch => FieldMediaType.Sketch,
+            _ => payloadKind switch
+            {
+                AttachmentPayloadKind.Photo => FieldMediaType.Photo,
+                AttachmentPayloadKind.Signature => FieldMediaType.Signature,
+                _ => FieldMediaType.File
+            }
+        };
+    }
+
+    private static object? NormalizeNumeric(object? value)
+    {
+        if (value is JsonElement json)
+        {
+            if (json.ValueKind == JsonValueKind.Number)
+            {
+                if (json.TryGetInt64(out var integer))
+                {
+                    return integer;
+                }
+
+                if (json.TryGetDouble(out var number))
+                {
+                    return number;
+                }
+            }
+
+            if (json.ValueKind == JsonValueKind.String)
+            {
+                value = json.GetString();
+            }
+        }
+
+        if (value is byte or short or int or long or float or double or decimal)
+        {
+            return value;
+        }
+
+        var text = ToScalarText(value);
+        if (long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var integerValue))
+        {
+            return integerValue;
+        }
+
+        if (decimal.TryParse(text, NumberStyles.Number, CultureInfo.InvariantCulture, out var decimalValue))
+        {
+            return decimalValue;
+        }
+
+        return text;
+    }
+
+    private static object? NormalizeDate(object? value)
+    {
+        if (value is DateOnly or DateTime)
+        {
+            return value;
+        }
+
+        if (value is DateTimeOffset offset)
+        {
+            return DateOnly.FromDateTime(offset.DateTime);
+        }
+
+        var text = ToJsonAwareText(value);
+        if (DateOnly.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateOnly))
+        {
+            return dateOnly;
+        }
+
+        if (DateTime.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dateTime))
+        {
+            return DateOnly.FromDateTime(dateTime);
+        }
+
+        return text;
+    }
+
+    private static object? NormalizeDateTime(object? value)
+    {
+        if (value is DateTime or DateTimeOffset)
+        {
+            return value;
+        }
+
+        var text = ToJsonAwareText(value);
+        if (DateTime.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dateTime))
+        {
+            return dateTime;
+        }
+
+        if (DateTimeOffset.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var offset))
+        {
+            return offset;
+        }
+
+        return text;
+    }
+
+    private static object? NormalizeTime(object? value)
+    {
+        if (value is TimeSpan)
+        {
+            return value;
+        }
+
+        var text = ToJsonAwareText(value);
+        return TimeSpan.TryParse(text, CultureInfo.InvariantCulture, out var time)
+            ? time
+            : text;
+    }
+
+    private static object? NormalizeBoolean(object? value)
+    {
+        if (value is JsonElement json)
+        {
+            return json.ValueKind switch
+            {
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                JsonValueKind.Number when json.TryGetInt32(out var number) => number != 0,
+                JsonValueKind.String => NormalizeBoolean(json.GetString()),
+                _ => null
+            };
+        }
+
+        if (value is bool)
+        {
+            return value;
+        }
+
+        var text = ToScalarText(value);
+        if (bool.TryParse(text, out var boolean))
+        {
+            return boolean;
+        }
+
+        if (int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var integer))
+        {
+            return integer != 0;
+        }
+
+        return text?.Trim().ToLowerInvariant() switch
+        {
+            "yes" or "y" => true,
+            "no" or "n" => false,
+            _ => null
+        };
+    }
+
+    private static object? NormalizeLocation(object? value)
+    {
+        if (value is FieldGeoPoint)
+        {
+            return value;
+        }
+
+        if (value is JsonElement json)
+        {
+            if (json.ValueKind == JsonValueKind.Object &&
+                TryReadDouble(json, "latitude", out var latitude) &&
+                TryReadDouble(json, "longitude", out var longitude))
+            {
+                return new FieldGeoPoint(
+                    latitude,
+                    longitude,
+                    TryReadDouble(json, "accuracyMeters", out var accuracy) ? accuracy : null);
+            }
+
+            if (json.ValueKind == JsonValueKind.String)
+            {
+                value = json.GetString();
+            }
+        }
+
+        var text = ToScalarText(value);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        var parts = text.Split([','], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length >= 2 &&
+            double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedLatitude) &&
+            double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedLongitude))
+        {
+            double? accuracy = null;
+            if (parts.Length >= 3 &&
+                double.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedAccuracy))
+            {
+                accuracy = parsedAccuracy;
+            }
+
+            return new FieldGeoPoint(parsedLatitude, parsedLongitude, accuracy);
+        }
+
+        return text;
+    }
+
+    private static bool TryReadDouble(JsonElement json, string propertyName, out double value)
+    {
+        if (json.TryGetProperty(propertyName, out var property) &&
+            property.ValueKind == JsonValueKind.Number &&
+            property.TryGetDouble(out value))
+        {
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static IReadOnlyList<string> JsonToStrings(JsonElement json)
+    {
+        return json.ValueKind switch
+        {
+            JsonValueKind.Array => json.EnumerateArray()
+                .Select(item => ToJsonAwareText(item))
+                .Where(item => !string.IsNullOrWhiteSpace(item))
+                .ToArray()!,
+            JsonValueKind.String => ToChoiceValues(json.GetString()),
+            JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False => [json.GetRawText()],
+            _ => []
+        };
+    }
+
+    private static string? ToScalarText(object? value)
+    {
+        if (value is JsonElement json)
+        {
+            return ToJsonAwareText(json);
+        }
+
+        return Convert.ToString(value, CultureInfo.InvariantCulture);
+    }
+
+    private static string? ToJsonAwareText(object? value)
+    {
+        if (value is not JsonElement json)
+        {
+            return ToScalarText(value);
+        }
+
+        return json.ValueKind switch
+        {
+            JsonValueKind.String => json.GetString(),
+            JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False => json.GetRawText(),
+            JsonValueKind.Null or JsonValueKind.Undefined => null,
+            _ => json.GetRawText()
+        };
+    }
+
+    private static bool IsBlank(object? value)
+    {
+        return value is null ||
+            value is string text && string.IsNullOrWhiteSpace(text) ||
+            value is JsonElement { ValueKind: JsonValueKind.Null or JsonValueKind.Undefined };
+    }
+
+    private static string FormatLocation(FieldGeoPoint point)
+    {
+        var accuracy = point.AccuracyMeters.HasValue
+            ? $", +/- {point.AccuracyMeters.Value:F0} m"
+            : string.Empty;
+        return $"{point.Latitude:F6}, {point.Longitude:F6}{accuracy}";
+    }
+}
+
+public sealed class FormDraftSnapshot
+{
+    public int LayerId { get; set; }
+    public string FeatureId { get; set; } = string.Empty;
+    public string? FormId { get; set; }
+    public Dictionary<string, object?> Values { get; set; } = new(StringComparer.Ordinal);
+    public DateTime UpdatedAtUtc { get; set; } = DateTime.UtcNow;
+}
+
+public interface IFormDraftService
+{
+    Task<FormDraftSnapshot?> GetDraftAsync(int layerId, string featureId, CancellationToken cancellationToken = default);
+    Task SaveDraftAsync(FormDraftSnapshot draft, CancellationToken cancellationToken = default);
+    Task DeleteDraftAsync(int layerId, string featureId, CancellationToken cancellationToken = default);
+}
+
+public sealed class SettingsFormDraftService : IFormDraftService
+{
+    private readonly ISettingsService _settingsService;
+
+    public SettingsFormDraftService(ISettingsService settingsService)
+    {
+        _settingsService = settingsService;
+    }
+
+    public Task<FormDraftSnapshot?> GetDraftAsync(
+        int layerId,
+        string featureId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return _settingsService.GetSettingAsync<FormDraftSnapshot?>(
+            BuildKey(layerId, featureId),
+            default);
+    }
+
+    public Task SaveDraftAsync(FormDraftSnapshot draft, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(draft);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        draft.UpdatedAtUtc = DateTime.UtcNow;
+        return _settingsService.SetSettingAsync(BuildKey(draft.LayerId, draft.FeatureId), draft);
+    }
+
+    public Task DeleteDraftAsync(
+        int layerId,
+        string featureId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return _settingsService.RemoveSettingAsync(BuildKey(layerId, featureId));
+    }
+
+    private static string BuildKey(int layerId, string featureId)
+        => $"field-collection:draft:{layerId}:{featureId}";
+}

--- a/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
+++ b/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
@@ -3,6 +3,7 @@ using Honua.Mobile.FieldCollection.Services;
 using Honua.Mobile.FieldCollection.Services.Configuration;
 using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using Honua.Mobile.FieldCollection.Services.Features;
+using Honua.Mobile.FieldCollection.Services.Forms;
 using Honua.Mobile.FieldCollection.Services.Metadata;
 using Honua.Mobile.FieldCollection.Services.Storage;
 using Honua.Mobile.FieldCollection.Services.Sync;
@@ -142,6 +143,7 @@ public static class MauiProgram
         // Other feature services
         services.AddSingleton<IFormService>(provider =>
             new FormService(provider.GetRequiredService<IFieldCollectionMetadataService>()));
+        services.AddSingleton<IFormDraftService, SettingsFormDraftService>();
         services.AddSingleton<IAttachmentService>(provider =>
         {
             var databaseService = provider.GetRequiredService<DatabaseService>();

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/WorkflowViewModels.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/WorkflowViewModels.cs
@@ -5,7 +5,11 @@ using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services;
 using Honua.Mobile.FieldCollection.Services.Configuration;
 using Honua.Mobile.FieldCollection.Services.Diagnostics;
+using Honua.Mobile.FieldCollection.Services.Forms;
 using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Sdk.Field.Forms;
+using Honua.Sdk.Field.Records;
+using Microsoft.Maui.Devices.Sensors;
 using StorageSyncSession = Honua.Mobile.FieldCollection.Services.Storage.Models.SyncSession;
 using FieldPoint = Honua.Mobile.FieldCollection.Models.Point;
 
@@ -30,6 +34,277 @@ public sealed partial class EditableAttributeItem : ObservableObject
 
     [ObservableProperty]
     private string valueText = string.Empty;
+}
+
+public sealed partial class EditableChoiceItem : ObservableObject
+{
+    [ObservableProperty]
+    private bool isSelected;
+
+    public string Value { get; init; } = string.Empty;
+
+    public string Label { get; init; } = string.Empty;
+
+    public event EventHandler? SelectionChanged;
+
+    partial void OnIsSelectedChanged(bool value)
+    {
+        SelectionChanged?.Invoke(this, EventArgs.Empty);
+    }
+}
+
+public sealed partial class EditableFormFieldItem : ObservableObject
+{
+    private bool _suppressValueChanged;
+
+    [ObservableProperty]
+    private string textValue = string.Empty;
+
+    [ObservableProperty]
+    private bool boolValue;
+
+    [ObservableProperty]
+    private DateTime dateValue = DateTime.Today;
+
+    [ObservableProperty]
+    private TimeSpan timeValue = DateTime.Now.TimeOfDay;
+
+    [ObservableProperty]
+    private FieldChoice? selectedChoice;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasValidationError))]
+    private string? validationError;
+
+    [ObservableProperty]
+    private string valueSummary = string.Empty;
+
+    public EditableFormFieldItem(FormField definition)
+    {
+        Definition = definition;
+        ControlKind = MobileFormControlSelector.Select(definition);
+        Label = definition.Required ? $"{definition.Label} *" : definition.Label;
+        HelpText = definition.HelpText ?? string.Empty;
+        foreach (var choice in definition.Choices)
+        {
+            var item = new EditableChoiceItem
+            {
+                Value = choice.Value,
+                Label = string.IsNullOrWhiteSpace(choice.Label) ? choice.Value : choice.Label
+            };
+            item.SelectionChanged += (_, _) => RaiseValueChanged();
+            Choices.Add(item);
+        }
+    }
+
+    public FormField Definition { get; }
+
+    public MobileFormControlKind ControlKind { get; }
+
+    public string Label { get; }
+
+    public string HelpText { get; }
+
+    public ObservableCollection<EditableChoiceItem> Choices { get; } = [];
+
+    public IAsyncRelayCommand<EditableFormFieldItem>? PrimaryActionCommand { get; set; }
+
+    public string PrimaryActionLabel { get; set; } = string.Empty;
+
+    public bool HasPrimaryAction => PrimaryActionCommand != null;
+
+    public bool HasValidationError => !string.IsNullOrWhiteSpace(ValidationError);
+
+    public bool IsSingleLineText => ControlKind is MobileFormControlKind.SingleLineText or MobileFormControlKind.Barcode;
+
+    public bool IsMultilineText => ControlKind == MobileFormControlKind.MultilineText;
+
+    public bool IsNumeric => ControlKind == MobileFormControlKind.Numeric;
+
+    public bool IsDate => ControlKind == MobileFormControlKind.Date;
+
+    public bool IsDateTime => ControlKind == MobileFormControlKind.DateTime;
+
+    public bool IsYesNo => ControlKind == MobileFormControlKind.YesNo;
+
+    public bool IsSingleChoice => ControlKind is MobileFormControlKind.SingleChoice or MobileFormControlKind.Dropdown;
+
+    public bool IsMultipleChoice => ControlKind == MobileFormControlKind.MultipleChoice;
+
+    public bool IsLocation => ControlKind == MobileFormControlKind.Location;
+
+    public bool IsMedia => ControlKind is MobileFormControlKind.Photo or MobileFormControlKind.File or MobileFormControlKind.Signature;
+
+    public bool IsUnsupported => ControlKind == MobileFormControlKind.Unsupported;
+
+    public event EventHandler? ValueChanged;
+
+    public void SetValue(object? value, IReadOnlyDictionary<string, AttachmentInfo>? attachmentsById = null)
+    {
+        _suppressValueChanged = true;
+        try
+        {
+            ValidationError = null;
+
+            switch (ControlKind)
+            {
+                case MobileFormControlKind.YesNo:
+                    BoolValue = MobileFormValueConverter.TryGetBoolean(value, out var boolean) && boolean;
+                    ValueSummary = BoolValue ? "Yes" : "No";
+                    break;
+                case MobileFormControlKind.Date:
+                    DateValue = MobileFormValueConverter.TryGetDate(value, out var date) ? date : DateTime.Today;
+                    ValueSummary = DateValue.ToString("yyyy-MM-dd");
+                    break;
+                case MobileFormControlKind.DateTime:
+                    var dateTime = MobileFormValueConverter.TryGetDateTime(value, out var parsedDateTime)
+                        ? parsedDateTime
+                        : DateTime.Now;
+                    DateValue = dateTime.Date;
+                    TimeValue = dateTime.TimeOfDay;
+                    ValueSummary = dateTime.ToString("u");
+                    break;
+                case MobileFormControlKind.SingleChoice:
+                case MobileFormControlKind.Dropdown:
+                    var selectedValue = MobileFormValueConverter.ToChoiceValues(value).FirstOrDefault();
+                    SelectedChoice = Definition.Choices.FirstOrDefault(choice =>
+                        string.Equals(choice.Value, selectedValue, StringComparison.Ordinal));
+                    ValueSummary = SelectedChoice?.Label ?? SelectedChoice?.Value ?? string.Empty;
+                    break;
+                case MobileFormControlKind.MultipleChoice:
+                    var selected = MobileFormValueConverter
+                        .ToChoiceValues(value)
+                        .ToHashSet(StringComparer.Ordinal);
+                    foreach (var choice in Choices)
+                    {
+                        choice.IsSelected = selected.Contains(choice.Value);
+                    }
+
+                    ValueSummary = string.Join(", ", Choices.Where(choice => choice.IsSelected).Select(choice => choice.Label));
+                    break;
+                case MobileFormControlKind.Location:
+                    if (MobileFormValueConverter.TryGetLocation(value, out var point))
+                    {
+                        TextValue = $"{point.Latitude},{point.Longitude},{point.AccuracyMeters?.ToString() ?? string.Empty}";
+                        ValueSummary = MobileFormValueConverter.ToDisplayText(Definition, point);
+                    }
+                    else
+                    {
+                        TextValue = MobileFormValueConverter.ToDisplayText(Definition, value);
+                        ValueSummary = TextValue;
+                    }
+
+                    break;
+                case MobileFormControlKind.Photo:
+                case MobileFormControlKind.File:
+                case MobileFormControlKind.Signature:
+                    SetMediaValue(MobileFormValueConverter.ToChoiceValues(value), attachmentsById);
+                    break;
+                default:
+                    TextValue = MobileFormValueConverter.ToDisplayText(Definition, value);
+                    ValueSummary = TextValue;
+                    break;
+            }
+        }
+        finally
+        {
+            _suppressValueChanged = false;
+        }
+    }
+
+    public object? ToValue()
+    {
+        return ControlKind switch
+        {
+            MobileFormControlKind.YesNo => MobileFormValueConverter.FromBoolean(Definition, BoolValue),
+            MobileFormControlKind.Date => MobileFormValueConverter.FromDate(Definition, DateValue),
+            MobileFormControlKind.DateTime => MobileFormValueConverter.FromDateTime(Definition, DateValue, TimeValue),
+            MobileFormControlKind.SingleChoice or MobileFormControlKind.Dropdown => SelectedChoice?.Value,
+            MobileFormControlKind.MultipleChoice => MobileFormValueConverter.FromChoiceValues(
+                Definition,
+                Choices.Where(choice => choice.IsSelected).Select(choice => choice.Value)),
+            MobileFormControlKind.Location => MobileFormValueConverter.NormalizeValue(Definition, TextValue),
+            MobileFormControlKind.Photo or MobileFormControlKind.File or MobileFormControlKind.Signature
+                => MobileFormValueConverter.ToChoiceValues(TextValue).ToArray(),
+            _ => MobileFormValueConverter.FromText(Definition, TextValue)
+        };
+    }
+
+    public void SetLocation(Location location)
+    {
+        var value = MobileFormValueConverter.FromLocation(
+            location.Latitude,
+            location.Longitude,
+            location.Accuracy);
+        SetValue(value);
+        RaiseValueChanged();
+    }
+
+    public void AddMediaAttachment(AttachmentInfo attachment)
+    {
+        var ids = MobileFormValueConverter.ToChoiceValues(TextValue).ToList();
+        if (!ids.Contains(attachment.Id, StringComparer.Ordinal))
+        {
+            ids.Add(attachment.Id);
+        }
+
+        SetMediaValue(ids, new Dictionary<string, AttachmentInfo>(StringComparer.Ordinal)
+        {
+            [attachment.Id] = attachment
+        });
+        RaiseValueChanged();
+    }
+
+    partial void OnTextValueChanged(string value)
+    {
+        ValueSummary = value;
+        RaiseValueChanged();
+    }
+
+    partial void OnBoolValueChanged(bool value)
+    {
+        ValueSummary = value ? "Yes" : "No";
+        RaiseValueChanged();
+    }
+
+    partial void OnDateValueChanged(DateTime value)
+    {
+        ValueSummary = ControlKind == MobileFormControlKind.DateTime
+            ? value.Date.Add(TimeValue).ToString("u")
+            : value.ToString("yyyy-MM-dd");
+        RaiseValueChanged();
+    }
+
+    partial void OnTimeValueChanged(TimeSpan value)
+    {
+        ValueSummary = DateValue.Date.Add(value).ToString("u");
+        RaiseValueChanged();
+    }
+
+    partial void OnSelectedChoiceChanged(FieldChoice? value)
+    {
+        ValueSummary = value?.Label ?? value?.Value ?? string.Empty;
+        RaiseValueChanged();
+    }
+
+    private void SetMediaValue(IReadOnlyList<string> attachmentIds, IReadOnlyDictionary<string, AttachmentInfo>? attachmentsById)
+    {
+        TextValue = string.Join(",", attachmentIds);
+        var names = attachmentIds
+            .Select(id => attachmentsById != null && attachmentsById.TryGetValue(id, out var attachment)
+                ? attachment.FileName
+                : id)
+            .ToArray();
+        ValueSummary = names.Length == 0 ? string.Empty : string.Join(", ", names);
+    }
+
+    private void RaiseValueChanged()
+    {
+        if (!_suppressValueChanged)
+        {
+            ValueChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
 }
 
 public partial class RecordDetailViewModel : BaseViewModel, IRouteAwareViewModel
@@ -210,6 +485,11 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
 {
     private readonly IFeatureService _featureService;
     private readonly IAttachmentService _attachmentService;
+    private readonly IFormService _formService;
+    private readonly IFormDraftService _formDraftService;
+    private readonly ILocationService _locationService;
+    private bool _isLoadingForm;
+    private FormDefinition? _formDefinition;
 
     [ObservableProperty]
     private int layerId = 1;
@@ -226,20 +506,33 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
     [ObservableProperty]
     private string geometrySummary = "No geometry";
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasValidationSummary))]
+    private string validationSummary = string.Empty;
+
+    public bool HasValidationSummary => !string.IsNullOrWhiteSpace(ValidationSummary);
+
     private FieldPoint? _location;
     private Feature? _existingFeature;
 
     public ObservableCollection<EditableAttributeItem> Attributes { get; } = [];
+    public ObservableCollection<EditableFormFieldItem> FormFields { get; } = [];
     public ObservableCollection<AttachmentInfo> Attachments { get; } = [];
 
     public RecordEditViewModel(
         INavigationService navigationService,
         IFeatureService featureService,
-        IAttachmentService attachmentService)
+        IAttachmentService attachmentService,
+        IFormService formService,
+        IFormDraftService formDraftService,
+        ILocationService locationService)
         : base(navigationService)
     {
         _featureService = featureService;
         _attachmentService = attachmentService;
+        _formService = formService;
+        _formDraftService = formDraftService;
+        _locationService = locationService;
         Title = "Create Record";
     }
 
@@ -263,39 +556,70 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
     {
         await ExecuteAsync(async () =>
         {
-            Attributes.Clear();
-            Attachments.Clear();
-            PageTitle = IsNew ? "Create Record" : "Edit Record";
-            Title = PageTitle;
-
-            if (IsNew && string.IsNullOrWhiteSpace(FeatureId))
+            _isLoadingForm = true;
+            try
             {
-                FeatureId = Guid.NewGuid().ToString("N");
-            }
-
-            if (!IsNew && !string.IsNullOrWhiteSpace(FeatureId))
-            {
-                _existingFeature = await _featureService.GetFeatureAsync(LayerId, FeatureId);
-            }
-
-            var source = _existingFeature?.Attributes ?? CreateDefaultAttributes();
-            foreach (var attribute in source.OrderBy(attribute => attribute.Key, StringComparer.OrdinalIgnoreCase))
-            {
-                Attributes.Add(new EditableAttributeItem
+                Attributes.Clear();
+                foreach (var field in FormFields)
                 {
-                    Key = attribute.Key,
-                    ValueText = RecordDetailViewModel.FormatValue(attribute.Value)
-                });
-            }
-
-            GeometrySummary = FormatGeometry(_existingFeature?.Geometry ?? _location);
-
-            if (!string.IsNullOrWhiteSpace(FeatureId))
-            {
-                foreach (var attachment in await _attachmentService.GetAttachmentsAsync(FeatureId))
-                {
-                    Attachments.Add(attachment);
+                    field.ValueChanged -= OnFormFieldValueChanged;
                 }
+
+                FormFields.Clear();
+                Attachments.Clear();
+                ValidationSummary = string.Empty;
+                PageTitle = IsNew ? "Create Record" : "Edit Record";
+                Title = PageTitle;
+
+                if (IsNew && string.IsNullOrWhiteSpace(FeatureId))
+                {
+                    FeatureId = Guid.NewGuid().ToString("N");
+                }
+
+                if (!IsNew && !string.IsNullOrWhiteSpace(FeatureId))
+                {
+                    _existingFeature = await _featureService.GetFeatureAsync(LayerId, FeatureId);
+                }
+
+                var source = _existingFeature?.Attributes ?? CreateDefaultAttributes();
+                var draft = string.IsNullOrWhiteSpace(FeatureId)
+                    ? null
+                    : await _formDraftService.GetDraftAsync(LayerId, FeatureId);
+                if (draft?.Values.Count > 0)
+                {
+                    source = new Dictionary<string, object?>(source, StringComparer.OrdinalIgnoreCase);
+                    foreach (var value in draft.Values)
+                    {
+                        source[value.Key] = value.Value;
+                    }
+                }
+
+                foreach (var attribute in source.OrderBy(attribute => attribute.Key, StringComparer.OrdinalIgnoreCase))
+                {
+                    Attributes.Add(new EditableAttributeItem
+                    {
+                        Key = attribute.Key,
+                        ValueText = RecordDetailViewModel.FormatValue(attribute.Value)
+                    });
+                }
+
+                GeometrySummary = FormatGeometry(_existingFeature?.Geometry ?? _location);
+
+                if (!string.IsNullOrWhiteSpace(FeatureId))
+                {
+                    foreach (var attachment in await _attachmentService.GetAttachmentsAsync(FeatureId))
+                    {
+                        Attachments.Add(attachment);
+                    }
+                }
+
+                _formDefinition = await _formService.GetFormDefinitionAsync(LayerId)
+                    ?? CreateAdHocFormDefinition(LayerId, source);
+                LoadFormFields(_formDefinition, source);
+            }
+            finally
+            {
+                _isLoadingForm = false;
             }
         });
     }
@@ -309,6 +633,17 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
             Key = $"field_{index}",
             ValueText = string.Empty
         });
+
+        if (_formDefinition != null)
+        {
+            var field = new FormField
+            {
+                FieldId = $"field_{index}",
+                Label = $"Field {index}",
+                Type = FormFieldType.Text
+            };
+            AddFormField(field, null);
+        }
     }
 
     [RelayCommand]
@@ -351,6 +686,71 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
     }
 
     [RelayCommand]
+    private async Task CaptureFormFieldLocation(EditableFormFieldItem field)
+    {
+        await ExecuteAsync(async () =>
+        {
+            var location = await _locationService.GetCurrentLocationAsync();
+            if (location == null)
+            {
+                await ShowError("Location Unavailable", "Unable to determine current location.");
+                return;
+            }
+
+            field.SetLocation(location);
+            await SaveDraftSnapshotAsync();
+        });
+    }
+
+    [RelayCommand]
+    private async Task CaptureFormFieldAttachment(EditableFormFieldItem field)
+    {
+        Microsoft.Maui.Storage.FileResult? file = null;
+        var payloadKind = field.ControlKind switch
+        {
+            MobileFormControlKind.Photo => AttachmentPayloadKind.Photo,
+            MobileFormControlKind.Signature => AttachmentPayloadKind.Signature,
+            _ => AttachmentPayloadKind.File
+        };
+
+        if (payloadKind == AttachmentPayloadKind.Photo && Microsoft.Maui.Media.MediaPicker.Default.IsCaptureSupported)
+        {
+            file = await Microsoft.Maui.Media.MediaPicker.Default.CapturePhotoAsync();
+        }
+
+        file ??= payloadKind switch
+        {
+            AttachmentPayloadKind.Photo => await Microsoft.Maui.Storage.FilePicker.Default.PickAsync(
+                new Microsoft.Maui.Storage.PickOptions { FileTypes = Microsoft.Maui.Storage.FilePickerFileType.Images }),
+            _ => await Microsoft.Maui.Storage.FilePicker.Default.PickAsync()
+        };
+
+        if (file == null)
+        {
+            return;
+        }
+
+        await AddAttachmentFromFileResultAsync(file, payloadKind, field);
+    }
+
+    [RelayCommand]
+    private async Task CaptureBarcode(EditableFormFieldItem field)
+    {
+        var value = await NavigationService.DisplayPromptAsync(
+            "Barcode / QR",
+            "Enter scanned code",
+            placeholder: "Code",
+            initialValue: field.TextValue);
+        if (value == null)
+        {
+            return;
+        }
+
+        field.TextValue = value;
+        await SaveDraftSnapshotAsync();
+    }
+
+    [RelayCommand]
     private async Task RemoveAttachment(AttachmentInfo attachment)
     {
         await ExecuteAsync(async () =>
@@ -362,7 +762,8 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
 
     private async Task AddAttachmentFromFileResultAsync(
         Microsoft.Maui.Storage.FileResult file,
-        AttachmentPayloadKind payloadKind)
+        AttachmentPayloadKind payloadKind,
+        EditableFormFieldItem? ownerField = null)
     {
         await ExecuteAsync(async () =>
         {
@@ -380,8 +781,11 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
                 string.IsNullOrWhiteSpace(file.ContentType)
                     ? "application/octet-stream"
                     : file.ContentType,
-                payloadKind);
+                payloadKind,
+                ownerField?.Definition.FieldId);
             Attachments.Add(attachment);
+            ownerField?.AddMediaAttachment(attachment);
+            await SaveDraftSnapshotAsync();
         });
     }
 
@@ -398,13 +802,20 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
             };
 
             feature.LayerId = LayerId;
-            feature.Attributes = Attributes
-                .Where(attribute => !string.IsNullOrWhiteSpace(attribute.Key))
-                .GroupBy(attribute => attribute.Key.Trim(), StringComparer.OrdinalIgnoreCase)
-                .ToDictionary(
-                    group => group.Key,
-                    group => ParseAttributeValue(group.Last().ValueText),
-                    StringComparer.OrdinalIgnoreCase);
+            var values = BuildFormValues();
+            if (_formDefinition != null)
+            {
+                var formData = BuildFormData(values);
+                var valid = await _formService.ValidateFormAsync(formData, _formDefinition);
+                ApplyValidationErrors(formData.ValidationErrors);
+                if (!valid)
+                {
+                    ValidationSummary = $"Fix {formData.ValidationErrors.Count} field error(s) before saving.";
+                    return;
+                }
+            }
+
+            feature.Attributes = values;
 
             if (IsNew)
             {
@@ -417,6 +828,7 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
 
             FeatureId = feature.Id;
             IsNew = false;
+            await _formDraftService.DeleteDraftAsync(LayerId, FeatureId);
             await NavigationService.NavigateToAsync(
                 "record-detail",
                 new Dictionary<string, object>
@@ -436,9 +848,177 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
             {
                 await _attachmentService.DeleteAttachmentAsync(attachment.Id);
             }
+
+            await _formDraftService.DeleteDraftAsync(LayerId, FeatureId);
         }
 
         await NavigationService.GoBackAsync();
+    }
+
+    private void LoadFormFields(FormDefinition formDefinition, IReadOnlyDictionary<string, object?> values)
+    {
+        var attachmentsById = Attachments.ToDictionary(attachment => attachment.Id, StringComparer.Ordinal);
+        foreach (var field in formDefinition.Sections.SelectMany(section => section.Fields))
+        {
+            values.TryGetValue(field.FieldId, out var value);
+            AddFormField(field, value, attachmentsById);
+        }
+    }
+
+    private void AddFormField(
+        FormField field,
+        object? value,
+        IReadOnlyDictionary<string, AttachmentInfo>? attachmentsById = null)
+    {
+        var item = new EditableFormFieldItem(field)
+        {
+            PrimaryActionCommand = field.Type switch
+            {
+                FormFieldType.Location => CaptureFormFieldLocationCommand,
+                FormFieldType.Photo or FormFieldType.File or FormFieldType.Signature => CaptureFormFieldAttachmentCommand,
+                FormFieldType.Barcode => CaptureBarcodeCommand,
+                _ => null
+            },
+            PrimaryActionLabel = field.Type switch
+            {
+                FormFieldType.Location => "Use current location",
+                FormFieldType.Photo => "Add photo",
+                FormFieldType.Signature => "Add signature",
+                FormFieldType.File => "Add file",
+                FormFieldType.Barcode => "Scan or enter code",
+                _ => string.Empty
+            }
+        };
+        item.SetValue(value, attachmentsById);
+        item.ValueChanged += OnFormFieldValueChanged;
+        FormFields.Add(item);
+    }
+
+    private void OnFormFieldValueChanged(object? sender, EventArgs e)
+    {
+        if (_isLoadingForm)
+        {
+            return;
+        }
+
+        ValidationSummary = string.Empty;
+        if (sender is EditableFormFieldItem item)
+        {
+            item.ValidationError = null;
+        }
+
+        _ = SaveDraftSnapshotAsync();
+    }
+
+    private async Task SaveDraftSnapshotAsync()
+    {
+        if (_isLoadingForm || string.IsNullOrWhiteSpace(FeatureId))
+        {
+            return;
+        }
+
+        await _formDraftService.SaveDraftAsync(new FormDraftSnapshot
+        {
+            LayerId = LayerId,
+            FeatureId = FeatureId,
+            FormId = _formDefinition?.FormId,
+            Values = BuildFormValues()
+        });
+    }
+
+    private Dictionary<string, object?> BuildFormValues()
+    {
+        if (FormFields.Count == 0)
+        {
+            return Attributes
+                .Where(attribute => !string.IsNullOrWhiteSpace(attribute.Key))
+                .GroupBy(attribute => attribute.Key.Trim(), StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    group => group.Key,
+                    group => ParseAttributeValue(group.Last().ValueText),
+                    StringComparer.OrdinalIgnoreCase);
+        }
+
+        return FormFields
+            .Where(field => !string.IsNullOrWhiteSpace(field.Definition.FieldId))
+            .ToDictionary(
+                field => field.Definition.FieldId,
+                field => field.ToValue(),
+                StringComparer.OrdinalIgnoreCase);
+    }
+
+    private FormData BuildFormData(Dictionary<string, object?> values)
+    {
+        var fields = FormFields.Select(field => field.Definition).ToArray();
+        var attachmentsById = Attachments.ToDictionary(attachment => attachment.Id, StringComparer.Ordinal);
+        var location = fields
+            .Where(field => field.Type == FormFieldType.Location)
+            .Select(field => values.TryGetValue(field.FieldId, out var value) &&
+                MobileFormValueConverter.TryGetLocation(value, out var point)
+                    ? point
+                    : (FieldGeoPoint?)null)
+            .FirstOrDefault(point => point != null);
+
+        return new FormData
+        {
+            LayerId = LayerId,
+            FeatureId = FeatureId,
+            Values = values,
+            Media = MobileFormValueConverter.BuildMediaAttachments(fields, values, attachmentsById).ToList(),
+            Location = location,
+            CreatedAt = _existingFeature?.CreatedAt ?? DateTime.UtcNow
+        };
+    }
+
+    private void ApplyValidationErrors(IReadOnlyDictionary<string, string> errors)
+    {
+        foreach (var field in FormFields)
+        {
+            field.ValidationError = errors.TryGetValue(field.Definition.FieldId, out var error)
+                ? error
+                : null;
+        }
+
+        ValidationSummary = errors.Count == 0
+            ? string.Empty
+            : $"Fix {errors.Count} field error(s) before saving.";
+    }
+
+    private static FormDefinition CreateAdHocFormDefinition(int layerId, IReadOnlyDictionary<string, object?> source)
+    {
+        return new FormDefinition
+        {
+            FormId = $"layer-{layerId}:ad-hoc",
+            Name = $"Layer {layerId}",
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "attributes",
+                    Label = "Attributes",
+                    Fields = source
+                        .OrderBy(attribute => attribute.Key, StringComparer.OrdinalIgnoreCase)
+                        .Select(attribute => new FormField
+                        {
+                            FieldId = attribute.Key,
+                            Label = attribute.Key,
+                            Type = InferAdHocFieldType(attribute.Value)
+                        })
+                        .ToList()
+                }
+            ]
+        };
+    }
+
+    private static FormFieldType InferAdHocFieldType(object? value)
+    {
+        return value switch
+        {
+            bool => FormFieldType.YesNo,
+            byte or short or int or long or float or double or decimal => FormFieldType.Numeric,
+            DateTime or DateTimeOffset => FormFieldType.DateTime,
+            _ => FormFieldType.Text
+        };
     }
 
     private static Dictionary<string, object?> CreateDefaultAttributes() =>

--- a/apps/Honua.Mobile.FieldCollection/Views/WorkflowPages.cs
+++ b/apps/Honua.Mobile.FieldCollection/Views/WorkflowPages.cs
@@ -1,5 +1,6 @@
 using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.ViewModels;
+using Honua.Sdk.Field.Forms;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Honua.Mobile.FieldCollection.Views;
@@ -247,42 +248,22 @@ internal static class WorkflowPageContent
 
     public static View CreateRecordEditContent()
     {
-        var attributes = new CollectionView
-        {
-            ItemTemplate = new DataTemplate(() =>
-            {
-                var key = new Entry { Placeholder = "Field" };
-                key.SetBinding(Entry.TextProperty, new Binding(nameof(EditableAttributeItem.Key)));
+        var fields = FormFieldList();
+        fields.SetBinding(ItemsView.ItemsSourceProperty, new Binding("FormFields"));
 
-                var value = new Entry { Placeholder = "Value" };
-                value.SetBinding(Entry.TextProperty, new Binding(nameof(EditableAttributeItem.ValueText)));
+        var validation = BoundMultilineLabel("ValidationSummary");
+        validation.TextColor = Colors.DarkRed;
+        validation.SetBinding(VisualElement.IsVisibleProperty, new Binding("HasValidationSummary"));
 
-                var grid = new Grid
-                {
-                    Padding = new Thickness(0, 6),
-                    ColumnDefinitions =
-                    {
-                        new ColumnDefinition { Width = new GridLength(130) },
-                        new ColumnDefinition { Width = GridLength.Star }
-                    }
-                };
-
-                Grid.SetColumn(key, 0);
-                Grid.SetColumn(value, 1);
-                grid.Children.Add(key);
-                grid.Children.Add(value);
-                return grid;
-            })
-        };
-        attributes.SetBinding(ItemsView.ItemsSourceProperty, new Binding("Attributes"));
         var attachments = AttachmentList("RemoveAttachmentCommand");
         attachments.SetBinding(ItemsView.ItemsSourceProperty, new Binding("Attachments"));
 
         return PageScroll(
             BoundHeader("PageTitle", "Record"),
             BoundLabel("GeometrySummary", "Geometry"),
-            SectionTitle("Attributes"),
-            attributes,
+            validation,
+            SectionTitle("Fields"),
+            fields,
             SectionTitle("Attachments"),
             attachments,
             ButtonRow(
@@ -291,6 +272,114 @@ internal static class WorkflowPageContent
                 CommandButton("Add photo", "AddPhotoAttachmentCommand"),
                 CommandButton("Save", "SaveRecordCommand"),
                 CommandButton("Cancel", "CancelCommand")));
+    }
+
+    private static CollectionView FormFieldList()
+    {
+        return new CollectionView
+        {
+            EmptyView = new Label { Text = "No fields" },
+            ItemTemplate = new DataTemplate(() =>
+            {
+                var label = new Label { FontAttributes = FontAttributes.Bold };
+                label.SetBinding(Label.TextProperty, new Binding(nameof(EditableFormFieldItem.Label)));
+
+                var help = new Label { FontSize = 12, TextColor = Colors.Gray };
+                help.SetBinding(Label.TextProperty, new Binding(nameof(EditableFormFieldItem.HelpText)));
+
+                var singleLine = new Entry { Placeholder = "Value" };
+                singleLine.SetBinding(Entry.TextProperty, new Binding(nameof(EditableFormFieldItem.TextValue), mode: BindingMode.TwoWay));
+                singleLine.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsSingleLineText)));
+
+                var numeric = new Entry { Placeholder = "Number", Keyboard = Keyboard.Numeric };
+                numeric.SetBinding(Entry.TextProperty, new Binding(nameof(EditableFormFieldItem.TextValue), mode: BindingMode.TwoWay));
+                numeric.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsNumeric)));
+
+                var multiline = new Editor { AutoSize = EditorAutoSizeOption.TextChanges, MinimumHeightRequest = 96 };
+                multiline.SetBinding(Editor.TextProperty, new Binding(nameof(EditableFormFieldItem.TextValue), mode: BindingMode.TwoWay));
+                multiline.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsMultilineText)));
+
+                var date = new DatePicker();
+                date.SetBinding(DatePicker.DateProperty, new Binding(nameof(EditableFormFieldItem.DateValue), mode: BindingMode.TwoWay));
+                date.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsDate)));
+
+                var dateTime = new HorizontalStackLayout { Spacing = 8 };
+                dateTime.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsDateTime)));
+                var datePart = new DatePicker();
+                datePart.SetBinding(DatePicker.DateProperty, new Binding(nameof(EditableFormFieldItem.DateValue), mode: BindingMode.TwoWay));
+                var timePart = new TimePicker();
+                timePart.SetBinding(TimePicker.TimeProperty, new Binding(nameof(EditableFormFieldItem.TimeValue), mode: BindingMode.TwoWay));
+                dateTime.Children.Add(datePart);
+                dateTime.Children.Add(timePart);
+
+                var yesNo = new Switch();
+                yesNo.SetBinding(Switch.IsToggledProperty, new Binding(nameof(EditableFormFieldItem.BoolValue), mode: BindingMode.TwoWay));
+                yesNo.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsYesNo)));
+
+                var choice = new Picker { ItemDisplayBinding = new Binding(nameof(FieldChoice.Label)) };
+                choice.SetBinding(Picker.ItemsSourceProperty, new Binding("Definition.Choices"));
+                choice.SetBinding(Picker.SelectedItemProperty, new Binding(nameof(EditableFormFieldItem.SelectedChoice), mode: BindingMode.TwoWay));
+                choice.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsSingleChoice)));
+
+                var choices = new VerticalStackLayout { Spacing = 6 };
+                choices.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsMultipleChoice)));
+                choices.SetBinding(BindableLayout.ItemsSourceProperty, new Binding(nameof(EditableFormFieldItem.Choices)));
+                BindableLayout.SetItemTemplate(choices, new DataTemplate(() =>
+                {
+                    var checkbox = new CheckBox();
+                    checkbox.SetBinding(CheckBox.IsCheckedProperty, new Binding(nameof(EditableChoiceItem.IsSelected), mode: BindingMode.TwoWay));
+
+                    var choiceLabel = new Label { VerticalOptions = LayoutOptions.Center };
+                    choiceLabel.SetBinding(Label.TextProperty, new Binding(nameof(EditableChoiceItem.Label)));
+
+                    return new HorizontalStackLayout
+                    {
+                        Spacing = 8,
+                        Children = { checkbox, choiceLabel }
+                    };
+                }));
+
+                var summary = new Label { FontSize = 12, TextColor = Colors.Gray };
+                summary.SetBinding(Label.TextProperty, new Binding(nameof(EditableFormFieldItem.ValueSummary)));
+                summary.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.HasPrimaryAction)));
+
+                var action = new Button();
+                action.SetBinding(Button.TextProperty, new Binding(nameof(EditableFormFieldItem.PrimaryActionLabel)));
+                action.SetBinding(Button.CommandProperty, new Binding(nameof(EditableFormFieldItem.PrimaryActionCommand)));
+                action.SetBinding(Button.CommandParameterProperty, new Binding("."));
+                action.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.HasPrimaryAction)));
+
+                var unsupported = new Label { Text = "Unsupported field type", TextColor = Colors.DarkRed };
+                unsupported.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsUnsupported)));
+
+                var error = new Label { FontSize = 12, TextColor = Colors.DarkRed };
+                error.SetBinding(Label.TextProperty, new Binding(nameof(EditableFormFieldItem.ValidationError)));
+                error.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.HasValidationError)));
+
+                return new VerticalStackLayout
+                {
+                    Padding = new Thickness(0, 8),
+                    Spacing = 6,
+                    Children =
+                    {
+                        label,
+                        help,
+                        singleLine,
+                        numeric,
+                        multiline,
+                        date,
+                        dateTime,
+                        yesNo,
+                        choice,
+                        choices,
+                        summary,
+                        action,
+                        unsupported,
+                        error
+                    }
+                };
+            })
+        };
     }
 
     public static View CreateAuthenticationContent()

--- a/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionMetadataServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionMetadataServiceTests.cs
@@ -325,6 +325,12 @@ public sealed class FieldCollectionMetadataServiceTests
             return Task.CompletedTask;
         }
 
+        public Task RemoveSettingAsync(string key)
+        {
+            _settings.Remove(key);
+            return Task.CompletedTask;
+        }
+
         public Task<bool> HasSettingAsync(string key)
         {
             return Task.FromResult(_settings.ContainsKey(key));

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -864,6 +864,12 @@ public sealed class GeoPackageSyncServiceTests
             return Task.CompletedTask;
         }
 
+        public Task RemoveSettingAsync(string key)
+        {
+            _values.Remove(key);
+            return Task.CompletedTask;
+        }
+
         public Task<bool> HasSettingAsync(string key)
         {
             return Task.FromResult(_values.ContainsKey(key));

--- a/tests/Honua.Mobile.FieldCollection.Tests/MobileFormRuntimeTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/MobileFormRuntimeTests.cs
@@ -1,0 +1,214 @@
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.FieldCollection.Services.Forms;
+using Honua.Sdk.Field.Forms;
+using Honua.Sdk.Field.Records;
+
+namespace Honua.Mobile.FieldCollection.Tests;
+
+public sealed class MobileFormRuntimeTests
+{
+    [Fact]
+    public void ControlSelector_SelectsPilotFieldTypeControls()
+    {
+        var cases = new (FormField Field, MobileFormControlKind Expected)[]
+        {
+            (Field("text", FormFieldType.Text), MobileFormControlKind.SingleLineText),
+            (Field("notes", FormFieldType.Text, maxLength: 1024), MobileFormControlKind.MultilineText),
+            (Field("number", FormFieldType.Numeric), MobileFormControlKind.Numeric),
+            (Field("date", FormFieldType.Date), MobileFormControlKind.Date),
+            (Field("datetime", FormFieldType.DateTime), MobileFormControlKind.DateTime),
+            (Field("yesno", FormFieldType.YesNo), MobileFormControlKind.YesNo),
+            (Field("single", FormFieldType.SingleChoice, choiceCount: 3), MobileFormControlKind.SingleChoice),
+            (Field("dropdown", FormFieldType.SingleChoice, choiceCount: 8), MobileFormControlKind.Dropdown),
+            (Field("multi", FormFieldType.MultipleChoice, choiceCount: 3), MobileFormControlKind.MultipleChoice),
+            (Field("gps", FormFieldType.Location), MobileFormControlKind.Location),
+            (Field("photo", FormFieldType.Photo), MobileFormControlKind.Photo),
+            (Field("file", FormFieldType.File), MobileFormControlKind.File),
+            (Field("signature", FormFieldType.Signature), MobileFormControlKind.Signature),
+            (Field("barcode", FormFieldType.Barcode), MobileFormControlKind.Barcode),
+        };
+
+        foreach (var (field, expected) in cases)
+        {
+            Assert.Equal(expected, MobileFormControlSelector.Select(field));
+        }
+    }
+
+    [Fact]
+    public void ValueConverter_NormalizesPilotFieldValues()
+    {
+        Assert.Equal("inspection", MobileFormValueConverter.NormalizeValue(Field("text", FormFieldType.Text), "inspection"));
+        Assert.Equal(42L, MobileFormValueConverter.NormalizeValue(Field("integer", FormFieldType.Numeric), "42"));
+        Assert.Equal(3.5m, MobileFormValueConverter.NormalizeValue(Field("decimal", FormFieldType.Numeric), "3.5"));
+        Assert.Equal(new DateOnly(2026, 5, 23), MobileFormValueConverter.NormalizeValue(Field("date", FormFieldType.Date), "2026-05-23"));
+        Assert.Equal(
+            new DateTime(2026, 5, 23, 8, 30, 0, DateTimeKind.Utc),
+            MobileFormValueConverter.NormalizeValue(Field("datetime", FormFieldType.DateTime), "2026-05-23T08:30:00Z"));
+        Assert.True((bool)MobileFormValueConverter.NormalizeValue(Field("yesno", FormFieldType.YesNo), "yes")!);
+        Assert.Equal("open", MobileFormValueConverter.NormalizeValue(Field("single", FormFieldType.SingleChoice), "open"));
+        var tags = Assert.IsAssignableFrom<IReadOnlyList<string>>(
+            MobileFormValueConverter.NormalizeValue(Field("multi", FormFieldType.MultipleChoice), "urgent, wet"));
+        Assert.Equal(["urgent", "wet"], tags);
+
+        var location = Assert.IsType<FieldGeoPoint>(
+            MobileFormValueConverter.NormalizeValue(Field("gps", FormFieldType.Location), "21.3,-157.8,5"));
+        Assert.Equal(21.3, location.Latitude);
+        Assert.Equal(-157.8, location.Longitude);
+        Assert.Equal(5, location.AccuracyMeters);
+
+        var photo = Assert.IsAssignableFrom<IReadOnlyList<string>>(
+            MobileFormValueConverter.NormalizeValue(Field("photo", FormFieldType.Photo), "photo-1"));
+        Assert.Equal(["photo-1"], photo);
+        var file = Assert.IsAssignableFrom<IReadOnlyList<string>>(
+            MobileFormValueConverter.NormalizeValue(Field("file", FormFieldType.File), "file-1"));
+        Assert.Equal(["file-1"], file);
+        var signature = Assert.IsAssignableFrom<IReadOnlyList<string>>(
+            MobileFormValueConverter.NormalizeValue(Field("signature", FormFieldType.Signature), "signature-1"));
+        Assert.Equal(["signature-1"], signature);
+        Assert.Equal("QR-123", MobileFormValueConverter.NormalizeValue(Field("barcode", FormFieldType.Barcode), "QR-123"));
+    }
+
+    [Fact]
+    public async Task FormData_ToSdkRecord_IncludesMediaAndLocationForSdkValidation()
+    {
+        var form = new FormDefinition
+        {
+            FormId = "inspection",
+            Name = "Inspection",
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "main",
+                    Label = "Main",
+                    Fields =
+                    [
+                        Field("gps", FormFieldType.Location, required: true),
+                        new FormField
+                        {
+                            FieldId = "photos",
+                            Label = "Photos",
+                            Type = FormFieldType.Photo,
+                            Required = true,
+                            Validation = new FieldValidationRule { MinMediaCount = 1 },
+                        },
+                    ],
+                },
+            ],
+        };
+        var formData = new FormData
+        {
+            LayerId = 7,
+            FeatureId = "asset-1",
+            Values =
+            {
+                ["gps"] = new FieldGeoPoint(21.3, -157.8, 4),
+                ["photos"] = new[] { "photo-1" },
+            },
+            Location = new FieldGeoPoint(21.3, -157.8, 4),
+            Media =
+            [
+                new FieldMediaAttachment
+                {
+                    AttachmentId = "photo-1",
+                    FieldId = "photos",
+                    FileName = "site.jpg",
+                    MediaType = FieldMediaType.Photo,
+                },
+            ],
+        };
+
+        var valid = await new FormService().ValidateFormAsync(formData, form);
+
+        Assert.True(valid);
+        Assert.Empty(formData.ValidationErrors);
+        var record = formData.ToSdkFieldRecord(form);
+        Assert.Single(record.Media);
+        Assert.Equal(21.3, record.Location?.Latitude);
+    }
+
+    [Fact]
+    public async Task DraftService_PreservesTypedValuesAcrossServiceRestart()
+    {
+        var settings = new InMemorySettingsService();
+        var service = new SettingsFormDraftService(settings);
+        await service.SaveDraftAsync(new FormDraftSnapshot
+        {
+            LayerId = 4,
+            FeatureId = "draft-1",
+            FormId = "inspection",
+            Values =
+            {
+                ["name"] = "Pump Station",
+                ["score"] = 3.5m,
+                ["tags"] = new[] { "urgent", "wet" },
+                ["captured_at"] = new DateTime(2026, 5, 23, 8, 30, 0, DateTimeKind.Utc),
+                ["gps"] = new FieldGeoPoint(21.3, -157.8, 4),
+            },
+        });
+
+        var restarted = new SettingsFormDraftService(settings);
+        var loaded = await restarted.GetDraftAsync(4, "draft-1");
+
+        Assert.NotNull(loaded);
+        Assert.Equal("Pump Station", MobileFormValueConverter.NormalizeValue(Field("name", FormFieldType.Text), loaded.Values["name"]));
+        Assert.Equal(3.5m, MobileFormValueConverter.NormalizeValue(Field("score", FormFieldType.Numeric), loaded.Values["score"]));
+        var loadedTags = Assert.IsAssignableFrom<IReadOnlyList<string>>(
+            MobileFormValueConverter.NormalizeValue(Field("tags", FormFieldType.MultipleChoice), loaded.Values["tags"]));
+        Assert.Equal(["urgent", "wet"], loadedTags);
+        Assert.True(MobileFormValueConverter.TryGetDateTime(loaded.Values["captured_at"], out _));
+        Assert.True(MobileFormValueConverter.TryGetLocation(loaded.Values["gps"], out _));
+    }
+
+    private static FormField Field(
+        string fieldId,
+        FormFieldType type,
+        bool required = false,
+        int? maxLength = null,
+        int choiceCount = 0)
+    {
+        return new FormField
+        {
+            FieldId = fieldId,
+            Label = fieldId,
+            Type = type,
+            Required = required,
+            Validation = maxLength.HasValue
+                ? new FieldValidationRule { MaxLength = maxLength.Value }
+                : new FieldValidationRule(),
+            Choices = Enumerable.Range(1, choiceCount)
+                .Select(index => new FieldChoice { Value = $"choice-{index}", Label = $"Choice {index}" })
+                .ToList(),
+        };
+    }
+
+    private sealed class InMemorySettingsService : ISettingsService
+    {
+        private readonly Dictionary<string, object?> _values = new(StringComparer.Ordinal);
+
+        public Task<T> GetSettingAsync<T>(string key, T defaultValue = default!)
+        {
+            return Task.FromResult(_values.TryGetValue(key, out var value) && value is T typed
+                ? typed
+                : defaultValue);
+        }
+
+        public Task SetSettingAsync<T>(string key, T value)
+        {
+            _values[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveSettingAsync(string key)
+        {
+            _values.Remove(key);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> HasSettingAsync(string key)
+        {
+            return Task.FromResult(_values.ContainsKey(key));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add a mobile form runtime that maps SDK form field types to mobile control kinds and normalizes typed values for text, multiline text, numeric, date/datetime, yes/no, choice/dropdown, multi-choice, location, photo, file, signature, and barcode fields.
- Switch the FieldCollection record editor to SDK schema-driven form fields with field-level validation, summary validation, draft persistence, and field-specific capture actions.
- Carry media and GPS values through `FormData` into SDK `FieldRecord` validation while keeping host-local file paths out of SDK records.

Closes #214

## Offline Impact
- Draft form values are persisted via the mobile settings service under a per-layer/per-feature key and restored when the editor is reopened after app restart.
- Saved form values continue to land in local GeoPackage feature attributes for offline sync.

## Platform Testing
- MAUI controls are generated in code and compile on the forced `net10.0` target before the expected local no-entry-point stop.
- Full platform build is still blocked locally by missing Android SDK (`XA5300`), same as the prior mobile PR; CI covers Android/Windows/iOS.

## Testing
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore --verbosity minimal`
- `dotnet test tests/Honua.Mobile.Field.Tests/Honua.Mobile.Field.Tests.csproj --no-restore --verbosity minimal`
- `dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --no-restore --verbosity minimal`
- `dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --no-restore --verbosity minimal`
- `dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0 --verbosity minimal` (expected `CS5001` after project code compiles)
- `dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj --verbosity minimal` (blocked locally by missing Android SDK `XA5300`)
- `git diff --check`
