### PR TITLE
mobile: add form rules and repeat sections

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Services/CoreServices.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/CoreServices.cs
@@ -1,8 +1,10 @@
 using System.ComponentModel;
 using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services.Forms;
 using Honua.Mobile.FieldCollection.Services.Storage;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Field.Forms;
+using Honua.Sdk.Field.Records;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Devices.Sensors;
 using Microsoft.Maui.Networking;
@@ -225,15 +227,38 @@ public class FormService : IFormService
     public Task<bool> ValidateFormAsync(FormData formData, FormDefinition definition)
     {
         var validationDefinition = EnsureValidationRules(definition);
-        var result = FormValidator.Validate(validationDefinition, formData.ToSdkFieldRecord(validationDefinition));
+        formData.Values = MobileFormRuleRuntime.ApplyCalculatedValues(validationDefinition, formData.Values);
 
         formData.ValidationErrors.Clear();
-        foreach (var error in result.Errors)
+
+        var nonRepeatDefinition = CreateNonRepeatDefinition(validationDefinition);
+        if (nonRepeatDefinition.Sections.Count > 0)
         {
-            formData.ValidationErrors[error.FieldId] = error.Message;
+            var result = FormValidator.Validate(nonRepeatDefinition, formData.ToSdkFieldRecord(nonRepeatDefinition));
+            foreach (var error in result.Errors)
+            {
+                formData.ValidationErrors[error.FieldId] = error.Message;
+            }
         }
 
-        return Task.FromResult(result.IsValid);
+        foreach (var section in validationDefinition.Sections.Where(section => section.Repeatable))
+        {
+            var repeatDefinition = CreateRepeatEntryDefinition(validationDefinition, section);
+            foreach (var repeatIndex in MobileFormRepeatKey.GetRepeatIndices(section, formData.Values))
+            {
+                var record = CreateRepeatEntryRecord(formData, section, repeatIndex, repeatDefinition.FormId);
+                var result = FormValidator.Validate(repeatDefinition, record);
+                foreach (var error in result.Errors)
+                {
+                    var errorKey = section.Fields.FirstOrDefault(field => string.Equals(field.FieldId, error.FieldId, StringComparison.Ordinal)) is { } errorField
+                        ? MobileFormRepeatKey.ForField(section, repeatIndex, errorField)
+                        : $"{section.SectionId}[{repeatIndex}].{error.FieldId}";
+                    formData.ValidationErrors[errorKey] = error.Message;
+                }
+            }
+        }
+
+        return Task.FromResult(formData.ValidationErrors.Count == 0);
     }
 
     private static FormDefinition EnsureValidationRules(FormDefinition definition)
@@ -242,6 +267,7 @@ public class FormService : IFormService
         {
             FormId = definition.FormId,
             Name = definition.Name,
+            Version = definition.Version,
             Description = definition.Description,
             Target = definition.Target,
             Sections = definition.Sections
@@ -249,27 +275,86 @@ public class FormService : IFormService
                 {
                     SectionId = section.SectionId,
                     Label = section.Label,
-                    Fields = section.Fields.Select(CloneField).ToList()
+                    Description = section.Description,
+                    Repeatable = section.Repeatable,
+                    Collapsible = section.Collapsible,
+                    InitiallyCollapsed = section.InitiallyCollapsed,
+                    Fields = section.Fields.Select(MobileFormRuleRuntime.CloneField).ToList()
                 })
                 .ToList(),
             Metadata = new Dictionary<string, string>(definition.Metadata, StringComparer.OrdinalIgnoreCase)
         };
     }
 
-    private static FormField CloneField(FormField field)
+    private static FormDefinition CreateNonRepeatDefinition(FormDefinition definition)
     {
-        return new FormField
+        return new FormDefinition
         {
-            FieldId = field.FieldId,
-            Label = field.Label,
-            Type = field.Type,
-            SourceFieldName = field.SourceFieldName,
-            Required = field.Required,
-            Choices = field.Choices,
-            Validation = field.Validation ?? new FieldValidationRule(),
-            VisibilityRule = field.VisibilityRule,
-            CalculatedExpression = field.CalculatedExpression,
-            HelpText = field.HelpText
+            FormId = definition.FormId,
+            Name = definition.Name,
+            Version = definition.Version,
+            Description = definition.Description,
+            Target = definition.Target,
+            Sections = definition.Sections
+                .Where(section => !section.Repeatable)
+                .Select(section => MobileFormRuleRuntime.CloneSection(section, repeatable: false))
+                .ToList(),
+            Metadata = new Dictionary<string, string>(definition.Metadata, StringComparer.OrdinalIgnoreCase)
+        };
+    }
+
+    private static FormDefinition CreateRepeatEntryDefinition(FormDefinition definition, FormSection section)
+    {
+        return new FormDefinition
+        {
+            FormId = definition.FormId,
+            Name = definition.Name,
+            Version = definition.Version,
+            Description = definition.Description,
+            Target = definition.Target,
+            Sections = [MobileFormRuleRuntime.CloneSection(section, repeatable: false)],
+            Metadata = new Dictionary<string, string>(definition.Metadata, StringComparer.OrdinalIgnoreCase)
+        };
+    }
+
+    private static FieldRecord CreateRepeatEntryRecord(
+        FormData formData,
+        FormSection section,
+        int repeatIndex,
+        string formId)
+    {
+        var values = MobileFormRuleRuntime.BuildRecordValuesForBinding(section, formData.Values, repeatIndex);
+        var repeatMedia = formData.Media
+            .Select(media => MobileFormRepeatKey.TryParse(media.FieldId, out var sectionId, out var mediaRepeatIndex, out var fieldId) &&
+                mediaRepeatIndex == repeatIndex &&
+                string.Equals(sectionId, section.SectionId, StringComparison.Ordinal)
+                    ? new FieldMediaAttachment
+                    {
+                        AttachmentId = media.AttachmentId,
+                        FieldId = fieldId,
+                        MediaType = media.MediaType,
+                        FileName = media.FileName,
+                        ContentType = media.ContentType,
+                        SizeBytes = media.SizeBytes,
+                        CaptureLocation = media.CaptureLocation,
+                        CapturedAtUtc = media.CapturedAtUtc,
+                        RequiresFaceBlur = media.RequiresFaceBlur
+                    }
+                    : null)
+            .Where(media => media != null)
+            .Cast<FieldMediaAttachment>()
+            .ToList();
+
+        return new FieldRecord
+        {
+            RecordId = formData.FeatureId ?? string.Empty,
+            FormId = formId,
+            Values = values,
+            Media = new System.Collections.ObjectModel.Collection<FieldMediaAttachment>(repeatMedia),
+            Location = formData.Location,
+            CreatedAtUtc = formData.CreatedAt == default
+                ? DateTimeOffset.UtcNow
+                : new DateTimeOffset(DateTime.SpecifyKind(formData.CreatedAt, DateTimeKind.Utc))
         };
     }
 

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Forms/MobileFormRuntime.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Forms/MobileFormRuntime.cs
@@ -583,12 +583,400 @@ public static class MobileFormValueConverter
     }
 }
 
+public sealed record MobileFormFieldBinding(
+    FormSection Section,
+    FormField Field,
+    string ValueKey,
+    int? RepeatIndex);
+
+public static class MobileFormRepeatKey
+{
+    public static string ForField(FormSection section, int repeatIndex, FormField field)
+    {
+        ArgumentNullException.ThrowIfNull(section);
+        ArgumentNullException.ThrowIfNull(field);
+
+        if (repeatIndex < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(repeatIndex), repeatIndex, "Repeat index must be non-negative.");
+        }
+
+        return $"{section.SectionId}[{repeatIndex}].{field.FieldId}";
+    }
+
+    public static bool TryParse(string? key, out string sectionId, out int repeatIndex, out string fieldId)
+    {
+        sectionId = string.Empty;
+        repeatIndex = -1;
+        fieldId = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return false;
+        }
+
+        var open = key.IndexOf('[', StringComparison.Ordinal);
+        var close = key.IndexOf(']', StringComparison.Ordinal);
+        if (open <= 0 || close <= open + 1 || close + 1 >= key.Length || key[close + 1] != '.')
+        {
+            return false;
+        }
+
+        if (!int.TryParse(key.AsSpan(open + 1, close - open - 1), NumberStyles.Integer, CultureInfo.InvariantCulture, out repeatIndex) ||
+            repeatIndex < 0)
+        {
+            return false;
+        }
+
+        sectionId = key[..open];
+        fieldId = key[(close + 2)..];
+        return !string.IsNullOrWhiteSpace(sectionId) && !string.IsNullOrWhiteSpace(fieldId);
+    }
+
+    public static IReadOnlyList<int> GetRepeatIndices(
+        FormSection section,
+        IReadOnlyDictionary<string, object?> values,
+        int defaultCount = 0)
+    {
+        ArgumentNullException.ThrowIfNull(section);
+        ArgumentNullException.ThrowIfNull(values);
+
+        var fieldIds = section.Fields
+            .Select(field => field.FieldId)
+            .Where(fieldId => !string.IsNullOrWhiteSpace(fieldId))
+            .ToHashSet(StringComparer.Ordinal);
+        var indices = values.Keys
+            .Select(key => TryParse(key, out var sectionId, out var repeatIndex, out var fieldId) &&
+                string.Equals(sectionId, section.SectionId, StringComparison.Ordinal) &&
+                fieldIds.Contains(fieldId)
+                    ? repeatIndex
+                    : -1)
+            .Where(index => index >= 0)
+            .Distinct()
+            .Order()
+            .ToList();
+
+        if (indices.Count > 0 || defaultCount <= 0)
+        {
+            return indices;
+        }
+
+        return Enumerable.Range(0, defaultCount).ToArray();
+    }
+
+    public static int GetRepeatCount(
+        FormSection section,
+        IReadOnlyDictionary<string, object?> values,
+        int defaultCount = 0)
+    {
+        var indices = GetRepeatIndices(section, values, defaultCount);
+        return indices.Count == 0 ? 0 : indices.Max() + 1;
+    }
+}
+
+public static class MobileFormRuleRuntime
+{
+    public static IReadOnlyList<MobileFormFieldBinding> BuildFieldBindings(
+        FormDefinition definition,
+        IReadOnlyDictionary<string, object?> values,
+        int initialRepeatCount = 1)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(values);
+
+        var bindings = new List<MobileFormFieldBinding>();
+        foreach (var section in definition.Sections)
+        {
+            if (!section.Repeatable)
+            {
+                bindings.AddRange(section.Fields.Select(field =>
+                    new MobileFormFieldBinding(section, field, field.FieldId, null)));
+                continue;
+            }
+
+            foreach (var repeatIndex in MobileFormRepeatKey.GetRepeatIndices(section, values, initialRepeatCount))
+            {
+                bindings.AddRange(section.Fields.Select(field =>
+                    new MobileFormFieldBinding(section, field, MobileFormRepeatKey.ForField(section, repeatIndex, field), repeatIndex)));
+            }
+        }
+
+        return bindings;
+    }
+
+    public static Dictionary<string, object?> ApplyDefaultValues(
+        FormDefinition definition,
+        IReadOnlyDictionary<string, object?> values,
+        int initialRepeatCount = 1)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(values);
+
+        var result = new Dictionary<string, object?>(values, StringComparer.OrdinalIgnoreCase);
+        foreach (var binding in BuildFieldBindings(definition, result, initialRepeatCount))
+        {
+            if (result.TryGetValue(binding.ValueKey, out var existing) && !IsBlank(existing))
+            {
+                continue;
+            }
+
+            if (TryGetDefaultValue(definition, binding.Section, binding.Field, out var defaultValue))
+            {
+                result[binding.ValueKey] = MobileFormValueConverter.NormalizeValue(binding.Field, defaultValue);
+            }
+        }
+
+        return result;
+    }
+
+    public static Dictionary<string, object?> ApplyCalculatedValues(
+        FormDefinition definition,
+        IReadOnlyDictionary<string, object?> values)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(values);
+
+        var result = new Dictionary<string, object?>(values, StringComparer.OrdinalIgnoreCase);
+        ApplyNonRepeatCalculations(definition, result);
+        ApplyRepeatCalculations(definition, result);
+        return result;
+    }
+
+    public static bool IsFieldVisible(
+        FormDefinition definition,
+        FormSection section,
+        FormField field,
+        IReadOnlyDictionary<string, object?> values,
+        int? repeatIndex = null)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(section);
+        ArgumentNullException.ThrowIfNull(field);
+        ArgumentNullException.ThrowIfNull(values);
+
+        if (field.VisibilityRule == null)
+        {
+            return true;
+        }
+
+        var probeField = new FormField
+        {
+            FieldId = field.FieldId,
+            Label = field.Label,
+            Type = field.Type,
+            SourceFieldName = field.SourceFieldName,
+            Required = true,
+            Choices = field.Choices.ToList(),
+            Validation = field.Validation ?? new FieldValidationRule(),
+            VisibilityRule = field.VisibilityRule,
+            CalculatedExpression = field.CalculatedExpression,
+            HelpText = field.HelpText
+        };
+
+        var probeDefinition = new FormDefinition
+        {
+            FormId = definition.FormId,
+            Name = definition.Name,
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = section.SectionId,
+                    Label = section.Label,
+                    Fields = [probeField]
+                }
+            ]
+        };
+        var recordValues = BuildRecordValuesForBinding(section, values, repeatIndex);
+        recordValues[field.FieldId] = null;
+        var result = FormValidator.Validate(probeDefinition, new FieldRecord
+        {
+            RecordId = "visibility-probe",
+            FormId = definition.FormId,
+            Values = recordValues
+        });
+
+        return result.Errors.Any(error => string.Equals(error.FieldId, field.FieldId, StringComparison.Ordinal));
+    }
+
+    public static FormField CloneField(FormField field)
+    {
+        ArgumentNullException.ThrowIfNull(field);
+
+        return new FormField
+        {
+            FieldId = field.FieldId,
+            Label = field.Label,
+            Type = field.Type,
+            SourceFieldName = field.SourceFieldName,
+            Required = field.Required,
+            Choices = field.Choices.ToList(),
+            Validation = field.Validation ?? new FieldValidationRule(),
+            VisibilityRule = field.VisibilityRule,
+            CalculatedExpression = field.CalculatedExpression,
+            HelpText = field.HelpText
+        };
+    }
+
+    public static FormSection CloneSection(FormSection section, bool repeatable)
+    {
+        ArgumentNullException.ThrowIfNull(section);
+
+        return new FormSection
+        {
+            SectionId = section.SectionId,
+            Label = section.Label,
+            Description = section.Description,
+            Repeatable = repeatable,
+            Collapsible = section.Collapsible,
+            InitiallyCollapsed = section.InitiallyCollapsed,
+            Fields = section.Fields.Select(CloneField).ToList()
+        };
+    }
+
+    public static Dictionary<string, object?> BuildRecordValuesForBinding(
+        FormSection section,
+        IReadOnlyDictionary<string, object?> values,
+        int? repeatIndex)
+    {
+        var recordValues = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var value in values)
+        {
+            if (MobileFormRepeatKey.TryParse(value.Key, out var repeatSectionId, out var parsedRepeatIndex, out var fieldId))
+            {
+                if (repeatIndex.HasValue &&
+                    parsedRepeatIndex == repeatIndex.Value &&
+                    string.Equals(repeatSectionId, section.SectionId, StringComparison.Ordinal))
+                {
+                    recordValues[fieldId] = value.Value;
+                }
+
+                continue;
+            }
+
+            recordValues[value.Key] = value.Value;
+        }
+
+        return recordValues;
+    }
+
+    private static void ApplyNonRepeatCalculations(FormDefinition definition, Dictionary<string, object?> values)
+    {
+        var sections = definition.Sections
+            .Where(section => !section.Repeatable)
+            .Select(section => CloneSection(section, repeatable: false))
+            .ToList();
+        if (sections.Count == 0)
+        {
+            return;
+        }
+
+        var form = CloneDefinition(definition, sections);
+        var record = new FieldRecord
+        {
+            RecordId = "calculation",
+            FormId = definition.FormId,
+            Values = values
+                .Where(value => !MobileFormRepeatKey.TryParse(value.Key, out _, out _, out _))
+                .ToDictionary(value => value.Key, value => value.Value, StringComparer.OrdinalIgnoreCase)
+        };
+        CalculatedFieldEvaluator.ApplyCalculatedFields(form, record);
+
+        foreach (var field in sections.SelectMany(section => section.Fields).Where(IsCalculatedField))
+        {
+            if (record.Values.TryGetValue(field.FieldId, out var calculated))
+            {
+                values[field.FieldId] = calculated;
+            }
+        }
+    }
+
+    private static void ApplyRepeatCalculations(FormDefinition definition, Dictionary<string, object?> values)
+    {
+        foreach (var section in definition.Sections.Where(section => section.Repeatable))
+        {
+            var repeatForm = CloneDefinition(definition, [CloneSection(section, repeatable: false)]);
+            foreach (var repeatIndex in MobileFormRepeatKey.GetRepeatIndices(section, values))
+            {
+                var record = new FieldRecord
+                {
+                    RecordId = $"calculation:{section.SectionId}:{repeatIndex}",
+                    FormId = definition.FormId,
+                    Values = BuildRecordValuesForBinding(section, values, repeatIndex)
+                };
+                CalculatedFieldEvaluator.ApplyCalculatedFields(repeatForm, record);
+
+                foreach (var field in section.Fields.Where(IsCalculatedField))
+                {
+                    if (record.Values.TryGetValue(field.FieldId, out var calculated))
+                    {
+                        values[MobileFormRepeatKey.ForField(section, repeatIndex, field)] = calculated;
+                    }
+                }
+            }
+        }
+    }
+
+    private static FormDefinition CloneDefinition(FormDefinition definition, List<FormSection> sections)
+    {
+        return new FormDefinition
+        {
+            FormId = definition.FormId,
+            Name = definition.Name,
+            Version = definition.Version,
+            Description = definition.Description,
+            Target = definition.Target,
+            Sections = sections,
+            Metadata = new Dictionary<string, string>(definition.Metadata, StringComparer.OrdinalIgnoreCase)
+        };
+    }
+
+    private static bool IsCalculatedField(FormField field)
+        => field.Type == FormFieldType.Calculated || !string.IsNullOrWhiteSpace(field.CalculatedExpression);
+
+    private static bool TryGetDefaultValue(
+        FormDefinition definition,
+        FormSection section,
+        FormField field,
+        out string defaultValue)
+    {
+        var keys = new[]
+        {
+            $"default:{section.SectionId}.{field.FieldId}",
+            $"default:{field.FieldId}",
+            $"defaults.{section.SectionId}.{field.FieldId}",
+            $"defaults.{field.FieldId}"
+        };
+
+        foreach (var key in keys)
+        {
+            if (definition.Metadata.TryGetValue(key, out defaultValue!) &&
+                !string.IsNullOrWhiteSpace(defaultValue))
+            {
+                return true;
+            }
+        }
+
+        defaultValue = string.Empty;
+        return false;
+    }
+
+    private static bool IsBlank(object? value)
+    {
+        return value is null ||
+            value is string text && string.IsNullOrWhiteSpace(text) ||
+            value is JsonElement { ValueKind: JsonValueKind.Null or JsonValueKind.Undefined };
+    }
+}
+
 public sealed class FormDraftSnapshot
 {
     public int LayerId { get; set; }
     public string FeatureId { get; set; } = string.Empty;
     public string? FormId { get; set; }
     public Dictionary<string, object?> Values { get; set; } = new(StringComparer.Ordinal);
+    public Dictionary<string, string> ValidationErrors { get; set; } = new(StringComparer.Ordinal);
+    public Dictionary<string, int> RepeatCounts { get; set; } = new(StringComparer.Ordinal);
     public DateTime UpdatedAtUtc { get; set; } = DateTime.UtcNow;
 }
 

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/WorkflowViewModels.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/WorkflowViewModels.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Honua.Mobile.FieldCollection.Models;
@@ -53,6 +54,23 @@ public sealed partial class EditableChoiceItem : ObservableObject
     }
 }
 
+public sealed partial class EditableRepeatSectionItem : ObservableObject
+{
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanRemove))]
+    private int entryCount;
+
+    public string SectionId { get; init; } = string.Empty;
+
+    public string Label { get; init; } = string.Empty;
+
+    public bool CanRemove => EntryCount > 0;
+
+    public ICommand? AddCommand { get; init; }
+
+    public ICommand? RemoveCommand { get; init; }
+}
+
 public sealed partial class EditableFormFieldItem : ObservableObject
 {
     private bool _suppressValueChanged;
@@ -79,13 +97,29 @@ public sealed partial class EditableFormFieldItem : ObservableObject
     [ObservableProperty]
     private string valueSummary = string.Empty;
 
+    [ObservableProperty]
+    private bool isVisible = true;
+
     public EditableFormFieldItem(FormField definition)
+        : this(new MobileFormFieldBinding(
+            new FormSection { SectionId = "default", Label = "Default", Fields = [definition] },
+            definition,
+            definition.FieldId,
+            null))
     {
-        Definition = definition;
-        ControlKind = MobileFormControlSelector.Select(definition);
-        Label = definition.Required ? $"{definition.Label} *" : definition.Label;
-        HelpText = definition.HelpText ?? string.Empty;
-        foreach (var choice in definition.Choices)
+    }
+
+    public EditableFormFieldItem(MobileFormFieldBinding binding)
+    {
+        Definition = binding.Field;
+        Section = binding.Section;
+        ValueKey = binding.ValueKey;
+        RepeatIndex = binding.RepeatIndex;
+        ControlKind = MobileFormControlSelector.Select(Definition);
+        IsReadOnly = Definition.Type == FormFieldType.Calculated || !string.IsNullOrWhiteSpace(Definition.CalculatedExpression);
+        Label = BuildLabel(binding);
+        HelpText = Definition.HelpText ?? string.Empty;
+        foreach (var choice in Definition.Choices)
         {
             var item = new EditableChoiceItem
             {
@@ -98,6 +132,12 @@ public sealed partial class EditableFormFieldItem : ObservableObject
     }
 
     public FormField Definition { get; }
+
+    public FormSection Section { get; }
+
+    public string ValueKey { get; }
+
+    public int? RepeatIndex { get; }
 
     public MobileFormControlKind ControlKind { get; }
 
@@ -114,6 +154,10 @@ public sealed partial class EditableFormFieldItem : ObservableObject
     public bool HasPrimaryAction => PrimaryActionCommand != null;
 
     public bool HasValidationError => !string.IsNullOrWhiteSpace(ValidationError);
+
+    public bool IsReadOnly { get; }
+
+    public bool IsEditable => !IsReadOnly;
 
     public bool IsSingleLineText => ControlKind is MobileFormControlKind.SingleLineText or MobileFormControlKind.Barcode;
 
@@ -305,6 +349,20 @@ public sealed partial class EditableFormFieldItem : ObservableObject
             ValueChanged?.Invoke(this, EventArgs.Empty);
         }
     }
+
+    private static string BuildLabel(MobileFormFieldBinding binding)
+    {
+        var label = binding.Field.Required ? $"{binding.Field.Label} *" : binding.Field.Label;
+        if (binding.RepeatIndex is not { } repeatIndex)
+        {
+            return label;
+        }
+
+        var sectionLabel = string.IsNullOrWhiteSpace(binding.Section.Label)
+            ? binding.Section.SectionId
+            : binding.Section.Label;
+        return $"{sectionLabel} {repeatIndex + 1}: {label}";
+    }
 }
 
 public partial class RecordDetailViewModel : BaseViewModel, IRouteAwareViewModel
@@ -490,6 +548,7 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
     private readonly ILocationService _locationService;
     private bool _isLoadingForm;
     private FormDefinition? _formDefinition;
+    private readonly Dictionary<string, int> _repeatSectionCounts = new(StringComparer.Ordinal);
 
     [ObservableProperty]
     private int layerId = 1;
@@ -517,6 +576,7 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
 
     public ObservableCollection<EditableAttributeItem> Attributes { get; } = [];
     public ObservableCollection<EditableFormFieldItem> FormFields { get; } = [];
+    public ObservableCollection<EditableRepeatSectionItem> RepeatSections { get; } = [];
     public ObservableCollection<AttachmentInfo> Attachments { get; } = [];
 
     public RecordEditViewModel(
@@ -566,7 +626,9 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
                 }
 
                 FormFields.Clear();
+                RepeatSections.Clear();
                 Attachments.Clear();
+                _repeatSectionCounts.Clear();
                 ValidationSummary = string.Empty;
                 PageTitle = IsNew ? "Create Record" : "Edit Record";
                 Title = PageTitle;
@@ -592,6 +654,11 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
                     {
                         source[value.Key] = value.Value;
                     }
+
+                    foreach (var repeatCount in draft.RepeatCounts)
+                    {
+                        _repeatSectionCounts[repeatCount.Key] = repeatCount.Value;
+                    }
                 }
 
                 foreach (var attribute in source.OrderBy(attribute => attribute.Key, StringComparer.OrdinalIgnoreCase))
@@ -616,6 +683,10 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
                 _formDefinition = await _formService.GetFormDefinitionAsync(LayerId)
                     ?? CreateAdHocFormDefinition(LayerId, source);
                 LoadFormFields(_formDefinition, source);
+                if (draft?.ValidationErrors.Count > 0)
+                {
+                    ApplyValidationErrors(draft.ValidationErrors);
+                }
             }
             finally
             {
@@ -636,13 +707,15 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
 
         if (_formDefinition != null)
         {
+            var section = _formDefinition.Sections.FirstOrDefault(section => !section.Repeatable) ??
+                new FormSection { SectionId = "attributes", Label = "Attributes" };
             var field = new FormField
             {
                 FieldId = $"field_{index}",
                 Label = $"Field {index}",
                 Type = FormFieldType.Text
             };
-            AddFormField(field, null);
+            AddFormField(new MobileFormFieldBinding(section, field, field.FieldId, null), null);
         }
     }
 
@@ -751,6 +824,45 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
     }
 
     [RelayCommand]
+    private async Task AddRepeatEntry(EditableRepeatSectionItem section)
+    {
+        if (_formDefinition == null || string.IsNullOrWhiteSpace(section.SectionId))
+        {
+            return;
+        }
+
+        var values = BuildFormValues(includeHidden: true);
+        _repeatSectionCounts[section.SectionId] = section.EntryCount + 1;
+        ReloadFormFields(values);
+        await SaveDraftSnapshotAsync();
+    }
+
+    [RelayCommand]
+    private async Task RemoveRepeatEntry(EditableRepeatSectionItem section)
+    {
+        if (_formDefinition == null || string.IsNullOrWhiteSpace(section.SectionId) || section.EntryCount <= 0)
+        {
+            return;
+        }
+
+        var values = BuildFormValues(includeHidden: true);
+        var removedIndex = section.EntryCount - 1;
+        foreach (var key in values.Keys.ToArray())
+        {
+            if (MobileFormRepeatKey.TryParse(key, out var sectionId, out var repeatIndex, out _) &&
+                repeatIndex == removedIndex &&
+                string.Equals(sectionId, section.SectionId, StringComparison.Ordinal))
+            {
+                values.Remove(key);
+            }
+        }
+
+        _repeatSectionCounts[section.SectionId] = removedIndex;
+        ReloadFormFields(values);
+        await SaveDraftSnapshotAsync();
+    }
+
+    [RelayCommand]
     private async Task RemoveAttachment(AttachmentInfo attachment)
     {
         await ExecuteAsync(async () =>
@@ -807,6 +919,8 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
             {
                 var formData = BuildFormData(values);
                 var valid = await _formService.ValidateFormAsync(formData, _formDefinition);
+                values = formData.Values;
+                ApplyCalculatedValues(values);
                 ApplyValidationErrors(formData.ValidationErrors);
                 if (!valid)
                 {
@@ -857,20 +971,75 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
 
     private void LoadFormFields(FormDefinition formDefinition, IReadOnlyDictionary<string, object?> values)
     {
-        var attachmentsById = Attachments.ToDictionary(attachment => attachment.Id, StringComparer.Ordinal);
-        foreach (var field in formDefinition.Sections.SelectMany(section => section.Fields))
+        var seededValues = new Dictionary<string, object?>(values, StringComparer.OrdinalIgnoreCase);
+        foreach (var section in formDefinition.Sections.Where(section => section.Repeatable))
         {
-            values.TryGetValue(field.FieldId, out var value);
-            AddFormField(field, value, attachmentsById);
+            if (!_repeatSectionCounts.TryGetValue(section.SectionId, out var repeatCount))
+            {
+                continue;
+            }
+
+            for (var repeatIndex = 0; repeatIndex < repeatCount; repeatIndex++)
+            {
+                foreach (var field in section.Fields)
+                {
+                    seededValues.TryAdd(MobileFormRepeatKey.ForField(section, repeatIndex, field), null);
+                }
+            }
         }
+
+        var resolvedValues = MobileFormRuleRuntime.ApplyCalculatedValues(
+            formDefinition,
+            MobileFormRuleRuntime.ApplyDefaultValues(formDefinition, seededValues));
+        var attachmentsById = Attachments.ToDictionary(attachment => attachment.Id, StringComparer.Ordinal);
+
+        foreach (var section in formDefinition.Sections)
+        {
+            if (!section.Repeatable)
+            {
+                foreach (var field in section.Fields)
+                {
+                    resolvedValues.TryGetValue(field.FieldId, out var value);
+                    AddFormField(new MobileFormFieldBinding(section, field, field.FieldId, null), value, attachmentsById);
+                }
+
+                continue;
+            }
+
+            var repeatCount = _repeatSectionCounts.TryGetValue(section.SectionId, out var configuredCount)
+                ? Math.Max(0, configuredCount)
+                : MobileFormRepeatKey.GetRepeatCount(section, resolvedValues, defaultCount: 1);
+            _repeatSectionCounts[section.SectionId] = repeatCount;
+            RepeatSections.Add(new EditableRepeatSectionItem
+            {
+                SectionId = section.SectionId,
+                Label = string.IsNullOrWhiteSpace(section.Label) ? section.SectionId : section.Label,
+                EntryCount = repeatCount,
+                AddCommand = AddRepeatEntryCommand,
+                RemoveCommand = RemoveRepeatEntryCommand
+            });
+
+            for (var repeatIndex = 0; repeatIndex < repeatCount; repeatIndex++)
+            {
+                foreach (var field in section.Fields)
+                {
+                    var valueKey = MobileFormRepeatKey.ForField(section, repeatIndex, field);
+                    resolvedValues.TryGetValue(valueKey, out var value);
+                    AddFormField(new MobileFormFieldBinding(section, field, valueKey, repeatIndex), value, attachmentsById);
+                }
+            }
+        }
+
+        RefreshFormRules();
     }
 
     private void AddFormField(
-        FormField field,
+        MobileFormFieldBinding binding,
         object? value,
         IReadOnlyDictionary<string, AttachmentInfo>? attachmentsById = null)
     {
-        var item = new EditableFormFieldItem(field)
+        var field = binding.Field;
+        var item = new EditableFormFieldItem(binding)
         {
             PrimaryActionCommand = field.Type switch
             {
@@ -894,6 +1063,31 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
         FormFields.Add(item);
     }
 
+    private void ReloadFormFields(IReadOnlyDictionary<string, object?> values)
+    {
+        if (_formDefinition == null)
+        {
+            return;
+        }
+
+        _isLoadingForm = true;
+        try
+        {
+            foreach (var field in FormFields)
+            {
+                field.ValueChanged -= OnFormFieldValueChanged;
+            }
+
+            FormFields.Clear();
+            RepeatSections.Clear();
+            LoadFormFields(_formDefinition, values);
+        }
+        finally
+        {
+            _isLoadingForm = false;
+        }
+    }
+
     private void OnFormFieldValueChanged(object? sender, EventArgs e)
     {
         if (_isLoadingForm)
@@ -907,6 +1101,7 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
             item.ValidationError = null;
         }
 
+        RefreshFormRules();
         _ = SaveDraftSnapshotAsync();
     }
 
@@ -922,11 +1117,15 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
             LayerId = LayerId,
             FeatureId = FeatureId,
             FormId = _formDefinition?.FormId,
-            Values = BuildFormValues()
+            Values = BuildFormValues(includeHidden: true),
+            ValidationErrors = FormFields
+                .Where(field => field.HasValidationError)
+                .ToDictionary(field => field.ValueKey, field => field.ValidationError!, StringComparer.OrdinalIgnoreCase),
+            RepeatCounts = new Dictionary<string, int>(_repeatSectionCounts, StringComparer.Ordinal)
         });
     }
 
-    private Dictionary<string, object?> BuildFormValues()
+    private Dictionary<string, object?> BuildFormValues(bool includeHidden = true)
     {
         if (FormFields.Count == 0)
         {
@@ -940,20 +1139,19 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
         }
 
         return FormFields
-            .Where(field => !string.IsNullOrWhiteSpace(field.Definition.FieldId))
+            .Where(field => !string.IsNullOrWhiteSpace(field.ValueKey) && (includeHidden || field.IsVisible))
             .ToDictionary(
-                field => field.Definition.FieldId,
+                field => field.ValueKey,
                 field => field.ToValue(),
                 StringComparer.OrdinalIgnoreCase);
     }
 
     private FormData BuildFormData(Dictionary<string, object?> values)
     {
-        var fields = FormFields.Select(field => field.Definition).ToArray();
         var attachmentsById = Attachments.ToDictionary(attachment => attachment.Id, StringComparer.Ordinal);
-        var location = fields
-            .Where(field => field.Type == FormFieldType.Location)
-            .Select(field => values.TryGetValue(field.FieldId, out var value) &&
+        var location = FormFields
+            .Where(field => field.IsVisible && field.Definition.Type == FormFieldType.Location)
+            .Select(field => values.TryGetValue(field.ValueKey, out var value) &&
                 MobileFormValueConverter.TryGetLocation(value, out var point)
                     ? point
                     : (FieldGeoPoint?)null)
@@ -964,17 +1162,52 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
             LayerId = LayerId,
             FeatureId = FeatureId,
             Values = values,
-            Media = MobileFormValueConverter.BuildMediaAttachments(fields, values, attachmentsById).ToList(),
+            Media = BuildMediaAttachments(values, attachmentsById),
             Location = location,
             CreatedAt = _existingFeature?.CreatedAt ?? DateTime.UtcNow
         };
+    }
+
+    private List<FieldMediaAttachment> BuildMediaAttachments(
+        IReadOnlyDictionary<string, object?> values,
+        IReadOnlyDictionary<string, AttachmentInfo> attachmentsById)
+    {
+        var media = new List<FieldMediaAttachment>();
+        foreach (var field in FormFields.Where(field => MobileFormValueConverter.IsMediaField(field.Definition)))
+        {
+            if (!values.TryGetValue(field.ValueKey, out var rawValue))
+            {
+                continue;
+            }
+
+            foreach (var attachmentId in MobileFormValueConverter.ToChoiceValues(rawValue))
+            {
+                if (!attachmentsById.TryGetValue(attachmentId, out var attachment))
+                {
+                    continue;
+                }
+
+                media.Add(new FieldMediaAttachment
+                {
+                    AttachmentId = attachment.Id,
+                    FieldId = field.ValueKey,
+                    FileName = attachment.FileName,
+                    ContentType = attachment.ContentType,
+                    SizeBytes = attachment.SizeBytes,
+                    CapturedAtUtc = new DateTimeOffset(attachment.CreatedAt == default ? DateTime.UtcNow : attachment.CreatedAt),
+                    MediaType = MobileFormValueConverter.ToSdkMediaType(field.Definition.Type, attachment.PayloadKind)
+                });
+            }
+        }
+
+        return media;
     }
 
     private void ApplyValidationErrors(IReadOnlyDictionary<string, string> errors)
     {
         foreach (var field in FormFields)
         {
-            field.ValidationError = errors.TryGetValue(field.Definition.FieldId, out var error)
+            field.ValidationError = errors.TryGetValue(field.ValueKey, out var error)
                 ? error
                 : null;
         }
@@ -982,6 +1215,53 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
         ValidationSummary = errors.Count == 0
             ? string.Empty
             : $"Fix {errors.Count} field error(s) before saving.";
+    }
+
+    private void RefreshFormRules()
+    {
+        if (_formDefinition == null || FormFields.Count == 0)
+        {
+            return;
+        }
+
+        var values = MobileFormRuleRuntime.ApplyCalculatedValues(_formDefinition, BuildFormValues(includeHidden: true));
+        ApplyCalculatedValues(values);
+        ApplyVisibility(values);
+    }
+
+    private void ApplyCalculatedValues(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in FormFields.Where(field =>
+            field.Definition.Type == FormFieldType.Calculated ||
+            !string.IsNullOrWhiteSpace(field.Definition.CalculatedExpression)))
+        {
+            if (values.TryGetValue(field.ValueKey, out var value))
+            {
+                field.SetValue(value);
+            }
+        }
+    }
+
+    private void ApplyVisibility(IReadOnlyDictionary<string, object?> values)
+    {
+        if (_formDefinition == null)
+        {
+            return;
+        }
+
+        foreach (var field in FormFields)
+        {
+            field.IsVisible = MobileFormRuleRuntime.IsFieldVisible(
+                _formDefinition,
+                field.Section,
+                field.Definition,
+                values,
+                field.RepeatIndex);
+            if (!field.IsVisible)
+            {
+                field.ValidationError = null;
+            }
+        }
     }
 
     private static FormDefinition CreateAdHocFormDefinition(int layerId, IReadOnlyDictionary<string, object?> source)

--- a/apps/Honua.Mobile.FieldCollection/Views/WorkflowPages.cs
+++ b/apps/Honua.Mobile.FieldCollection/Views/WorkflowPages.cs
@@ -248,6 +248,9 @@ internal static class WorkflowPageContent
 
     public static View CreateRecordEditContent()
     {
+        var repeatSections = RepeatSectionList();
+        repeatSections.SetBinding(ItemsView.ItemsSourceProperty, new Binding("RepeatSections"));
+
         var fields = FormFieldList();
         fields.SetBinding(ItemsView.ItemsSourceProperty, new Binding("FormFields"));
 
@@ -262,6 +265,7 @@ internal static class WorkflowPageContent
             BoundHeader("PageTitle", "Record"),
             BoundLabel("GeometrySummary", "Geometry"),
             validation,
+            repeatSections,
             SectionTitle("Fields"),
             fields,
             SectionTitle("Attachments"),
@@ -290,21 +294,26 @@ internal static class WorkflowPageContent
                 var singleLine = new Entry { Placeholder = "Value" };
                 singleLine.SetBinding(Entry.TextProperty, new Binding(nameof(EditableFormFieldItem.TextValue), mode: BindingMode.TwoWay));
                 singleLine.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsSingleLineText)));
+                singleLine.SetBinding(VisualElement.IsEnabledProperty, new Binding(nameof(EditableFormFieldItem.IsEditable)));
 
                 var numeric = new Entry { Placeholder = "Number", Keyboard = Keyboard.Numeric };
                 numeric.SetBinding(Entry.TextProperty, new Binding(nameof(EditableFormFieldItem.TextValue), mode: BindingMode.TwoWay));
                 numeric.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsNumeric)));
+                numeric.SetBinding(VisualElement.IsEnabledProperty, new Binding(nameof(EditableFormFieldItem.IsEditable)));
 
                 var multiline = new Editor { AutoSize = EditorAutoSizeOption.TextChanges, MinimumHeightRequest = 96 };
                 multiline.SetBinding(Editor.TextProperty, new Binding(nameof(EditableFormFieldItem.TextValue), mode: BindingMode.TwoWay));
                 multiline.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsMultilineText)));
+                multiline.SetBinding(VisualElement.IsEnabledProperty, new Binding(nameof(EditableFormFieldItem.IsEditable)));
 
                 var date = new DatePicker();
                 date.SetBinding(DatePicker.DateProperty, new Binding(nameof(EditableFormFieldItem.DateValue), mode: BindingMode.TwoWay));
                 date.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsDate)));
+                date.SetBinding(VisualElement.IsEnabledProperty, new Binding(nameof(EditableFormFieldItem.IsEditable)));
 
                 var dateTime = new HorizontalStackLayout { Spacing = 8 };
                 dateTime.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsDateTime)));
+                dateTime.SetBinding(VisualElement.IsEnabledProperty, new Binding(nameof(EditableFormFieldItem.IsEditable)));
                 var datePart = new DatePicker();
                 datePart.SetBinding(DatePicker.DateProperty, new Binding(nameof(EditableFormFieldItem.DateValue), mode: BindingMode.TwoWay));
                 var timePart = new TimePicker();
@@ -315,14 +324,17 @@ internal static class WorkflowPageContent
                 var yesNo = new Switch();
                 yesNo.SetBinding(Switch.IsToggledProperty, new Binding(nameof(EditableFormFieldItem.BoolValue), mode: BindingMode.TwoWay));
                 yesNo.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsYesNo)));
+                yesNo.SetBinding(VisualElement.IsEnabledProperty, new Binding(nameof(EditableFormFieldItem.IsEditable)));
 
                 var choice = new Picker { ItemDisplayBinding = new Binding(nameof(FieldChoice.Label)) };
                 choice.SetBinding(Picker.ItemsSourceProperty, new Binding("Definition.Choices"));
                 choice.SetBinding(Picker.SelectedItemProperty, new Binding(nameof(EditableFormFieldItem.SelectedChoice), mode: BindingMode.TwoWay));
                 choice.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsSingleChoice)));
+                choice.SetBinding(VisualElement.IsEnabledProperty, new Binding(nameof(EditableFormFieldItem.IsEditable)));
 
                 var choices = new VerticalStackLayout { Spacing = 6 };
                 choices.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsMultipleChoice)));
+                choices.SetBinding(VisualElement.IsEnabledProperty, new Binding(nameof(EditableFormFieldItem.IsEditable)));
                 choices.SetBinding(BindableLayout.ItemsSourceProperty, new Binding(nameof(EditableFormFieldItem.Choices)));
                 BindableLayout.SetItemTemplate(choices, new DataTemplate(() =>
                 {
@@ -348,6 +360,7 @@ internal static class WorkflowPageContent
                 action.SetBinding(Button.CommandProperty, new Binding(nameof(EditableFormFieldItem.PrimaryActionCommand)));
                 action.SetBinding(Button.CommandParameterProperty, new Binding("."));
                 action.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.HasPrimaryAction)));
+                action.SetBinding(VisualElement.IsEnabledProperty, new Binding(nameof(EditableFormFieldItem.IsEditable)));
 
                 var unsupported = new Label { Text = "Unsupported field type", TextColor = Colors.DarkRed };
                 unsupported.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsUnsupported)));
@@ -356,7 +369,7 @@ internal static class WorkflowPageContent
                 error.SetBinding(Label.TextProperty, new Binding(nameof(EditableFormFieldItem.ValidationError)));
                 error.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.HasValidationError)));
 
-                return new VerticalStackLayout
+                var row = new VerticalStackLayout
                 {
                     Padding = new Thickness(0, 8),
                     Spacing = 6,
@@ -378,6 +391,54 @@ internal static class WorkflowPageContent
                         error
                     }
                 };
+                row.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsVisible)));
+                return row;
+            })
+        };
+    }
+
+    private static CollectionView RepeatSectionList()
+    {
+        return new CollectionView
+        {
+            ItemTemplate = new DataTemplate(() =>
+            {
+                var label = new Label { FontAttributes = FontAttributes.Bold, VerticalOptions = LayoutOptions.Center };
+                label.SetBinding(Label.TextProperty, new Binding(nameof(EditableRepeatSectionItem.Label)));
+
+                var count = new Label { FontSize = 12, TextColor = Colors.Gray, VerticalOptions = LayoutOptions.Center };
+                count.SetBinding(Label.TextProperty, new Binding(nameof(EditableRepeatSectionItem.EntryCount), stringFormat: "{0} entries"));
+
+                var add = new Button { Text = "Add" };
+                add.SetBinding(Button.CommandProperty, new Binding(nameof(EditableRepeatSectionItem.AddCommand)));
+                add.SetBinding(Button.CommandParameterProperty, new Binding("."));
+
+                var remove = new Button { Text = "Remove" };
+                remove.SetBinding(Button.CommandProperty, new Binding(nameof(EditableRepeatSectionItem.RemoveCommand)));
+                remove.SetBinding(Button.CommandParameterProperty, new Binding("."));
+                remove.SetBinding(VisualElement.IsEnabledProperty, new Binding(nameof(EditableRepeatSectionItem.CanRemove)));
+
+                var grid = new Grid
+                {
+                    Padding = new Thickness(0, 6),
+                    ColumnDefinitions =
+                    {
+                        new ColumnDefinition { Width = GridLength.Star },
+                        new ColumnDefinition { Width = GridLength.Auto },
+                        new ColumnDefinition { Width = GridLength.Auto },
+                        new ColumnDefinition { Width = GridLength.Auto }
+                    },
+                    ColumnSpacing = 8
+                };
+                Grid.SetColumn(label, 0);
+                Grid.SetColumn(count, 1);
+                Grid.SetColumn(add, 2);
+                Grid.SetColumn(remove, 3);
+                grid.Children.Add(label);
+                grid.Children.Add(count);
+                grid.Children.Add(add);
+                grid.Children.Add(remove);
+                return grid;
             })
         };
     }

--- a/tests/Honua.Mobile.FieldCollection.Tests/MobileFormRuntimeTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/MobileFormRuntimeTests.cs
@@ -146,6 +146,14 @@ public sealed class MobileFormRuntimeTests
                 ["captured_at"] = new DateTime(2026, 5, 23, 8, 30, 0, DateTimeKind.Utc),
                 ["gps"] = new FieldGeoPoint(21.3, -157.8, 4),
             },
+            ValidationErrors =
+            {
+                ["name"] = "Name is required.",
+            },
+            RepeatCounts =
+            {
+                ["visits"] = 2,
+            },
         });
 
         var restarted = new SettingsFormDraftService(settings);
@@ -159,6 +167,160 @@ public sealed class MobileFormRuntimeTests
         Assert.Equal(["urgent", "wet"], loadedTags);
         Assert.True(MobileFormValueConverter.TryGetDateTime(loaded.Values["captured_at"], out _));
         Assert.True(MobileFormValueConverter.TryGetLocation(loaded.Values["gps"], out _));
+        Assert.Equal("Name is required.", loaded.ValidationErrors["name"]);
+        Assert.Equal(2, loaded.RepeatCounts["visits"]);
+    }
+
+    [Fact]
+    public void RuleRuntime_AppliesDefaultsCalculationsAndSdkVisibility()
+    {
+        var form = new FormDefinition
+        {
+            FormId = "inspection",
+            Name = "Inspection",
+            Metadata = new Dictionary<string, string> { ["default:status"] = "open" },
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "main",
+                    Label = "Main",
+                    Fields =
+                    [
+                        Field("asset", FormFieldType.Text),
+                        Field("status", FormFieldType.SingleChoice, choiceCount: 2),
+                        new FormField
+                        {
+                            FieldId = "display",
+                            Label = "Display",
+                            Type = FormFieldType.Calculated,
+                            CalculatedExpression = "concat($asset,'-', $status)",
+                        },
+                        new FormField
+                        {
+                            FieldId = "close_reason",
+                            Label = "Close reason",
+                            Type = FormFieldType.Text,
+                            Required = true,
+                            VisibilityRule = new FieldVisibilityRule
+                            {
+                                DependsOnFieldId = "status",
+                                Operator = ComparisonOperator.Equals,
+                                MatchValue = "closed",
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var values = MobileFormRuleRuntime.ApplyDefaultValues(form, new Dictionary<string, object?>
+        {
+            ["asset"] = "pump"
+        });
+        values = MobileFormRuleRuntime.ApplyCalculatedValues(form, values);
+
+        Assert.Equal("open", values["status"]);
+        Assert.Equal("pump-open", values["display"]);
+        var closeReason = form.Sections[0].Fields.Single(field => field.FieldId == "close_reason");
+        Assert.False(MobileFormRuleRuntime.IsFieldVisible(form, form.Sections[0], closeReason, values));
+
+        values["status"] = "closed";
+
+        Assert.True(MobileFormRuleRuntime.IsFieldVisible(form, form.Sections[0], closeReason, values));
+    }
+
+    [Fact]
+    public async Task FormService_ValidateFormAsync_MapsRepeatErrorsToRepeatValueKeys()
+    {
+        var visits = new FormSection
+        {
+            SectionId = "visits",
+            Label = "Visits",
+            Repeatable = true,
+            Fields =
+            [
+                new FormField
+                {
+                    FieldId = "condition",
+                    Label = "Condition",
+                    Type = FormFieldType.Text,
+                    Required = true,
+                },
+                new FormField
+                {
+                    FieldId = "repair_notes",
+                    Label = "Repair notes",
+                    Type = FormFieldType.Text,
+                    Required = true,
+                    VisibilityRule = new FieldVisibilityRule
+                    {
+                        DependsOnFieldId = "condition",
+                        Operator = ComparisonOperator.Equals,
+                        MatchValue = "damaged",
+                    },
+                },
+            ],
+        };
+        var form = new FormDefinition
+        {
+            FormId = "inspection",
+            Name = "Inspection",
+            Sections = [visits],
+        };
+        var conditionKey = MobileFormRepeatKey.ForField(visits, 0, visits.Fields[0]);
+        var notesKey = MobileFormRepeatKey.ForField(visits, 0, visits.Fields[1]);
+        var formData = new FormData
+        {
+            LayerId = 7,
+            Values =
+            {
+                [conditionKey] = "damaged",
+            },
+        };
+
+        var valid = await new FormService().ValidateFormAsync(formData, form);
+
+        Assert.False(valid);
+        Assert.DoesNotContain("condition", formData.ValidationErrors.Keys);
+        Assert.Contains(notesKey, formData.ValidationErrors.Keys);
+
+        formData.Values[notesKey] = "Replace gasket.";
+        valid = await new FormService().ValidateFormAsync(formData, form);
+
+        Assert.True(valid);
+        Assert.Empty(formData.ValidationErrors);
+    }
+
+    [Fact]
+    public void RepeatKey_BuildFieldBindings_SerializesRepeatFieldsUnderSectionKeys()
+    {
+        var section = new FormSection
+        {
+            SectionId = "visits",
+            Label = "Visits",
+            Repeatable = true,
+            Fields =
+            [
+                Field("condition", FormFieldType.Text),
+                Field("notes", FormFieldType.Text),
+            ],
+        };
+        var form = new FormDefinition
+        {
+            FormId = "inspection",
+            Name = "Inspection",
+            Sections = [section],
+        };
+        var values = new Dictionary<string, object?>
+        {
+            [MobileFormRepeatKey.ForField(section, 1, section.Fields[0])] = "ok",
+        };
+
+        var bindings = MobileFormRuleRuntime.BuildFieldBindings(form, values);
+
+        Assert.Contains(bindings, binding => binding.ValueKey == "visits[1].condition");
+        Assert.Contains(bindings, binding => binding.ValueKey == "visits[1].notes");
     }
 
     private static FormField Field(


### PR DESCRIPTION
## Summary
- add mobile form runtime helpers for SDK-backed visibility probes, calculated/default value application, and repeat value keys
- render repeat section add/remove controls plus hidden/read-only/calculated field states in the FieldCollection edit workflow
- validate repeat entries through SDK FormValidator and map errors back to repeat field keys; persist draft repeat counts and validation state

Closes #215

## Offline Impact
- repeat entries and field validation state are stored in local form draft snapshots
- hidden/conditional fields preserve draft values while no longer blocking submit when hidden

## Platform Testing
- non-platform FieldCollection build reaches the expected net10.0 CS5001 after app/core code compiles
- full Android build still requires Android SDK locally

## Testing
- dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore --verbosity minimal
- dotnet test tests/Honua.Mobile.Field.Tests/Honua.Mobile.Field.Tests.csproj --no-restore --verbosity minimal
- dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --no-restore --verbosity minimal
- dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --no-restore --verbosity minimal
- dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --no-restore --verbosity minimal
- dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0 --verbosity minimal (expected CS5001 only)
- dotnet format Honua.Mobile.sln --verify-no-changes --no-restore --verbosity minimal