### PR TITLE
test: add offline workflow acceptance coverage

### DIFF
--- a/scripts/run-field-workflow-appium-smoke.sh
+++ b/scripts/run-field-workflow-appium-smoke.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ARTIFACT_DIR="${HONUA_MOBILE_APPIUM_ARTIFACT_DIR:-${ROOT_DIR}/TestResults/appium-field-workflow}"
+RESULT_FILE="${ARTIFACT_DIR}/honua-mobile-field-workflow-appium-smoke-result.json"
+REQUIRED_STEPS='["launch","configure-server","download-project","create-record","sync"]'
+
+mkdir -p "${ARTIFACT_DIR}"
+
+json_array() {
+  python3 - "$@" <<'PY'
+import json
+import sys
+
+print(json.dumps(sys.argv[1:]))
+PY
+}
+
+write_result() {
+  local status="$1"
+  local reason="$2"
+  local missing_json="$3"
+
+  python3 - "${RESULT_FILE}" "${status}" "${reason}" "${missing_json}" "${REQUIRED_STEPS}" <<'PY'
+import json
+import sys
+
+result_file, status, reason, missing_json, steps_json = sys.argv[1:]
+payload = {
+    "schemaVersion": "honua.mobile.field-workflow-appium-smoke.v1",
+    "status": status,
+    "reason": reason,
+    "requiredSteps": json.loads(steps_json),
+    "missingConfiguration": json.loads(missing_json),
+}
+with open(result_file, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2)
+    handle.write("\n")
+PY
+}
+
+is_truthy() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if ! is_truthy "${HONUA_MOBILE_APPIUM_SMOKE:-}"; then
+  write_result \
+    "skipped" \
+    "Set HONUA_MOBILE_APPIUM_SMOKE=1 to run the gated Appium field workflow smoke." \
+    "[]"
+  echo "::notice::Skipping Appium field workflow smoke; HONUA_MOBILE_APPIUM_SMOKE is not enabled."
+  exit 0
+fi
+
+missing=()
+for name in \
+  HONUA_MOBILE_APPIUM_SERVER_URL \
+  HONUA_MOBILE_FIELD_APP_PATH \
+  HONUA_MOBILE_SMOKE_BASE_URL \
+  HONUA_MOBILE_SMOKE_SERVICE_ID \
+  HONUA_MOBILE_SMOKE_LAYER_ID
+do
+  if [[ -z "${!name:-}" ]]; then
+    missing+=("${name}")
+  fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  missing_json="$(json_array "${missing[@]}")"
+  write_result \
+    "skipped" \
+    "Appium field workflow smoke is gated until device, app, and server settings are configured." \
+    "${missing_json}"
+  echo "::notice::Skipping Appium field workflow smoke; missing configuration: ${missing[*]}."
+  exit 0
+fi
+
+if [[ -z "${HONUA_MOBILE_APPIUM_COMMAND:-}" ]]; then
+  write_result \
+    "skipped" \
+    "HONUA_MOBILE_APPIUM_COMMAND must point to the repository or lab runner that drives launch, server configuration, project download, record creation, and sync." \
+    "[]"
+  echo "::notice::Skipping Appium field workflow smoke; HONUA_MOBILE_APPIUM_COMMAND is not configured."
+  exit 0
+fi
+
+set +e
+bash -lc "${HONUA_MOBILE_APPIUM_COMMAND}"
+exit_code=$?
+set -e
+
+if [[ ${exit_code} -eq 0 ]]; then
+  write_result "passed" "Configured Appium field workflow smoke completed." "[]"
+  exit 0
+fi
+
+write_result "failed" "Configured Appium field workflow smoke failed with exit code ${exit_code}." "[]"
+exit "${exit_code}"

--- a/tests/Honua.Mobile.FieldCollection.Tests/ProductAcceptanceFormWorkflowTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/ProductAcceptanceFormWorkflowTests.cs
@@ -1,0 +1,210 @@
+using System.Text.Json;
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.FieldCollection.Services.Forms;
+using Honua.Sdk.Field.Forms;
+using Honua.Sdk.Field.Records;
+
+namespace Honua.Mobile.FieldCollection.Tests;
+
+public sealed class ProductAcceptanceFormWorkflowTests : IDisposable
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+
+    private readonly string _artifactDirectory;
+
+    public ProductAcceptanceFormWorkflowTests()
+    {
+        _artifactDirectory = Path.Combine(Path.GetTempPath(), $"honua-form-acceptance-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_artifactDirectory);
+    }
+
+    [Fact]
+    public async Task FormRulesRepeatSectionsScenario_ValidatesMediaAndWritesQueueArtifact()
+    {
+        var form = CreateInspectionFormDefinition();
+        var repeatSection = form.Sections.Single(section => section.SectionId == "visits");
+        var conditionField = repeatSection.Fields.Single(field => field.FieldId == "condition");
+        var repairNotesField = repeatSection.Fields.Single(field => field.FieldId == "repair_notes");
+        var photoField = repeatSection.Fields.Single(field => field.FieldId == "photos");
+        var values = MobileFormRuleRuntime.ApplyDefaultValues(
+            form,
+            new Dictionary<string, object?>
+            {
+                ["asset"] = "pump-101",
+                [MobileFormRepeatKey.ForField(repeatSection, 0, conditionField)] = "damaged",
+                [MobileFormRepeatKey.ForField(repeatSection, 0, repairNotesField)] = "replace gasket",
+                [MobileFormRepeatKey.ForField(repeatSection, 0, photoField)] = "photo-acceptance-1",
+            },
+            initialRepeatCount: 1);
+        var formData = new FormData
+        {
+            LayerId = 0,
+            FeatureId = "asset-form-101",
+            Values = values,
+            Media =
+            [
+                new FieldMediaAttachment
+                {
+                    AttachmentId = "photo-acceptance-1",
+                    FieldId = MobileFormRepeatKey.ForField(repeatSection, 0, photoField),
+                    FileName = "repeat-photo.jpg",
+                    ContentType = "image/jpeg",
+                    MediaType = FieldMediaType.Photo,
+                    SizeBytes = 128,
+                },
+            ],
+        };
+
+        var valid = await new FormService().ValidateFormAsync(formData, form);
+        var bindings = MobileFormRuleRuntime.BuildFieldBindings(form, formData.Values, initialRepeatCount: 1);
+        var record = formData.ToSdkFieldRecord(form);
+        var artifact = ProductAcceptanceFormArtifact.From(
+            form,
+            record,
+            repeatSection.SectionId,
+            repeatEntryCount: 1,
+            bindings.Count);
+        var artifactPath = Path.Combine(_artifactDirectory, "form-rules-repeat-sections.evidence.json");
+        await File.WriteAllTextAsync(artifactPath, JsonSerializer.Serialize(artifact, JsonOptions));
+
+        Assert.True(valid, string.Join(" | ", formData.ValidationErrors.Select(error => $"{error.Key}: {error.Value}")));
+        Assert.Empty(formData.ValidationErrors);
+        Assert.Equal("open", record.Values["status"]);
+        Assert.Equal("pump-101-open", record.Values["display"]);
+        Assert.Contains(bindings, binding => binding.ValueKey == "visits[0].condition");
+        Assert.Single(record.Media);
+        Assert.Equal("photo-acceptance-1", record.Media[0].AttachmentId);
+        Assert.True(File.Exists(artifactPath));
+
+        var artifactJson = await File.ReadAllTextAsync(artifactPath);
+        Assert.Contains("\"schemaVersion\": \"honua.mobile.form-repeat-acceptance.evidence.v1\"", artifactJson);
+        Assert.Contains("\"scenarioId\": \"form-rules-repeat-sections\"", artifactJson);
+        Assert.Contains("\"attachmentRoundTripCount\": 1", artifactJson);
+        Assert.Contains("\"repeatEntryCount\": 1", artifactJson);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_artifactDirectory))
+        {
+            Directory.Delete(_artifactDirectory, recursive: true);
+        }
+    }
+
+    private static FormDefinition CreateInspectionFormDefinition()
+    {
+        var visits = new FormSection
+        {
+            SectionId = "visits",
+            Label = "Visits",
+            Repeatable = true,
+            Fields =
+            [
+                CreateFormField("condition", FormFieldType.SingleChoice, required: true, choices: ["ok", "damaged"]),
+                new FormField
+                {
+                    FieldId = "repair_notes",
+                    Label = "Repair notes",
+                    Type = FormFieldType.Text,
+                    Required = true,
+                    VisibilityRule = new FieldVisibilityRule
+                    {
+                        DependsOnFieldId = "condition",
+                        Operator = ComparisonOperator.Equals,
+                        MatchValue = "damaged",
+                    },
+                },
+                new FormField
+                {
+                    FieldId = "photos",
+                    Label = "Photos",
+                    Type = FormFieldType.Photo,
+                    Required = true,
+                    Validation = new FieldValidationRule { MinMediaCount = 1 },
+                },
+            ],
+        };
+
+        return new FormDefinition
+        {
+            FormId = "inspection",
+            Name = "Inspection",
+            Metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["default:status"] = "open",
+            },
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "main",
+                    Label = "Main",
+                    Fields =
+                    [
+                        CreateFormField("asset", FormFieldType.Text, required: true),
+                        CreateFormField("status", FormFieldType.SingleChoice, choices: ["open", "closed"]),
+                        new FormField
+                        {
+                            FieldId = "display",
+                            Label = "Display",
+                            Type = FormFieldType.Calculated,
+                            CalculatedExpression = "concat($asset,'-', $status)",
+                        },
+                    ],
+                },
+                visits,
+            ],
+        };
+    }
+
+    private static FormField CreateFormField(
+        string fieldId,
+        FormFieldType type,
+        bool required = false,
+        IReadOnlyList<string>? choices = null)
+        => new()
+        {
+            FieldId = fieldId,
+            Label = fieldId,
+            Type = type,
+            Required = required,
+            Choices = choices is null
+                ? []
+                : choices.Select(choice => new FieldChoice { Value = choice, Label = choice }).ToList(),
+        };
+
+    private sealed record ProductAcceptanceFormArtifact(
+        string SchemaVersion,
+        string ScenarioId,
+        string FormId,
+        string RecordId,
+        string RepeatSectionId,
+        int RepeatEntryCount,
+        int BindingCount,
+        int AttachmentRoundTripCount,
+        IReadOnlyDictionary<string, object?> Values,
+        IReadOnlyList<string> AttachmentIds)
+    {
+        public static ProductAcceptanceFormArtifact From(
+            FormDefinition form,
+            FieldRecord record,
+            string repeatSectionId,
+            int repeatEntryCount,
+            int bindingCount)
+            => new(
+                "honua.mobile.form-repeat-acceptance.evidence.v1",
+                "form-rules-repeat-sections",
+                form.FormId,
+                record.RecordId,
+                repeatSectionId,
+                repeatEntryCount,
+                bindingCount,
+                record.Media.Count,
+                new Dictionary<string, object?>(record.Values, StringComparer.Ordinal),
+                record.Media.Select(media => media.AttachmentId).ToArray());
+    }
+}

--- a/tests/Honua.Mobile.ServerIntegration.Tests/DisconnectedFieldWorkflowAcceptanceTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/DisconnectedFieldWorkflowAcceptanceTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -6,6 +8,7 @@ using Honua.Mobile.Offline.Sync;
 using Honua.Mobile.Sdk;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Offline.Abstractions;
+using Microsoft.Data.Sqlite;
 
 // Disambiguate the mobile orchestrator from Honua.Sdk.Offline.OfflineSyncEngine.
 using OfflineSyncEngine = Honua.Mobile.Offline.Sync.OfflineSyncEngine;
@@ -20,6 +23,8 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
     private const string WorkflowName = "disconnected-field-workflow";
     private const string DefaultPackageId = "pkg_acceptance_field_workflow";
     private const string DefaultServiceId = "assets";
+    private const int FieldDayOperationCount = 500;
+    private static readonly TimeSpan FieldDayDatasetBudget = TimeSpan.FromSeconds(10);
     private const string FailureCategoryConfiguration = "configuration";
     private const string FailureCategoryPackage = "package";
     private const string FailureCategoryLocalCache = "local-cache";
@@ -219,6 +224,249 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
         Assert.Equal(DefaultPackageId, createPayload.PackageId);
         Assert.Equal("0", createPayload.SourceId);
         Assert.Equal("op-acceptance-media-001", createPayload.Metadata!["mediaOperationId"]);
+    }
+
+    [Fact]
+    public void AcceptancePlan_CoversCompetitiveProductScenarios_AndGatedDeviceSmoke()
+    {
+        var config = AcceptanceHarnessConfiguration.Loopback(
+            new Uri("http://127.0.0.1:5000"),
+            Path.Combine(_rootDirectory, "evidence"));
+
+        var scenarioCoverage = AcceptanceWorkflowPlan.Create(config).ScenarioCoverage
+            .ToDictionary(scenario => scenario.Id, StringComparer.Ordinal);
+
+        Assert.Equal(
+            [
+                "offline-create-sync",
+                "offline-edit-delete-sync",
+                "conflict-manual-review",
+                "attachment-round-trip",
+                "form-rules-repeat-sections",
+                "bad-network-retry",
+                "restart-durability",
+                "field-day-scale-budget",
+                "appium-field-workflow-smoke",
+            ],
+            scenarioCoverage.Keys);
+
+        Assert.Equal("service", scenarioCoverage["offline-create-sync"].AutomationLevel);
+        Assert.Equal("loopback-server", scenarioCoverage["offline-edit-delete-sync"].AutomationLevel);
+        Assert.Equal("gated-device", scenarioCoverage["appium-field-workflow-smoke"].AutomationLevel);
+        Assert.Contains("launch", scenarioCoverage["appium-field-workflow-smoke"].Steps);
+        Assert.Contains("configure-server", scenarioCoverage["appium-field-workflow-smoke"].Steps);
+        Assert.Contains("download-project", scenarioCoverage["appium-field-workflow-smoke"].Steps);
+        Assert.Contains("create-record", scenarioCoverage["appium-field-workflow-smoke"].Steps);
+        Assert.Contains("sync", scenarioCoverage["appium-field-workflow-smoke"].Steps);
+        Assert.Equal(
+            "HONUA_MOBILE_APPIUM_SMOKE",
+            scenarioCoverage["appium-field-workflow-smoke"].Metadata["skipGate"]);
+    }
+
+    [Fact]
+    public async Task ManualConflictReviewScenario_LeavesFailedOperationAndEmitsEvidence()
+    {
+        var config = AcceptanceHarnessConfiguration.Loopback(
+            new Uri("http://127.0.0.1:5000"),
+            Path.Combine(_rootDirectory, "evidence"));
+        var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions
+        {
+            DatabasePath = config.DatabasePath,
+        });
+        var plan = AcceptanceWorkflowPlan.Create(config);
+        var evidence = DisconnectedFieldWorkflowEvidence.Started(config, plan);
+        var conflictOperation = plan.SyncableOperations.Single(operation => operation.Kind == "feature-update");
+
+        await store.InitializeAsync();
+        await store.EnqueueAsync(conflictOperation.SyncOperation!);
+
+        await RunPhaseAsync(evidence, "manual-conflict-review", async phase =>
+        {
+            var sync = new OfflineSyncEngine(
+                store,
+                new ConflictUploader("server rejected base sync token; conflict requires manual review"),
+                new OfflineSyncEngineOptions
+                {
+                    BatchSize = 10,
+                    ConflictStrategy = SyncConflictStrategy.ManualReview,
+                });
+
+            var result = await sync.SyncAsync();
+            var rows = await ReadSyncQueueRowsAsync(config.DatabasePath);
+            var failed = Assert.Single(rows);
+
+            phase.Details["loaded"] = result.Loaded.ToString();
+            phase.Details["succeeded"] = result.Succeeded.ToString();
+            phase.Details["failed"] = result.Failed.ToString();
+            phase.Details["queueStatus"] = failed.Status;
+            phase.Details["lastError"] = failed.LastError ?? string.Empty;
+            evidence.FinalState.ManualReviewCount = rows.Count(row => row.Status == "failed");
+            evidence.FinalState.PendingOperationCount = await store.CountPendingAsync();
+            evidence.FinalState.LocalVerification = "manual-review conflict remains available in the GeoPackage sync queue";
+
+            Assert.Equal(1, result.Loaded);
+            Assert.Equal(0, result.Succeeded);
+            Assert.Equal(1, result.Failed);
+            Assert.Equal("failed", failed.Status);
+            Assert.Contains("manual review", failed.LastError, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(0, evidence.FinalState.PendingOperationCount);
+        });
+
+        evidence.Status = "passed";
+        evidence.CompletedAtUtc = DateTimeOffset.UtcNow;
+        var evidencePath = await WriteEvidenceAsync(evidence);
+
+        Assert.True(File.Exists(evidencePath));
+        var evidenceJson = await File.ReadAllTextAsync(evidencePath);
+        Assert.Contains("\"manual-conflict-review\"", evidenceJson);
+        Assert.Contains("\"manualReviewCount\": 1", evidenceJson);
+    }
+
+    [Fact]
+    public async Task BadNetworkRetryScenario_PersistsRetryThroughRestart_AndDrainsOnReconnect()
+    {
+        var config = AcceptanceHarnessConfiguration.Loopback(
+            new Uri("http://127.0.0.1:5000"),
+            Path.Combine(_rootDirectory, "evidence"));
+        var plan = AcceptanceWorkflowPlan.Create(config);
+        var evidence = DisconnectedFieldWorkflowEvidence.Started(config, plan);
+        var uploader = new RetryThenSuccessUploader("Connection refused by field network");
+
+        var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions
+        {
+            DatabasePath = config.DatabasePath,
+        });
+        await store.InitializeAsync();
+        await store.EnqueueAsync(plan.SyncableOperations[0].SyncOperation!);
+
+        await RunPhaseAsync(evidence, "bad-network-retry", async phase =>
+        {
+            var firstSync = new OfflineSyncEngine(
+                store,
+                uploader,
+                new OfflineSyncEngineOptions { BatchSize = 10, MaxAttempts = 3 });
+            var firstResult = await firstSync.SyncAsync();
+            var retryRows = await ReadSyncQueueRowsAsync(config.DatabasePath);
+            var retry = Assert.Single(retryRows);
+
+            phase.Details["firstLoaded"] = firstResult.Loaded.ToString();
+            phase.Details["firstFailed"] = firstResult.Failed.ToString();
+            phase.Details["retryStatus"] = retry.Status;
+            phase.Details["retryAttemptCount"] = retry.AttemptCount.ToString();
+            phase.Details["retryError"] = retry.LastError ?? string.Empty;
+            evidence.FinalState.RetryOperationCount = retryRows.Count(row => row.Status == "retry");
+
+            Assert.Equal(1, firstResult.Failed);
+            Assert.Equal("retry", retry.Status);
+            Assert.Equal(1, retry.AttemptCount);
+            Assert.Contains("Connection refused", retry.LastError, StringComparison.Ordinal);
+        });
+
+        await RunPhaseAsync(evidence, "restart-durability", async phase =>
+        {
+            var restartedStore = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions
+            {
+                DatabasePath = config.DatabasePath,
+            });
+            var pendingAfterRestart = await restartedStore.CountPendingAsync();
+
+            var secondSync = new OfflineSyncEngine(
+                restartedStore,
+                uploader,
+                new OfflineSyncEngineOptions { BatchSize = 10, MaxAttempts = 3 });
+            var secondResult = await secondSync.SyncAsync();
+
+            phase.Details["pendingAfterRestart"] = pendingAfterRestart.ToString();
+            phase.Details["secondSucceeded"] = secondResult.Succeeded.ToString();
+            phase.Details["remainingQueueRows"] = (await ReadSyncQueueRowsAsync(config.DatabasePath)).Count.ToString();
+            evidence.FinalState.PendingOperationCountBeforeReconnect = pendingAfterRestart;
+            evidence.FinalState.PendingOperationCount = await restartedStore.CountPendingAsync();
+            evidence.FinalState.LocalVerification = "retry row survived service restart and drained after reconnect";
+
+            Assert.Equal(1, pendingAfterRestart);
+            Assert.Equal(1, secondResult.Succeeded);
+            Assert.Equal(0, evidence.FinalState.PendingOperationCount);
+            Assert.Empty(await ReadSyncQueueRowsAsync(config.DatabasePath));
+        });
+
+        evidence.Status = "passed";
+        evidence.CompletedAtUtc = DateTimeOffset.UtcNow;
+        var evidencePath = await WriteEvidenceAsync(evidence);
+
+        Assert.True(File.Exists(evidencePath));
+        var evidenceJson = await File.ReadAllTextAsync(evidencePath);
+        Assert.Contains("\"bad-network-retry\"", evidenceJson);
+        Assert.Contains("\"restart-durability\"", evidenceJson);
+        Assert.Contains("\"retryOperationCount\": 1", evidenceJson);
+    }
+
+    [Fact]
+    public async Task FieldDayDatasetScenario_QueuesAndSyncsWithinPerformanceBudget()
+    {
+        var config = AcceptanceHarnessConfiguration.Loopback(
+            new Uri("http://127.0.0.1:5000"),
+            Path.Combine(_rootDirectory, "evidence"));
+        var plan = AcceptanceWorkflowPlan.Create(config);
+        var evidence = DisconnectedFieldWorkflowEvidence.Started(config, plan);
+        var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions
+        {
+            DatabasePath = config.DatabasePath,
+        });
+        await store.InitializeAsync();
+
+        await RunPhaseAsync(evidence, "field-day-scale-budget", async phase =>
+        {
+            var enqueueStopwatch = Stopwatch.StartNew();
+            for (var index = 0; index < FieldDayOperationCount; index++)
+            {
+                await store.EnqueueAsync(CreateFieldDayOperation(config, index));
+            }
+
+            enqueueStopwatch.Stop();
+
+            var pendingBeforeSync = await store.CountPendingAsync();
+            var syncStopwatch = Stopwatch.StartNew();
+            var sync = new OfflineSyncEngine(
+                new GeoPackageSyncStore(new GeoPackageSyncStoreOptions
+                {
+                    DatabasePath = config.DatabasePath,
+                }),
+                new AlwaysSuccessUploader(),
+                new OfflineSyncEngineOptions
+                {
+                    BatchSize = FieldDayOperationCount,
+                    MaxAttempts = 1,
+                });
+            var result = await sync.SyncAsync();
+            syncStopwatch.Stop();
+
+            phase.Details["operationCount"] = FieldDayOperationCount.ToString();
+            phase.Details["pendingBeforeSync"] = pendingBeforeSync.ToString();
+            phase.Details["succeeded"] = result.Succeeded.ToString();
+            phase.Details["enqueueElapsedMilliseconds"] = enqueueStopwatch.ElapsedMilliseconds.ToString();
+            phase.Details["syncElapsedMilliseconds"] = syncStopwatch.ElapsedMilliseconds.ToString();
+            phase.Details["budgetMilliseconds"] = FieldDayDatasetBudget.TotalMilliseconds.ToString("F0");
+            evidence.FinalState.FieldDayOperationCount = FieldDayOperationCount;
+            evidence.FinalState.FieldDaySyncElapsedMilliseconds = syncStopwatch.ElapsedMilliseconds;
+            evidence.FinalState.PendingOperationCount = await store.CountPendingAsync();
+
+            Assert.Equal(FieldDayOperationCount, pendingBeforeSync);
+            Assert.Equal(FieldDayOperationCount, result.Succeeded);
+            Assert.Equal(0, result.Failed);
+            Assert.Equal(0, evidence.FinalState.PendingOperationCount);
+            Assert.True(
+                enqueueStopwatch.Elapsed + syncStopwatch.Elapsed < FieldDayDatasetBudget,
+                $"Field-day enqueue+sync budget exceeded: enqueue={enqueueStopwatch.Elapsed}, sync={syncStopwatch.Elapsed}, budget={FieldDayDatasetBudget}.");
+        });
+
+        evidence.Status = "passed";
+        evidence.CompletedAtUtc = DateTimeOffset.UtcNow;
+        var evidencePath = await WriteEvidenceAsync(evidence);
+
+        Assert.True(File.Exists(evidencePath));
+        var evidenceJson = await File.ReadAllTextAsync(evidencePath);
+        Assert.Contains("\"field-day-scale-budget\"", evidenceJson);
+        Assert.Contains($"\"fieldDayOperationCount\": {FieldDayOperationCount}", evidenceJson);
     }
 
     [Theory]
@@ -613,6 +861,72 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
         };
     }
 
+    private static OfflineEditOperation CreateFieldDayOperation(AcceptanceHarnessConfiguration config, int index)
+    {
+        var objectId = 10_000 + index;
+        var feature = JsonSerializer.SerializeToElement(new
+        {
+            attributes = new
+            {
+                objectid = objectId,
+                name = $"Field Day Asset {index:D4}",
+                status = "created-offline",
+                honua_acceptance_run = config.RunId,
+            },
+            geometry = new
+            {
+                x = -157.8 + index * 0.000001,
+                y = 21.3 + index * 0.000001,
+            },
+        }, JsonOptions);
+
+        return CreateFeatureOperation(
+            config,
+            $"op-field-day-{index:D4}",
+            "field-day-create",
+            OfflineOperationType.Add,
+            config.LayerIds[0],
+            priority: index + 1,
+            feature: feature,
+            extraMetadata: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["dataset"] = "field-day-scale-budget",
+                ["sequence"] = index.ToString(CultureInfo.InvariantCulture),
+            });
+    }
+
+    private static async Task<IReadOnlyList<SyncQueueRow>> ReadSyncQueueRowsAsync(string databasePath)
+    {
+        await using var connection = new SqliteConnection($"Data Source={databasePath}");
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT operation_id, status, attempt_count, last_error
+            FROM honua_sync_queue
+            ORDER BY operation_id;
+            """;
+
+        var rows = new List<SyncQueueRow>();
+        await using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            rows.Add(new SyncQueueRow(
+                reader.GetString(0),
+                reader.GetString(1),
+                reader.GetInt32(2),
+                reader.IsDBNull(3) ? null : reader.GetString(3)));
+        }
+
+        return rows;
+    }
+
+    private sealed record SyncQueueRow(
+        string OperationId,
+        string Status,
+        int AttemptCount,
+        string? LastError);
+
     private static IReplicaSyncClient CreateReplicaClient(AcceptanceHarnessConfiguration config)
     {
         var http = new HttpClient { BaseAddress = config.BaseUri };
@@ -665,6 +979,8 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
         public required IReadOnlyList<string> Sequence { get; init; }
 
         public required IReadOnlyList<PlannedAcceptanceOperation> Operations { get; init; }
+
+        public required IReadOnlyList<AcceptanceScenarioEvidence> ScenarioCoverage { get; init; }
 
         public IReadOnlyList<PlannedAcceptanceOperation> SyncableOperations
             => Operations.Where(operation => operation.IsSyncable).ToArray();
@@ -756,6 +1072,7 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
             return new AcceptanceWorkflowPlan
             {
                 Sequence = ["online-download", "offline-edit", "reconnect-sync", "verify"],
+                ScenarioCoverage = CreateScenarioCoverage(),
                 Operations =
                 [
                     new PlannedAcceptanceOperation
@@ -802,6 +1119,79 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
                 ],
             };
         }
+
+        private static IReadOnlyList<AcceptanceScenarioEvidence> CreateScenarioCoverage()
+            =>
+            [
+                new AcceptanceScenarioEvidence
+                {
+                    Id = "offline-create-sync",
+                    AutomationLevel = "service",
+                    Steps = ["queue-create", "reconnect-sync", "verify-server"],
+                    Artifacts = ["sync-state", "geopackage-state", "server-apply-edits"],
+                },
+                new AcceptanceScenarioEvidence
+                {
+                    Id = "offline-edit-delete-sync",
+                    AutomationLevel = "loopback-server",
+                    Steps = ["queue-update", "queue-delete", "reconnect-sync", "verify-server"],
+                    Artifacts = ["sync-state", "geopackage-state", "server-apply-edits"],
+                },
+                new AcceptanceScenarioEvidence
+                {
+                    Id = "conflict-manual-review",
+                    AutomationLevel = "service",
+                    Steps = ["queue-conflicting-edit", "sync", "verify-manual-review"],
+                    Artifacts = ["sync-queue-state", "failure-category"],
+                },
+                new AcceptanceScenarioEvidence
+                {
+                    Id = "attachment-round-trip",
+                    AutomationLevel = "service",
+                    Steps = ["capture-media", "queue-metadata", "push-attachment", "pull-attachment"],
+                    Artifacts = ["attachment-metadata", "local-media-path"],
+                },
+                new AcceptanceScenarioEvidence
+                {
+                    Id = "form-rules-repeat-sections",
+                    AutomationLevel = "service",
+                    Steps = ["apply-defaults", "calculate-values", "validate-repeat", "queue-record"],
+                    Artifacts = ["form-validation-state", "offline-operation-payload"],
+                },
+                new AcceptanceScenarioEvidence
+                {
+                    Id = "bad-network-retry",
+                    AutomationLevel = "service",
+                    Steps = ["sync-temporary-failure", "persist-retry", "sync-success"],
+                    Artifacts = ["sync-queue-state", "retry-attempt-count"],
+                },
+                new AcceptanceScenarioEvidence
+                {
+                    Id = "restart-durability",
+                    AutomationLevel = "service",
+                    Steps = ["queue-offline-change", "restart-store", "resume-sync"],
+                    Artifacts = ["geopackage-state", "sync-queue-state"],
+                },
+                new AcceptanceScenarioEvidence
+                {
+                    Id = "field-day-scale-budget",
+                    AutomationLevel = "service",
+                    Steps = ["queue-large-dataset", "sync-large-dataset", "assert-budget"],
+                    Artifacts = ["operation-count", "elapsed-milliseconds"],
+                },
+                new AcceptanceScenarioEvidence
+                {
+                    Id = "appium-field-workflow-smoke",
+                    AutomationLevel = "gated-device",
+                    Steps = ["launch", "configure-server", "download-project", "create-record", "sync"],
+                    Artifacts = ["device-run-json", "appium-log", "sync-state"],
+                    Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        ["skipGate"] = "HONUA_MOBILE_APPIUM_SMOKE",
+                        ["skipReason"] = "Device/Appium smoke is gated because it needs a simulator or device plus live server credentials.",
+                    },
+                },
+            ];
     }
 
     private sealed class PlannedAcceptanceOperation
@@ -852,6 +1242,19 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
         public required Dictionary<string, string> Metadata { get; init; }
     }
 
+    private sealed class AcceptanceScenarioEvidence
+    {
+        public required string Id { get; init; }
+
+        public required string AutomationLevel { get; init; }
+
+        public required IReadOnlyList<string> Steps { get; init; }
+
+        public required IReadOnlyList<string> Artifacts { get; init; }
+
+        public Dictionary<string, string> Metadata { get; init; } = new(StringComparer.Ordinal);
+    }
+
     private sealed class SyncRunFailedException : Exception
     {
         private SyncRunFailedException(string message, string failureCategory)
@@ -868,6 +1271,54 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
                 ?? $"Expected all planned operations to sync; loaded={result.Loaded}, succeeded={result.Succeeded}, failed={result.Failed}.";
             return new SyncRunFailedException(reason, ClassifySyncFailureReason(reason));
         }
+    }
+
+    private sealed class ConflictUploader : IOfflineOperationUploader
+    {
+        private readonly string _message;
+
+        public ConflictUploader(string message)
+        {
+            _message = message;
+        }
+
+        public Task<UploadResult> UploadAsync(OfflineEditOperation operation, bool forceWrite, CancellationToken ct = default)
+            => Task.FromResult(new UploadResult
+            {
+                Outcome = UploadOutcome.Conflict,
+                Message = _message,
+            });
+    }
+
+    private sealed class RetryThenSuccessUploader : IOfflineOperationUploader
+    {
+        private readonly string _firstFailureMessage;
+        private readonly HashSet<string> _failedOnce = new(StringComparer.Ordinal);
+
+        public RetryThenSuccessUploader(string firstFailureMessage)
+        {
+            _firstFailureMessage = firstFailureMessage;
+        }
+
+        public Task<UploadResult> UploadAsync(OfflineEditOperation operation, bool forceWrite, CancellationToken ct = default)
+        {
+            if (_failedOnce.Add(operation.OperationId))
+            {
+                return Task.FromResult(new UploadResult
+                {
+                    Outcome = UploadOutcome.RetryableFailure,
+                    Message = _firstFailureMessage,
+                });
+            }
+
+            return Task.FromResult(new UploadResult { Outcome = UploadOutcome.Success });
+        }
+    }
+
+    private sealed class AlwaysSuccessUploader : IOfflineOperationUploader
+    {
+        public Task<UploadResult> UploadAsync(OfflineEditOperation operation, bool forceWrite, CancellationToken ct = default)
+            => Task.FromResult(new UploadResult { Outcome = UploadOutcome.Success });
     }
 
     private sealed class AcceptanceHarnessConfiguration
@@ -1016,6 +1467,8 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
 
         public List<PlannedOperationEvidence> PlannedOperations { get; } = [];
 
+        public List<AcceptanceScenarioEvidence> ScenarioCoverage { get; } = [];
+
         public IReadOnlyDictionary<string, string> FailureCategories { get; init; } =
             DisconnectedFieldWorkflowAcceptanceTests.FailureCategories();
 
@@ -1033,6 +1486,8 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
             };
             evidence.OperationIds.AddRange(plan.Operations.Select(operation => operation.OperationId));
             evidence.PlannedOperations.AddRange(plan.Operations.Select(operation => operation.ToEvidence()));
+            evidence.ScenarioCoverage.AddRange(plan.ScenarioCoverage);
+            evidence.FinalState.GeoPackagePath = config.DatabasePath;
             return evidence;
         }
 
@@ -1104,11 +1559,25 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
 
     private sealed class AcceptanceFinalStateEvidence
     {
+        public string? GeoPackagePath { get; set; }
+
         public int LocalFeatureCount { get; set; }
 
         public int PendingOperationCountBeforeReconnect { get; set; }
 
         public int PendingOperationCount { get; set; }
+
+        public int ManualReviewCount { get; set; }
+
+        public int RetryOperationCount { get; set; }
+
+        public int AttachmentRoundTripCount { get; set; }
+
+        public int FormRepeatEntryCount { get; set; }
+
+        public int FieldDayOperationCount { get; set; }
+
+        public long FieldDaySyncElapsedMilliseconds { get; set; }
 
         public int RunTaggedFeatureCountBeforeReconnect { get; set; }
 

--- a/tests/Honua.Mobile.Smoke.Tests/PlatformSmokeScriptTests.cs
+++ b/tests/Honua.Mobile.Smoke.Tests/PlatformSmokeScriptTests.cs
@@ -7,6 +7,7 @@ public sealed class PlatformSmokeScriptTests
     [Theory]
     [InlineData("run-android-platform-smoke.sh", "Skipping Android live Honua platform smoke")]
     [InlineData("run-ios-platform-smoke.sh", "Skipping iOS live Honua platform smoke")]
+    [InlineData("run-field-workflow-appium-smoke.sh", "Skipping Appium field workflow smoke")]
     public void PlatformSmokeScript_SkipsWhenLiveHonuaConfigIsMissing(string scriptName, string expectedMessage)
     {
         if (!IsBashAvailable())
@@ -21,8 +22,44 @@ public sealed class PlatformSmokeScriptTests
         Assert.Contains(expectedMessage, result.Output);
     }
 
-    private static ScriptResult RunScript(string root, string scriptName)
+    [Fact]
+    public void FieldWorkflowAppiumSmokeScript_WritesSkippedArtifactWithRequiredSteps()
     {
+        if (!IsBashAvailable())
+        {
+            return;
+        }
+
+        var root = FindRepositoryRoot();
+        var artifactDirectory = Path.Combine(Path.GetTempPath(), $"honua-appium-smoke-{Guid.NewGuid():N}");
+
+        try
+        {
+            var result = RunScript(root, "run-field-workflow-appium-smoke.sh", artifactDirectory);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.NotNull(result.ArtifactJson);
+            Assert.Contains("\"status\": \"skipped\"", result.ArtifactJson);
+            Assert.Contains("\"launch\"", result.ArtifactJson);
+            Assert.Contains("\"configure-server\"", result.ArtifactJson);
+            Assert.Contains("\"download-project\"", result.ArtifactJson);
+            Assert.Contains("\"create-record\"", result.ArtifactJson);
+            Assert.Contains("\"sync\"", result.ArtifactJson);
+            Assert.Contains("HONUA_MOBILE_APPIUM_SMOKE", result.ArtifactJson);
+        }
+        finally
+        {
+            if (Directory.Exists(artifactDirectory))
+            {
+                Directory.Delete(artifactDirectory, recursive: true);
+            }
+        }
+    }
+
+    private static ScriptResult RunScript(string root, string scriptName, string? artifactDirectory = null)
+    {
+        var appiumArtifactDirectory = artifactDirectory
+            ?? Path.Combine(Path.GetTempPath(), $"honua-appium-smoke-{Guid.NewGuid():N}");
         var startInfo = new ProcessStartInfo
         {
             FileName = "bash",
@@ -35,6 +72,11 @@ public sealed class PlatformSmokeScriptTests
         startInfo.Environment.Remove("HONUA_MOBILE_SMOKE_SERVICE_ID");
         startInfo.Environment.Remove("HONUA_MOBILE_SMOKE_LAYER_ID");
         startInfo.Environment.Remove("HONUA_MOBILE_SMOKE_API_KEY");
+        startInfo.Environment.Remove("HONUA_MOBILE_APPIUM_SMOKE");
+        startInfo.Environment.Remove("HONUA_MOBILE_APPIUM_SERVER_URL");
+        startInfo.Environment.Remove("HONUA_MOBILE_FIELD_APP_PATH");
+        startInfo.Environment.Remove("HONUA_MOBILE_APPIUM_COMMAND");
+        startInfo.Environment["HONUA_MOBILE_APPIUM_ARTIFACT_DIR"] = appiumArtifactDirectory;
 
         using var process = Process.Start(startInfo)
             ?? throw new InvalidOperationException($"Failed to start {scriptName}.");
@@ -42,7 +84,17 @@ public sealed class PlatformSmokeScriptTests
         var stderr = process.StandardError.ReadToEnd();
         process.WaitForExit();
 
-        return new ScriptResult(process.ExitCode, stdout + stderr);
+        var artifactPath = Path.Combine(appiumArtifactDirectory, "honua-mobile-field-workflow-appium-smoke-result.json");
+        var artifactJson = File.Exists(artifactPath)
+            ? File.ReadAllText(artifactPath)
+            : null;
+
+        if (artifactDirectory is null && Directory.Exists(appiumArtifactDirectory))
+        {
+            Directory.Delete(appiumArtifactDirectory, recursive: true);
+        }
+
+        return new ScriptResult(process.ExitCode, stdout + stderr, artifactJson);
     }
 
     private static bool IsBashAvailable()
@@ -97,5 +149,5 @@ public sealed class PlatformSmokeScriptTests
         throw new InvalidOperationException("Could not locate repository root from test output directory.");
     }
 
-    private sealed record ScriptResult(int ExitCode, string Output);
+    private sealed record ScriptResult(int ExitCode, string Output, string? ArtifactJson);
 }


### PR DESCRIPTION
Closes #217

## Summary
- expand the disconnected field workflow harness with explicit product acceptance scenario coverage metadata
- add deterministic service-level acceptance tests for manual conflict review, bad-network retry, restart durability, and field-day queue/sync budget
- add FieldCollection form/repeat/media acceptance evidence plus a gated Appium smoke script that writes a clear skipped artifact when device settings are absent

## Platform Impact
- Test and script only; no MAUI runtime behavior changes.
- Adds a gated Appium entrypoint for launch/configure/download/create/sync smoke coverage when device lab configuration is present.

## Offline Impact
- Verifies GeoPackage sync queue evidence for create/edit/delete, manual conflict review, retry rows, restart persistence, and large offline queue drain behavior.
- Keeps SDK form schema and media validation in FieldCollection tests rather than adding mobile-local contracts.

## Testing
- dotnet restore tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --ignore-failed-sources --verbosity minimal
- dotnet restore tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --ignore-failed-sources --verbosity minimal
- dotnet build tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --no-restore --verbosity minimal
- dotnet build tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore --verbosity minimal
- dotnet build tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --no-restore --verbosity minimal
- dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --no-build --no-restore --verbosity minimal
- dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-build --no-restore --verbosity minimal
- dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --no-build --no-restore --verbosity minimal
- dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --no-restore --verbosity minimal
- dotnet test tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj --no-restore --verbosity minimal
- dotnet test tests/Honua.Mobile.Field.Tests/Honua.Mobile.Field.Tests.csproj --no-restore --verbosity minimal
- dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --no-restore --verbosity minimal
- dotnet format Honua.Mobile.sln --verify-no-changes --no-restore --verbosity minimal
- git diff --check && git diff --cached --check
- bash scripts/run-field-workflow-appium-smoke.sh