### PR TITLE
mobile: harden auth sessions

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Services/IAuthenticationService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/IAuthenticationService.cs
@@ -1,5 +1,8 @@
 using System.ComponentModel;
 using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Honua.Mobile.Sdk.Auth;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Storage;
 
@@ -8,6 +11,10 @@ namespace Honua.Mobile.FieldCollection.Services;
 public interface IAuthenticationService : INotifyPropertyChanged
 {
     bool IsAuthenticated { get; }
+    bool RequiresReauthentication { get; }
+    string? SessionStatusMessage { get; }
+    DateTimeOffset? ExpiresAtUtc { get; }
+    HonuaAuthScheme? AuthScheme { get; }
     string? CurrentUserId { get; }
     string? CurrentUserName { get; }
     string? ApiKey { get; }
@@ -15,7 +22,9 @@ public interface IAuthenticationService : INotifyPropertyChanged
 
     Task<AuthenticationResult> AuthenticateAsync(string serverUrl, string apiKey);
     Task<AuthenticationResult> AuthenticateWithCredentialsAsync(string serverUrl, string username, string password);
-    Task<bool> RefreshTokenAsync();
+    Task<bool> RefreshTokenAsync(CancellationToken cancellationToken = default);
+    Task<bool> EnsureValidSessionAsync(CancellationToken cancellationToken = default);
+    ValueTask<HonuaAuthToken?> GetAuthTokenAsync(CancellationToken cancellationToken = default);
     Task LogoutAsync();
     Task<bool> ValidateConnectionAsync(string serverUrl, string? apiKey = null);
 }
@@ -28,16 +37,142 @@ public class AuthenticationResult
     public string? UserName { get; set; }
     public string? Token { get; set; }
     public DateTime? ExpiresAt { get; set; }
+    public DateTimeOffset? ExpiresAtUtc { get; set; }
 
-    public static AuthenticationResult Success(string userId, string userName, string token, DateTime? expiresAt = null) =>
-        new() { IsSuccess = true, UserId = userId, UserName = userName, Token = token, ExpiresAt = expiresAt };
+    public static AuthenticationResult Success(
+        string userId,
+        string userName,
+        string token,
+        DateTimeOffset? expiresAtUtc = null) =>
+        new()
+        {
+            IsSuccess = true,
+            UserId = userId,
+            UserName = userName,
+            Token = token,
+            ExpiresAt = expiresAtUtc?.UtcDateTime,
+            ExpiresAtUtc = expiresAtUtc
+        };
 
     public static AuthenticationResult Failure(string errorMessage) =>
         new() { IsSuccess = false, ErrorMessage = errorMessage };
 }
 
+internal interface IAuthenticationSessionStore
+{
+    Task<string?> GetAsync(string key);
+    Task SetAsync(string key, string value);
+    void Remove(string key);
+}
+
+internal sealed class SecureStorageAuthenticationSessionStore : IAuthenticationSessionStore
+{
+    public Task<string?> GetAsync(string key) => SecureStorage.GetAsync(key);
+
+    public Task SetAsync(string key, string value) => SecureStorage.SetAsync(key, value);
+
+    public void Remove(string key) => SecureStorage.Remove(key);
+}
+
+internal sealed class AuthenticationSessionTokenStore : IAuthTokenStore
+{
+    internal const string AuthSchemeKey = "auth_scheme";
+    internal const string AccessTokenKey = "access_token";
+    internal const string RefreshTokenKey = "refresh_token";
+    internal const string ExpiresAtUtcKey = "expires_at_utc";
+
+    private readonly IAuthenticationSessionStore _store;
+
+    public AuthenticationSessionTokenStore(IAuthenticationSessionStore store)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+    }
+
+    public async ValueTask<HonuaAuthToken?> ReadAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        var schemeText = await _store.GetAsync(AuthSchemeKey).ConfigureAwait(false);
+        var accessToken = await _store.GetAsync(AccessTokenKey).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(accessToken) || !TryReadScheme(schemeText, out var scheme))
+        {
+            return null;
+        }
+
+        var refreshToken = await _store.GetAsync(RefreshTokenKey).ConfigureAwait(false);
+        var expiresText = await _store.GetAsync(ExpiresAtUtcKey).ConfigureAwait(false);
+        var expiresAtUtc = DateTimeOffset.TryParse(expiresText, out var parsed)
+            ? parsed.ToUniversalTime()
+            : (DateTimeOffset?)null;
+
+        return new HonuaAuthToken(scheme, accessToken, refreshToken, expiresAtUtc);
+    }
+
+    public async ValueTask WriteAsync(HonuaAuthToken token, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(token);
+        ct.ThrowIfCancellationRequested();
+
+        await _store.SetAsync(AuthSchemeKey, token.Scheme.ToString()).ConfigureAwait(false);
+        await _store.SetAsync(AccessTokenKey, token.AccessToken).ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(token.RefreshToken))
+        {
+            _store.Remove(RefreshTokenKey);
+        }
+        else
+        {
+            await _store.SetAsync(RefreshTokenKey, token.RefreshToken).ConfigureAwait(false);
+        }
+
+        if (token.ExpiresAtUtc.HasValue)
+        {
+            await _store.SetAsync(ExpiresAtUtcKey, token.ExpiresAtUtc.Value.ToString("O")).ConfigureAwait(false);
+        }
+        else
+        {
+            _store.Remove(ExpiresAtUtcKey);
+        }
+    }
+
+    public ValueTask ClearAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        _store.Remove(AuthSchemeKey);
+        _store.Remove(AccessTokenKey);
+        _store.Remove(RefreshTokenKey);
+        _store.Remove(ExpiresAtUtcKey);
+        return ValueTask.CompletedTask;
+    }
+
+    private static bool TryReadScheme(string? value, out HonuaAuthScheme scheme)
+    {
+        scheme = default;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        if (string.Equals(value, "api_key", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "apiKey", StringComparison.OrdinalIgnoreCase))
+        {
+            scheme = HonuaAuthScheme.ApiKey;
+            return true;
+        }
+
+        return Enum.TryParse(value, ignoreCase: true, out scheme);
+    }
+}
+
 public class AuthenticationService : IAuthenticationService
 {
+    private const string ServerUrlKey = "server_url";
+    private const string ApiKeyKey = "api_key";
+    private const string UserIdKey = "user_id";
+    private const string UserNameKey = "user_name";
+    private const string TokenEndpointPathKey = "token_endpoint_path";
+    private static readonly TimeSpan RefreshSkew = TimeSpan.FromMinutes(2);
+
     private static readonly string[] ConnectionValidationPaths =
     {
         "/health",
@@ -51,22 +186,55 @@ public class AuthenticationService : IAuthenticationService
         "/health"
     };
 
+    private static readonly string[] TokenEndpointPaths =
+    {
+        "/oauth/token",
+        "/api/auth/token"
+    };
+
     private readonly HttpClient _httpClient;
     private readonly ILogger<AuthenticationService>? _logger;
+    private readonly IAuthenticationSessionStore _sessionStore;
+    private readonly AuthenticationSessionTokenStore _tokenStore;
+    private readonly IAuthTokenProvider? _authTokenProvider;
+    private readonly TimeProvider _timeProvider;
     private string? _currentUserId;
     private string? _currentUserName;
     private string? _apiKey;
     private string? _serverUrl;
+    private bool _requiresReauthentication;
+    private string? _sessionStatusMessage;
+    private DateTimeOffset? _expiresAtUtc;
+    private HonuaAuthScheme? _authScheme;
 
     public AuthenticationService()
-        : this(new HttpClient { Timeout = TimeSpan.FromSeconds(10) })
+        : this(new HttpClient { Timeout = TimeSpan.FromSeconds(10) }, logger: null)
     {
     }
 
     public AuthenticationService(HttpClient httpClient, ILogger<AuthenticationService>? logger = null)
+        : this(
+            httpClient,
+            sessionStore: new SecureStorageAuthenticationSessionStore(),
+            authTokenProvider: null,
+            timeProvider: null,
+            logger: logger)
+    {
+    }
+
+    internal AuthenticationService(
+        HttpClient httpClient,
+        IAuthenticationSessionStore sessionStore,
+        IAuthTokenProvider? authTokenProvider = null,
+        TimeProvider? timeProvider = null,
+        ILogger<AuthenticationService>? logger = null)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _logger = logger;
+        _sessionStore = sessionStore ?? throw new ArgumentNullException(nameof(sessionStore));
+        _tokenStore = new AuthenticationSessionTokenStore(_sessionStore);
+        _authTokenProvider = authTokenProvider;
+        _timeProvider = timeProvider ?? TimeProvider.System;
 
         if (_httpClient.Timeout == Timeout.InfiniteTimeSpan || _httpClient.Timeout > TimeSpan.FromSeconds(10))
         {
@@ -76,7 +244,74 @@ public class AuthenticationService : IAuthenticationService
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    public bool IsAuthenticated => !string.IsNullOrEmpty(ServerUrl) && !string.IsNullOrEmpty(ApiKey);
+    public bool IsAuthenticated =>
+        !string.IsNullOrEmpty(ServerUrl) &&
+        !RequiresReauthentication &&
+        ((AuthScheme == HonuaAuthScheme.ApiKey && !string.IsNullOrEmpty(ApiKey)) ||
+            AuthScheme == HonuaAuthScheme.Bearer ||
+            !string.IsNullOrEmpty(ApiKey));
+
+    public bool RequiresReauthentication
+    {
+        get => _requiresReauthentication;
+        private set
+        {
+            if (_requiresReauthentication == value)
+            {
+                return;
+            }
+
+            _requiresReauthentication = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsAuthenticated));
+        }
+    }
+
+    public string? SessionStatusMessage
+    {
+        get => _sessionStatusMessage;
+        private set
+        {
+            if (_sessionStatusMessage == value)
+            {
+                return;
+            }
+
+            _sessionStatusMessage = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public DateTimeOffset? ExpiresAtUtc
+    {
+        get => _expiresAtUtc;
+        private set
+        {
+            if (_expiresAtUtc == value)
+            {
+                return;
+            }
+
+            _expiresAtUtc = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public HonuaAuthScheme? AuthScheme
+    {
+        get => _authScheme;
+        private set
+        {
+            if (_authScheme == value)
+            {
+                return;
+            }
+
+            _authScheme = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsAuthenticated));
+        }
+    }
 
     public string? CurrentUserId
     {
@@ -117,6 +352,7 @@ public class AuthenticationService : IAuthenticationService
         {
             _serverUrl = value;
             OnPropertyChanged();
+            OnPropertyChanged(nameof(IsAuthenticated));
         }
     }
 
@@ -134,7 +370,7 @@ public class AuthenticationService : IAuthenticationService
                 return AuthenticationResult.Failure(validationError);
             }
 
-            var isValid = await ValidateConnectionAsync(serverUrl, apiKey);
+            var isValid = await ValidateConnectionAsync(serverUrl, apiKey).ConfigureAwait(false);
             if (!isValid)
             {
                 return AuthenticationResult.Failure("Unable to connect to server or invalid API key");
@@ -143,16 +379,22 @@ public class AuthenticationService : IAuthenticationService
             var normalizedServerUrl = normalizedUri.ToString().TrimEnd('/');
             var userId = normalizedUri.Host;
             var userName = $"API key ({normalizedUri.Host})";
+            var token = new HonuaAuthToken(HonuaAuthScheme.ApiKey, apiKey);
 
-            await SecureStorage.SetAsync("api_key", apiKey);
-            await SecureStorage.SetAsync("server_url", normalizedServerUrl);
-            await SecureStorage.SetAsync("user_id", userId);
-            await SecureStorage.SetAsync("user_name", userName);
+            await _sessionStore.SetAsync(ApiKeyKey, apiKey).ConfigureAwait(false);
+            await _sessionStore.SetAsync(ServerUrlKey, normalizedServerUrl).ConfigureAwait(false);
+            await _sessionStore.SetAsync(UserIdKey, userId).ConfigureAwait(false);
+            await _sessionStore.SetAsync(UserNameKey, userName).ConfigureAwait(false);
+            _sessionStore.Remove(TokenEndpointPathKey);
+            await _tokenStore.WriteAsync(token).ConfigureAwait(false);
 
             ServerUrl = normalizedServerUrl;
             ApiKey = apiKey;
             CurrentUserId = userId;
             CurrentUserName = userName;
+            ApplyTokenToState(token);
+            RequiresReauthentication = false;
+            SessionStatusMessage = "Signed in";
 
             return AuthenticationResult.Success(CurrentUserId, CurrentUserName, apiKey);
         }
@@ -163,44 +405,253 @@ public class AuthenticationService : IAuthenticationService
         }
     }
 
-    public Task<AuthenticationResult> AuthenticateWithCredentialsAsync(string serverUrl, string username, string password)
-    {
-        return Task.FromResult(AuthenticationResult.Failure(
-            "Username/password authentication is not configured for this app. Use an API key."));
-    }
-
-    public async Task<bool> RefreshTokenAsync()
+    public async Task<AuthenticationResult> AuthenticateWithCredentialsAsync(
+        string serverUrl,
+        string username,
+        string password)
     {
         try
         {
-            if (string.IsNullOrEmpty(ServerUrl) || string.IsNullOrEmpty(ApiKey))
-                return false;
+            if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password))
+            {
+                return AuthenticationResult.Failure("Username and password are required");
+            }
 
-            // TODO: Implement token refresh logic
-            return await ValidateConnectionAsync(ServerUrl, ApiKey);
+            if (!TryNormalizeServerUri(serverUrl, out var normalizedUri, out var validationError))
+            {
+                return AuthenticationResult.Failure(validationError);
+            }
+
+            foreach (var path in TokenEndpointPaths)
+            {
+                using var response = await RequestCredentialTokenAsync(
+                    normalizedUri,
+                    path,
+                    username,
+                    password).ConfigureAwait(false);
+
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    continue;
+                }
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    return AuthenticationResult.Failure("Credential authentication failed. Sign in again.");
+                }
+
+                var parsed = await ParseTokenResponseAsync(
+                    response,
+                    _timeProvider.GetUtcNow(),
+                    fallbackUserId: username,
+                    fallbackUserName: username).ConfigureAwait(false);
+                await StoreTokenSessionAsync(normalizedUri, parsed, path).ConfigureAwait(false);
+
+                return AuthenticationResult.Success(
+                    parsed.UserId,
+                    parsed.UserName,
+                    parsed.Token.AccessToken,
+                    parsed.Token.ExpiresAtUtc);
+            }
+
+            return AuthenticationResult.Failure(
+                "Username/password authentication is not configured for this server. Use an API key.");
         }
         catch (Exception ex)
         {
-            _logger?.LogWarning(ex, "Token refresh validation failed");
+            _logger?.LogWarning(ex, "Credential authentication failed");
+            return AuthenticationResult.Failure("Authentication failed. Check the server URL and credentials.");
+        }
+    }
+
+    public async Task<bool> RefreshTokenAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await LoadStoredSessionAsync(cancellationToken).ConfigureAwait(false);
+            if (string.IsNullOrEmpty(ServerUrl))
+            {
+                MarkReauthenticationRequired("Sign in required before syncing.");
+                return false;
+            }
+
+            if (AuthScheme == HonuaAuthScheme.ApiKey || !string.IsNullOrEmpty(ApiKey))
+            {
+                if (string.IsNullOrEmpty(ApiKey))
+                {
+                    MarkReauthenticationRequired("Authentication is required. Sign in again.");
+                    return false;
+                }
+
+                var isValid = await ValidateConnectionAsync(ServerUrl, ApiKey).ConfigureAwait(false);
+                if (!isValid)
+                {
+                    MarkReauthenticationRequired("Authentication is invalid. Sign in again.");
+                    return false;
+                }
+
+                RequiresReauthentication = false;
+                SessionStatusMessage = "Session active";
+                return true;
+            }
+
+            var current = await _tokenStore.ReadAsync(cancellationToken).ConfigureAwait(false);
+            if (current is null)
+            {
+                MarkReauthenticationRequired("Session expired. Sign in again.");
+                return false;
+            }
+
+            if (current.Scheme != HonuaAuthScheme.Bearer || string.IsNullOrWhiteSpace(current.RefreshToken))
+            {
+                if (IsBearerExpired(current))
+                {
+                    MarkReauthenticationRequired("Session expired. Sign in again.");
+                    return false;
+                }
+
+                ApplyTokenToState(current);
+                RequiresReauthentication = false;
+                SessionStatusMessage = "Session active";
+                return true;
+            }
+
+            var provider = await CreateRefreshProviderAsync().ConfigureAwait(false);
+            var refreshed = await provider.RefreshTokenAsync(cancellationToken).ConfigureAwait(false);
+            if (refreshed is null)
+            {
+                MarkReauthenticationRequired("Session expired. Sign in again.");
+                return false;
+            }
+
+            await _tokenStore.WriteAsync(refreshed, cancellationToken).ConfigureAwait(false);
+            ApplyTokenToState(refreshed);
+
+            if (IsBearerExpired(refreshed))
+            {
+                MarkReauthenticationRequired("Session expired. Sign in again.");
+                return false;
+            }
+
+            RequiresReauthentication = false;
+            SessionStatusMessage = refreshed.Scheme == HonuaAuthScheme.Bearer
+                ? "Session refreshed"
+                : "Session active";
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Token refresh failed");
+            MarkReauthenticationRequired("Session could not be refreshed. Sign in again.");
             return false;
         }
     }
 
+    public async Task<bool> EnsureValidSessionAsync(CancellationToken cancellationToken = default)
+    {
+        var token = await GetAuthTokenAsync(cancellationToken).ConfigureAwait(false);
+        if (token is null)
+        {
+            if (!RequiresReauthentication)
+            {
+                SessionStatusMessage = "Authentication is required.";
+            }
+
+            return false;
+        }
+
+        if (IsBearerExpired(token))
+        {
+            MarkReauthenticationRequired("Session expired. Sign in again.");
+            return false;
+        }
+
+        RequiresReauthentication = false;
+        SessionStatusMessage = token.Scheme == HonuaAuthScheme.Bearer && token.ExpiresAtUtc.HasValue
+            ? $"Session active until {token.ExpiresAtUtc.Value.UtcDateTime:u}"
+            : "Session active";
+        return true;
+    }
+
+    public async ValueTask<HonuaAuthToken?> GetAuthTokenAsync(CancellationToken cancellationToken = default)
+    {
+        await LoadStoredSessionAsync(cancellationToken).ConfigureAwait(false);
+        if (RequiresReauthentication)
+        {
+            return null;
+        }
+
+        var token = await _tokenStore.ReadAsync(cancellationToken).ConfigureAwait(false);
+        if (token is null && !string.IsNullOrWhiteSpace(ApiKey))
+        {
+            token = new HonuaAuthToken(HonuaAuthScheme.ApiKey, ApiKey);
+            await _tokenStore.WriteAsync(token, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (token is null)
+        {
+            return null;
+        }
+
+        if (token.Scheme == HonuaAuthScheme.Bearer && token.ShouldRefresh(_timeProvider.GetUtcNow(), RefreshSkew))
+        {
+            var refreshed = await RefreshTokenAsync(cancellationToken).ConfigureAwait(false);
+            if (!refreshed)
+            {
+                return null;
+            }
+
+            token = await _tokenStore.ReadAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        if (token is null)
+        {
+            return null;
+        }
+
+        if (IsBearerExpired(token))
+        {
+            MarkReauthenticationRequired("Session expired. Sign in again.");
+            return null;
+        }
+
+        ApplyTokenToState(token);
+        return token;
+    }
+
     public async Task LogoutAsync()
     {
-        // Clear secure storage
-        SecureStorage.Remove("server_url");
-        SecureStorage.Remove("api_key");
-        SecureStorage.Remove("user_id");
-        SecureStorage.Remove("user_name");
+        _sessionStore.Remove(ServerUrlKey);
+        _sessionStore.Remove(ApiKeyKey);
+        _sessionStore.Remove(UserIdKey);
+        _sessionStore.Remove(UserNameKey);
+        _sessionStore.Remove(TokenEndpointPathKey);
+        await _tokenStore.ClearAsync().ConfigureAwait(false);
 
-        // Clear properties
+        try
+        {
+            if (_authTokenProvider is not null)
+            {
+                await _authTokenProvider.ClearTokenAsync().ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Auth token provider clearing failed during sign-out");
+        }
+
         ServerUrl = null;
         ApiKey = null;
         CurrentUserId = null;
         CurrentUserName = null;
-
-        await Task.CompletedTask;
+        AuthScheme = null;
+        ExpiresAtUtc = null;
+        RequiresReauthentication = false;
+        SessionStatusMessage = "Signed out. Local offline edits remain on this device until explicitly removed.";
     }
 
     public async Task<bool> ValidateConnectionAsync(string serverUrl, string? apiKey = null)
@@ -224,7 +675,7 @@ public class AuthenticationService : IAuthenticationService
 
                 using var response = await _httpClient.SendAsync(
                     request,
-                    HttpCompletionOption.ResponseHeadersRead);
+                    HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
 
                 if (IsAcceptedValidationStatus(response.StatusCode, hasApiKey))
                 {
@@ -244,6 +695,196 @@ public class AuthenticationService : IAuthenticationService
             _logger?.LogDebug(ex, "Server connection validation failed");
             return false;
         }
+    }
+
+    private async Task<HttpResponseMessage> RequestCredentialTokenAsync(
+        Uri serverUri,
+        string tokenEndpointPath,
+        string username,
+        string password)
+    {
+        var payload = new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["grantType"] = "password",
+            ["username"] = username,
+            ["password"] = password
+        };
+
+        return await _httpClient.PostAsJsonAsync(
+            new Uri(serverUri, tokenEndpointPath),
+            payload).ConfigureAwait(false);
+    }
+
+    private async Task StoreTokenSessionAsync(Uri serverUri, ParsedAuthToken parsed, string tokenEndpointPath)
+    {
+        var normalizedServerUrl = serverUri.ToString().TrimEnd('/');
+        await _sessionStore.SetAsync(ServerUrlKey, normalizedServerUrl).ConfigureAwait(false);
+        await _sessionStore.SetAsync(UserIdKey, parsed.UserId).ConfigureAwait(false);
+        await _sessionStore.SetAsync(UserNameKey, parsed.UserName).ConfigureAwait(false);
+        await _sessionStore.SetAsync(TokenEndpointPathKey, tokenEndpointPath).ConfigureAwait(false);
+        _sessionStore.Remove(ApiKeyKey);
+        await _tokenStore.WriteAsync(parsed.Token).ConfigureAwait(false);
+
+        ServerUrl = normalizedServerUrl;
+        ApiKey = null;
+        CurrentUserId = parsed.UserId;
+        CurrentUserName = parsed.UserName;
+        ApplyTokenToState(parsed.Token);
+        RequiresReauthentication = false;
+        SessionStatusMessage = "Signed in";
+    }
+
+    private async Task LoadStoredSessionAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrEmpty(ServerUrl))
+        {
+            ServerUrl = await _sessionStore.GetAsync(ServerUrlKey).ConfigureAwait(false);
+        }
+
+        if (string.IsNullOrEmpty(ApiKey))
+        {
+            ApiKey = await _sessionStore.GetAsync(ApiKeyKey).ConfigureAwait(false);
+        }
+
+        if (string.IsNullOrEmpty(CurrentUserId))
+        {
+            CurrentUserId = await _sessionStore.GetAsync(UserIdKey).ConfigureAwait(false);
+        }
+
+        if (string.IsNullOrEmpty(CurrentUserName))
+        {
+            CurrentUserName = await _sessionStore.GetAsync(UserNameKey).ConfigureAwait(false);
+        }
+
+        var token = await _tokenStore.ReadAsync(cancellationToken).ConfigureAwait(false);
+        if (token is not null)
+        {
+            ApplyTokenToState(token);
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(ApiKey))
+        {
+            AuthScheme = HonuaAuthScheme.ApiKey;
+            ExpiresAtUtc = null;
+        }
+    }
+
+    private async Task<IAuthTokenProvider> CreateRefreshProviderAsync()
+    {
+        if (_authTokenProvider is not null)
+        {
+            return _authTokenProvider;
+        }
+
+        if (string.IsNullOrWhiteSpace(ServerUrl) ||
+            !Uri.TryCreate(ServerUrl, UriKind.Absolute, out var serverUri))
+        {
+            return new RefreshingAuthTokenProvider(_tokenStore, _httpClient);
+        }
+
+        var path = await _sessionStore.GetAsync(TokenEndpointPathKey).ConfigureAwait(false);
+        var refreshEndpoint = Uri.TryCreate(path, UriKind.Absolute, out var absoluteUri)
+            ? absoluteUri
+            : new Uri(serverUri, string.IsNullOrWhiteSpace(path) ? TokenEndpointPaths[0] : path);
+
+        return new RefreshingAuthTokenProvider(
+            _tokenStore,
+            _httpClient,
+            new RefreshingAuthTokenProviderOptions
+            {
+                RefreshEndpoint = refreshEndpoint,
+                TimeProvider = _timeProvider,
+                RefreshSkew = RefreshSkew
+            });
+    }
+
+    private void ApplyTokenToState(HonuaAuthToken token)
+    {
+        AuthScheme = token.Scheme;
+        ExpiresAtUtc = token.ExpiresAtUtc;
+        if (token.Scheme == HonuaAuthScheme.ApiKey && string.IsNullOrWhiteSpace(ApiKey))
+        {
+            ApiKey = token.AccessToken;
+        }
+        else if (token.Scheme == HonuaAuthScheme.Bearer)
+        {
+            ApiKey = null;
+        }
+    }
+
+    private bool IsBearerExpired(HonuaAuthToken token) =>
+        token.Scheme == HonuaAuthScheme.Bearer &&
+        token.ExpiresAtUtc.HasValue &&
+        token.ExpiresAtUtc.Value <= _timeProvider.GetUtcNow();
+
+    private void MarkReauthenticationRequired(string message)
+    {
+        RequiresReauthentication = true;
+        SessionStatusMessage = message;
+    }
+
+    private static async Task<ParsedAuthToken> ParseTokenResponseAsync(
+        HttpResponseMessage response,
+        DateTimeOffset nowUtc,
+        string fallbackUserId,
+        string fallbackUserName)
+    {
+        await using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        using var document = await JsonDocument.ParseAsync(stream).ConfigureAwait(false);
+        var payload = document.RootElement;
+
+        var accessToken = ReadString(payload, "accessToken", "access_token")
+            ?? throw new InvalidOperationException("Token response did not include an access token.");
+        var refreshToken = ReadString(payload, "refreshToken", "refresh_token");
+        var tokenType = ReadString(payload, "tokenType", "token_type");
+        var scheme = string.Equals(tokenType, "api_key", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(tokenType, "apiKey", StringComparison.OrdinalIgnoreCase)
+                ? HonuaAuthScheme.ApiKey
+                : HonuaAuthScheme.Bearer;
+        var expiresAtUtc = ReadExpiresAt(payload, nowUtc);
+        var userId = ReadString(payload, "userId", "user_id", "sub", "subject") ?? fallbackUserId;
+        var userName = ReadString(payload, "userName", "user_name", "name", "username") ?? fallbackUserName;
+        var token = new HonuaAuthToken(scheme, accessToken, refreshToken, expiresAtUtc);
+
+        return new ParsedAuthToken(token, userId, userName);
+    }
+
+    private static string? ReadString(JsonElement payload, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (payload.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String)
+            {
+                var text = value.GetString();
+                return string.IsNullOrWhiteSpace(text) ? null : text;
+            }
+        }
+
+        return null;
+    }
+
+    private static DateTimeOffset? ReadExpiresAt(JsonElement payload, DateTimeOffset nowUtc)
+    {
+        var expiresAt = ReadString(payload, "expiresAtUtc", "expires_at_utc", "expiresAt", "expires_at");
+        if (DateTimeOffset.TryParse(expiresAt, out var parsed))
+        {
+            return parsed.ToUniversalTime();
+        }
+
+        if (payload.TryGetProperty("expiresIn", out var expiresIn) ||
+            payload.TryGetProperty("expires_in", out expiresIn))
+        {
+            if (expiresIn.TryGetInt64(out var seconds))
+            {
+                return nowUtc.AddSeconds(seconds);
+            }
+        }
+
+        return null;
     }
 
     private static bool TryNormalizeServerUri(string serverUrl, out Uri normalizedUri, out string errorMessage)
@@ -288,4 +929,6 @@ public class AuthenticationService : IAuthenticationService
     {
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
+
+    private sealed record ParsedAuthToken(HonuaAuthToken Token, string UserId, string UserName);
 }

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs
@@ -110,14 +110,14 @@ public sealed class HonuaSdkFieldCollectionFeatureSyncClient :
     {
         if (!TryCreateOptions(out var options))
         {
-            throw new InvalidOperationException("Honua server URL and API key are required for field sync.");
+            throw new InvalidOperationException("Honua server URL and authentication are required for field sync.");
         }
 
         var httpClient = _httpClientFactory.CreateClient("HonuaFieldSync");
         return new HonuaMobileClient(
             httpClient,
             options,
-            new FieldCollectionApiKeyTokenProvider(_authenticationService));
+            new FieldCollectionAuthTokenProvider(_authenticationService));
     }
 
     private bool TryCreateOptions(out HonuaMobileClientOptions options)
@@ -125,7 +125,7 @@ public sealed class HonuaSdkFieldCollectionFeatureSyncClient :
         options = null!;
 
         if (string.IsNullOrWhiteSpace(_authenticationService.ServerUrl) ||
-            string.IsNullOrWhiteSpace(_authenticationService.ApiKey) ||
+            !_authenticationService.IsAuthenticated ||
             !Uri.TryCreate(_authenticationService.ServerUrl.Trim(), UriKind.Absolute, out var baseUri))
         {
             return false;
@@ -143,6 +143,7 @@ public sealed class HonuaSdkFieldCollectionFeatureSyncClient :
         {
             BaseUri = baseUri,
             ApiKey = _authenticationService.ApiKey,
+            AuthTokenProvider = new FieldCollectionAuthTokenProvider(_authenticationService),
             AllowInsecureTransportForDevelopment = baseUri.Scheme == Uri.UriSchemeHttp && baseUri.IsLoopback,
             PreferGrpcForFeatureQueries = false,
             PreferGrpcForFeatureEdits = false,
@@ -1341,11 +1342,11 @@ public sealed class QueuedFieldCollectionChangeUploader :
     }
 }
 
-internal sealed class FieldCollectionApiKeyTokenProvider : IAuthTokenProvider
+internal sealed class FieldCollectionAuthTokenProvider : IAuthTokenProvider
 {
     private readonly IAuthenticationService _authenticationService;
 
-    public FieldCollectionApiKeyTokenProvider(IAuthenticationService authenticationService)
+    public FieldCollectionAuthTokenProvider(IAuthenticationService authenticationService)
     {
         _authenticationService = authenticationService;
     }
@@ -1353,13 +1354,16 @@ internal sealed class FieldCollectionApiKeyTokenProvider : IAuthTokenProvider
     public ValueTask<HonuaAuthToken?> GetTokenAsync(CancellationToken ct = default)
     {
         ct.ThrowIfCancellationRequested();
-        return string.IsNullOrWhiteSpace(_authenticationService.ApiKey)
-            ? ValueTask.FromResult<HonuaAuthToken?>(null)
-            : ValueTask.FromResult<HonuaAuthToken?>(new HonuaAuthToken(HonuaAuthScheme.ApiKey, _authenticationService.ApiKey));
+        return _authenticationService.GetAuthTokenAsync(ct);
     }
 
-    public ValueTask<HonuaAuthToken?> RefreshTokenAsync(CancellationToken ct = default)
-        => GetTokenAsync(ct);
+    public async ValueTask<HonuaAuthToken?> RefreshTokenAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return await _authenticationService.RefreshTokenAsync(ct).ConfigureAwait(false)
+            ? await _authenticationService.GetAuthTokenAsync(ct).ConfigureAwait(false)
+            : null;
+    }
 
     public ValueTask StoreTokenAsync(HonuaAuthToken token, CancellationToken ct = default)
         => ValueTask.CompletedTask;

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/GeoPackageSyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/GeoPackageSyncService.cs
@@ -166,7 +166,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
 
     public async Task<SyncResult> SyncAsync()
     {
-        var unavailableReason = GetSyncUnavailableReason();
+        var unavailableReason = await GetSyncUnavailableReasonAsync();
         if (unavailableReason != null)
         {
             return SyncUnavailableResult("sync", unavailableReason);
@@ -288,7 +288,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
 
     public async Task<SyncResult> PullChangesAsync()
     {
-        var unavailableReason = GetSyncUnavailableReason();
+        var unavailableReason = await GetSyncUnavailableReasonAsync();
         if (unavailableReason != null)
         {
             return SyncUnavailableResult("pull changes", unavailableReason);
@@ -395,7 +395,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
 
     public async Task<SyncResult> PushChangesAsync()
     {
-        var unavailableReason = GetSyncUnavailableReason();
+        var unavailableReason = await GetSyncUnavailableReasonAsync();
         if (unavailableReason != null)
         {
             return SyncUnavailableResult("push changes", unavailableReason);
@@ -975,21 +975,23 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
             capability.IsRemoteSyncConfigured;
     }
 
-    private string? GetSyncUnavailableReason()
+    private async Task<string?> GetSyncUnavailableReasonAsync()
     {
-        if (!IsRemoteSyncConfigured)
-        {
-            return "remote field sync is not configured";
-        }
-
         if (!_connectivityService.IsConnected)
         {
             return "the device is offline";
         }
 
-        if (!_authService.IsAuthenticated)
+        if (!await _authService.EnsureValidSessionAsync().ConfigureAwait(false))
         {
-            return "authentication is required";
+            return _authService.RequiresReauthentication
+                ? _authService.SessionStatusMessage ?? "session expired; sign in again"
+                : "authentication is required";
+        }
+
+        if (!IsRemoteSyncConfigured)
+        {
+            return "remote field sync is not configured";
         }
 
         return null;

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/SyncCenterViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/SyncCenterViewModel.cs
@@ -93,7 +93,9 @@ public partial class SyncCenterViewModel : BaseViewModel
 
     private void OnAuthServicePropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(IAuthenticationService.IsAuthenticated))
+        if (e.PropertyName == nameof(IAuthenticationService.IsAuthenticated) ||
+            e.PropertyName == nameof(IAuthenticationService.RequiresReauthentication) ||
+            e.PropertyName == nameof(IAuthenticationService.SessionStatusMessage))
         {
             UpdateFromSyncService();
         }
@@ -117,24 +119,27 @@ public partial class SyncCenterViewModel : BaseViewModel
             IsRemoteSyncConfigured &&
             IsOnline &&
             _authService.IsAuthenticated &&
+            !_authService.RequiresReauthentication &&
             !IsSyncing;
     }
 
     private void UpdateSyncStatusMessage()
     {
-        if (!IsRemoteSyncConfigured)
-        {
-            SyncStatusMessage = PendingChangesCount > 0
-                ? $"Remote sync not configured - {PendingChangesCount} changes remain on this device"
-                : "Remote sync not configured";
-        }
-        else if (!IsOnline)
+        if (!IsOnline)
         {
             SyncStatusMessage = "Offline - sync unavailable";
         }
         else if (!_authService.IsAuthenticated)
         {
-            SyncStatusMessage = "Not authenticated";
+            SyncStatusMessage = _authService.RequiresReauthentication
+                ? _authService.SessionStatusMessage ?? "Session expired - sign in again"
+                : "Not authenticated";
+        }
+        else if (!IsRemoteSyncConfigured)
+        {
+            SyncStatusMessage = PendingChangesCount > 0
+                ? $"Remote sync not configured - {PendingChangesCount} changes remain on this device"
+                : "Remote sync not configured";
         }
         else
         {
@@ -169,12 +174,6 @@ public partial class SyncCenterViewModel : BaseViewModel
             return;
         }
 
-        if (!IsRemoteSyncConfigured)
-        {
-            await ShowError("Sync Not Configured", "Remote field sync is not configured for this app build. Pending changes remain on this device.");
-            return;
-        }
-
         if (!IsOnline)
         {
             await ShowError("No Connection", "Please check your internet connection and try again.");
@@ -183,7 +182,15 @@ public partial class SyncCenterViewModel : BaseViewModel
 
         if (!_authService.IsAuthenticated)
         {
-            await ShowError("Not Authenticated", "Please sign in before syncing.");
+            await ShowError(
+                _authService.RequiresReauthentication ? "Sign In Required" : "Not Authenticated",
+                _authService.SessionStatusMessage ?? "Please sign in before syncing.");
+            return;
+        }
+
+        if (!IsRemoteSyncConfigured)
+        {
+            await ShowError("Sync Not Configured", "Remote field sync is not configured for this app build. Pending changes remain on this device.");
             return;
         }
 

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/WorkflowViewModels.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/WorkflowViewModels.cs
@@ -1394,6 +1394,15 @@ public sealed partial class AuthenticationViewModel : BaseViewModel, IRouteAware
     private string statusMessage = "Not signed in";
 
     [ObservableProperty]
+    private string sessionStatus = "Not signed in";
+
+    [ObservableProperty]
+    private bool requiresReauthentication;
+
+    [ObservableProperty]
+    private DateTimeOffset? sessionExpiresAtUtc;
+
+    [ObservableProperty]
     private bool isAuthenticated;
 
     public AuthenticationViewModel(INavigationService navigationService, IAuthenticationService authService)
@@ -1439,6 +1448,7 @@ public sealed partial class AuthenticationViewModel : BaseViewModel, IRouteAware
     private async Task Logout()
     {
         await _authService.LogoutAsync();
+        ApiKey = string.Empty;
         RefreshState();
     }
 
@@ -1447,7 +1457,12 @@ public sealed partial class AuthenticationViewModel : BaseViewModel, IRouteAware
         ServerUrl = _authService.ServerUrl ?? ServerUrl;
         ApiKey = _authService.ApiKey ?? ApiKey;
         IsAuthenticated = _authService.IsAuthenticated;
-        StatusMessage = IsAuthenticated
+        RequiresReauthentication = _authService.RequiresReauthentication;
+        SessionExpiresAtUtc = _authService.ExpiresAtUtc;
+        SessionStatus = _authService.SessionStatusMessage ?? (IsAuthenticated ? "Session active" : "Not signed in");
+        StatusMessage = RequiresReauthentication
+            ? SessionStatus
+            : IsAuthenticated
             ? $"Signed in as {_authService.CurrentUserName ?? _authService.CurrentUserId ?? "current user"}"
             : "Not signed in";
     }

--- a/tests/Honua.Mobile.FieldCollection.Tests/AuthenticationServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/AuthenticationServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.Sdk.Auth;
 
 namespace Honua.Mobile.FieldCollection.Tests;
 
@@ -66,5 +67,232 @@ public sealed class AuthenticationServiceTests
 
         Assert.False(await service.ValidateConnectionAsync("http://api.honua.test", "key"));
         Assert.True(await service.ValidateConnectionAsync("http://localhost:5000", "key"));
+    }
+
+    [Fact]
+    public async Task AuthenticateWithCredentialsAsync_WhenTokenEndpointSucceeds_StoresBearerSession()
+    {
+        var now = new DateTimeOffset(2026, 5, 23, 12, 0, 0, TimeSpan.Zero);
+        var requestedPaths = new List<string>();
+        var store = new InMemoryAuthenticationSessionStore();
+        using var http = new HttpClient(new StubHttpMessageHandler(request =>
+        {
+            requestedPaths.Add(request.RequestUri!.PathAndQuery);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {
+                      "access_token": "bearer-access",
+                      "refresh_token": "bearer-refresh",
+                      "expires_in": 3600,
+                      "user_id": "field-user",
+                      "user_name": "Field User"
+                    }
+                    """)
+            };
+        }));
+        var service = new AuthenticationService(
+            http,
+            sessionStore: store,
+            timeProvider: new FixedTimeProvider(now));
+
+        var result = await service.AuthenticateWithCredentialsAsync(
+            "https://api.honua.test",
+            "field-user",
+            "password");
+        var token = await service.GetAuthTokenAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.True(service.IsAuthenticated);
+        Assert.Equal(HonuaAuthScheme.Bearer, service.AuthScheme);
+        Assert.Null(service.ApiKey);
+        Assert.Equal("bearer-access", token?.AccessToken);
+        Assert.Equal(now.AddHours(1), service.ExpiresAtUtc);
+        Assert.Equal(["/oauth/token"], requestedPaths);
+    }
+
+    [Fact]
+    public async Task EnsureValidSessionAsync_WithExpiredBearerToken_RefreshesBeforeUse()
+    {
+        var now = new DateTimeOffset(2026, 5, 23, 12, 0, 0, TimeSpan.Zero);
+        var store = new InMemoryAuthenticationSessionStore();
+        var tokenStore = new AuthenticationSessionTokenStore(store);
+        await store.SetAsync("server_url", "https://api.honua.test");
+        await store.SetAsync("user_id", "field-user");
+        await store.SetAsync("user_name", "Field User");
+        await tokenStore.WriteAsync(new HonuaAuthToken(
+            HonuaAuthScheme.Bearer,
+            "expired-access",
+            "refresh-token",
+            now.AddMinutes(-10)));
+        var provider = new RecordingAuthTokenProvider
+        {
+            RefreshResult = new HonuaAuthToken(
+                HonuaAuthScheme.Bearer,
+                "fresh-access",
+                "next-refresh",
+                now.AddHours(1))
+        };
+        using var http = new HttpClient(new StubHttpMessageHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)));
+        var service = new AuthenticationService(
+            http,
+            sessionStore: store,
+            authTokenProvider: provider,
+            timeProvider: new FixedTimeProvider(now));
+
+        var isValid = await service.EnsureValidSessionAsync();
+        var token = await service.GetAuthTokenAsync();
+
+        Assert.True(isValid);
+        Assert.False(service.RequiresReauthentication);
+        Assert.Equal("fresh-access", token?.AccessToken);
+        Assert.Equal(now.AddHours(1), service.ExpiresAtUtc);
+        Assert.Equal(1, provider.RefreshCalls);
+    }
+
+    [Fact]
+    public async Task EnsureValidSessionAsync_WhenBearerRefreshFails_RequiresReauthentication()
+    {
+        var now = new DateTimeOffset(2026, 5, 23, 12, 0, 0, TimeSpan.Zero);
+        var store = new InMemoryAuthenticationSessionStore();
+        var tokenStore = new AuthenticationSessionTokenStore(store);
+        await store.SetAsync("server_url", "https://api.honua.test");
+        await tokenStore.WriteAsync(new HonuaAuthToken(
+            HonuaAuthScheme.Bearer,
+            "expired-access",
+            "refresh-token",
+            now.AddMinutes(-10)));
+        var provider = new RecordingAuthTokenProvider
+        {
+            RefreshException = new HonuaMobileAuthException("Refresh token expired.")
+        };
+        using var http = new HttpClient(new StubHttpMessageHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)));
+        var service = new AuthenticationService(
+            http,
+            sessionStore: store,
+            authTokenProvider: provider,
+            timeProvider: new FixedTimeProvider(now));
+
+        var isValid = await service.EnsureValidSessionAsync();
+
+        Assert.False(isValid);
+        Assert.True(service.RequiresReauthentication);
+        Assert.False(service.IsAuthenticated);
+        Assert.Contains("Sign in again", service.SessionStatusMessage);
+        Assert.Equal(1, provider.RefreshCalls);
+    }
+
+    [Fact]
+    public async Task LogoutAsync_ClearsStoredSecretsAndKeepsOfflineDataPolicyVisible()
+    {
+        var store = new InMemoryAuthenticationSessionStore();
+        var tokenStore = new AuthenticationSessionTokenStore(store);
+        var provider = new RecordingAuthTokenProvider();
+        await store.SetAsync("server_url", "https://api.honua.test");
+        await store.SetAsync("api_key", "api-secret");
+        await store.SetAsync("user_id", "field-user");
+        await store.SetAsync("user_name", "Field User");
+        await tokenStore.WriteAsync(new HonuaAuthToken(
+            HonuaAuthScheme.Bearer,
+            "access-secret",
+            "refresh-secret",
+            DateTimeOffset.UtcNow.AddHours(1)));
+        using var http = new HttpClient(new StubHttpMessageHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)));
+        var service = new AuthenticationService(
+            http,
+            sessionStore: store,
+            authTokenProvider: provider);
+
+        await service.LogoutAsync();
+
+        Assert.Null(await tokenStore.ReadAsync());
+        Assert.DoesNotContain(store.Values, value =>
+            value is "api-secret" or "access-secret" or "refresh-secret");
+        Assert.True(provider.ClearCalled);
+        Assert.False(service.IsAuthenticated);
+        Assert.Contains("Local offline edits remain", service.SessionStatusMessage);
+    }
+
+    private sealed class InMemoryAuthenticationSessionStore : IAuthenticationSessionStore
+    {
+        private readonly Dictionary<string, string> _values = new(StringComparer.Ordinal);
+
+        public IReadOnlyCollection<string> Values => _values.Values.ToArray();
+
+        public Task<string?> GetAsync(string key)
+        {
+            _values.TryGetValue(key, out var value);
+            return Task.FromResult<string?>(value);
+        }
+
+        public Task SetAsync(string key, string value)
+        {
+            _values[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public void Remove(string key)
+        {
+            _values.Remove(key);
+        }
+    }
+
+    private sealed class RecordingAuthTokenProvider : IAuthTokenProvider
+    {
+        public HonuaAuthToken? CurrentToken { get; set; }
+        public HonuaAuthToken? RefreshResult { get; set; }
+        public Exception? RefreshException { get; set; }
+        public int RefreshCalls { get; private set; }
+        public bool ClearCalled { get; private set; }
+
+        public ValueTask<HonuaAuthToken?> GetTokenAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(CurrentToken);
+        }
+
+        public ValueTask<HonuaAuthToken?> RefreshTokenAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            RefreshCalls++;
+            if (RefreshException is not null)
+            {
+                throw RefreshException;
+            }
+
+            CurrentToken = RefreshResult ?? CurrentToken;
+            return ValueTask.FromResult(CurrentToken);
+        }
+
+        public ValueTask StoreTokenAsync(HonuaAuthToken token, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            CurrentToken = token;
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask ClearTokenAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            ClearCalled = true;
+            CurrentToken = null;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+
+        public FixedTimeProvider(DateTimeOffset now)
+        {
+            _now = now;
+        }
+
+        public override DateTimeOffset GetUtcNow() => _now;
     }
 }

--- a/tests/Honua.Mobile.FieldCollection.Tests/DiagnosticRedactorTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/DiagnosticRedactorTests.cs
@@ -13,6 +13,8 @@ public sealed class DiagnosticRedactorTests
               "api_key": "api-secret",
               "x-api-key": "header-secret",
               "access-key": "access-secret",
+              "access_token": "access-token-secret",
+              "refresh_token": "refresh-token-secret",
               "nested": { "Authorization": "Bearer auth-secret" },
               "safe": "visible"
             }
@@ -23,7 +25,20 @@ public sealed class DiagnosticRedactorTests
         Assert.DoesNotContain("api-secret", redacted);
         Assert.DoesNotContain("header-secret", redacted);
         Assert.DoesNotContain("access-secret", redacted);
+        Assert.DoesNotContain("access-token-secret", redacted);
+        Assert.DoesNotContain("refresh-token-secret", redacted);
         Assert.DoesNotContain("auth-secret", redacted);
+    }
+
+    [Fact]
+    public void RedactSensitiveText_RedactsBearerAndTokenPairs()
+    {
+        var redacted = DiagnosticRedactor.RedactSensitiveText(
+            "Authorization: Bearer bearer-secret refresh_token=refresh-secret");
+
+        Assert.DoesNotContain("bearer-secret", redacted);
+        Assert.DoesNotContain("refresh-secret", redacted);
+        Assert.Contains("[redacted]", redacted);
     }
 
     [Fact]

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -59,6 +59,30 @@ public sealed class GeoPackageSyncServiceTests
     }
 
     [Fact]
+    public async Task PushChangesAsync_WhenSessionRequiresReauthentication_LeavesPendingEditsQueued()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.StoreFeatureAsync(CreateFeature("asset-1", version: 1));
+        var auth = new TestAuthenticationService
+        {
+            IsAuthenticated = false,
+            RequiresReauthentication = true,
+            SessionStatusMessage = "Session expired. Sign in again.",
+            EnsureValidSessionResult = false
+        };
+        using var sync = CreateSyncService(storage, authService: auth);
+
+        var result = await sync.PushChangesAsync();
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Session expired", result.ErrorMessage);
+        Assert.Single(await storage.GetPendingChangesAsync());
+        Assert.Equal(1, auth.EnsureValidSessionCalls);
+    }
+
+    [Fact]
     public async Task PullChangesAsync_WhenUsingLocalOnlyProductionPuller_ReturnsConfigurationFailure()
     {
         var databasePath = CreateDatabasePath();
@@ -612,11 +636,12 @@ public sealed class GeoPackageSyncServiceTests
         GeoPackageStorageService storage,
         IFieldCollectionChangeUploader? uploader = null,
         IFieldCollectionChangePuller? puller = null,
+        IAuthenticationService? authService = null,
         IMobileExceptionReporter? exceptionReporter = null)
     {
         return new GeoPackageSyncService(
             storage,
-            new TestAuthenticationService(),
+            authService ?? new TestAuthenticationService(),
             new TestConnectivityService(),
             uploader ?? new FixedResultUploader(true),
             puller ?? new FixedPuller([]),

--- a/tests/Honua.Mobile.FieldCollection.Tests/TestSupport.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/TestSupport.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.Sdk.Auth;
 using Microsoft.Maui.Networking;
 
 namespace Honua.Mobile.FieldCollection.Tests;
@@ -26,10 +27,16 @@ internal sealed class TestAuthenticationService : IAuthenticationService
     public event PropertyChangedEventHandler? PropertyChanged;
 
     public bool IsAuthenticated { get; init; } = true;
+    public bool RequiresReauthentication { get; init; }
+    public string? SessionStatusMessage { get; init; } = "Session active";
+    public DateTimeOffset? ExpiresAtUtc { get; init; }
+    public HonuaAuthScheme? AuthScheme { get; init; } = HonuaAuthScheme.ApiKey;
     public string? CurrentUserId { get; init; } = "test-user";
     public string? CurrentUserName { get; init; } = "Test User";
     public string? ApiKey { get; init; } = "test-api-key";
     public string? ServerUrl { get; init; } = "https://api.honua.test";
+    public int EnsureValidSessionCalls { get; private set; }
+    public bool EnsureValidSessionResult { get; init; } = true;
 
     public Task<AuthenticationResult> AuthenticateAsync(string serverUrl, string apiKey)
     {
@@ -44,9 +51,29 @@ internal sealed class TestAuthenticationService : IAuthenticationService
         return Task.FromResult(AuthenticationResult.Failure("Not configured."));
     }
 
-    public Task<bool> RefreshTokenAsync()
+    public Task<bool> RefreshTokenAsync(CancellationToken cancellationToken = default)
     {
         return Task.FromResult(true);
+    }
+
+    public Task<bool> EnsureValidSessionAsync(CancellationToken cancellationToken = default)
+    {
+        EnsureValidSessionCalls++;
+        return Task.FromResult(EnsureValidSessionResult);
+    }
+
+    public ValueTask<HonuaAuthToken?> GetAuthTokenAsync(CancellationToken cancellationToken = default)
+    {
+        var token = AuthScheme switch
+        {
+            HonuaAuthScheme.ApiKey when !string.IsNullOrWhiteSpace(ApiKey) =>
+                new HonuaAuthToken(HonuaAuthScheme.ApiKey, ApiKey),
+            HonuaAuthScheme.Bearer when !string.IsNullOrWhiteSpace(ApiKey) =>
+                new HonuaAuthToken(HonuaAuthScheme.Bearer, ApiKey, expiresAtUtc: ExpiresAtUtc),
+            _ => null
+        };
+
+        return ValueTask.FromResult(token);
     }
 
     public Task LogoutAsync()

--- a/tests/Honua.Mobile.ServerIntegration.Tests/FieldCollectionServerIntegrationTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/FieldCollectionServerIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Honua.Mobile.Sdk.Auth;
 using Honua.Mobile.FieldCollection.Services;
 using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using Honua.Mobile.Maui.Diagnostics;
@@ -172,6 +173,14 @@ public sealed class FieldCollectionServerIntegrationTests : IDisposable
 
         public bool IsAuthenticated => true;
 
+        public bool RequiresReauthentication => false;
+
+        public string? SessionStatusMessage => "Session active";
+
+        public DateTimeOffset? ExpiresAtUtc => null;
+
+        public HonuaAuthScheme? AuthScheme => HonuaAuthScheme.ApiKey;
+
         public string? CurrentUserId => "integration-user";
 
         public string? CurrentUserName => "Integration User";
@@ -186,7 +195,12 @@ public sealed class FieldCollectionServerIntegrationTests : IDisposable
         public Task<AuthenticationResult> AuthenticateWithCredentialsAsync(string serverUrl, string username, string password)
             => Task.FromResult(AuthenticationResult.Failure("Username/password authentication is not configured."));
 
-        public Task<bool> RefreshTokenAsync() => Task.FromResult(true);
+        public Task<bool> RefreshTokenAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+        public Task<bool> EnsureValidSessionAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+        public ValueTask<HonuaAuthToken?> GetAuthTokenAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<HonuaAuthToken?>(new HonuaAuthToken(HonuaAuthScheme.ApiKey, ApiKey!));
 
         public Task LogoutAsync() => Task.CompletedTask;
 

--- a/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
@@ -1020,6 +1020,14 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
 
         public bool IsAuthenticated => true;
 
+        public bool RequiresReauthentication => false;
+
+        public string? SessionStatusMessage => "Session active";
+
+        public DateTimeOffset? ExpiresAtUtc => null;
+
+        public HonuaAuthScheme? AuthScheme => HonuaAuthScheme.ApiKey;
+
         public string? CurrentUserId => "live-image";
 
         public string? CurrentUserName => "Live Image";
@@ -1043,7 +1051,12 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
             string password)
             => Task.FromResult(FieldServices.AuthenticationResult.Failure("Credentials are not used in live image tests."));
 
-        public Task<bool> RefreshTokenAsync() => Task.FromResult(true);
+        public Task<bool> RefreshTokenAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+        public Task<bool> EnsureValidSessionAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+        public ValueTask<HonuaAuthToken?> GetAuthTokenAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<HonuaAuthToken?>(new HonuaAuthToken(HonuaAuthScheme.ApiKey, ApiKey!));
 
         public Task LogoutAsync() => Task.CompletedTask;
 


### PR DESCRIPTION
## Summary
- Add mobile auth session state backed by secure storage and SDK `HonuaAuthToken` contracts.
- Support bearer credential sessions, token refresh before API/sync use, re-auth-required state, and sign-out secret clearing with offline edit policy messaging.
- Make field sync resolve auth tokens through the auth service, block expired/invalid sessions without draining pending edits, and surface re-auth messages in sync/auth view models.
- Expand redaction coverage for bearer/access/refresh tokens and update auth fakes across tests.

Closes #218.

## Platform Impact
- MAUI-facing auth and sync view models now expose session status, expiry, and re-auth-required state.
- Secure secret persistence continues through MAUI `SecureStorage`; no platform-specific storage paths changed.
- Android/iOS/Windows behavior should remain shared through the field collection core service and MAUI view-model bindings.

## Sync Impact
- Full sync, pull, and push call `EnsureValidSessionAsync()` before remote work.
- Expired bearer tokens refresh before sync/API operations when refresh support exists.
- Invalid or expired sessions return a re-auth message and leave pending offline edits queued.
- Sign-out clears stored auth secrets while explicitly preserving local offline edits unless a separate data cleanup policy removes them.

## Testing
- `dotnet restore tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --ignore-failed-sources --verbosity minimal`
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore --verbosity minimal`
- `dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --no-restore --verbosity minimal`
- `dotnet format Honua.Mobile.sln --verify-no-changes --no-restore --verbosity minimal`
- `git diff --check && git diff --cached --check`

## Local Environment Note
- Android MAUI app build was attempted after restoring `net10.0-android`, but local validation is blocked by missing Android SDK: `XA5300: The Android SDK directory could not be found`.