### PR TITLE
mobile: add field device diagnostics

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Diagnostics/FieldDeviceDiagnosticsSnapshot.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Diagnostics/FieldDeviceDiagnosticsSnapshot.cs
@@ -1,0 +1,502 @@
+using System.Globalization;
+
+namespace Honua.Mobile.FieldCollection.Services.Diagnostics;
+
+public sealed class FieldDeviceDiagnosticsInput
+{
+    public DateTime GeneratedAtUtc { get; set; } = DateTime.UtcNow;
+    public string AppVersion { get; set; } = string.Empty;
+    public string BuildNumber { get; set; } = string.Empty;
+    public string BuildEnvironment { get; set; } = string.Empty;
+    public string SourceDisplay { get; set; } = string.Empty;
+    public string WorkflowRunDisplay { get; set; } = string.Empty;
+    public string ServiceEndpointState { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+    public string OperatingSystem { get; set; } = string.Empty;
+    public string DeviceModel { get; set; } = string.Empty;
+    public string DeviceType { get; set; } = string.Empty;
+    public string Architecture { get; set; } = string.Empty;
+    public string Manufacturer { get; set; } = string.Empty;
+    public bool IsConnected { get; set; }
+    public bool ServerReachable { get; set; }
+    public bool IsSyncing { get; set; }
+    public bool IsRemoteSyncConfigured { get; set; }
+    public string SyncStatus { get; set; } = string.Empty;
+    public DateTime? LastSyncTime { get; set; }
+    public int PendingChangeCount { get; set; }
+    public int ConflictCount { get; set; }
+    public int FailedOperationCount { get; set; }
+    public int RetryOperationCount { get; set; }
+    public int PendingAttachmentCount { get; set; }
+    public int FailedAttachmentCount { get; set; }
+    public int AttachmentUploadFailedCount { get; set; }
+    public int AttachmentDownloadFailedCount { get; set; }
+    public int AttachmentDeleteFailedCount { get; set; }
+    public string DatabaseSizeDisplay { get; set; } = string.Empty;
+    public int TotalFeatureCount { get; set; }
+    public int LayerCount { get; set; }
+    public string PackageId { get; set; } = string.Empty;
+    public string PackageFileName { get; set; } = string.Empty;
+    public string PackageSizeDisplay { get; set; } = string.Empty;
+    public string MetadataCacheStatus { get; set; } = string.Empty;
+    public int MetadataSourceCount { get; set; }
+    public string FeatureCacheStatus { get; set; } = string.Empty;
+    public int FeatureSourceCount { get; set; }
+    public int CachedFeatureCount { get; set; }
+    public long? LocalGeneration { get; set; }
+    public long? ServerGeneration { get; set; }
+}
+
+public sealed class FieldDeviceDiagnosticsSnapshot
+{
+    public DateTime GeneratedAtUtc { get; init; }
+    public string HealthStatus { get; init; } = "Unknown";
+    public string HealthReason { get; init; } = string.Empty;
+    public string AppVersion { get; init; } = string.Empty;
+    public string BuildNumber { get; init; } = string.Empty;
+    public string BuildEnvironment { get; init; } = string.Empty;
+    public string SourceDisplay { get; init; } = string.Empty;
+    public string WorkflowRunDisplay { get; init; } = string.Empty;
+    public string ServiceEndpointState { get; init; } = string.Empty;
+    public string Platform { get; init; } = string.Empty;
+    public string OperatingSystem { get; init; } = string.Empty;
+    public string DeviceModel { get; init; } = string.Empty;
+    public string DeviceType { get; init; } = string.Empty;
+    public string Architecture { get; init; } = string.Empty;
+    public string Manufacturer { get; init; } = string.Empty;
+    public string ConnectivityState { get; init; } = string.Empty;
+    public bool ServerReachable { get; init; }
+    public bool IsSyncing { get; init; }
+    public bool IsRemoteSyncConfigured { get; init; }
+    public string SyncStatus { get; init; } = string.Empty;
+    public DateTime? LastSyncTime { get; init; }
+    public string LastSyncAge { get; init; } = string.Empty;
+    public int PendingChangeCount { get; init; }
+    public int PendingAttachmentCount { get; init; }
+    public int FailedOperationCount { get; init; }
+    public int FailedAttachmentCount { get; init; }
+    public int RetryOperationCount { get; init; }
+    public int ConflictCount { get; init; }
+    public string DatabaseSizeDisplay { get; init; } = string.Empty;
+    public int TotalFeatureCount { get; init; }
+    public int LayerCount { get; init; }
+    public string PackageId { get; init; } = string.Empty;
+    public string PackageFileName { get; init; } = string.Empty;
+    public string PackageSizeDisplay { get; init; } = string.Empty;
+    public string PackageState { get; init; } = string.Empty;
+    public int CachedFeatureCount { get; init; }
+    public long? LocalGeneration { get; init; }
+    public long? ServerGeneration { get; init; }
+    public IReadOnlyList<FieldDiagnosticFailureCategory> FailureCategories { get; init; } = [];
+    public IReadOnlyList<string> SupportActions { get; init; } = [];
+    public FieldDeviceInventoryDescriptor DeviceInventory { get; init; } = new();
+
+    public string SupportActionsText => string.Join(Environment.NewLine, SupportActions);
+
+    public string SummaryText
+    {
+        get
+        {
+            var lines = new List<string>
+            {
+                $"Health {HealthStatus}: {HealthReason}",
+                $"App {AppVersion} ({BuildNumber})",
+                $"Build {BuildEnvironment}; {SourceDisplay}",
+                $"Workflow {WorkflowRunDisplay}",
+                $"Endpoint {ServiceEndpointState}",
+                $"Device {Manufacturer} {DeviceModel} ({DeviceType}, {Architecture})",
+                $"OS {OperatingSystem}; platform {Platform}",
+                $"Connectivity {ConnectivityState}; server reachable {ServerReachable}",
+                $"Sync {SyncStatus}; remote configured {IsRemoteSyncConfigured}; active {IsSyncing}",
+                $"Last sync {FormatDateTime(LastSyncTime)} ({LastSyncAge})",
+                $"Pending changes {PendingChangeCount}; pending attachments {PendingAttachmentCount}",
+                $"Failures operations {FailedOperationCount}; attachments {FailedAttachmentCount}; retries {RetryOperationCount}",
+                $"Conflicts {ConflictCount}",
+                $"Storage database {DatabaseSizeDisplay}; package {PackageSizeDisplay}; cached features {CachedFeatureCount}",
+                $"Package {PackageId}; state {PackageState}; generations local {FormatGeneration(LocalGeneration)} server {FormatGeneration(ServerGeneration)}",
+                "Support actions:",
+            };
+
+            lines.AddRange(SupportActions.Select(action => $"- {action}"));
+            return string.Join(Environment.NewLine, lines);
+        }
+    }
+
+    public static FieldDeviceDiagnosticsSnapshot Empty { get; } = Create(new FieldDeviceDiagnosticsInput());
+
+    public static FieldDeviceDiagnosticsSnapshot Create(FieldDeviceDiagnosticsInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        var failureCategories = BuildFailureCategories(input);
+        var healthStatus = DetermineHealthStatus(failureCategories);
+        var supportActions = BuildSupportActions(input, failureCategories);
+        var packageFileName = DiagnosticRedactor.RedactPath(input.PackageFileName);
+        var packageState = BuildPackageState(input);
+        var lastSyncAge = BuildLastSyncAge(input.LastSyncTime, input.GeneratedAtUtc);
+
+        return new FieldDeviceDiagnosticsSnapshot
+        {
+            GeneratedAtUtc = input.GeneratedAtUtc,
+            HealthStatus = healthStatus,
+            HealthReason = BuildHealthReason(healthStatus, failureCategories),
+            AppVersion = input.AppVersion,
+            BuildNumber = input.BuildNumber,
+            BuildEnvironment = input.BuildEnvironment,
+            SourceDisplay = input.SourceDisplay,
+            WorkflowRunDisplay = input.WorkflowRunDisplay,
+            ServiceEndpointState = input.ServiceEndpointState,
+            Platform = input.Platform,
+            OperatingSystem = input.OperatingSystem,
+            DeviceModel = input.DeviceModel,
+            DeviceType = input.DeviceType,
+            Architecture = input.Architecture,
+            Manufacturer = input.Manufacturer,
+            ConnectivityState = input.IsConnected ? "Online" : "Offline",
+            ServerReachable = input.ServerReachable,
+            IsSyncing = input.IsSyncing,
+            IsRemoteSyncConfigured = input.IsRemoteSyncConfigured,
+            SyncStatus = input.SyncStatus,
+            LastSyncTime = input.LastSyncTime,
+            LastSyncAge = lastSyncAge,
+            PendingChangeCount = input.PendingChangeCount,
+            PendingAttachmentCount = input.PendingAttachmentCount,
+            FailedOperationCount = input.FailedOperationCount,
+            FailedAttachmentCount = input.FailedAttachmentCount,
+            RetryOperationCount = input.RetryOperationCount,
+            ConflictCount = input.ConflictCount,
+            DatabaseSizeDisplay = input.DatabaseSizeDisplay,
+            TotalFeatureCount = input.TotalFeatureCount,
+            LayerCount = input.LayerCount,
+            PackageId = input.PackageId,
+            PackageFileName = packageFileName,
+            PackageSizeDisplay = input.PackageSizeDisplay,
+            PackageState = packageState,
+            CachedFeatureCount = input.CachedFeatureCount,
+            LocalGeneration = input.LocalGeneration,
+            ServerGeneration = input.ServerGeneration,
+            FailureCategories = failureCategories,
+            SupportActions = supportActions,
+            DeviceInventory = BuildDeviceInventory(input, healthStatus, packageState, packageFileName),
+        };
+    }
+
+    public IReadOnlyDictionary<string, object?> ToReportProperties()
+    {
+        return new Dictionary<string, object?>
+        {
+            ["healthStatus"] = HealthStatus,
+            ["healthReason"] = HealthReason,
+            ["appVersion"] = AppVersion,
+            ["buildNumber"] = BuildNumber,
+            ["platform"] = Platform,
+            ["operatingSystem"] = OperatingSystem,
+            ["remoteSyncConfigured"] = IsRemoteSyncConfigured,
+            ["syncStatus"] = SyncStatus,
+            ["lastSyncAge"] = LastSyncAge,
+            ["pendingChanges"] = PendingChangeCount,
+            ["pendingAttachments"] = PendingAttachmentCount,
+            ["failedOperations"] = FailedOperationCount,
+            ["failedAttachments"] = FailedAttachmentCount,
+            ["conflicts"] = ConflictCount,
+            ["packageState"] = PackageState,
+            ["failureCategories"] = string.Join(",", FailureCategories.Select(category => category.Category)),
+            ["supportActions"] = string.Join(" | ", SupportActions),
+        };
+    }
+
+    private static IReadOnlyList<FieldDiagnosticFailureCategory> BuildFailureCategories(FieldDeviceDiagnosticsInput input)
+    {
+        var categories = new List<FieldDiagnosticFailureCategory>();
+
+        if (!input.IsConnected)
+        {
+            categories.Add(new FieldDiagnosticFailureCategory("Connectivity", "Warning", 1, "Device is offline."));
+        }
+        else if (input.IsRemoteSyncConfigured && !input.ServerReachable)
+        {
+            categories.Add(new FieldDiagnosticFailureCategory("Connectivity", "Warning", 1, "Configured server is not reachable."));
+        }
+
+        if (!input.IsRemoteSyncConfigured)
+        {
+            categories.Add(new FieldDiagnosticFailureCategory("RemoteSync", "Warning", 1, "Remote sync is not configured."));
+        }
+
+        if (input.FailedOperationCount > 0)
+        {
+            categories.Add(new FieldDiagnosticFailureCategory("SyncFailures", "Critical", input.FailedOperationCount, "Local feature changes failed to sync."));
+        }
+
+        if (input.FailedAttachmentCount > 0)
+        {
+            categories.Add(new FieldDiagnosticFailureCategory("AttachmentFailures", "Critical", input.FailedAttachmentCount, BuildAttachmentFailureDetail(input)));
+        }
+
+        if (input.ConflictCount > 0)
+        {
+            categories.Add(new FieldDiagnosticFailureCategory("Conflicts", "Warning", input.ConflictCount, "Sync conflicts require review."));
+        }
+
+        var pendingTotal = input.PendingChangeCount + input.PendingAttachmentCount;
+        if (pendingTotal > 0)
+        {
+            categories.Add(new FieldDiagnosticFailureCategory("PendingQueue", "Info", pendingTotal, "Local work remains queued for upload."));
+        }
+
+        if (input.RetryOperationCount > 0)
+        {
+            categories.Add(new FieldDiagnosticFailureCategory("Retries", "Warning", input.RetryOperationCount, "Sync retries are recorded."));
+        }
+
+        if (IsUnavailable(input.MetadataCacheStatus) || IsUnavailable(input.FeatureCacheStatus))
+        {
+            categories.Add(new FieldDiagnosticFailureCategory("OfflineCache", "Warning", 1, "Offline cache metadata or feature cache is unavailable."));
+        }
+
+        return categories;
+    }
+
+    private static string BuildAttachmentFailureDetail(FieldDeviceDiagnosticsInput input)
+    {
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "Attachment sync failures: upload {0}, download {1}, delete {2}.",
+            input.AttachmentUploadFailedCount,
+            input.AttachmentDownloadFailedCount,
+            input.AttachmentDeleteFailedCount);
+    }
+
+    private static string DetermineHealthStatus(IReadOnlyList<FieldDiagnosticFailureCategory> categories)
+    {
+        if (categories.Any(category => string.Equals(category.Severity, "Critical", StringComparison.OrdinalIgnoreCase)))
+        {
+            return "Critical";
+        }
+
+        if (categories.Any(category => string.Equals(category.Severity, "Warning", StringComparison.OrdinalIgnoreCase)))
+        {
+            return "Attention";
+        }
+
+        if (categories.Any(category => string.Equals(category.Severity, "Info", StringComparison.OrdinalIgnoreCase)))
+        {
+            return "Pending";
+        }
+
+        return "Healthy";
+    }
+
+    private static string BuildHealthReason(string status, IReadOnlyList<FieldDiagnosticFailureCategory> categories)
+    {
+        if (categories.Count == 0)
+        {
+            return "No local sync or cache issues detected.";
+        }
+
+        var highest = categories
+            .Where(category => status == "Critical"
+                ? category.Severity == "Critical"
+                : status == "Attention"
+                    ? category.Severity == "Warning"
+                    : category.Severity == "Info")
+            .Select(category => category.Detail)
+            .FirstOrDefault();
+
+        return highest ?? categories[0].Detail;
+    }
+
+    private static IReadOnlyList<string> BuildSupportActions(
+        FieldDeviceDiagnosticsInput input,
+        IReadOnlyList<FieldDiagnosticFailureCategory> categories)
+    {
+        if (categories.Count == 0)
+        {
+            return ["No local action required."];
+        }
+
+        var actions = new List<string>();
+
+        if (input.FailedOperationCount > 0)
+        {
+            actions.Add("Review sync error details and retry push when the server is reachable.");
+        }
+
+        if (input.FailedAttachmentCount > 0)
+        {
+            actions.Add("Resolve attachment upload/download failures before clearing device media.");
+        }
+
+        if (input.ConflictCount > 0)
+        {
+            actions.Add("Open conflict review and resolve queued records.");
+        }
+
+        if (input.PendingChangeCount > 0 || input.PendingAttachmentCount > 0)
+        {
+            actions.Add("Keep the app open on a stable connection until pending work is uploaded.");
+        }
+
+        if (!input.IsConnected)
+        {
+            actions.Add("Reconnect to Wi-Fi or cellular data and refresh diagnostics.");
+        }
+        else if (input.IsRemoteSyncConfigured && !input.ServerReachable)
+        {
+            actions.Add("Verify the configured server endpoint is reachable from this network.");
+        }
+
+        if (!input.IsRemoteSyncConfigured)
+        {
+            actions.Add("Configure remote sync before expecting queued edits to leave the device.");
+        }
+
+        if (IsUnavailable(input.MetadataCacheStatus) || IsUnavailable(input.FeatureCacheStatus))
+        {
+            actions.Add("Refresh offline project metadata and verify the package cache is present.");
+        }
+
+        return actions.Distinct(StringComparer.Ordinal).ToArray();
+    }
+
+    private static FieldDeviceInventoryDescriptor BuildDeviceInventory(
+        FieldDeviceDiagnosticsInput input,
+        string healthStatus,
+        string packageState,
+        string packageFileName)
+    {
+        return new FieldDeviceInventoryDescriptor
+        {
+            AppVersion = input.AppVersion,
+            BuildNumber = input.BuildNumber,
+            BuildEnvironment = input.BuildEnvironment,
+            Platform = input.Platform,
+            OperatingSystem = input.OperatingSystem,
+            DeviceModel = input.DeviceModel,
+            DeviceType = input.DeviceType,
+            Architecture = input.Architecture,
+            HealthStatus = healthStatus,
+            RemoteSyncConfigured = input.IsRemoteSyncConfigured,
+            LastSyncTime = input.LastSyncTime,
+            PendingChangeCount = input.PendingChangeCount,
+            PendingAttachmentCount = input.PendingAttachmentCount,
+            ConflictCount = input.ConflictCount,
+            PackageId = input.PackageId,
+            PackageFileName = packageFileName,
+            PackageState = packageState,
+            Capabilities =
+            [
+                "offline-cache",
+                "sync-health",
+                "sanitized-diagnostic-export",
+                "exception-report-queue"
+            ],
+        };
+    }
+
+    private static string BuildPackageState(FieldDeviceDiagnosticsInput input)
+    {
+        return $"metadata {BlankToUnknown(input.MetadataCacheStatus)} ({input.MetadataSourceCount} sources); " +
+            $"features {BlankToUnknown(input.FeatureCacheStatus)} ({input.FeatureSourceCount} sources)";
+    }
+
+    private static string BuildLastSyncAge(DateTime? lastSyncTime, DateTime generatedAtUtc)
+    {
+        if (!lastSyncTime.HasValue || lastSyncTime.Value == default)
+        {
+            return "never";
+        }
+
+        var lastSyncUtc = ToUtc(lastSyncTime.Value);
+        var elapsed = generatedAtUtc - lastSyncUtc;
+        if (elapsed < TimeSpan.Zero)
+        {
+            return "in the future";
+        }
+
+        if (elapsed.TotalMinutes < 1)
+        {
+            return "less than 1 minute ago";
+        }
+
+        if (elapsed.TotalHours < 1)
+        {
+            return FormatAge((int)elapsed.TotalMinutes, "minute");
+        }
+
+        if (elapsed.TotalDays < 1)
+        {
+            return FormatAge((int)elapsed.TotalHours, "hour");
+        }
+
+        return FormatAge((int)elapsed.TotalDays, "day");
+    }
+
+    private static string FormatAge(int value, string unit)
+    {
+        return value == 1
+            ? $"1 {unit} ago"
+            : $"{value} {unit}s ago";
+    }
+
+    private static bool IsUnavailable(string? status)
+    {
+        return string.IsNullOrWhiteSpace(status) ||
+            status.Equals("Missing", StringComparison.OrdinalIgnoreCase) ||
+            status.Equals("Unavailable", StringComparison.OrdinalIgnoreCase) ||
+            status.Equals("Error", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string BlankToUnknown(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? "Unknown" : value.Trim();
+    }
+
+    private static DateTime ToUtc(DateTime value)
+    {
+        return value.Kind == DateTimeKind.Unspecified
+            ? DateTime.SpecifyKind(value, DateTimeKind.Utc)
+            : value.ToUniversalTime();
+    }
+
+    private static string FormatDateTime(DateTime? value)
+    {
+        return value.HasValue && value.Value != default
+            ? ToUtc(value.Value).ToString("u", CultureInfo.InvariantCulture)
+            : "never";
+    }
+
+    private static string FormatGeneration(long? generation)
+    {
+        return generation?.ToString(CultureInfo.InvariantCulture) ?? "unknown";
+    }
+}
+
+public sealed record FieldDiagnosticFailureCategory(
+    string Category,
+    string Severity,
+    int Count,
+    string Detail);
+
+public sealed class FieldDeviceInventoryDescriptor
+{
+    public string SchemaVersion { get; init; } = "honua.mobile.device-inventory.v1";
+    public string AppVersion { get; init; } = string.Empty;
+    public string BuildNumber { get; init; } = string.Empty;
+    public string BuildEnvironment { get; init; } = string.Empty;
+    public string Platform { get; init; } = string.Empty;
+    public string OperatingSystem { get; init; } = string.Empty;
+    public string DeviceModel { get; init; } = string.Empty;
+    public string DeviceType { get; init; } = string.Empty;
+    public string Architecture { get; init; } = string.Empty;
+    public string HealthStatus { get; init; } = string.Empty;
+    public bool RemoteSyncConfigured { get; init; }
+    public DateTime? LastSyncTime { get; init; }
+    public int PendingChangeCount { get; init; }
+    public int PendingAttachmentCount { get; init; }
+    public int ConflictCount { get; init; }
+    public string PackageId { get; init; } = string.Empty;
+    public string PackageFileName { get; init; } = string.Empty;
+    public string PackageState { get; init; } = string.Empty;
+    public IReadOnlyList<string> Capabilities { get; init; } = [];
+}

--- a/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/DiagnosticService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Diagnostics/DiagnosticService.cs
@@ -1,7 +1,9 @@
 using Honua.Mobile.FieldCollection.Services.Storage;
 using Honua.Mobile.FieldCollection.Services.Configuration;
+using Honua.Mobile.Maui.Diagnostics;
 using System.Text.Json;
 using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.ApplicationModel.DataTransfer;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Networking;
 using Microsoft.Extensions.Logging;
@@ -19,13 +21,20 @@ public class DiagnosticService
     private readonly IConnectivityService _connectivityService;
     private readonly IAuthenticationService _authService;
     private readonly MobileBuildConfiguration _buildConfiguration;
+    private readonly IMobileExceptionReporter _exceptionReporter;
     private readonly ILogger<DiagnosticService>? _logger;
+
+    private static readonly JsonSerializerOptions ExportJsonOptions = new()
+    {
+        WriteIndented = true
+    };
 
     public DiagnosticService(
         DatabaseService databaseService,
         ISyncService syncService,
         IConnectivityService connectivityService,
         IAuthenticationService authService,
+        IMobileExceptionReporter exceptionReporter,
         MobileBuildConfiguration? buildConfiguration = null,
         ILogger<DiagnosticService>? logger = null)
     {
@@ -33,6 +42,7 @@ public class DiagnosticService
         _syncService = syncService;
         _connectivityService = connectivityService;
         _authService = authService;
+        _exceptionReporter = exceptionReporter;
         _buildConfiguration = buildConfiguration ?? MobileBuildConfiguration.Empty;
         _logger = logger;
     }
@@ -231,19 +241,29 @@ public class DiagnosticService
             OfflineCache = await GetOfflineCacheDiagnosticsAsync()
         };
 
+        report.FieldDevice = CreateFieldDeviceDiagnostics(report);
         return report;
+    }
+
+    public async Task<DiagnosticReport> GenerateSanitizedDiagnosticReportAsync()
+    {
+        var report = await GenerateDiagnosticReportAsync();
+        RedactSensitiveFields(report);
+        return report;
+    }
+
+    public async Task<string> GenerateSanitizedDiagnosticsJsonAsync()
+    {
+        var report = await GenerateSanitizedDiagnosticReportAsync();
+        var json = JsonSerializer.Serialize(report, ExportJsonOptions);
+        return RedactSerializedJson(json);
     }
 
     public async Task<string> ExportDiagnosticsAsync()
     {
         try
         {
-            var report = await GenerateDiagnosticReportAsync();
-            RedactSensitiveFields(report);
-            var json = JsonSerializer.Serialize(report, new JsonSerializerOptions
-            {
-                WriteIndented = true
-            });
+            var json = await GenerateSanitizedDiagnosticsJsonAsync();
 
             var fileName = $"honua_diagnostics_{DateTime.UtcNow:yyyyMMdd_HHmmss}.json";
             var documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
@@ -255,6 +275,41 @@ public class DiagnosticService
         catch (Exception ex)
         {
             throw new InvalidOperationException("Failed to export diagnostics.", ex);
+        }
+    }
+
+    public async Task CopyDiagnosticsAsync()
+    {
+        try
+        {
+            var json = await GenerateSanitizedDiagnosticsJsonAsync();
+            await Clipboard.Default.SetTextAsync(json);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to copy diagnostics.", ex);
+        }
+    }
+
+    public async Task ReportDiagnosticsAsync()
+    {
+        try
+        {
+            var report = await GenerateSanitizedDiagnosticReportAsync();
+            var snapshot = report.FieldDevice;
+            await _exceptionReporter.ReportAsync(
+                new FieldDeviceDiagnosticsReportException(snapshot.HealthStatus, snapshot.HealthReason),
+                new MobileExceptionReportContext
+                {
+                    Source = "FieldCollection.Diagnostics",
+                    Operation = "diagnostics.field-device-health",
+                    Severity = ToExceptionSeverity(snapshot.HealthStatus),
+                    Properties = snapshot.ToReportProperties(),
+                });
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to report diagnostics.", ex);
         }
     }
 
@@ -336,7 +391,80 @@ public class DiagnosticService
         report.OfflineCache.PackageFileName = DiagnosticRedactor.RedactPath(report.OfflineCache.PackageFileName);
     }
 
+    private static string RedactSerializedJson(string json)
+    {
+        var redactedJson = DiagnosticRedactor.RedactJson(json);
+        using var document = JsonDocument.Parse(redactedJson);
+        return JsonSerializer.Serialize(document.RootElement, ExportJsonOptions);
+    }
+
+    private static MobileExceptionSeverity ToExceptionSeverity(string healthStatus)
+    {
+        return healthStatus switch
+        {
+            "Critical" => MobileExceptionSeverity.Critical,
+            "Attention" => MobileExceptionSeverity.Warning,
+            _ => MobileExceptionSeverity.Warning
+        };
+    }
+
+    private FieldDeviceDiagnosticsSnapshot CreateFieldDeviceDiagnostics(DiagnosticReport report)
+    {
+        return FieldDeviceDiagnosticsSnapshot.Create(new FieldDeviceDiagnosticsInput
+        {
+            GeneratedAtUtc = report.GeneratedAt,
+            AppVersion = report.AppVersion,
+            BuildNumber = report.Build.Metadata.ApplicationVersion,
+            BuildEnvironment = report.Build.Metadata.BuildEnvironment,
+            SourceDisplay = report.Build.Metadata.SourceDisplay,
+            WorkflowRunDisplay = report.Build.Metadata.WorkflowRunDisplay,
+            ServiceEndpointState = report.Build.ServiceEndpoint.DisplayValue,
+            Platform = report.System.Platform,
+            OperatingSystem = report.System.OperatingSystem,
+            DeviceModel = report.System.DeviceModel,
+            DeviceType = report.System.DeviceType,
+            Architecture = report.System.Architecture,
+            Manufacturer = report.System.Manufacturer,
+            IsConnected = report.Connectivity.IsConnected,
+            ServerReachable = report.Connectivity.ServerReachable,
+            IsSyncing = report.Sync.IsSyncing,
+            IsRemoteSyncConfigured = report.Sync.IsRemoteSyncConfigured,
+            SyncStatus = report.Sync.SyncStatus,
+            LastSyncTime = report.Sync.LastSyncTime ?? report.OfflineCache.LastSyncTime,
+            PendingChangeCount = Math.Max(report.Sync.PendingChanges, report.OfflineCache.Operations.PendingCount),
+            ConflictCount = Math.Max(report.Sync.ConflictCount, report.OfflineCache.Operations.ConflictCount),
+            FailedOperationCount = report.OfflineCache.Operations.FailedCount,
+            RetryOperationCount = report.OfflineCache.Operations.RetryCount,
+            PendingAttachmentCount = report.OfflineCache.Operations.AttachmentPendingCount,
+            FailedAttachmentCount = report.OfflineCache.Operations.AttachmentFailedCount,
+            AttachmentUploadFailedCount = report.OfflineCache.Operations.AttachmentUploadFailedCount,
+            AttachmentDownloadFailedCount = report.OfflineCache.Operations.AttachmentDownloadFailedCount,
+            AttachmentDeleteFailedCount = report.OfflineCache.Operations.AttachmentDeleteFailedCount,
+            DatabaseSizeDisplay = report.Database.DatabaseSize,
+            TotalFeatureCount = report.Database.TotalFeatures,
+            LayerCount = report.Database.LayerCount,
+            PackageId = report.OfflineCache.PackageId,
+            PackageFileName = report.OfflineCache.PackageFileName,
+            PackageSizeDisplay = report.OfflineCache.PackageSizeDisplay,
+            MetadataCacheStatus = report.OfflineCache.MetadataCache.Status,
+            MetadataSourceCount = report.OfflineCache.MetadataCache.SourceCount,
+            FeatureCacheStatus = report.OfflineCache.FeatureCache.Status,
+            FeatureSourceCount = report.OfflineCache.FeatureCache.SourceCount,
+            CachedFeatureCount = report.OfflineCache.FeatureCache.TotalFeatureCount,
+            LocalGeneration = report.OfflineCache.LocalGeneration,
+            ServerGeneration = report.OfflineCache.ServerGeneration
+        });
+    }
+
     #endregion
+}
+
+internal sealed class FieldDeviceDiagnosticsReportException : Exception
+{
+    public FieldDeviceDiagnosticsReportException(string healthStatus, string healthReason)
+        : base($"Field device diagnostics report: {healthStatus}. {healthReason}")
+    {
+    }
 }
 
 #region Diagnostic Models
@@ -412,6 +540,7 @@ public class DiagnosticReport
     public DateTime GeneratedAt { get; set; }
     public string AppVersion { get; set; } = string.Empty;
     public MobileBuildConfiguration Build { get; set; } = MobileBuildConfiguration.Empty;
+    public FieldDeviceDiagnosticsSnapshot FieldDevice { get; set; } = FieldDeviceDiagnosticsSnapshot.Empty;
     public SystemDiagnostics System { get; set; } = new();
     public ConnectivityDiagnostics Connectivity { get; set; } = new();
     public SyncDiagnostics Sync { get; set; } = new();

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/WorkflowViewModels.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/WorkflowViewModels.cs
@@ -1476,7 +1476,16 @@ public sealed partial class DiagnosticsViewModel : BaseViewModel, IRouteAwareVie
     private string summary = "Diagnostics not loaded";
 
     [ObservableProperty]
+    private string healthStatus = "Unknown";
+
+    [ObservableProperty]
+    private string supportActions = string.Empty;
+
+    [ObservableProperty]
     private string exportPath = string.Empty;
+
+    [ObservableProperty]
+    private string reportStatus = string.Empty;
 
     public DiagnosticsViewModel(INavigationService navigationService, DiagnosticService diagnosticService)
         : base(navigationService)
@@ -1507,6 +1516,26 @@ public sealed partial class DiagnosticsViewModel : BaseViewModel, IRouteAwareVie
     }
 
     [RelayCommand]
+    private async Task CopyDiagnostics()
+    {
+        await ExecuteAsync(async () =>
+        {
+            await _diagnosticService.CopyDiagnosticsAsync();
+            ReportStatus = "Sanitized diagnostics copied";
+        });
+    }
+
+    [RelayCommand]
+    private async Task ReportDiagnostics()
+    {
+        await ExecuteAsync(async () =>
+        {
+            await _diagnosticService.ReportDiagnosticsAsync();
+            ReportStatus = "Sanitized diagnostics report queued";
+        });
+    }
+
+    [RelayCommand]
     private async Task CompactDatabase()
     {
         await ExecuteAsync(async () =>
@@ -1520,17 +1549,9 @@ public sealed partial class DiagnosticsViewModel : BaseViewModel, IRouteAwareVie
     private async Task UpdateSummaryAsync()
     {
         var report = await _diagnosticService.GenerateDiagnosticReportAsync();
-        Summary =
-            $"App {report.AppVersion}\n" +
-            $"Platform {report.System.Platform}\n" +
-            $"Online {report.Connectivity.IsConnected}\n" +
-            $"Remote sync configured {report.Sync.IsRemoteSyncConfigured}\n" +
-            $"Pending changes {report.Sync.PendingChanges}\n" +
-            $"Pending attachments {report.OfflineCache.Operations.AttachmentPendingCount}\n" +
-            $"Attachment failures {report.OfflineCache.Operations.AttachmentFailedCount}\n" +
-            $"Conflicts {report.Sync.ConflictCount}\n" +
-            $"Database {report.Database.DatabaseSize}\n" +
-            $"Offline cache {report.OfflineCache.PackageSizeDisplay}";
+        HealthStatus = $"{report.FieldDevice.HealthStatus}: {report.FieldDevice.HealthReason}";
+        SupportActions = report.FieldDevice.SupportActionsText;
+        Summary = report.FieldDevice.SummaryText;
     }
 }
 

--- a/apps/Honua.Mobile.FieldCollection/Views/WorkflowPages.cs
+++ b/apps/Honua.Mobile.FieldCollection/Views/WorkflowPages.cs
@@ -461,16 +461,25 @@ internal static class WorkflowPageContent
 
     public static View CreateDiagnosticsContent()
     {
+        var health = BoundLabel("HealthStatus", "Health");
         var summary = BoundMultilineLabel("Summary");
+        var actions = BoundMultilineLabel("SupportActions");
         var exportPath = BoundLabel("ExportPath", "Export");
+        var reportStatus = BoundLabel("ReportStatus", "Report");
 
         return PageScroll(
             SectionTitle("Diagnostics"),
+            health,
             summary,
+            SectionTitle("Support actions"),
+            actions,
             exportPath,
+            reportStatus,
             ButtonRow(
                 CommandButton("Refresh", "LoadDiagnosticsCommand"),
                 CommandButton("Export", "ExportDiagnosticsCommand"),
+                CommandButton("Copy", "CopyDiagnosticsCommand"),
+                CommandButton("Report", "ReportDiagnosticsCommand"),
                 CommandButton("Compact", "CompactDatabaseCommand")));
     }
 

--- a/tests/Honua.Mobile.FieldCollection.Tests/FieldDeviceDiagnosticsSnapshotTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/FieldDeviceDiagnosticsSnapshotTests.cs
@@ -1,0 +1,107 @@
+using Honua.Mobile.FieldCollection.Services.Diagnostics;
+
+namespace Honua.Mobile.FieldCollection.Tests;
+
+public sealed class FieldDeviceDiagnosticsSnapshotTests
+{
+    [Fact]
+    public void Create_WhenFailuresExist_CategorizesStateAndActions()
+    {
+        var snapshot = FieldDeviceDiagnosticsSnapshot.Create(new FieldDeviceDiagnosticsInput
+        {
+            GeneratedAtUtc = new DateTime(2026, 5, 23, 12, 0, 0, DateTimeKind.Utc),
+            AppVersion = "1.2.3",
+            BuildNumber = "42",
+            BuildEnvironment = "staging",
+            SourceDisplay = "honua-io/honua-mobile@abcdef on main",
+            WorkflowRunDisplay = "GitHub Actions run 100",
+            ServiceEndpointState = "Staging: https://api.staging.example.test",
+            Platform = "Android",
+            OperatingSystem = "Android 16",
+            DeviceModel = "Pixel",
+            DeviceType = "Physical",
+            Architecture = "Arm64",
+            Manufacturer = "Google",
+            IsConnected = true,
+            ServerReachable = false,
+            IsRemoteSyncConfigured = true,
+            SyncStatus = "Error",
+            LastSyncTime = new DateTime(2026, 5, 22, 12, 0, 0, DateTimeKind.Utc),
+            PendingChangeCount = 3,
+            PendingAttachmentCount = 2,
+            FailedOperationCount = 1,
+            RetryOperationCount = 4,
+            FailedAttachmentCount = 2,
+            AttachmentUploadFailedCount = 1,
+            AttachmentDownloadFailedCount = 1,
+            ConflictCount = 1,
+            DatabaseSizeDisplay = "2.00 MB",
+            TotalFeatureCount = 15,
+            LayerCount = 2,
+            PackageId = "field-cache",
+            PackageFileName = "/private/device/cache/honua_field_collection.gpkg",
+            PackageSizeDisplay = "4.00 MB",
+            MetadataCacheStatus = "Available",
+            MetadataSourceCount = 2,
+            FeatureCacheStatus = "Available",
+            FeatureSourceCount = 2,
+            CachedFeatureCount = 15,
+            LocalGeneration = 7,
+            ServerGeneration = 9
+        });
+
+        Assert.Equal("Critical", snapshot.HealthStatus);
+        Assert.Contains(snapshot.FailureCategories, category => category.Category == "SyncFailures");
+        Assert.Contains(snapshot.FailureCategories, category => category.Category == "AttachmentFailures");
+        Assert.Contains(snapshot.FailureCategories, category => category.Category == "Conflicts");
+        Assert.Contains("Resolve attachment", snapshot.SupportActionsText);
+        Assert.Contains("Pending changes 3", snapshot.SummaryText);
+        Assert.Contains("Last sync 2026-05-22 12:00:00Z (1 day ago)", snapshot.SummaryText);
+        Assert.Equal("honua_field_collection.gpkg", snapshot.PackageFileName);
+        Assert.DoesNotContain("/private/device/cache", snapshot.SummaryText);
+
+        var properties = snapshot.ToReportProperties();
+        Assert.Equal("Critical", properties["healthStatus"]);
+        Assert.Equal(3, properties["pendingChanges"]);
+        Assert.Equal(2, properties["failedAttachments"]);
+    }
+
+    [Fact]
+    public void Create_WhenHealthy_ProducesInventoryShapeForFutureRemoteUse()
+    {
+        var snapshot = FieldDeviceDiagnosticsSnapshot.Create(new FieldDeviceDiagnosticsInput
+        {
+            GeneratedAtUtc = new DateTime(2026, 5, 23, 12, 0, 0, DateTimeKind.Utc),
+            AppVersion = "1.2.3",
+            BuildNumber = "42",
+            BuildEnvironment = "production",
+            SourceDisplay = "Source not stamped",
+            WorkflowRunDisplay = "Local build",
+            ServiceEndpointState = "Production: https://api.example.test",
+            Platform = "iOS",
+            OperatingSystem = "iOS 19",
+            DeviceModel = "iPhone",
+            DeviceType = "Physical",
+            Architecture = "Arm64",
+            Manufacturer = "Apple",
+            IsConnected = true,
+            ServerReachable = true,
+            IsRemoteSyncConfigured = true,
+            SyncStatus = "Idle",
+            LastSyncTime = new DateTime(2026, 5, 23, 11, 55, 0, DateTimeKind.Utc),
+            DatabaseSizeDisplay = "1.00 MB",
+            PackageId = "field-cache",
+            PackageFileName = "field-cache.gpkg",
+            PackageSizeDisplay = "2.00 MB",
+            MetadataCacheStatus = "Available",
+            FeatureCacheStatus = "Available"
+        });
+
+        Assert.Equal("Healthy", snapshot.HealthStatus);
+        Assert.Equal("No local action required.", Assert.Single(snapshot.SupportActions));
+        Assert.Equal("honua.mobile.device-inventory.v1", snapshot.DeviceInventory.SchemaVersion);
+        Assert.Contains("sync-health", snapshot.DeviceInventory.Capabilities);
+        Assert.Equal("field-cache", snapshot.DeviceInventory.PackageId);
+        Assert.Equal("Available", snapshot.PackageState.Split(' ', StringSplitOptions.RemoveEmptyEntries)[1]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a field device diagnostics snapshot for support-facing app, build, OS, storage, cache, sync, failure, and package state.
- Surface health status and support actions on the diagnostics page, plus sanitized export, copy, and exception-report queue actions.
- Include a mobile-only device inventory descriptor shape for future remote inventory/config without adding server APIs.

## Validation
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore --verbosity minimal` (90 passed)
- `dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --no-restore --verbosity minimal` (26 passed)
- `dotnet format Honua.Mobile.sln --verify-no-changes --no-restore --verbosity minimal` (passes with existing PlatformSmoke reference warnings)
- `git diff --check`
- Attempted `dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj -f net10.0-android --no-restore --verbosity minimal`; local build is blocked by missing Android SDK (`XA5300`).

Closes #221