### PR TITLE
mobile: add SDK geofence workflow adapter

### DIFF
--- a/docs/guides/native-display-and-location.md
+++ b/docs/guides/native-display-and-location.md
@@ -187,6 +187,10 @@ leaving platform APIs behind app-provided adapters:
 - `HonuaBackgroundLocationLifecycleController` owns the active background
   session/geofence lifecycle, including suspend shutdown and battery-saver
   deferral.
+- `HonuaSdkGeofenceWorkflowController` consumes SDK-owned
+  `Honua.Sdk.Geometry.HonuaGeofenceDefinition` instances, maps them to native
+  monitoring regions, and emits workflow/sync events through
+  `IHonuaGeofenceWorkflowEventSink`.
 
 ```csharp
 builder.Services
@@ -209,6 +213,68 @@ var location = await locations.AcquireCurrentLocationAsync(
     },
     ct);
 ```
+
+### SDK Geofence and Proximity Workflows
+
+Portable geofence rules and transition state stay in `honua-sdk-dotnet`. The
+mobile adapter only performs native runtime work:
+
+- Convert SDK geofence definitions into OS geofence regions broad enough to
+  wake the app for enter, exit, and proximity workflows.
+- Delegate foreground/background permission checks to the platform permission
+  adapter.
+- Keep background polling off by default. If a workflow enables background
+  updates, the controller clamps the interval to at least five minutes unless
+  the app sets a stricter `MinimumBackgroundInterval`.
+- Defer active background sessions when battery saver is enabled and restart
+  when the lifecycle controller receives `BatterySaverDisabled`.
+- Publish native transitions as `HonuaGeofenceWorkflowEvent` values so field UI,
+  local persistence, and sync queues can register sinks without owning platform
+  geofence APIs.
+
+```csharp
+using Honua.Mobile.Maui.Location;
+using Honua.Sdk.Geometry;
+
+builder.Services.AddSingleton<IHonuaGeofenceWorkflowEventSink, FieldSyncQueueSink>();
+
+var workflow = serviceProvider.GetRequiredService<HonuaSdkGeofenceWorkflowController>();
+await workflow.StartAsync(
+    new HonuaSdkGeofenceWorkflowRequest
+    {
+        Definitions = sdkGeofenceDefinitions,
+        BackgroundUpdates = null, // OS geofence wakeups only; no GPS polling.
+        MinimumNativeRadiusMeters = 25,
+        Metadata = new Dictionary<string, object?>
+        {
+            ["workflow"] = "inspection-arrival",
+        },
+    },
+    ct);
+```
+
+Android platform notes:
+
+- Request foreground location before background location, and surface the
+  Android 10+ background permission handoff clearly in the app UX.
+- Use native geofencing APIs or a fused-location monitor inside the app adapter;
+  keep exact geofence evaluation in the SDK evaluator when the app has a fresh
+  position sample.
+- Prefer OS geofence wakeups for enter/exit/proximity starts. Enable background
+  updates only for workflows that need continuous progress and keep the minimum
+  interval/distance bounded.
+
+iOS platform notes:
+
+- Include `NSLocationWhenInUseUsageDescription` and
+  `NSLocationAlwaysAndWhenInUseUsageDescription`; request Always access only
+  after the user has accepted foreground location.
+- Use Core Location region monitoring for wakeups. Significant-change or
+  standard background location updates should be reserved for workflows that
+  need them and should respect battery-saver lifecycle events.
+- Persist emitted `HonuaGeofenceWorkflowEvent` values before starting network
+  sync so transitions are not lost when iOS suspends the app shortly after a
+  region callback.
 
 ### External GNSS and High-Accuracy Capture
 

--- a/src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
+++ b/src/Honua.Mobile.Maui/Honua.Mobile.Maui.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Honua.Sdk.Abstractions" Version="$(HonuaSdkDotNetTrainVersion)" />
     <PackageReference Include="Honua.Sdk.Field" Version="$(HonuaSdkDotNetTrainVersion)" />
+    <PackageReference Include="Honua.Sdk.Geometry" Version="$(HonuaSdkDotNetTrainVersion)" />
     <PackageReference Include="Honua.Sdk.Offline" Version="$(HonuaSdkDotNetTrainVersion)" />
     <PackageReference Include="Honua.Sdk.Offline.Abstractions" Version="$(HonuaSdkDotNetTrainVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -484,6 +484,11 @@ public static class HonuaMobileServiceCollectionExtensions
         services.AddSingleton(sp => new HonuaBackgroundLocationLifecycleController(
             sp.GetRequiredService<HonuaDeviceLocationCoordinator>(),
             sp.GetService<ILogger<HonuaBackgroundLocationLifecycleController>>()));
+        services.AddSingleton(sp => new HonuaSdkGeofenceWorkflowController(
+            sp.GetRequiredService<HonuaDeviceLocationCoordinator>(),
+            sp.GetRequiredService<HonuaBackgroundLocationLifecycleController>(),
+            sp.GetServices<IHonuaGeofenceWorkflowEventSink>(),
+            sp.GetService<ILogger<HonuaSdkGeofenceWorkflowController>>()));
         return services;
     }
 }

--- a/src/Honua.Mobile.Maui/Location/HonuaSdkGeofenceWorkflowController.cs
+++ b/src/Honua.Mobile.Maui/Location/HonuaSdkGeofenceWorkflowController.cs
@@ -432,23 +432,16 @@ public sealed class HonuaSdkGeofenceWorkflowController : IDisposable, IAsyncDisp
         SdkGeofenceDefinition definition,
         string regionId)
     {
-        var metadata = new Dictionary<string, object?>(request.Metadata, StringComparer.OrdinalIgnoreCase)
-        {
-            ["honua.sdk.geofence_id"] = definition.GeofenceId,
-            ["honua.native.region_id"] = regionId,
-        };
+        var metadata = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        MergeMetadata(metadata, request.Metadata);
+
+        metadata["honua.sdk.geofence_id"] = definition.GeofenceId;
+        metadata["honua.native.region_id"] = regionId;
 
         AddMetadata(metadata, "honua.sdk.source_id", definition.Source?.Id);
         AddMetadata(metadata, "honua.sdk.source_protocol", definition.Source?.Protocol);
         AddMetadata(metadata, "honua.sdk.source_query_where", definition.SourceQuery?.Where);
-
-        foreach (var item in definition.Metadata)
-        {
-            if (!string.IsNullOrWhiteSpace(item.Key))
-            {
-                metadata[item.Key] = item.Value;
-            }
-        }
+        MergeMetadata(metadata, definition.Metadata);
 
         return metadata;
     }
@@ -475,6 +468,19 @@ public sealed class HonuaSdkGeofenceWorkflowController : IDisposable, IAsyncDisp
         }
 
         return metadata;
+    }
+
+    private static void MergeMetadata<TValue>(
+        IDictionary<string, object?> metadata,
+        IEnumerable<KeyValuePair<string, TValue>> source)
+    {
+        foreach (var item in source)
+        {
+            if (!string.IsNullOrWhiteSpace(item.Key))
+            {
+                metadata[item.Key] = item.Value;
+            }
+        }
     }
 
     private static void AddMetadata(IDictionary<string, object?> metadata, string key, object? value)

--- a/src/Honua.Mobile.Maui/Location/HonuaSdkGeofenceWorkflowController.cs
+++ b/src/Honua.Mobile.Maui/Location/HonuaSdkGeofenceWorkflowController.cs
@@ -1,0 +1,517 @@
+using Honua.Mobile.Maui.Annotations;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NetTopologySuite.Geometries;
+using SdkGeofenceDefinition = Honua.Sdk.Geometry.HonuaGeofenceDefinition;
+using SdkGeofenceStatus = Honua.Sdk.Geometry.HonuaGeofenceStatus;
+using SdkGeofenceTransition = Honua.Sdk.Geometry.HonuaGeofenceTransition;
+
+namespace Honua.Mobile.Maui.Location;
+
+/// <summary>
+/// SDK-backed geofence workflow request translated into mobile-owned platform monitoring.
+/// </summary>
+public sealed record HonuaSdkGeofenceWorkflowRequest
+{
+    public IReadOnlyList<SdkGeofenceDefinition> Definitions { get; init; } = [];
+
+    public HonuaBackgroundLocationOptions? BackgroundUpdates { get; init; }
+
+    public HonuaLocationAccess RequiredAccess { get; init; } = HonuaLocationAccess.Background;
+
+    public bool ReplaceExisting { get; init; } = true;
+
+    public bool AllowBatterySaverDeferral { get; init; } = true;
+
+    public TimeSpan MinimumBackgroundInterval { get; init; } = TimeSpan.FromMinutes(5);
+
+    public double MinimumNativeRadiusMeters { get; init; } = 25;
+
+    public string Purpose { get; init; } = "Honua geofence workflow";
+
+    public IReadOnlyDictionary<string, object?> Metadata { get; init; } = new Dictionary<string, object?>();
+
+    public void Validate()
+    {
+        ArgumentNullException.ThrowIfNull(Definitions);
+        ArgumentException.ThrowIfNullOrWhiteSpace(Purpose);
+
+        if (Definitions.Count == 0)
+        {
+            throw new ArgumentException("At least one SDK geofence definition is required.", nameof(Definitions));
+        }
+
+        if (MinimumBackgroundInterval <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MinimumBackgroundInterval),
+                "Minimum background interval must be positive.");
+        }
+
+        if (MinimumNativeRadiusMeters <= 0 ||
+            double.IsNaN(MinimumNativeRadiusMeters) ||
+            double.IsInfinity(MinimumNativeRadiusMeters))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MinimumNativeRadiusMeters),
+                "Minimum native radius must be finite and positive.");
+        }
+
+        BackgroundUpdates?.Validate();
+
+        var geofenceIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var definition in Definitions)
+        {
+            ArgumentNullException.ThrowIfNull(definition);
+            ArgumentException.ThrowIfNullOrWhiteSpace(definition.GeofenceId);
+
+            if (!geofenceIds.Add(definition.GeofenceId))
+            {
+                throw new InvalidOperationException($"SDK geofence '{definition.GeofenceId}' is defined more than once.");
+            }
+
+            if (definition.Geometry is null || definition.Geometry.IsEmpty)
+            {
+                throw new ArgumentException(
+                    $"SDK geofence '{definition.GeofenceId}' does not include a geometry.",
+                    nameof(Definitions));
+            }
+
+            if (definition.BufferDistance is < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(Definitions),
+                    $"SDK geofence '{definition.GeofenceId}' has a negative buffer distance.");
+            }
+
+            if (definition.ProximityDistance is < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(Definitions),
+                    $"SDK geofence '{definition.GeofenceId}' has a negative proximity distance.");
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Native region binding for an SDK geofence definition.
+/// </summary>
+public sealed record HonuaSdkGeofenceRegionBinding
+{
+    public required string RegionId { get; init; }
+
+    public required string GeofenceId { get; init; }
+
+    public required SdkGeofenceDefinition Definition { get; init; }
+
+    public IReadOnlyDictionary<string, object?> Metadata { get; init; } = new Dictionary<string, object?>();
+}
+
+/// <summary>
+/// Native geofence monitoring plan generated from SDK-owned geofence definitions.
+/// </summary>
+public sealed record HonuaSdkGeofenceMonitoringPlan
+{
+    public required HonuaGeofenceMonitoringRequest NativeRequest { get; init; }
+
+    public required IReadOnlyDictionary<string, HonuaSdkGeofenceRegionBinding> RegionBindings { get; init; }
+}
+
+/// <summary>
+/// Mobile workflow event emitted after a native geofence transition maps back to an SDK geofence definition.
+/// </summary>
+public sealed record HonuaGeofenceWorkflowEvent
+{
+    public required string GeofenceId { get; init; }
+
+    public required string RegionId { get; init; }
+
+    public required HonuaGeofenceTransitionKind NativeTransition { get; init; }
+
+    public required SdkGeofenceTransition SdkTransition { get; init; }
+
+    public required SdkGeofenceStatus SdkStatus { get; init; }
+
+    public HonuaDeviceLocation? Location { get; init; }
+
+    public DateTimeOffset OccurredAt { get; init; } = DateTimeOffset.UtcNow;
+
+    public IReadOnlyDictionary<string, object?> Metadata { get; init; } = new Dictionary<string, object?>();
+}
+
+/// <summary>
+/// Receives mobile geofence workflow events for field UX, local persistence, or sync queue integration.
+/// </summary>
+public interface IHonuaGeofenceWorkflowEventSink
+{
+    ValueTask EnqueueAsync(HonuaGeofenceWorkflowEvent workflowEvent, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Bridges SDK geofence definitions to mobile-owned native geofence lifecycle and workflow events.
+/// </summary>
+public sealed class HonuaSdkGeofenceWorkflowController : IDisposable, IAsyncDisposable
+{
+    private const double MetersPerDegreeLatitude = 111_320d;
+
+    private readonly HonuaDeviceLocationCoordinator _locations;
+    private readonly HonuaBackgroundLocationLifecycleController _lifecycle;
+    private readonly IReadOnlyList<IHonuaGeofenceWorkflowEventSink> _eventSinks;
+    private readonly ILogger<HonuaSdkGeofenceWorkflowController> _logger;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private IReadOnlyDictionary<string, HonuaSdkGeofenceRegionBinding> _regionBindings =
+        new Dictionary<string, HonuaSdkGeofenceRegionBinding>(StringComparer.Ordinal);
+    private bool _disposed;
+
+    public HonuaSdkGeofenceWorkflowController(
+        HonuaDeviceLocationCoordinator locations,
+        HonuaBackgroundLocationLifecycleController lifecycle,
+        IEnumerable<IHonuaGeofenceWorkflowEventSink> eventSinks,
+        ILogger<HonuaSdkGeofenceWorkflowController>? logger = null)
+    {
+        _locations = locations ?? throw new ArgumentNullException(nameof(locations));
+        _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
+        _eventSinks = eventSinks?.ToArray() ?? [];
+        _logger = logger ?? NullLogger<HonuaSdkGeofenceWorkflowController>.Instance;
+
+        _locations.GeofenceTransitioned += OnGeofenceTransitioned;
+    }
+
+    public event EventHandler<HonuaGeofenceWorkflowEvent>? WorkflowEventEmitted;
+
+    public HonuaBackgroundLocationRuntimeState State => _lifecycle.State;
+
+    public async ValueTask StartAsync(
+        HonuaSdkGeofenceWorkflowRequest request,
+        CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(request);
+        request.Validate();
+
+        var plan = CreateMonitoringPlan(request);
+        var lifecycleRequest = new HonuaBackgroundLocationLifecycleRequest
+        {
+            BackgroundUpdates = CreateBackgroundOptions(request),
+            Geofences = plan.NativeRequest,
+            AllowBatterySaverDeferral = request.AllowBatterySaverDeferral,
+            Metadata = request.Metadata,
+        };
+
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            _regionBindings = plan.RegionBindings;
+            try
+            {
+                await _lifecycle.StartAsync(lifecycleRequest, ct).ConfigureAwait(false);
+            }
+            catch
+            {
+                _regionBindings = new Dictionary<string, HonuaSdkGeofenceRegionBinding>(StringComparer.Ordinal);
+                throw;
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async ValueTask StopAsync(
+        HonuaBackgroundLocationStopReason reason = HonuaBackgroundLocationStopReason.UserStopped,
+        CancellationToken ct = default)
+    {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await _lifecycle.StopAsync(reason, ct).ConfigureAwait(false);
+            _regionBindings = new Dictionary<string, HonuaSdkGeofenceRegionBinding>(StringComparer.Ordinal);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async ValueTask HandleLifecycleEventAsync(
+        HonuaLocationLifecycleEvent lifecycleEvent,
+        CancellationToken ct = default)
+    {
+        await _lifecycle.HandleLifecycleEventAsync(lifecycleEvent, ct).ConfigureAwait(false);
+
+        if (lifecycleEvent is HonuaLocationLifecycleEvent.Suspended or HonuaLocationLifecycleEvent.Shutdown)
+        {
+            _regionBindings = new Dictionary<string, HonuaSdkGeofenceRegionBinding>(StringComparer.Ordinal);
+        }
+    }
+
+    public static HonuaSdkGeofenceMonitoringPlan CreateMonitoringPlan(HonuaSdkGeofenceWorkflowRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        request.Validate();
+
+        var regions = new List<HonuaGeofenceRegion>(request.Definitions.Count);
+        var bindings = new Dictionary<string, HonuaSdkGeofenceRegionBinding>(StringComparer.Ordinal);
+
+        foreach (var definition in request.Definitions)
+        {
+            var regionId = definition.GeofenceId;
+            var center = GetEnvelopeCenter(definition.Geometry);
+            var radius = EstimateNativeRadiusMeters(definition, center, request.MinimumNativeRadiusMeters);
+            var metadata = BuildRegionMetadata(request, definition, regionId);
+
+            regions.Add(new HonuaGeofenceRegion
+            {
+                Id = regionId,
+                Center = center,
+                RadiusMeters = radius,
+                NotifyOnEntry = true,
+                NotifyOnExit = true,
+                Metadata = metadata,
+            });
+
+            bindings[regionId] = new HonuaSdkGeofenceRegionBinding
+            {
+                RegionId = regionId,
+                GeofenceId = definition.GeofenceId,
+                Definition = definition,
+                Metadata = metadata,
+            };
+        }
+
+        return new HonuaSdkGeofenceMonitoringPlan
+        {
+            NativeRequest = new HonuaGeofenceMonitoringRequest
+            {
+                Regions = regions,
+                RequiredAccess = request.RequiredAccess,
+                ReplaceExisting = request.ReplaceExisting,
+            },
+            RegionBindings = bindings,
+        };
+    }
+
+    public async ValueTask PublishTransitionAsync(
+        HonuaGeofenceTransition transition,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(transition);
+        transition.Validate();
+
+        if (!_regionBindings.TryGetValue(transition.RegionId, out var binding))
+        {
+            _logger.LogDebug("Ignoring native geofence transition for unknown region {RegionId}.", transition.RegionId);
+            return;
+        }
+
+        var workflowEvent = new HonuaGeofenceWorkflowEvent
+        {
+            GeofenceId = binding.GeofenceId,
+            RegionId = transition.RegionId,
+            NativeTransition = transition.Kind,
+            SdkTransition = ToSdkTransition(transition.Kind),
+            SdkStatus = ToSdkStatus(transition.Kind),
+            Location = transition.Location,
+            OccurredAt = transition.OccurredAt,
+            Metadata = BuildEventMetadata(binding, transition),
+        };
+
+        WorkflowEventEmitted?.Invoke(this, workflowEvent);
+
+        foreach (var sink in _eventSinks)
+        {
+            await sink.EnqueueAsync(workflowEvent, ct).ConfigureAwait(false);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _locations.GeofenceTransitioned -= OnGeofenceTransitioned;
+        await StopAsync(HonuaBackgroundLocationStopReason.Shutdown).ConfigureAwait(false);
+        _gate.Dispose();
+        _disposed = true;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _locations.GeofenceTransitioned -= OnGeofenceTransitioned;
+        StopAsync(HonuaBackgroundLocationStopReason.Shutdown).AsTask().GetAwaiter().GetResult();
+        _gate.Dispose();
+        _disposed = true;
+    }
+
+    private void OnGeofenceTransitioned(object? sender, HonuaGeofenceTransition transition)
+    {
+        try
+        {
+            PublishTransitionAsync(transition).AsTask().GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to publish geofence workflow transition for region {RegionId}.", transition.RegionId);
+        }
+    }
+
+    private static HonuaBackgroundLocationOptions? CreateBackgroundOptions(HonuaSdkGeofenceWorkflowRequest request)
+    {
+        if (request.BackgroundUpdates is null)
+        {
+            return null;
+        }
+
+        var options = request.BackgroundUpdates;
+        return options with
+        {
+            MinimumInterval = options.MinimumInterval < request.MinimumBackgroundInterval
+                ? request.MinimumBackgroundInterval
+                : options.MinimumInterval,
+            AllowBatterySaverDeferral = options.AllowBatterySaverDeferral && request.AllowBatterySaverDeferral,
+            Purpose = string.IsNullOrWhiteSpace(options.Purpose) ? request.Purpose : options.Purpose,
+        };
+    }
+
+    private static HonuaMapCoordinate GetEnvelopeCenter(Geometry geometry)
+    {
+        var envelope = geometry.EnvelopeInternal;
+        if (envelope.IsNull)
+        {
+            throw new ArgumentException("SDK geofence geometry envelope cannot be empty.", nameof(geometry));
+        }
+
+        return new HonuaMapCoordinate(
+            (envelope.MinY + envelope.MaxY) / 2,
+            (envelope.MinX + envelope.MaxX) / 2);
+    }
+
+    private static double EstimateNativeRadiusMeters(
+        SdkGeofenceDefinition definition,
+        HonuaMapCoordinate center,
+        double minimumNativeRadiusMeters)
+    {
+        var envelope = definition.Geometry.EnvelopeInternal;
+        var envelopeRadius = Math.Max(
+            EstimateDistanceMeters(center, envelope.MinY, envelope.MinX),
+            Math.Max(
+                EstimateDistanceMeters(center, envelope.MinY, envelope.MaxX),
+                Math.Max(
+                    EstimateDistanceMeters(center, envelope.MaxY, envelope.MinX),
+                    EstimateDistanceMeters(center, envelope.MaxY, envelope.MaxX))));
+        var sdkPadding = Math.Max(
+            NormalizeNonNegative(definition.BufferDistance),
+            NormalizeNonNegative(definition.ProximityDistance));
+
+        return Math.Max(minimumNativeRadiusMeters, envelopeRadius + sdkPadding);
+    }
+
+    private static double EstimateDistanceMeters(HonuaMapCoordinate center, double latitude, double longitude)
+    {
+        var latitudeMeters = (latitude - center.Latitude) * MetersPerDegreeLatitude;
+        var longitudeMeters = (longitude - center.Longitude) *
+            MetersPerDegreeLatitude *
+            Math.Cos(center.Latitude * Math.PI / 180);
+        return Math.Sqrt(latitudeMeters * latitudeMeters + longitudeMeters * longitudeMeters);
+    }
+
+    private static double NormalizeNonNegative(double? value)
+        => value.HasValue && double.IsFinite(value.Value) && value.Value > 0 ? value.Value : 0;
+
+    private static IReadOnlyDictionary<string, object?> BuildRegionMetadata(
+        HonuaSdkGeofenceWorkflowRequest request,
+        SdkGeofenceDefinition definition,
+        string regionId)
+    {
+        var metadata = new Dictionary<string, object?>(request.Metadata, StringComparer.OrdinalIgnoreCase)
+        {
+            ["honua.sdk.geofence_id"] = definition.GeofenceId,
+            ["honua.native.region_id"] = regionId,
+        };
+
+        AddMetadata(metadata, "honua.sdk.source_id", definition.Source?.Id);
+        AddMetadata(metadata, "honua.sdk.source_protocol", definition.Source?.Protocol);
+        AddMetadata(metadata, "honua.sdk.source_query_where", definition.SourceQuery?.Where);
+
+        foreach (var item in definition.Metadata)
+        {
+            if (!string.IsNullOrWhiteSpace(item.Key))
+            {
+                metadata[item.Key] = item.Value;
+            }
+        }
+
+        return metadata;
+    }
+
+    private static IReadOnlyDictionary<string, object?> BuildEventMetadata(
+        HonuaSdkGeofenceRegionBinding binding,
+        HonuaGeofenceTransition transition)
+    {
+        var metadata = new Dictionary<string, object?>(binding.Metadata, StringComparer.OrdinalIgnoreCase)
+        {
+            ["honua.native.transition"] = transition.Kind.ToString(),
+            ["honua.sdk.transition"] = ToSdkTransition(transition.Kind).ToString(),
+            ["honua.sdk.status"] = ToSdkStatus(transition.Kind).ToString(),
+        };
+
+        if (transition.Location?.Provider is { Length: > 0 } provider)
+        {
+            metadata["honua.location.provider"] = provider;
+        }
+
+        if (transition.Location?.AccuracyMeters is { } accuracy)
+        {
+            metadata["honua.location.accuracy_m"] = accuracy;
+        }
+
+        return metadata;
+    }
+
+    private static void AddMetadata(IDictionary<string, object?> metadata, string key, object? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        if (value is string text && string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+
+        metadata[key] = value;
+    }
+
+    private static SdkGeofenceTransition ToSdkTransition(HonuaGeofenceTransitionKind kind)
+    {
+        return kind switch
+        {
+            HonuaGeofenceTransitionKind.Enter => SdkGeofenceTransition.Entered,
+            HonuaGeofenceTransitionKind.Exit => SdkGeofenceTransition.Exited,
+            HonuaGeofenceTransitionKind.Proximity => SdkGeofenceTransition.Approached,
+            HonuaGeofenceTransitionKind.Dwell => SdkGeofenceTransition.None,
+            _ => SdkGeofenceTransition.None,
+        };
+    }
+
+    private static SdkGeofenceStatus ToSdkStatus(HonuaGeofenceTransitionKind kind)
+    {
+        return kind switch
+        {
+            HonuaGeofenceTransitionKind.Enter or HonuaGeofenceTransitionKind.Dwell => SdkGeofenceStatus.Inside,
+            HonuaGeofenceTransitionKind.Proximity => SdkGeofenceStatus.Proximity,
+            HonuaGeofenceTransitionKind.Exit => SdkGeofenceStatus.Outside,
+            _ => SdkGeofenceStatus.Outside,
+        };
+    }
+}

--- a/tests/Honua.Mobile.Maui.Tests/HonuaDeviceLocationTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaDeviceLocationTests.cs
@@ -1,7 +1,12 @@
 using Honua.Mobile.Maui;
 using Honua.Mobile.Maui.Annotations;
 using Honua.Mobile.Maui.Location;
+using Honua.Sdk.Abstractions.Features;
 using Microsoft.Extensions.DependencyInjection;
+using NetTopologySuite.Geometries;
+using SdkGeofenceStatus = Honua.Sdk.Geometry.HonuaGeofenceStatus;
+using SdkGeofenceTransition = Honua.Sdk.Geometry.HonuaGeofenceTransition;
+using SdkGeofenceDefinition = Honua.Sdk.Geometry.HonuaGeofenceDefinition;
 
 namespace Honua.Mobile.Maui.Tests;
 
@@ -314,6 +319,126 @@ public sealed class HonuaDeviceLocationTests
     }
 
     [Fact]
+    public async Task SdkGeofenceWorkflowController_StartAsync_MapsSdkDefinitionsToNativeGeofences()
+    {
+        var backgroundProvider = new RecordingBackgroundLocationProvider();
+        var monitor = new RecordingGeofenceMonitor();
+        var coordinator = new HonuaDeviceLocationCoordinator(
+            new RecordingPermissionService
+            {
+                CheckStatus = HonuaLocationPermissionStatus.Background,
+            },
+            new RecordingLocationProvider(),
+            backgroundProvider,
+            monitor);
+        var controller = new HonuaSdkGeofenceWorkflowController(
+            coordinator,
+            new HonuaBackgroundLocationLifecycleController(coordinator),
+            []);
+
+        await controller.StartAsync(new HonuaSdkGeofenceWorkflowRequest
+        {
+            Definitions = [CreateSdkGeofenceDefinition()],
+            BackgroundUpdates = new HonuaBackgroundLocationOptions
+            {
+                MinimumInterval = TimeSpan.FromSeconds(15),
+                MinimumDistanceMeters = 10,
+                Purpose = "proximity fixture",
+            },
+            MinimumBackgroundInterval = TimeSpan.FromMinutes(5),
+            Metadata = new Dictionary<string, object?>
+            {
+                ["workflow"] = "inspection-arrival",
+            },
+        });
+
+        var region = monitor.Requests.Single().Regions.Single();
+        Assert.Equal("job-site", region.Id);
+        Assert.Equal(new HonuaMapCoordinate(21.3069, -157.8583), region.Center);
+        Assert.Equal(75, region.RadiusMeters, precision: 6);
+        Assert.Equal("inspection-arrival", region.Metadata["workflow"]);
+        Assert.Equal("inspections", region.Metadata["honua.sdk.source_id"]);
+        Assert.Equal(FeatureProtocolIds.OgcFeatures, region.Metadata["honua.sdk.source_protocol"]);
+        Assert.Equal(TimeSpan.FromMinutes(5), backgroundProvider.Options.Single().MinimumInterval);
+    }
+
+    [Fact]
+    public async Task SdkGeofenceWorkflowController_PublishesNativeTransitionsToWorkflowAndSyncSinks()
+    {
+        var monitor = new RecordingGeofenceMonitor();
+        var sink = new RecordingWorkflowEventSink();
+        var coordinator = new HonuaDeviceLocationCoordinator(
+            new RecordingPermissionService
+            {
+                CheckStatus = HonuaLocationPermissionStatus.Background,
+            },
+            new RecordingLocationProvider(),
+            new RecordingBackgroundLocationProvider(),
+            monitor);
+        var controller = new HonuaSdkGeofenceWorkflowController(
+            coordinator,
+            new HonuaBackgroundLocationLifecycleController(coordinator),
+            [sink]);
+        var emitted = new List<HonuaGeofenceWorkflowEvent>();
+        controller.WorkflowEventEmitted += (_, workflowEvent) => emitted.Add(workflowEvent);
+
+        await controller.StartAsync(new HonuaSdkGeofenceWorkflowRequest
+        {
+            Definitions = [CreateSdkGeofenceDefinition()],
+        });
+        monitor.Emit(new HonuaGeofenceTransition
+        {
+            RegionId = "job-site",
+            Kind = HonuaGeofenceTransitionKind.Proximity,
+            Location = new HonuaDeviceLocation
+            {
+                Coordinate = new HonuaMapCoordinate(21.3068, -157.8582),
+                AccuracyMeters = 8,
+                IsBackground = true,
+                Provider = "android-fused",
+            },
+            OccurredAt = DateTimeOffset.Parse("2026-05-23T08:00:00Z"),
+        });
+
+        var workflowEvent = Assert.Single(sink.Events);
+        Assert.Same(workflowEvent, Assert.Single(emitted));
+        Assert.Equal("job-site", workflowEvent.GeofenceId);
+        Assert.Equal(HonuaGeofenceTransitionKind.Proximity, workflowEvent.NativeTransition);
+        Assert.Equal(SdkGeofenceTransition.Approached, workflowEvent.SdkTransition);
+        Assert.Equal(SdkGeofenceStatus.Proximity, workflowEvent.SdkStatus);
+        Assert.Equal("android-fused", workflowEvent.Metadata["honua.location.provider"]);
+        Assert.Equal(8d, workflowEvent.Metadata["honua.location.accuracy_m"]);
+    }
+
+    [Fact]
+    public async Task SdkGeofenceWorkflowController_DefaultsToOsGeofencesWithoutBackgroundPolling()
+    {
+        var backgroundProvider = new RecordingBackgroundLocationProvider();
+        var monitor = new RecordingGeofenceMonitor();
+        var coordinator = new HonuaDeviceLocationCoordinator(
+            new RecordingPermissionService
+            {
+                CheckStatus = HonuaLocationPermissionStatus.Background,
+            },
+            new RecordingLocationProvider(),
+            backgroundProvider,
+            monitor);
+        var controller = new HonuaSdkGeofenceWorkflowController(
+            coordinator,
+            new HonuaBackgroundLocationLifecycleController(coordinator),
+            []);
+
+        await controller.StartAsync(new HonuaSdkGeofenceWorkflowRequest
+        {
+            Definitions = [CreateSdkGeofenceDefinition()],
+        });
+
+        Assert.Empty(backgroundProvider.Options);
+        Assert.Single(monitor.Requests);
+        Assert.Equal(HonuaBackgroundLocationRuntimeState.Running, controller.State);
+    }
+
+    [Fact]
     public void AddHonuaDeviceLocation_RegistersCoordinatorWithOptionalProviders()
     {
         using var provider = new ServiceCollection()
@@ -326,6 +451,7 @@ public sealed class HonuaDeviceLocationTests
 
         Assert.NotNull(provider.GetRequiredService<HonuaDeviceLocationCoordinator>());
         Assert.NotNull(provider.GetRequiredService<HonuaBackgroundLocationLifecycleController>());
+        Assert.NotNull(provider.GetRequiredService<HonuaSdkGeofenceWorkflowController>());
     }
 
     [Fact]
@@ -366,6 +492,30 @@ public sealed class HonuaDeviceLocationTests
                 },
             ],
         };
+
+    private static SdkGeofenceDefinition CreateSdkGeofenceDefinition()
+    {
+        var geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+        return new SdkGeofenceDefinition
+        {
+            GeofenceId = "job-site",
+            Geometry = geometryFactory.CreatePoint(new Coordinate(-157.8583, 21.3069)),
+            ProximityDistance = 75,
+            Source = new SourceDescriptor
+            {
+                Id = "inspections",
+                Protocol = FeatureProtocolIds.OgcFeatures,
+            },
+            SourceQuery = new SourceQuery
+            {
+                Where = "status = 'open'",
+            },
+            Metadata = new Dictionary<string, string>
+            {
+                ["field_workflow"] = "inspection-arrival",
+            },
+        };
+    }
 
     private sealed class RecordingPermissionService : IHonuaDeviceLocationPermissionService
     {
@@ -481,6 +631,17 @@ public sealed class HonuaDeviceLocationTests
                 throw exception;
             }
 
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingWorkflowEventSink : IHonuaGeofenceWorkflowEventSink
+    {
+        public List<HonuaGeofenceWorkflowEvent> Events { get; } = [];
+
+        public ValueTask EnqueueAsync(HonuaGeofenceWorkflowEvent workflowEvent, CancellationToken ct = default)
+        {
+            Events.Add(workflowEvent);
             return ValueTask.CompletedTask;
         }
     }

--- a/tests/Honua.Mobile.Maui.Tests/HonuaDeviceLocationTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaDeviceLocationTests.cs
@@ -363,6 +363,36 @@ public sealed class HonuaDeviceLocationTests
     }
 
     [Fact]
+    public async Task SdkGeofenceWorkflowController_StartAsync_MergesCaseCollidingRequestMetadata()
+    {
+        var monitor = new RecordingGeofenceMonitor();
+        var coordinator = new HonuaDeviceLocationCoordinator(
+            new RecordingPermissionService
+            {
+                CheckStatus = HonuaLocationPermissionStatus.Background,
+            },
+            new RecordingLocationProvider(),
+            geofenceMonitor: monitor);
+        var controller = new HonuaSdkGeofenceWorkflowController(
+            coordinator,
+            new HonuaBackgroundLocationLifecycleController(coordinator),
+            []);
+
+        await controller.StartAsync(new HonuaSdkGeofenceWorkflowRequest
+        {
+            Definitions = [CreateSdkGeofenceDefinition()],
+            Metadata = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["workflow"] = "initial",
+                ["Workflow"] = "case-override",
+            },
+        });
+
+        var region = monitor.Requests.Single().Regions.Single();
+        Assert.Equal("case-override", region.Metadata["workflow"]);
+    }
+
+    [Fact]
     public async Task SdkGeofenceWorkflowController_PublishesNativeTransitionsToWorkflowAndSyncSinks()
     {
         var monitor = new RecordingGeofenceMonitor();


### PR DESCRIPTION
## Summary
- add `HonuaSdkGeofenceWorkflowController` to consume `Honua.Sdk.Geometry` geofence definitions and map them into native mobile geofence monitoring requests
- emit enter/exit/proximity workflow events through `IHonuaGeofenceWorkflowEventSink` for field UX and sync queue adapters
- keep geofence workflows OS-wakeup-only by default and clamp optional background polling to a bounded minimum interval
- document Android/iOS permission, lifecycle, and battery-aware behavior

Closes #223.

## Validation
- `dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --no-restore --verbosity minimal`
- `dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --no-restore --verbosity minimal`
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore --verbosity minimal`
- `dotnet format Honua.Mobile.sln --verify-no-changes --no-restore --verbosity minimal` (existing PlatformSmoke reference-load warnings)
- `git diff --check`