### PR TITLE
mobile: add AI-assisted capture hooks

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Models/CoreModels.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Models/CoreModels.cs
@@ -1,6 +1,7 @@
 using Microsoft.Maui.Devices.Sensors;
 using System.Globalization;
 using System.Text.Json;
+using Honua.Mobile.FieldCollection.Services.Ai;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Field.Records;
 
@@ -211,11 +212,23 @@ public class AttachmentInfo
     public string? Description { get; set; }
     public FieldLocationCaptureEvidence? CaptureLocation { get; set; }
     public string? ThumbnailUrl { get; set; }
+    public MobileAiMediaState? AiMediaState { get; set; }
     public AttachmentSyncStatus SyncStatus { get; set; } = AttachmentSyncStatus.Synced;
     public int RetryCount { get; set; }
     public string? LastError { get; set; }
     public bool IsDeleted { get; set; }
     public DateTime? DeletedAt { get; set; }
+
+    public string StatusSummary
+    {
+        get
+        {
+            var aiSummary = AiMediaState?.Summary;
+            return string.IsNullOrWhiteSpace(aiSummary)
+                ? SyncStatus.ToString()
+                : $"{SyncStatus} - {aiSummary}";
+        }
+    }
 }
 
 public enum AttachmentSyncStatus

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Ai/MobileAiCaptureServices.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Ai/MobileAiCaptureServices.cs
@@ -1,0 +1,444 @@
+using System.Text.Json.Serialization;
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Sdk.Field.Forms;
+
+namespace Honua.Mobile.FieldCollection.Services.Ai;
+
+public enum MobileAiCaptureCapability
+{
+    VoiceToFields,
+    PhotoToFields,
+    MediaRedaction
+}
+
+public enum MobileAiCaptureStatus
+{
+    Disabled,
+    Unavailable,
+    Queued,
+    Completed,
+    Failed
+}
+
+public enum MobileAiSuggestionDecision
+{
+    Pending,
+    Applied,
+    Rejected
+}
+
+public enum MobileAiMediaProcessingStatus
+{
+    NotRequested,
+    Queued,
+    Processing,
+    Completed,
+    Failed,
+    Skipped
+}
+
+public sealed record MobileAiCapturePolicy
+{
+    public bool IsEnabled { get; init; }
+    public bool AllowVoiceToFields { get; init; } = true;
+    public bool AllowPhotoToFields { get; init; } = true;
+    public bool AllowMediaRedaction { get; init; } = true;
+    public bool QueueWhenProviderUnavailable { get; init; } = true;
+}
+
+public sealed record MobileAiFormFieldDescriptor
+{
+    public required string TargetKey { get; init; }
+    public required string FieldId { get; init; }
+    public required string Label { get; init; }
+    public FormFieldType FieldType { get; init; }
+    public bool IsRequired { get; init; }
+    public IReadOnlyList<string> Choices { get; init; } = [];
+}
+
+public sealed record MobileAiAttachmentDescriptor
+{
+    public required string AttachmentId { get; init; }
+    public string? FieldId { get; init; }
+    public required string FileName { get; init; }
+    public required string ContentType { get; init; }
+    public AttachmentPayloadKind PayloadKind { get; init; }
+    public long SizeBytes { get; init; }
+    public string? LocalPath { get; init; }
+    public FieldLocationCaptureEvidence? CaptureLocation { get; init; }
+    public MobileAiMediaState? AiState { get; init; }
+
+    public static MobileAiAttachmentDescriptor FromAttachment(AttachmentInfo attachment)
+    {
+        ArgumentNullException.ThrowIfNull(attachment);
+
+        return new MobileAiAttachmentDescriptor
+        {
+            AttachmentId = attachment.Id,
+            FileName = attachment.FileName,
+            ContentType = attachment.ContentType,
+            PayloadKind = attachment.PayloadKind,
+            SizeBytes = attachment.SizeBytes,
+            LocalPath = attachment.LocalPath,
+            CaptureLocation = attachment.CaptureLocation,
+            AiState = attachment.AiMediaState
+        };
+    }
+}
+
+public sealed record MobileAiCaptureRequest
+{
+    public MobileAiCapturePolicy Policy { get; init; } = new();
+    public int LayerId { get; init; }
+    public string FeatureId { get; init; } = string.Empty;
+    public string? FormId { get; init; }
+    public IReadOnlyDictionary<string, object?> CurrentValues { get; init; } =
+        new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+    public IReadOnlyList<MobileAiFormFieldDescriptor> Fields { get; init; } = [];
+    public IReadOnlyList<MobileAiAttachmentDescriptor> Attachments { get; init; } = [];
+    public string? VoiceTranscript { get; init; }
+    public IReadOnlySet<MobileAiCaptureCapability> Capabilities { get; init; } =
+        new HashSet<MobileAiCaptureCapability>();
+}
+
+public sealed record MobileAiFieldSuggestion
+{
+    public required string TargetKey { get; init; }
+    public string? FieldId { get; init; }
+    public object? SuggestedValue { get; init; }
+    public double? Confidence { get; init; }
+    public string? Reason { get; init; }
+    public MobileAiSuggestionDecision Decision { get; init; } = MobileAiSuggestionDecision.Pending;
+}
+
+public sealed record MobileAiCaptureResult
+{
+    public MobileAiCaptureStatus Status { get; init; }
+    public string? Message { get; init; }
+    public string? QueueItemId { get; init; }
+    public IReadOnlyList<MobileAiFieldSuggestion> Suggestions { get; init; } = [];
+
+    public static MobileAiCaptureResult Disabled()
+        => new()
+        {
+            Status = MobileAiCaptureStatus.Disabled,
+            Message = "AI assistance is disabled."
+        };
+
+    public static MobileAiCaptureResult Queued(string queueItemId)
+        => new()
+        {
+            Status = MobileAiCaptureStatus.Queued,
+            QueueItemId = queueItemId,
+            Message = "AI assistance is queued until a provider is available."
+        };
+
+    public static MobileAiCaptureResult Unavailable()
+        => new()
+        {
+            Status = MobileAiCaptureStatus.Unavailable,
+            Message = "No AI capture provider is available."
+        };
+}
+
+public sealed record MobileAiMediaRequest
+{
+    public MobileAiCapturePolicy Policy { get; init; } = new();
+    public int LayerId { get; init; }
+    public string FeatureId { get; init; } = string.Empty;
+    public required MobileAiAttachmentDescriptor Attachment { get; init; }
+}
+
+public sealed record MobileAiMediaState
+{
+    public MobileAiMediaProcessingStatus RedactionStatus { get; init; } = MobileAiMediaProcessingStatus.NotRequested;
+    public MobileAiMediaProcessingStatus EnrichmentStatus { get; init; } = MobileAiMediaProcessingStatus.NotRequested;
+    public bool RequiresFaceBlur { get; init; }
+    public string? ProviderId { get; init; }
+    public string? LastError { get; init; }
+    public DateTimeOffset UpdatedAtUtc { get; init; } = DateTimeOffset.UtcNow;
+
+    [JsonIgnore]
+    public string Summary
+    {
+        get
+        {
+            if (RequiresFaceBlur && RedactionStatus != MobileAiMediaProcessingStatus.Completed)
+            {
+                return $"AI redaction {RedactionStatus}";
+            }
+
+            if (RedactionStatus != MobileAiMediaProcessingStatus.NotRequested)
+            {
+                return $"AI redaction {RedactionStatus}";
+            }
+
+            if (EnrichmentStatus != MobileAiMediaProcessingStatus.NotRequested)
+            {
+                return $"AI enrichment {EnrichmentStatus}";
+            }
+
+            return string.Empty;
+        }
+    }
+
+    public static MobileAiMediaState Queued()
+        => new()
+        {
+            RedactionStatus = MobileAiMediaProcessingStatus.Queued,
+            EnrichmentStatus = MobileAiMediaProcessingStatus.Queued,
+            UpdatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+    public static MobileAiMediaState Disabled()
+        => new()
+        {
+            RedactionStatus = MobileAiMediaProcessingStatus.NotRequested,
+            EnrichmentStatus = MobileAiMediaProcessingStatus.NotRequested,
+            UpdatedAtUtc = DateTimeOffset.UtcNow
+        };
+}
+
+public sealed record MobileAiCaptureQueueItem
+{
+    public required string QueueItemId { get; init; }
+    public int LayerId { get; init; }
+    public string FeatureId { get; init; } = string.Empty;
+    public string? FormId { get; init; }
+    public IReadOnlyList<string> TargetKeys { get; init; } = [];
+    public IReadOnlyList<string> AttachmentIds { get; init; } = [];
+    public IReadOnlyList<MobileAiCaptureCapability> Capabilities { get; init; } = [];
+    public DateTimeOffset CreatedAtUtc { get; init; } = DateTimeOffset.UtcNow;
+    public string Reason { get; init; } = "provider-unavailable";
+
+    public static MobileAiCaptureQueueItem FromFormRequest(MobileAiCaptureRequest request)
+    {
+        return new MobileAiCaptureQueueItem
+        {
+            QueueItemId = Guid.NewGuid().ToString("N"),
+            LayerId = request.LayerId,
+            FeatureId = request.FeatureId,
+            FormId = request.FormId,
+            TargetKeys = request.Fields
+                .Select(field => field.TargetKey)
+                .Where(key => !string.IsNullOrWhiteSpace(key))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
+            AttachmentIds = request.Attachments
+                .Select(attachment => attachment.AttachmentId)
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray(),
+            Capabilities = request.Capabilities.Distinct().ToArray()
+        };
+    }
+
+    public static MobileAiCaptureQueueItem FromMediaRequest(MobileAiMediaRequest request)
+    {
+        return new MobileAiCaptureQueueItem
+        {
+            QueueItemId = Guid.NewGuid().ToString("N"),
+            LayerId = request.LayerId,
+            FeatureId = request.FeatureId,
+            AttachmentIds = [request.Attachment.AttachmentId],
+            Capabilities =
+            [
+                MobileAiCaptureCapability.MediaRedaction,
+                MobileAiCaptureCapability.PhotoToFields
+            ]
+        };
+    }
+}
+
+public interface IMobileAiCaptureProvider
+{
+    bool IsAvailable { get; }
+    ValueTask<MobileAiCaptureResult> RequestFieldSuggestionsAsync(
+        MobileAiCaptureRequest request,
+        CancellationToken cancellationToken = default);
+    ValueTask<MobileAiMediaState> RequestMediaEnrichmentAsync(
+        MobileAiMediaRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+public interface IMobileAiCaptureQueue
+{
+    ValueTask EnqueueAsync(MobileAiCaptureQueueItem item, CancellationToken cancellationToken = default);
+    ValueTask<IReadOnlyList<MobileAiCaptureQueueItem>> GetPendingAsync(CancellationToken cancellationToken = default);
+    ValueTask ClearAsync(CancellationToken cancellationToken = default);
+}
+
+public interface IMobileAiCaptureService
+{
+    ValueTask<MobileAiCaptureResult> RequestFieldSuggestionsAsync(
+        MobileAiCaptureRequest request,
+        CancellationToken cancellationToken = default);
+    ValueTask<MobileAiMediaState> RequestMediaEnrichmentAsync(
+        MobileAiMediaRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class NullMobileAiCaptureProvider : IMobileAiCaptureProvider
+{
+    public bool IsAvailable => false;
+
+    public ValueTask<MobileAiCaptureResult> RequestFieldSuggestionsAsync(
+        MobileAiCaptureRequest request,
+        CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(MobileAiCaptureResult.Unavailable());
+
+    public ValueTask<MobileAiMediaState> RequestMediaEnrichmentAsync(
+        MobileAiMediaRequest request,
+        CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(MobileAiMediaState.Queued());
+}
+
+public sealed class MobileAiCaptureCoordinator : IMobileAiCaptureService
+{
+    private readonly IMobileAiCaptureProvider _provider;
+    private readonly IMobileAiCaptureQueue _queue;
+
+    public MobileAiCaptureCoordinator(IMobileAiCaptureProvider provider, IMobileAiCaptureQueue queue)
+    {
+        _provider = provider;
+        _queue = queue;
+    }
+
+    public async ValueTask<MobileAiCaptureResult> RequestFieldSuggestionsAsync(
+        MobileAiCaptureRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!request.Policy.IsEnabled)
+        {
+            return MobileAiCaptureResult.Disabled();
+        }
+
+        if (!_provider.IsAvailable)
+        {
+            return await QueueOrUnavailableAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        try
+        {
+            return await _provider.RequestFieldSuggestionsAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return new MobileAiCaptureResult
+            {
+                Status = MobileAiCaptureStatus.Failed,
+                Message = "AI assistance failed without exposing capture payload details."
+            };
+        }
+    }
+
+    public async ValueTask<MobileAiMediaState> RequestMediaEnrichmentAsync(
+        MobileAiMediaRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!request.Policy.IsEnabled || !request.Policy.AllowMediaRedaction)
+        {
+            return MobileAiMediaState.Disabled();
+        }
+
+        if (!_provider.IsAvailable)
+        {
+            if (request.Policy.QueueWhenProviderUnavailable)
+            {
+                await _queue.EnqueueAsync(
+                    MobileAiCaptureQueueItem.FromMediaRequest(request),
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            return MobileAiMediaState.Queued();
+        }
+
+        try
+        {
+            return await _provider.RequestMediaEnrichmentAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return new MobileAiMediaState
+            {
+                RedactionStatus = MobileAiMediaProcessingStatus.Failed,
+                EnrichmentStatus = MobileAiMediaProcessingStatus.Failed,
+                LastError = "AI media processing failed without exposing capture payload details.",
+                UpdatedAtUtc = DateTimeOffset.UtcNow
+            };
+        }
+    }
+
+    private async ValueTask<MobileAiCaptureResult> QueueOrUnavailableAsync(
+        MobileAiCaptureRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!request.Policy.QueueWhenProviderUnavailable)
+        {
+            return MobileAiCaptureResult.Unavailable();
+        }
+
+        var item = MobileAiCaptureQueueItem.FromFormRequest(request);
+        await _queue.EnqueueAsync(item, cancellationToken).ConfigureAwait(false);
+        return MobileAiCaptureResult.Queued(item.QueueItemId);
+    }
+}
+
+public sealed class SettingsMobileAiCaptureQueue : IMobileAiCaptureQueue
+{
+    private const string QueueKey = "field-collection:ai-capture-queue";
+
+    private readonly ISettingsService _settingsService;
+
+    public SettingsMobileAiCaptureQueue(ISettingsService settingsService)
+    {
+        _settingsService = settingsService;
+    }
+
+    public async ValueTask EnqueueAsync(
+        MobileAiCaptureQueueItem item,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var pending = await LoadAsync().ConfigureAwait(false);
+        pending.RemoveAll(existing => string.Equals(existing.QueueItemId, item.QueueItemId, StringComparison.Ordinal));
+        pending.Add(item);
+        await _settingsService.SetSettingAsync(QueueKey, pending).ConfigureAwait(false);
+    }
+
+    public async ValueTask<IReadOnlyList<MobileAiCaptureQueueItem>> GetPendingAsync(
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return await LoadAsync().ConfigureAwait(false);
+    }
+
+    public ValueTask ClearAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ValueTask(_settingsService.RemoveSettingAsync(QueueKey));
+    }
+
+    private async Task<List<MobileAiCaptureQueueItem>> LoadAsync()
+    {
+        return await _settingsService
+            .GetSettingAsync(QueueKey, new List<MobileAiCaptureQueueItem>())
+            .ConfigureAwait(false) ?? [];
+    }
+}

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/CoreServices.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/CoreServices.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services.Ai;
 using Honua.Mobile.FieldCollection.Services.Forms;
 using Honua.Mobile.FieldCollection.Services.Storage;
 using Honua.Sdk.Abstractions.Features;
@@ -89,6 +90,10 @@ public interface IAttachmentService
     Task<IEnumerable<AttachmentInfo>> GetAttachmentsAsync(string featureId);
     Task<IReadOnlyList<AttachmentInfo>> GetPendingAttachmentsAsync(CancellationToken cancellationToken = default);
     Task<bool> AttachmentContentExistsAsync(string attachmentId);
+    Task UpdateAttachmentAiStateAsync(
+        string attachmentId,
+        MobileAiMediaState? state,
+        CancellationToken cancellationToken = default);
 }
 
 public interface ISettingsService
@@ -658,6 +663,16 @@ public class AttachmentService : IAttachmentService
     {
         var storage = EnsureStorageConfigured();
         return await storage.GetAttachmentsForFeatureAsync(featureId).ConfigureAwait(false);
+    }
+
+    public async Task UpdateAttachmentAiStateAsync(
+        string attachmentId,
+        MobileAiMediaState? state,
+        CancellationToken cancellationToken = default)
+    {
+        var storage = EnsureStorageConfigured();
+        cancellationToken.ThrowIfCancellationRequested();
+        await storage.UpdateAttachmentAiStateAsync(attachmentId, state).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<AttachmentInfo>> GetPendingAttachmentsAsync(

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Diagnostics/OfflineCacheDiagnostics.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Diagnostics/OfflineCacheDiagnostics.cs
@@ -196,7 +196,16 @@ public static partial class DiagnosticRedactor
             normalized.Contains("password", StringComparison.Ordinal) ||
             normalized.Contains("apikey", StringComparison.Ordinal) ||
             normalized.Contains("accesskey", StringComparison.Ordinal) ||
-            normalized.Contains("authorization", StringComparison.Ordinal);
+            normalized.Contains("authorization", StringComparison.Ordinal) ||
+            normalized.Contains("localpath", StringComparison.Ordinal) ||
+            normalized.Contains("rawmedia", StringComparison.Ordinal) ||
+            normalized.Contains("mediapayload", StringComparison.Ordinal) ||
+            normalized.Contains("photopayload", StringComparison.Ordinal) ||
+            normalized.Contains("imagepayload", StringComparison.Ordinal) ||
+            normalized.Contains("audiopayload", StringComparison.Ordinal) ||
+            normalized.Contains("voicetranscript", StringComparison.Ordinal) ||
+            normalized.Contains("biometric", StringComparison.Ordinal) ||
+            normalized.Contains("faceembedding", StringComparison.Ordinal);
     }
 
     [GeneratedRegex("Bearer\\s+[A-Za-z0-9._~+/=-]+", RegexOptions.IgnoreCase)]

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using NetTopologySuite.IO;
 using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services.Ai;
 using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using Honua.Mobile.FieldCollection.Services.Metadata;
 using Honua.Mobile.FieldCollection.Services.Storage.Models;
@@ -198,6 +199,11 @@ public class GeoPackageStorageService : IDisposable
         if (!columnNames.Contains("capture_location_json"))
         {
             await _connection.ExecuteAsync("ALTER TABLE local_attachments ADD COLUMN capture_location_json TEXT");
+        }
+
+        if (!columnNames.Contains("ai_media_state_json"))
+        {
+            await _connection.ExecuteAsync("ALTER TABLE local_attachments ADD COLUMN ai_media_state_json TEXT");
         }
 
         await _connection.ExecuteAsync(
@@ -984,6 +990,29 @@ public class GeoPackageStorageService : IDisposable
         }
     }
 
+    public async Task UpdateAttachmentAiStateAsync(string attachmentId, MobileAiMediaState? state)
+    {
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            await _connection.ExecuteAsync(
+                """
+                UPDATE local_attachments
+                SET ai_media_state_json = ?,
+                    updated_at = ?
+                WHERE id = ?
+                """,
+                SerializeAiMediaState(state),
+                DateTime.UtcNow,
+                attachmentId);
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
     public async Task<int> GetPendingAttachmentChangesCountAsync()
     {
         await EnsureInitializedAsync();
@@ -1045,6 +1074,7 @@ public class GeoPackageStorageService : IDisposable
             Description = attachment.Description,
             CaptureLocationJson = FieldLocationMetadataMapper.SerializeEvidence(attachment.CaptureLocation),
             ThumbnailUrl = attachment.ThumbnailUrl,
+            AiMediaStateJson = SerializeAiMediaState(attachment.AiMediaState),
             SyncStatus = attachment.SyncStatus,
             RetryCount = attachment.RetryCount,
             LastError = attachment.LastError,
@@ -1074,12 +1104,33 @@ public class GeoPackageStorageService : IDisposable
             Description = attachment.Description,
             CaptureLocation = FieldLocationMetadataMapper.DeserializeEvidence(attachment.CaptureLocationJson),
             ThumbnailUrl = attachment.ThumbnailUrl,
+            AiMediaState = DeserializeAiMediaState(attachment.AiMediaStateJson),
             SyncStatus = attachment.SyncStatus,
             RetryCount = attachment.RetryCount,
             LastError = attachment.LastError,
             IsDeleted = attachment.IsDeleted,
             DeletedAt = attachment.DeletedAt
         };
+    }
+
+    private static string? SerializeAiMediaState(MobileAiMediaState? state)
+        => state is null ? null : JsonSerializer.Serialize(state, SchemaJsonOptions);
+
+    private static MobileAiMediaState? DeserializeAiMediaState(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<MobileAiMediaState>(json, SchemaJsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 
     #endregion

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/Models/StorageModels.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/Models/StorageModels.cs
@@ -111,6 +111,9 @@ public class LocalAttachment
     [Column("thumbnail_url")]
     public string? ThumbnailUrl { get; set; }
 
+    [Column("ai_media_state_json")]
+    public string? AiMediaStateJson { get; set; }
+
     [Column("sync_status")]
     [Indexed]
     public AttachmentSyncStatus SyncStatus { get; set; } = AttachmentSyncStatus.Synced;

--- a/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
+++ b/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Maui;
 using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.FieldCollection.Services.Ai;
 using Honua.Mobile.FieldCollection.Services.Configuration;
 using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using Honua.Mobile.FieldCollection.Services.Features;
@@ -161,6 +162,9 @@ public static class MauiProgram
                 databaseService.GetStorageService(),
                 logger: provider.GetService<ILogger<LocalRecordExportService>>());
         });
+        services.AddSingleton<IMobileAiCaptureProvider, NullMobileAiCaptureProvider>();
+        services.AddSingleton<IMobileAiCaptureQueue, SettingsMobileAiCaptureQueue>();
+        services.AddSingleton<IMobileAiCaptureService, MobileAiCaptureCoordinator>();
 
         // Configuration services
         var buildConfiguration = MobileBuildConfiguration.FromAssembly(

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/WorkflowViewModels.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/WorkflowViewModels.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.FieldCollection.Services.Ai;
 using Honua.Mobile.FieldCollection.Services.Configuration;
 using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using Honua.Mobile.FieldCollection.Services.Forms;
@@ -69,6 +70,31 @@ public sealed partial class EditableRepeatSectionItem : ObservableObject
     public ICommand? AddCommand { get; init; }
 
     public ICommand? RemoveCommand { get; init; }
+}
+
+public sealed partial class MobileAiFieldSuggestionItem : ObservableObject
+{
+    [ObservableProperty]
+    private bool isSelected = true;
+
+    public required MobileAiFieldSuggestion Suggestion { get; init; }
+
+    public required string Label { get; init; }
+
+    public string ValueText => RecordDetailViewModel.FormatValue(Suggestion.SuggestedValue);
+
+    public string DetailText
+    {
+        get
+        {
+            var confidence = Suggestion.Confidence.HasValue
+                ? $" ({Suggestion.Confidence.Value:P0})"
+                : string.Empty;
+            return string.IsNullOrWhiteSpace(Suggestion.Reason)
+                ? $"AI suggestion{confidence}"
+                : $"{Suggestion.Reason}{confidence}";
+        }
+    }
 }
 
 public sealed partial class EditableFormFieldItem : ObservableObject
@@ -560,6 +586,7 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
     private readonly IFormService _formService;
     private readonly IFormDraftService _formDraftService;
     private readonly ILocationService _locationService;
+    private readonly IMobileAiCaptureService _aiCaptureService;
     private bool _isLoadingForm;
     private FormDefinition? _formDefinition;
     private readonly Dictionary<string, int> _repeatSectionCounts = new(StringComparer.Ordinal);
@@ -585,6 +612,15 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
 
     public bool HasValidationSummary => !string.IsNullOrWhiteSpace(ValidationSummary);
 
+    [ObservableProperty]
+    private bool aiAssistanceEnabled;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasAiCaptureSummary))]
+    private string aiCaptureSummary = string.Empty;
+
+    public bool HasAiCaptureSummary => !string.IsNullOrWhiteSpace(AiCaptureSummary);
+
     private FieldPoint? _location;
     private string? _captureSource;
     private DateTime? _capturedAtUtc;
@@ -600,6 +636,7 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
     public ObservableCollection<EditableFormFieldItem> FormFields { get; } = [];
     public ObservableCollection<EditableRepeatSectionItem> RepeatSections { get; } = [];
     public ObservableCollection<AttachmentInfo> Attachments { get; } = [];
+    public ObservableCollection<MobileAiFieldSuggestionItem> AiSuggestions { get; } = [];
 
     public RecordEditViewModel(
         INavigationService navigationService,
@@ -607,7 +644,8 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
         IAttachmentService attachmentService,
         IFormService formService,
         IFormDraftService formDraftService,
-        ILocationService locationService)
+        ILocationService locationService,
+        IMobileAiCaptureService aiCaptureService)
         : base(navigationService)
     {
         _featureService = featureService;
@@ -615,6 +653,7 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
         _formService = formService;
         _formDraftService = formDraftService;
         _locationService = locationService;
+        _aiCaptureService = aiCaptureService;
         Title = "Create Record";
     }
 
@@ -655,10 +694,12 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
                 FormFields.Clear();
                 RepeatSections.Clear();
                 Attachments.Clear();
+                AiSuggestions.Clear();
                 _repeatSectionCounts.Clear();
                 _locationEvidenceByField.Clear();
                 _supplementalFormValues.Clear();
                 ValidationSummary = string.Empty;
+                AiCaptureSummary = string.Empty;
                 PageTitle = IsNew ? "Create Record" : "Edit Record";
                 Title = PageTitle;
 
@@ -860,6 +901,92 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
     }
 
     [RelayCommand]
+    private async Task RequestAiSuggestions()
+    {
+        if (_formDefinition == null)
+        {
+            return;
+        }
+
+        if (!AiAssistanceEnabled)
+        {
+            var enabled = await ShowConfirmation(
+                "AI assistance",
+                "Allow AI assistance for this draft? Field values and attachment metadata may be sent to the configured provider; raw media stays local unless the host provider explicitly uses local files.",
+                "Allow",
+                "Cancel");
+            if (!enabled)
+            {
+                AiCaptureSummary = "AI assistance not enabled.";
+                return;
+            }
+
+            AiAssistanceEnabled = true;
+        }
+
+        await ExecuteAsync(async () =>
+        {
+            await RefreshAiMediaStatesAsync();
+
+            var result = await _aiCaptureService.RequestFieldSuggestionsAsync(BuildAiCaptureRequest());
+            AiSuggestions.Clear();
+            foreach (var suggestion in result.Suggestions)
+            {
+                AiSuggestions.Add(new MobileAiFieldSuggestionItem
+                {
+                    Suggestion = suggestion,
+                    Label = GetFieldLabel(suggestion.TargetKey)
+                });
+            }
+
+            AiCaptureSummary = result.Status switch
+            {
+                MobileAiCaptureStatus.Completed => AiSuggestions.Count == 0
+                    ? "AI returned no field suggestions."
+                    : $"{AiSuggestions.Count} AI suggestion(s) ready.",
+                MobileAiCaptureStatus.Queued => "AI suggestions queued until a provider is available.",
+                MobileAiCaptureStatus.Disabled => "AI assistance is disabled.",
+                MobileAiCaptureStatus.Unavailable => "No AI provider is available.",
+                _ => result.Message ?? "AI assistance failed."
+            };
+        });
+    }
+
+    [RelayCommand]
+    private async Task ApplyAiSuggestions()
+    {
+        var selected = AiSuggestions.Where(item => item.IsSelected).ToArray();
+        if (selected.Length == 0)
+        {
+            AiCaptureSummary = "No AI suggestions selected.";
+            return;
+        }
+
+        foreach (var item in selected)
+        {
+            var field = FormFields.FirstOrDefault(field =>
+                string.Equals(field.ValueKey, item.Suggestion.TargetKey, StringComparison.OrdinalIgnoreCase));
+            field?.SetValue(item.Suggestion.SuggestedValue);
+        }
+
+        AiSuggestions.Clear();
+        AiCaptureSummary = $"Applied {selected.Length} AI suggestion(s).";
+        RefreshFormRules();
+        await SaveDraftSnapshotAsync();
+    }
+
+    [RelayCommand]
+    private Task RejectAiSuggestions()
+    {
+        var count = AiSuggestions.Count;
+        AiSuggestions.Clear();
+        AiCaptureSummary = count == 0
+            ? "No AI suggestions to reject."
+            : $"Rejected {count} AI suggestion(s).";
+        return Task.CompletedTask;
+    }
+
+    [RelayCommand]
     private async Task AddRepeatEntry(EditableRepeatSectionItem section)
     {
         if (_formDefinition == null || string.IsNullOrWhiteSpace(section.SectionId))
@@ -935,10 +1062,59 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
                 payloadKind,
                 ownerField?.Definition.FieldId,
                 captureLocation);
+            attachment.AiMediaState = await RequestAttachmentAiStateAsync(attachment);
+            if (attachment.AiMediaState is not null)
+            {
+                await _attachmentService.UpdateAttachmentAiStateAsync(attachment.Id, attachment.AiMediaState);
+            }
+
             Attachments.Add(attachment);
             ownerField?.AddMediaAttachment(attachment);
             await SaveDraftSnapshotAsync();
         });
+    }
+
+    private async Task<MobileAiMediaState?> RequestAttachmentAiStateAsync(AttachmentInfo attachment)
+    {
+        if (!AiAssistanceEnabled || attachment.PayloadKind != AttachmentPayloadKind.Photo)
+        {
+            return null;
+        }
+
+        return await _aiCaptureService.RequestMediaEnrichmentAsync(new MobileAiMediaRequest
+        {
+            Policy = CreateAiCapturePolicy(),
+            LayerId = LayerId,
+            FeatureId = FeatureId,
+            Attachment = MobileAiAttachmentDescriptor.FromAttachment(attachment)
+        });
+    }
+
+    private async Task RefreshAiMediaStatesAsync()
+    {
+        foreach (var attachment in Attachments.Where(ShouldRequestAiMediaState).ToArray())
+        {
+            var state = await RequestAttachmentAiStateAsync(attachment);
+            if (state is null)
+            {
+                continue;
+            }
+
+            attachment.AiMediaState = state;
+            await _attachmentService.UpdateAttachmentAiStateAsync(attachment.Id, state);
+        }
+    }
+
+    private static bool ShouldRequestAiMediaState(AttachmentInfo attachment)
+    {
+        if (attachment.PayloadKind != AttachmentPayloadKind.Photo)
+        {
+            return false;
+        }
+
+        return attachment.AiMediaState is null ||
+            (attachment.AiMediaState.RedactionStatus == MobileAiMediaProcessingStatus.NotRequested &&
+                attachment.AiMediaState.EnrichmentStatus == MobileAiMediaProcessingStatus.NotRequested);
     }
 
     [RelayCommand]
@@ -1199,6 +1375,62 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
         });
     }
 
+    private MobileAiCaptureRequest BuildAiCaptureRequest()
+    {
+        var fields = FormFields
+            .Where(field => field.IsVisible && field.IsEditable && !string.IsNullOrWhiteSpace(field.ValueKey))
+            .Select(field => new MobileAiFormFieldDescriptor
+            {
+                TargetKey = field.ValueKey,
+                FieldId = field.Definition.FieldId,
+                Label = field.Label,
+                FieldType = field.Definition.Type,
+                IsRequired = field.Definition.Required,
+                Choices = field.Definition.Choices
+                    .Select(choice => choice.Value)
+                    .Where(value => !string.IsNullOrWhiteSpace(value))
+                    .ToArray()
+            })
+            .ToArray();
+
+        var attachments = Attachments
+            .Select(MobileAiAttachmentDescriptor.FromAttachment)
+            .ToArray();
+
+        return new MobileAiCaptureRequest
+        {
+            Policy = CreateAiCapturePolicy(),
+            LayerId = LayerId,
+            FeatureId = FeatureId,
+            FormId = _formDefinition?.FormId,
+            CurrentValues = BuildFormValues(includeHidden: false),
+            Fields = fields,
+            Attachments = attachments,
+            Capabilities = new HashSet<MobileAiCaptureCapability>
+            {
+                MobileAiCaptureCapability.VoiceToFields,
+                MobileAiCaptureCapability.PhotoToFields
+            }
+        };
+    }
+
+    private MobileAiCapturePolicy CreateAiCapturePolicy()
+        => new()
+        {
+            IsEnabled = AiAssistanceEnabled,
+            AllowVoiceToFields = true,
+            AllowPhotoToFields = true,
+            AllowMediaRedaction = true,
+            QueueWhenProviderUnavailable = true
+        };
+
+    private string GetFieldLabel(string targetKey)
+    {
+        var field = FormFields.FirstOrDefault(field =>
+            string.Equals(field.ValueKey, targetKey, StringComparison.OrdinalIgnoreCase));
+        return field?.Label ?? targetKey;
+    }
+
     private async Task<FieldLocationCaptureEvidence?> TryCaptureCurrentLocationEvidenceAsync()
     {
         try
@@ -1324,7 +1556,8 @@ public sealed partial class RecordEditViewModel : BaseViewModel, IRouteAwareView
                     SizeBytes = attachment.SizeBytes,
                     CapturedAtUtc = new DateTimeOffset(attachment.CreatedAt == default ? DateTime.UtcNow : attachment.CreatedAt),
                     CaptureLocation = attachment.CaptureLocation?.ToFieldGeoPoint(),
-                    MediaType = MobileFormValueConverter.ToSdkMediaType(field.Definition.Type, attachment.PayloadKind)
+                    MediaType = MobileFormValueConverter.ToSdkMediaType(field.Definition.Type, attachment.PayloadKind),
+                    RequiresFaceBlur = attachment.AiMediaState?.RequiresFaceBlur == true
                 });
             }
         }

--- a/apps/Honua.Mobile.FieldCollection/Views/WorkflowPages.cs
+++ b/apps/Honua.Mobile.FieldCollection/Views/WorkflowPages.cs
@@ -261,10 +261,23 @@ internal static class WorkflowPageContent
         var attachments = AttachmentList("RemoveAttachmentCommand");
         attachments.SetBinding(ItemsView.ItemsSourceProperty, new Binding("Attachments"));
 
+        var aiSummary = BoundMultilineLabel("AiCaptureSummary");
+        aiSummary.SetBinding(VisualElement.IsVisibleProperty, new Binding("HasAiCaptureSummary"));
+
+        var aiSuggestions = AiSuggestionList();
+        aiSuggestions.SetBinding(ItemsView.ItemsSourceProperty, new Binding("AiSuggestions"));
+
         return PageScroll(
             BoundHeader("PageTitle", "Record"),
             BoundLabel("GeometrySummary", "Geometry"),
             validation,
+            Toggle("AiAssistanceEnabled", "AI assistance"),
+            aiSummary,
+            aiSuggestions,
+            ButtonRow(
+                CommandButton("Suggest fields", "RequestAiSuggestionsCommand"),
+                CommandButton("Apply suggestions", "ApplyAiSuggestionsCommand"),
+                CommandButton("Reject suggestions", "RejectAiSuggestionsCommand")),
             repeatSections,
             SectionTitle("Fields"),
             fields,
@@ -393,6 +406,47 @@ internal static class WorkflowPageContent
                 };
                 row.SetBinding(VisualElement.IsVisibleProperty, new Binding(nameof(EditableFormFieldItem.IsVisible)));
                 return row;
+            })
+        };
+    }
+
+    private static CollectionView AiSuggestionList()
+    {
+        return new CollectionView
+        {
+            EmptyView = new Label { Text = string.Empty },
+            ItemTemplate = new DataTemplate(() =>
+            {
+                var selected = new CheckBox { VerticalOptions = LayoutOptions.Center };
+                selected.SetBinding(CheckBox.IsCheckedProperty, new Binding(nameof(MobileAiFieldSuggestionItem.IsSelected), mode: BindingMode.TwoWay));
+
+                var label = new Label { FontAttributes = FontAttributes.Bold };
+                label.SetBinding(Label.TextProperty, new Binding(nameof(MobileAiFieldSuggestionItem.Label)));
+
+                var value = new Label { LineBreakMode = LineBreakMode.WordWrap };
+                value.SetBinding(Label.TextProperty, new Binding(nameof(MobileAiFieldSuggestionItem.ValueText)));
+
+                var detail = new Label { FontSize = 12, TextColor = Colors.Gray };
+                detail.SetBinding(Label.TextProperty, new Binding(nameof(MobileAiFieldSuggestionItem.DetailText)));
+
+                var text = new VerticalStackLayout
+                {
+                    Spacing = 2,
+                    Children = { label, value, detail }
+                };
+                Grid.SetColumn(text, 1);
+
+                return new Grid
+                {
+                    Padding = new Thickness(0, 6),
+                    ColumnDefinitions =
+                    [
+                        new ColumnDefinition(GridLength.Auto),
+                        new ColumnDefinition(GridLength.Star)
+                    ],
+                    ColumnSpacing = 8,
+                    Children = { selected, text }
+                };
             })
         };
     }
@@ -639,7 +693,7 @@ internal static class WorkflowPageContent
                 var details = new Label { FontSize = 12, TextColor = Colors.Gray };
                 details.SetBinding(
                     Label.TextProperty,
-                    new Binding(nameof(AttachmentInfo.SyncStatus), stringFormat: "{0}"));
+                    new Binding(nameof(AttachmentInfo.StatusSummary)));
 
                 var action = new Button { Text = commandPath.StartsWith("Open", StringComparison.Ordinal) ? "Open" : "Remove" };
                 action.SetBinding(

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -6,6 +6,7 @@ This repository owns mobile SDK packages, MAUI integration, offline field workfl
 
 - `Honua.Mobile.Sdk`: transport, auth, gRPC-first feature queries, REST fallback, routing, scene metadata adapter, and secure transport checks.
 - `Honua.Mobile.Field`: SDK-backed field form validation, calculated fields, duplicate detection, media attachment metadata conversion, and record workflow.
+- Field collection reference workflow: opt-in AI capture adapter hooks for field suggestions, media redaction state, provider-unavailable queueing, and sanitized diagnostics.
 - `Honua.Mobile.Offline`: GeoPackage storage, sync queue, pull/push sync, conflicts, map area download, delta cursors, TTL/cache governance, and R-tree bbox lookup.
 - `Honua.Mobile.Maui`: DI registration, native display boundaries, map annotations, secure auth token storage, device location, background location, and geofencing contracts.
 - `@honua/embed`: framework-agnostic `<honua-map>` and `<honua-scene>` components with display adapters, scene package caching, snippets, and DOM behavior tests.
@@ -18,7 +19,7 @@ This repository owns mobile SDK packages, MAUI integration, offline field workfl
 - Embed package: `src/Honua.Embed/`
 - Apps and examples: `apps/`, `examples/`, `templates/`
 - Tests: `tests/`, `src/Honua.Embed/tests/`
-- 3D/offline docs: `docs/guides/3d-scene-embed.md`, `docs/guides/offline-3d-scene-packages.md`, `docs/guides/protected-3d-scene-auth.md`
+- 3D/offline/capture docs: `docs/guides/3d-scene-embed.md`, `docs/guides/offline-3d-scene-packages.md`, `docs/guides/protected-3d-scene-auth.md`, `docs/guides/field-ai-assisted-capture.md`
 
 ## 3D Status
 

--- a/docs/guides/field-ai-assisted-capture.md
+++ b/docs/guides/field-ai-assisted-capture.md
@@ -1,0 +1,43 @@
+# AI-Assisted Field Capture Hooks
+
+Honua mobile exposes opt-in AI-assisted capture hooks for field forms without
+owning portable model execution contracts. Mobile owns the capture UX, local
+media paths, attachment state, privacy gating, and provider adapter points. SDK
+or server packages should own stable request/response contracts and model
+execution.
+
+## Mobile-Owned Flow
+
+- `IMobileAiCaptureService` is the form workflow entry point.
+- `IMobileAiCaptureProvider` is the host adapter for voice-to-fields,
+  photo-to-fields, and media redaction/enrichment.
+- `MobileAiCapturePolicy` keeps AI assistance opt-in. The reference form edit
+  workflow prompts before first use and keeps media redaction disabled unless
+  assistance is enabled.
+- `SettingsMobileAiCaptureQueue` stores only sanitized intent when a provider is
+  unavailable: layer id, feature id, target field keys, attachment ids, requested
+  capabilities, and timestamps. It does not store transcripts, raw media,
+  current field values, local file paths, or provider secrets.
+
+## Form Suggestions
+
+The record edit workflow can request AI field suggestions and then apply or
+reject them. Suggestions target mobile form value keys, including repeat section
+keys, so the UI can apply values without redefining SDK form schemas.
+
+Provider adapters receive current form values and local attachment descriptors at
+runtime. They should avoid logging request payloads and should return only field
+suggestions that the user can inspect before applying.
+
+## Media State Before Sync
+
+Captured photo attachments can carry `MobileAiMediaState` with redaction and
+enrichment status. The edit workflow surfaces this state beside the sync status
+before upload, and the SDK media attachment is marked `RequiresFaceBlur` when
+the mobile AI state requires it.
+
+## Diagnostics
+
+Diagnostics redaction treats AI capture payload names as sensitive. Voice
+transcripts, raw media payloads, local paths, biometric fields, and face
+embeddings are redacted before export, copy, or report operations.

--- a/tests/Honua.Mobile.FieldCollection.Tests/DiagnosticRedactorTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/DiagnosticRedactorTests.cs
@@ -31,6 +31,28 @@ public sealed class DiagnosticRedactorTests
     }
 
     [Fact]
+    public void RedactJson_RedactsAiCapturePayloadAndBiometricFields()
+    {
+        var redacted = DiagnosticRedactor.RedactJson(
+            """
+            {
+              "voiceTranscript": "replace pump seal",
+              "rawMediaPayload": "base64-photo",
+              "localPath": "/private/mobile/photo.jpg",
+              "faceEmbedding": "biometric-vector",
+              "safeStatus": "queued"
+            }
+            """);
+
+        Assert.Contains("queued", redacted);
+        Assert.Contains("[redacted]", redacted);
+        Assert.DoesNotContain("replace pump seal", redacted);
+        Assert.DoesNotContain("base64-photo", redacted);
+        Assert.DoesNotContain("/private/mobile/photo.jpg", redacted);
+        Assert.DoesNotContain("biometric-vector", redacted);
+    }
+
+    [Fact]
     public void RedactSensitiveText_RedactsBearerAndTokenPairs()
     {
         var redacted = DiagnosticRedactor.RedactSensitiveText(

--- a/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionAttachmentServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionAttachmentServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.FieldCollection.Services.Ai;
 using Honua.Mobile.FieldCollection.Services.Storage;
 using Honua.Mobile.FieldCollection.Services.Sync;
 using Honua.Sdk.Abstractions.Features;
@@ -89,6 +90,48 @@ public sealed class FieldCollectionAttachmentServiceTests
             Assert.Equal(FieldLocationSourceKind.ExternalGnss, attachment.CaptureLocation?.SourceKind);
             Assert.Equal("Trimble R12", attachment.CaptureLocation?.Receiver?.Name);
             Assert.Equal(21.3069, attachment.CaptureLocation?.Latitude);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateAttachmentAiStateAsync_PersistsMediaRedactionState()
+    {
+        var databasePath = CreateDatabasePath();
+        var attachmentRoot = CreateAttachmentRoot();
+        await using var cleanup = new FileCleanup(databasePath, attachmentRoot);
+
+        string attachmentId;
+        using (var storage = new GeoPackageStorageService(databasePath))
+        {
+            var service = new AttachmentService(storage, attachmentRoot);
+            await using var content = new MemoryStream(Encoding.UTF8.GetBytes("photo"));
+            var attachment = await service.SaveAttachmentAsync(
+                1,
+                "asset-1",
+                content,
+                "asset.jpg",
+                "image/jpeg",
+                AttachmentPayloadKind.Photo);
+            attachmentId = attachment.Id;
+
+            await service.UpdateAttachmentAiStateAsync(attachment.Id, new MobileAiMediaState
+            {
+                RedactionStatus = MobileAiMediaProcessingStatus.Queued,
+                EnrichmentStatus = MobileAiMediaProcessingStatus.Completed,
+                RequiresFaceBlur = true,
+                ProviderId = "mock"
+            });
+        }
+
+        using (var restartedStorage = new GeoPackageStorageService(databasePath))
+        {
+            var restartedService = new AttachmentService(restartedStorage, attachmentRoot);
+            var attachment = Assert.Single(await restartedService.GetAttachmentsAsync("asset-1"));
+
+            Assert.Equal(attachmentId, attachment.Id);
+            Assert.True(attachment.AiMediaState?.RequiresFaceBlur);
+            Assert.Equal(MobileAiMediaProcessingStatus.Queued, attachment.AiMediaState?.RedactionStatus);
+            Assert.Contains("AI redaction Queued", attachment.StatusSummary);
         }
     }
 

--- a/tests/Honua.Mobile.FieldCollection.Tests/MobileAiCaptureServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/MobileAiCaptureServiceTests.cs
@@ -1,0 +1,275 @@
+using System.Text.Json;
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.FieldCollection.Services.Ai;
+using Honua.Sdk.Field.Forms;
+
+namespace Honua.Mobile.FieldCollection.Tests;
+
+public sealed class MobileAiCaptureServiceTests
+{
+    [Fact]
+    public async Task RequestFieldSuggestionsAsync_WhenProviderUnavailable_QueuesSanitizedIntent()
+    {
+        var settings = new InMemorySettingsService();
+        var queue = new SettingsMobileAiCaptureQueue(settings);
+        var service = new MobileAiCaptureCoordinator(new RecordingAiProvider { Available = false }, queue);
+
+        var result = await service.RequestFieldSuggestionsAsync(new MobileAiCaptureRequest
+        {
+            Policy = new MobileAiCapturePolicy { IsEnabled = true },
+            LayerId = 4,
+            FeatureId = "asset-1",
+            FormId = "inspection",
+            VoiceTranscript = "replace pump seal",
+            CurrentValues = new Dictionary<string, object?>
+            {
+                ["apiKey"] = "secret-value",
+                ["notes"] = "visible to provider only"
+            },
+            Fields =
+            [
+                new MobileAiFormFieldDescriptor
+                {
+                    TargetKey = "condition",
+                    FieldId = "condition",
+                    Label = "Condition",
+                    FieldType = FormFieldType.Text,
+                    IsRequired = true
+                }
+            ],
+            Attachments =
+            [
+                new MobileAiAttachmentDescriptor
+                {
+                    AttachmentId = "photo-1",
+                    FileName = "asset.jpg",
+                    ContentType = "image/jpeg",
+                    PayloadKind = AttachmentPayloadKind.Photo,
+                    LocalPath = "/private/mobile/photo.jpg"
+                }
+            ],
+            Capabilities = new HashSet<MobileAiCaptureCapability>
+            {
+                MobileAiCaptureCapability.VoiceToFields,
+                MobileAiCaptureCapability.PhotoToFields
+            }
+        });
+
+        Assert.Equal(MobileAiCaptureStatus.Queued, result.Status);
+        var item = Assert.Single(await queue.GetPendingAsync());
+        Assert.Equal(["condition"], item.TargetKeys);
+        Assert.Equal(["photo-1"], item.AttachmentIds);
+
+        var queuedJson = JsonSerializer.Serialize(item);
+        Assert.DoesNotContain("replace pump seal", queuedJson);
+        Assert.DoesNotContain("secret-value", queuedJson);
+        Assert.DoesNotContain("/private/mobile/photo.jpg", queuedJson);
+    }
+
+    [Fact]
+    public async Task RequestFieldSuggestionsAsync_WithProvider_ReturnsSuggestions()
+    {
+        var provider = new RecordingAiProvider
+        {
+            Available = true,
+            FieldResult = new MobileAiCaptureResult
+            {
+                Status = MobileAiCaptureStatus.Completed,
+                Suggestions =
+                [
+                    new MobileAiFieldSuggestion
+                    {
+                        TargetKey = "condition",
+                        SuggestedValue = "needs repair",
+                        Confidence = 0.84,
+                        Reason = "photo"
+                    }
+                ]
+            }
+        };
+        var service = new MobileAiCaptureCoordinator(provider, new SettingsMobileAiCaptureQueue(new InMemorySettingsService()));
+
+        var result = await service.RequestFieldSuggestionsAsync(new MobileAiCaptureRequest
+        {
+            Policy = new MobileAiCapturePolicy { IsEnabled = true },
+            Fields =
+            [
+                new MobileAiFormFieldDescriptor
+                {
+                    TargetKey = "condition",
+                    FieldId = "condition",
+                    Label = "Condition",
+                    FieldType = FormFieldType.Text,
+                    IsRequired = false
+                }
+            ]
+        });
+
+        Assert.Equal(MobileAiCaptureStatus.Completed, result.Status);
+        Assert.Equal("needs repair", Assert.Single(result.Suggestions).SuggestedValue);
+        Assert.Single(provider.FieldRequests);
+    }
+
+    [Fact]
+    public async Task RequestMediaEnrichmentAsync_WhenProviderUnavailable_QueuesMediaState()
+    {
+        var settings = new InMemorySettingsService();
+        var queue = new SettingsMobileAiCaptureQueue(settings);
+        var service = new MobileAiCaptureCoordinator(new RecordingAiProvider { Available = false }, queue);
+
+        var state = await service.RequestMediaEnrichmentAsync(new MobileAiMediaRequest
+        {
+            Policy = new MobileAiCapturePolicy { IsEnabled = true },
+            LayerId = 4,
+            FeatureId = "asset-1",
+            Attachment = new MobileAiAttachmentDescriptor
+            {
+                AttachmentId = "photo-1",
+                FileName = "asset.jpg",
+                ContentType = "image/jpeg",
+                PayloadKind = AttachmentPayloadKind.Photo,
+                LocalPath = "/private/mobile/photo.jpg"
+            }
+        });
+
+        Assert.Equal(MobileAiMediaProcessingStatus.Queued, state.RedactionStatus);
+        Assert.Equal(MobileAiMediaProcessingStatus.Queued, state.EnrichmentStatus);
+        var item = Assert.Single(await queue.GetPendingAsync());
+        Assert.Equal(["photo-1"], item.AttachmentIds);
+        Assert.Contains(MobileAiCaptureCapability.MediaRedaction, item.Capabilities);
+    }
+
+    [Fact]
+    public async Task SettingsMobileAiCaptureQueue_RoundTripsThroughJsonSettings()
+    {
+        var queue = new SettingsMobileAiCaptureQueue(new JsonSettingsService());
+
+        await queue.EnqueueAsync(new MobileAiCaptureQueueItem
+        {
+            QueueItemId = "queued-1",
+            LayerId = 4,
+            FeatureId = "asset-1",
+            FormId = "inspection",
+            TargetKeys = ["condition"],
+            AttachmentIds = ["photo-1"],
+            Capabilities =
+            [
+                MobileAiCaptureCapability.VoiceToFields,
+                MobileAiCaptureCapability.MediaRedaction
+            ]
+        });
+
+        var item = Assert.Single(await queue.GetPendingAsync());
+        Assert.Equal("queued-1", item.QueueItemId);
+        Assert.Equal(["condition"], item.TargetKeys);
+        Assert.Equal(["photo-1"], item.AttachmentIds);
+        Assert.Contains(MobileAiCaptureCapability.MediaRedaction, item.Capabilities);
+    }
+
+    [Fact]
+    public void MobileAiMediaState_DoesNotPersistComputedSummary()
+    {
+        var json = JsonSerializer.Serialize(new MobileAiMediaState
+        {
+            RedactionStatus = MobileAiMediaProcessingStatus.Queued,
+            EnrichmentStatus = MobileAiMediaProcessingStatus.Completed,
+            RequiresFaceBlur = true
+        });
+
+        Assert.DoesNotContain("Summary", json);
+    }
+
+    private sealed class RecordingAiProvider : IMobileAiCaptureProvider
+    {
+        public bool Available { get; init; }
+        public bool IsAvailable => Available;
+        public MobileAiCaptureResult FieldResult { get; init; } =
+            new() { Status = MobileAiCaptureStatus.Completed };
+        public MobileAiMediaState MediaState { get; init; } =
+            new()
+            {
+                RedactionStatus = MobileAiMediaProcessingStatus.Completed,
+                EnrichmentStatus = MobileAiMediaProcessingStatus.Completed
+            };
+        public List<MobileAiCaptureRequest> FieldRequests { get; } = [];
+        public List<MobileAiMediaRequest> MediaRequests { get; } = [];
+
+        public ValueTask<MobileAiCaptureResult> RequestFieldSuggestionsAsync(
+            MobileAiCaptureRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            FieldRequests.Add(request);
+            return ValueTask.FromResult(FieldResult);
+        }
+
+        public ValueTask<MobileAiMediaState> RequestMediaEnrichmentAsync(
+            MobileAiMediaRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            MediaRequests.Add(request);
+            return ValueTask.FromResult(MediaState);
+        }
+    }
+
+    private sealed class JsonSettingsService : ISettingsService
+    {
+        private readonly Dictionary<string, string> _values = new(StringComparer.Ordinal);
+
+        public Task<T> GetSettingAsync<T>(string key, T defaultValue = default!)
+        {
+            if (!_values.TryGetValue(key, out var value))
+            {
+                return Task.FromResult(defaultValue);
+            }
+
+            return Task.FromResult(JsonSerializer.Deserialize<T>(value) ?? defaultValue);
+        }
+
+        public Task SetSettingAsync<T>(string key, T value)
+        {
+            _values[key] = JsonSerializer.Serialize(value);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveSettingAsync(string key)
+        {
+            _values.Remove(key);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> HasSettingAsync(string key)
+        {
+            return Task.FromResult(_values.ContainsKey(key));
+        }
+    }
+
+    private sealed class InMemorySettingsService : ISettingsService
+    {
+        private readonly Dictionary<string, object?> _values = new(StringComparer.Ordinal);
+
+        public Task<T> GetSettingAsync<T>(string key, T defaultValue = default!)
+        {
+            return Task.FromResult(_values.TryGetValue(key, out var value) && value is T typed
+                ? typed
+                : defaultValue);
+        }
+
+        public Task SetSettingAsync<T>(string key, T value)
+        {
+            _values[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveSettingAsync(string key)
+        {
+            _values.Remove(key);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> HasSettingAsync(string key)
+        {
+            return Task.FromResult(_values.ContainsKey(key));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #224.

Adds mobile-owned AI-assisted capture hooks for the field collection workflow without introducing portable AI/provider contracts into the mobile repo. The change includes:

- `IMobileAiCaptureService` / provider / settings-backed queue adapter points for field suggestions and media enrichment.
- Opt-in record edit UX to request, apply, or reject AI field suggestions.
- Photo attachment AI media state persisted in GeoPackage storage and shown alongside sync status before upload.
- Diagnostics redaction for AI capture payload names, local media paths, biometric fields, and face embeddings.
- Guide docs for host/provider integration boundaries.

## Platform Impact

- Android: CI builds the field collection app and runs the API 33 platform smoke path; local Android build was blocked by the missing Android SDK on this machine.
- Windows: CI builds the reference app and field collection app.
- iOS: CI validates MAUI components; app build steps are skipped by the current workflow conditions.

## Offline / Sync Impact

AI provider-unavailable work is queued as sanitized intent only: layer id, feature id, target field keys, attachment ids, requested capabilities, and timestamps. Raw media, transcripts, field payloads, local paths, and secrets are not stored in the queue. Attachment AI media state is stored in the local GeoPackage so redaction/enrichment status is visible before sync, and media marked for face blur flows into SDK attachment metadata.

## Validation

- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore --verbosity minimal` - 103 passed
- `dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --no-restore --verbosity minimal` - 90 passed
- `dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --no-restore --verbosity minimal` - 26 passed
- `dotnet format Honua.Mobile.sln --verify-no-changes --no-restore --verbosity minimal` - passed with existing `Honua.Mobile.PlatformSmoke` reference-load warnings
- `git diff --cached --check` - passed
- `dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj -f net10.0-android --no-restore --verbosity minimal` - blocked locally by missing Android SDK (`XA5300`)
- GitHub CI for #245 - passed, including build/format, test suite, live integration, Android build + API 33 smoke, Windows build, iOS MAUI smoke, quality gates, security scan, and gRPC validation