### PR TITLE
mobile: harden plugin host runtime

### DIFF
--- a/docs/guides/plugin-client-extension-hosts.md
+++ b/docs/guides/plugin-client-extension-hosts.md
@@ -1,6 +1,6 @@
 # Plugin Client Extension Hosts
 
-Issue [#16](https://github.com/honua-io/honua-mobile/issues/16) is scoped to
+Issue [#226](https://github.com/honua-io/honua-mobile/issues/226) is scoped to
 client host/runtime extension points for mobile and web. Portable plugin
 contracts remain outside this repo.
 
@@ -29,6 +29,8 @@ registration.
   extensions, and native feature renderer adapters.
 - `HonuaPluginManifest` adapters that preflight SDK-owned manifest validation
   and mobile host compatibility before plugin activation.
+- `IHonuaMapPluginTrustService` and `IHonuaMapPluginPermissionService` adapter
+  points for host trust checks and permission prompts.
 - `AddHonuaMapPluginHost` and `AddHonuaMapPlugin<TPlugin>` DI helpers in a
   separate plugin-host registration extension file.
 
@@ -105,17 +107,26 @@ public sealed class TenantInspectionMapPlugin : IHonuaMapPlugin
 throws while activating, or registers duplicate contributions, is reported in
 `HonuaMapPluginActivationReport.Failures`. Contributions from that failed
 plugin are not merged into the host snapshot, so other plugins can continue to
-load.
+load. Failure messages in activation reports are redacted with the mobile
+exception redactor before they are exposed to diagnostics.
 
 This is runtime failure isolation, not a process sandbox. Code signing,
-enterprise trust, permission enforcement, and package provenance require the SDK
-and server work linked above.
+enterprise trust, and package provenance still require the SDK and server work
+linked above. The mobile host can fail closed today when its trust service marks
+a plugin untrusted or revoked. SDK-owned manifest permissions are passed to the
+mobile permission service before activation; required permissions block loading
+when not granted, while optional permissions are omitted from the plugin
+context.
 
 `HonuaMapPluginDescriptor.SdkManifest` is optional for purely host-local
 extensions, but plugin packages that publish portable manifests should attach
 the SDK `HonuaPluginManifest` or call `ToMapPluginDescriptor`. The MAUI host
 then uses SDK validation and rejects manifests that do not include the `mobile`
 host kind before plugin code is activated.
+
+Runtime unload is represented by dropping a plugin contribution snapshot or by
+reactivating with `HonuaMapPluginActivationOptions.DisabledPluginIds`. Hosts
+that mount toolbar buttons or panels should re-render from the new snapshot.
 
 ### Mobile Adapter Checklist
 
@@ -142,11 +153,18 @@ Web hosts should expose browser/runtime extension points only:
 - Failure events that identify which extension failed without tearing down the
   host component.
 
+`@honua-io/embed` registration options now support runtime trust state,
+required permission gates, and granted permission checks for browser host
+extensions. These are not durable plugin manifests; they are host-side loading
+guards. Command click failures are emitted through
+`honua-embed-extension-error` with a redacted message and do not remove the
+control or break the map/scene element.
+
 Web host plugins should consume SDK-owned TypeScript or generated contract
-packages when they need shared manifests, permissions, validation, feature
-queries, routing, scenes, or data transforms. Until a shared TypeScript package
-is published, `@honua-io/embed` should keep extension metadata runtime-only and
-avoid adding local manifest or permission schemas.
+packages when they need shared manifests, validation, feature queries, routing,
+scenes, or data transforms. Until a shared TypeScript package is published,
+`@honua-io/embed` should keep extension metadata runtime-only and avoid adding
+local manifest schemas.
 
 ## Intentionally Not Implemented Here
 

--- a/src/Honua.Embed/src/extensions.ts
+++ b/src/Honua.Embed/src/extensions.ts
@@ -9,12 +9,14 @@ export interface HonuaEmbedConfigByTarget {
 }
 
 export type HonuaEmbedExtensionCleanup = () => void;
+export type HonuaEmbedExtensionTrustState = 'approved' | 'untrusted' | 'revoked';
 
 export interface HonuaEmbedExtensionContext<TTarget extends HonuaEmbedTarget = HonuaEmbedTarget> {
   readonly target: TTarget;
   readonly element: HTMLElement;
   readonly shadowRoot: ShadowRoot;
   readonly config: HonuaEmbedConfigByTarget[TTarget];
+  hasPermission(permission: string): boolean;
   addControl(options: HonuaEmbedControlOptions<TTarget>): HonuaEmbedContribution;
   setCssVariable(name: string, value: string | null): void;
   dispatch(type: string, detail?: unknown, init?: Omit<CustomEventInit, 'detail'>): boolean;
@@ -48,16 +50,31 @@ export interface HonuaEmbedExtensionRegistration {
   unregister(): void;
 }
 
+export interface HonuaEmbedExtensionPermission {
+  permission: string;
+  required?: boolean;
+  reason?: string;
+}
+
+export interface HonuaEmbedExtensionRegistrationOptions {
+  trustState?: HonuaEmbedExtensionTrustState;
+  permissions?: readonly HonuaEmbedExtensionPermission[];
+  grantedPermissions?: readonly string[];
+}
+
 export interface HonuaEmbedExtensionDescriptor {
   readonly id: string;
   readonly target: readonly HonuaEmbedTarget[];
   readonly priority: number;
+  readonly trustState: HonuaEmbedExtensionTrustState;
+  readonly permissions: readonly string[];
 }
 
 export interface HonuaEmbedExtensionErrorDetail {
   extensionId: string;
   target: HonuaEmbedTarget;
-  lifecycle: 'activate' | 'configChanged' | 'deactivate';
+  lifecycle: 'activate' | 'configChanged' | 'command' | 'deactivate';
+  message: string;
   error: unknown;
 }
 
@@ -70,16 +87,29 @@ interface HonuaEmbedExtensionHostOptions<TTarget extends HonuaEmbedTarget> {
 
 interface ActiveExtension {
   extension: HonuaEmbedExtension;
+  policy: HonuaEmbedExtensionRegistrationPolicy;
   cleanup?: HonuaEmbedExtensionCleanup;
   contributions: HonuaEmbedContribution[];
 }
 
+interface HonuaEmbedExtensionRegistrationPolicy {
+  trustState: HonuaEmbedExtensionTrustState;
+  permissions: readonly HonuaEmbedExtensionPermission[];
+  grantedPermissions: ReadonlySet<string>;
+}
+
+interface RegisteredExtension {
+  extension: HonuaEmbedExtension;
+  policy: HonuaEmbedExtensionRegistrationPolicy;
+}
+
 const DEFAULT_CONTROLS_SELECTOR = '[data-honua-extension-controls]';
-const extensions = new Map<string, HonuaEmbedExtension>();
+const extensions = new Map<string, RegisteredExtension>();
 const hosts = new Set<HonuaEmbedExtensionHost<HonuaEmbedTarget>>();
 
 export function registerHonuaEmbedExtension<TTarget extends HonuaEmbedTarget>(
   extension: HonuaEmbedExtension<TTarget>,
+  options?: HonuaEmbedExtensionRegistrationOptions,
 ): HonuaEmbedExtensionRegistration {
   const id = extension.id.trim();
   if (!id) {
@@ -90,10 +120,11 @@ export function registerHonuaEmbedExtension<TTarget extends HonuaEmbedTarget>(
     throw new Error(`A Honua embed extension is already registered with id "${id}".`);
   }
 
+  const policy = normalizeRegistrationPolicy(id, options);
   const normalized = { ...extension, id } as HonuaEmbedExtension;
-  extensions.set(id, normalized);
+  extensions.set(id, { extension: normalized, policy });
   for (const host of hosts) {
-    host.activate(normalized);
+    host.activate(normalized, policy);
   }
 
   let registered = true;
@@ -114,12 +145,14 @@ export function registerHonuaEmbedExtension<TTarget extends HonuaEmbedTarget>(
 }
 
 export function listHonuaEmbedExtensions(target?: HonuaEmbedTarget): HonuaEmbedExtensionDescriptor[] {
-  return sortedExtensions()
-    .filter((extension) => !target || extensionTargets(extension).includes(target))
-    .map((extension) => ({
-      id: extension.id,
-      target: extensionTargets(extension),
-      priority: extension.priority ?? 0,
+  return sortedExtensionEntries()
+    .filter((entry) => !target || extensionTargets(entry.extension).includes(target))
+    .map((entry) => ({
+      id: entry.extension.id,
+      target: extensionTargets(entry.extension),
+      priority: entry.extension.priority ?? 0,
+      trustState: entry.policy.trustState,
+      permissions: entry.policy.permissions.map((permission) => permission.permission),
     }));
 }
 
@@ -145,8 +178,8 @@ export class HonuaEmbedExtensionHost<TTarget extends HonuaEmbedTarget> {
 
     this.#connected = true;
     hosts.add(this as HonuaEmbedExtensionHost<HonuaEmbedTarget>);
-    for (const extension of sortedExtensions()) {
-      this.activate(extension);
+    for (const entry of sortedExtensionEntries()) {
+      this.activate(entry.extension, entry.policy);
     }
   }
 
@@ -177,12 +210,15 @@ export class HonuaEmbedExtensionHost<TTarget extends HonuaEmbedTarget> {
     }
   }
 
-  activate(extension: HonuaEmbedExtension): void {
+  activate(
+    extension: HonuaEmbedExtension,
+    policy: HonuaEmbedExtensionRegistrationPolicy = createDefaultRegistrationPolicy(),
+  ): void {
     if (!this.#connected || this.#active.has(extension.id) || !extensionTargets(extension).includes(this.#target)) {
       return;
     }
 
-    const active: ActiveExtension = { extension, contributions: [] };
+    const active: ActiveExtension = { extension, policy, contributions: [] };
     this.#active.set(extension.id, active);
 
     try {
@@ -229,6 +265,10 @@ export class HonuaEmbedExtensionHost<TTarget extends HonuaEmbedTarget> {
       },
       get config() {
         return thisHost.#getConfig();
+      },
+      hasPermission(permission) {
+        const active = thisHost.#active.get(extensionId);
+        return active?.policy.grantedPermissions.has(permission.trim()) ?? false;
       },
       addControl(options) {
         return thisHost.#addControl(extensionId, options);
@@ -279,7 +319,11 @@ export class HonuaEmbedExtensionHost<TTarget extends HonuaEmbedTarget> {
     }
 
     button.addEventListener('click', (event) => {
-      options.onClick?.(event, this.#context(extensionId));
+      try {
+        options.onClick?.(event, this.#context(extensionId));
+      } catch (error) {
+        this.#emitError(extensionId, 'command', error);
+      }
     });
 
     outlet.append(button);
@@ -337,6 +381,7 @@ export class HonuaEmbedExtensionHost<TTarget extends HonuaEmbedTarget> {
         extensionId,
         target: this.#target,
         lifecycle,
+        message: redactExtensionError(error),
         error,
       },
     }));
@@ -349,10 +394,10 @@ export function createHonuaEmbedExtensionHost<TTarget extends HonuaEmbedTarget>(
   return new HonuaEmbedExtensionHost(options);
 }
 
-function sortedExtensions(): HonuaEmbedExtension[] {
+function sortedExtensionEntries(): RegisteredExtension[] {
   return [...extensions.values()].sort((left, right) => {
-    const priority = (left.priority ?? 0) - (right.priority ?? 0);
-    return priority === 0 ? left.id.localeCompare(right.id) : priority;
+    const priority = (left.extension.priority ?? 0) - (right.extension.priority ?? 0);
+    return priority === 0 ? left.extension.id.localeCompare(right.extension.id) : priority;
   });
 }
 
@@ -373,4 +418,48 @@ function setOutletActive(outlet: HTMLElement): void {
   if (parent?.classList.contains('controls')) {
     parent.dataset.honuaExtensionActive = active;
   }
+}
+
+function createDefaultRegistrationPolicy(): HonuaEmbedExtensionRegistrationPolicy {
+  return {
+    trustState: 'approved',
+    permissions: [],
+    grantedPermissions: new Set(),
+  };
+}
+
+function normalizeRegistrationPolicy(
+  extensionId: string,
+  options?: HonuaEmbedExtensionRegistrationOptions,
+): HonuaEmbedExtensionRegistrationPolicy {
+  const trustState = options?.trustState ?? 'approved';
+  if (trustState !== 'approved') {
+    throw new Error(`Honua embed extension "${extensionId}" is not approved to load: ${trustState}.`);
+  }
+
+  const permissions = options?.permissions ?? [];
+  const grantedPermissions = new Set((options?.grantedPermissions ?? [])
+    .map((permission) => permission.trim())
+    .filter(Boolean));
+  const missingRequired = permissions.find((permission) =>
+    permission.required !== false && !grantedPermissions.has(permission.permission.trim()));
+  if (missingRequired) {
+    throw new Error(
+      `Honua embed extension "${extensionId}" requires permission "${missingRequired.permission}" before registration.`,
+    );
+  }
+
+  return {
+    trustState,
+    permissions,
+    grantedPermissions,
+  };
+}
+
+function redactExtensionError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message
+    .replace(/\b(authorization)\s*[:=]\s*(?:bearer|basic)?\s*[A-Za-z0-9._~+/=-]+/gi, '$1=[redacted]')
+    .replace(/\b(access[_-]?token|refresh[_-]?token|token|x[_-]?api[_-]?key|api[_-]?key|apikey|access[_-]?key|accesskey|password|passwd|secret|client[_-]?secret|credential)\b\s*[:=]\s*["']?[^"'&\s,;]+["']?/gi, '$1=[redacted]')
+    .slice(0, 1000);
 }

--- a/src/Honua.Embed/src/index.ts
+++ b/src/Honua.Embed/src/index.ts
@@ -14,7 +14,10 @@ export type {
   HonuaEmbedExtensionContext,
   HonuaEmbedExtensionDescriptor,
   HonuaEmbedExtensionErrorDetail,
+  HonuaEmbedExtensionPermission,
   HonuaEmbedExtensionRegistration,
+  HonuaEmbedExtensionRegistrationOptions,
+  HonuaEmbedExtensionTrustState,
   HonuaEmbedTarget,
 } from './extensions';
 export {

--- a/src/Honua.Embed/tests/honua-extensions.test.ts
+++ b/src/Honua.Embed/tests/honua-extensions.test.ts
@@ -104,7 +104,7 @@ describe('honua embed extensions', () => {
     expect(map.shadowRoot!.querySelector('[data-honua-extension-control="reset"]')).toBeNull();
     expect(scene.shadowRoot!.querySelector('[data-honua-extension-control="reset"]')).not.toBeNull();
     expect(listHonuaEmbedExtensions('scene')).toMatchObject([
-      { id: 'scene-reset', target: ['scene'], priority: 0 },
+      { id: 'scene-reset', target: ['scene'], priority: 0, trustState: 'approved' },
     ]);
   });
 
@@ -144,5 +144,84 @@ describe('honua embed extensions', () => {
       lifecycle: 'activate',
       error,
     });
+    expect(listener.mock.calls[0][0].detail.message).toBe('failed to activate');
+  });
+
+  it('fails closed when an extension is untrusted', () => {
+    expect(() => registerHonuaEmbedExtension({
+      id: 'untrusted-extension',
+      activate: vi.fn(),
+    }, {
+      trustState: 'untrusted',
+    })).toThrow(/not approved/);
+  });
+
+  it('requires granted permissions before registering required browser hooks', () => {
+    expect(() => registerHonuaEmbedExtension({
+      id: 'camera-extension',
+      activate: vi.fn(),
+    }, {
+      permissions: [{ permission: 'camera.capture', required: true }],
+    })).toThrow(/requires permission/);
+
+    const registration = registerHonuaEmbedExtension({
+      id: 'approved-camera-extension',
+      activate(context) {
+        context.addControl({
+          id: 'camera',
+          label: context.hasPermission('camera.capture') ? 'Camera' : 'Denied',
+        });
+      },
+    }, {
+      permissions: [{ permission: 'camera.capture', required: true }],
+      grantedPermissions: ['camera.capture'],
+    });
+    registrations.push(registration);
+
+    const element = document.createElement('honua-map');
+    document.body.append(element);
+
+    expect(element.shadowRoot!.querySelector('[data-honua-extension-control="camera"]')).not.toBeNull();
+    expect(listHonuaEmbedExtensions()).toMatchObject([
+      {
+        id: 'approved-camera-extension',
+        permissions: ['camera.capture'],
+        trustState: 'approved',
+      },
+    ]);
+  });
+
+  it('isolates command failures and redacts sensitive error messages', () => {
+    const registration = registerHonuaEmbedExtension({
+      id: 'command-failure-extension',
+      target: 'map',
+      activate(context) {
+        context.addControl({
+          id: 'explode',
+          label: 'Explode',
+          onClick() {
+            throw new Error('token=secret-value');
+          },
+        });
+      },
+    });
+    registrations.push(registration);
+
+    const element = document.createElement('honua-map');
+    const listener = vi.fn();
+    element.addEventListener('honua-embed-extension-error', listener);
+    document.body.append(element);
+
+    const button = element.shadowRoot!.querySelector<HTMLButtonElement>('[data-honua-extension-control="explode"]')!;
+    button.click();
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].detail).toMatchObject({
+      extensionId: 'command-failure-extension',
+      lifecycle: 'command',
+      message: 'token=[redacted]',
+    });
+    expect(listener.mock.calls[0][0].detail.message).not.toContain('secret-value');
+    expect(button.isConnected).toBe(true);
   });
 });

--- a/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginContracts.cs
+++ b/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginContracts.cs
@@ -65,11 +65,106 @@ public interface IHonuaMapPluginContext
 
     HonuaMapPluginDescriptor Plugin { get; }
 
+    IReadOnlyList<HonuaPluginPermissionDeclaration> GrantedPermissions { get; }
+
+    bool HasPermission(string permission, string access);
+
     void AddToolbarButton(HonuaMapPluginToolbarButton button);
 
     void AddUiExtension(HonuaMapPluginUiExtension extension);
 
     void AddFeatureRenderer(HonuaMapPluginFeatureRenderer renderer);
+}
+
+public enum HonuaMapPluginTrustState
+{
+    Approved,
+    Untrusted,
+    Revoked,
+}
+
+public sealed record HonuaMapPluginTrustEvaluation
+{
+    public HonuaMapPluginTrustState State { get; init; } = HonuaMapPluginTrustState.Approved;
+
+    public string? Reason { get; init; }
+
+    public bool CanLoad => State == HonuaMapPluginTrustState.Approved;
+
+    public static HonuaMapPluginTrustEvaluation Approved()
+        => new() { State = HonuaMapPluginTrustState.Approved };
+
+    public static HonuaMapPluginTrustEvaluation Untrusted(string? reason = null)
+        => new() { State = HonuaMapPluginTrustState.Untrusted, Reason = reason };
+
+    public static HonuaMapPluginTrustEvaluation Revoked(string? reason = null)
+        => new() { State = HonuaMapPluginTrustState.Revoked, Reason = reason };
+}
+
+public interface IHonuaMapPluginTrustService
+{
+    ValueTask<HonuaMapPluginTrustEvaluation> EvaluateTrustAsync(
+        HonuaMapPluginDescriptor plugin,
+        CancellationToken ct = default);
+}
+
+public sealed class LocalHonuaMapPluginTrustService : IHonuaMapPluginTrustService
+{
+    public ValueTask<HonuaMapPluginTrustEvaluation> EvaluateTrustAsync(
+        HonuaMapPluginDescriptor plugin,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(plugin);
+        ct.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(HonuaMapPluginTrustEvaluation.Approved());
+    }
+}
+
+public sealed record HonuaMapPluginPermissionRequest
+{
+    public required HonuaMapPluginDescriptor Plugin { get; init; }
+
+    public required HonuaPluginPermissionDeclaration Permission { get; init; }
+}
+
+public sealed record HonuaMapPluginPermissionDecision
+{
+    public bool Granted { get; init; }
+
+    public string? Reason { get; init; }
+
+    public static HonuaMapPluginPermissionDecision Grant()
+        => new() { Granted = true };
+
+    public static HonuaMapPluginPermissionDecision Deny(string? reason = null)
+        => new() { Granted = false, Reason = reason };
+}
+
+public interface IHonuaMapPluginPermissionService
+{
+    ValueTask<HonuaMapPluginPermissionDecision> RequestPermissionAsync(
+        HonuaMapPluginPermissionRequest request,
+        CancellationToken ct = default);
+}
+
+public sealed class DenyByDefaultHonuaMapPluginPermissionService : IHonuaMapPluginPermissionService
+{
+    public ValueTask<HonuaMapPluginPermissionDecision> RequestPermissionAsync(
+        HonuaMapPluginPermissionRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ct.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(HonuaMapPluginPermissionDecision.Deny(
+            "No mobile plugin permission service approved this request."));
+    }
+}
+
+public sealed record HonuaMapPluginActivationOptions
+{
+    public IReadOnlyList<string> DisabledPluginIds { get; init; } = [];
 }
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginContributionRegistry.cs
+++ b/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginContributionRegistry.cs
@@ -21,6 +21,24 @@ public sealed record HonuaMapPluginContributionSnapshot
 
     public IReadOnlyList<HonuaMapPluginContribution<HonuaMapPluginFeatureRenderer>> FeatureRenderers { get; init; } =
         [];
+
+    public HonuaMapPluginContributionSnapshot WithoutPlugin(string pluginId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pluginId);
+
+        return new HonuaMapPluginContributionSnapshot
+        {
+            ToolbarButtons = ToolbarButtons
+                .Where(item => !string.Equals(item.PluginId, pluginId, StringComparison.Ordinal))
+                .ToArray(),
+            UiExtensions = UiExtensions
+                .Where(item => !string.Equals(item.PluginId, pluginId, StringComparison.Ordinal))
+                .ToArray(),
+            FeatureRenderers = FeatureRenderers
+                .Where(item => !string.Equals(item.PluginId, pluginId, StringComparison.Ordinal))
+                .ToArray(),
+        };
+    }
 }
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginHost.cs
+++ b/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginHost.cs
@@ -1,3 +1,5 @@
+using Honua.Mobile.Maui.Diagnostics;
+using Honua.Sdk.Abstractions.Plugins;
 using Microsoft.Extensions.Logging;
 
 namespace Honua.Mobile.Maui.Plugins;
@@ -22,6 +24,19 @@ public sealed record HonuaMapPluginActivationReport
     public HonuaMapPluginContributionSnapshot Contributions { get; init; } = new();
 
     public bool HasFailures => Failures.Count > 0;
+
+    public HonuaMapPluginActivationReport WithoutPlugin(string pluginId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pluginId);
+
+        return this with
+        {
+            ActivatedPlugins = ActivatedPlugins
+                .Where(plugin => !string.Equals(plugin.Id, pluginId, StringComparison.Ordinal))
+                .ToArray(),
+            Contributions = Contributions.WithoutPlugin(pluginId),
+        };
+    }
 }
 
 /// <summary>
@@ -29,29 +44,63 @@ public sealed record HonuaMapPluginActivationReport
 /// </summary>
 public sealed class HonuaMapPluginHost
 {
+    private static readonly MobileExceptionReportingOptions FailureRedactionOptions = new()
+    {
+        MaxMessageLength = 500,
+    };
+
     private readonly IReadOnlyList<IHonuaMapPlugin> _plugins;
     private readonly IServiceProvider _services;
+    private readonly IHonuaMapPluginTrustService _trustService;
+    private readonly IHonuaMapPluginPermissionService _permissionService;
     private readonly ILogger<HonuaMapPluginHost>? _logger;
 
     public HonuaMapPluginHost(
         IEnumerable<IHonuaMapPlugin> plugins,
         IServiceProvider services,
         ILogger<HonuaMapPluginHost>? logger = null)
+        : this(
+            plugins,
+            services,
+            new LocalHonuaMapPluginTrustService(),
+            new DenyByDefaultHonuaMapPluginPermissionService(),
+            logger)
+    {
+    }
+
+    public HonuaMapPluginHost(
+        IEnumerable<IHonuaMapPlugin> plugins,
+        IServiceProvider services,
+        IHonuaMapPluginTrustService trustService,
+        IHonuaMapPluginPermissionService permissionService,
+        ILogger<HonuaMapPluginHost>? logger = null)
     {
         ArgumentNullException.ThrowIfNull(plugins);
 
         _plugins = plugins.ToArray();
         _services = services ?? throw new ArgumentNullException(nameof(services));
+        _trustService = trustService ?? throw new ArgumentNullException(nameof(trustService));
+        _permissionService = permissionService ?? throw new ArgumentNullException(nameof(permissionService));
         _logger = logger;
     }
 
     public async ValueTask<HonuaMapPluginActivationReport> ActivateAsync(CancellationToken ct = default)
+        => await ActivateAsync(new HonuaMapPluginActivationOptions(), ct).ConfigureAwait(false);
+
+    public async ValueTask<HonuaMapPluginActivationReport> ActivateAsync(
+        HonuaMapPluginActivationOptions? options,
+        CancellationToken ct = default)
     {
+        options ??= new HonuaMapPluginActivationOptions();
         var activated = new List<HonuaMapPluginDescriptor>();
         var failures = new List<HonuaMapPluginActivationFailure>();
         var contributions = new HonuaMapPluginContributionRegistry();
-        var candidates = new List<(HonuaMapPluginDescriptor Descriptor, IHonuaMapPlugin Plugin)>();
+        var candidates = new List<(
+            HonuaMapPluginDescriptor Descriptor,
+            IHonuaMapPlugin Plugin,
+            IReadOnlyList<HonuaPluginPermissionDeclaration> GrantedPermissions)>();
         var pluginIds = new HashSet<string>(StringComparer.Ordinal);
+        var disabledPluginIds = options.DisabledPluginIds.ToHashSet(StringComparer.Ordinal);
 
         foreach (var plugin in _plugins)
         {
@@ -61,8 +110,7 @@ public sealed class HonuaMapPluginHost
             {
                 var ex = new InvalidOperationException("Map plugin registration resolved to null.");
                 const string pluginId = "<null>";
-                _logger?.LogError(ex, "Map plugin {PluginId} failed during activation.", pluginId);
-                failures.Add(new HonuaMapPluginActivationFailure(pluginId, ex.Message, ex));
+                AddFailure(failures, pluginId, ex);
                 continue;
             }
 
@@ -71,7 +119,29 @@ public sealed class HonuaMapPluginHost
                 var descriptor = plugin.Descriptor;
                 ArgumentNullException.ThrowIfNull(descriptor);
                 descriptor.Validate();
-                candidates.Add((descriptor, plugin));
+
+                if (disabledPluginIds.Contains(descriptor.Id))
+                {
+                    continue;
+                }
+
+                IReadOnlyList<HonuaPluginPermissionDeclaration> grantedPermissions;
+                try
+                {
+                    await EnsureTrustedAsync(descriptor, ct).ConfigureAwait(false);
+                    grantedPermissions = await RequestRequiredPermissionsAsync(descriptor, ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    AddFailure(failures, descriptor.Id, ex);
+                    continue;
+                }
+
+                candidates.Add((descriptor, plugin, grantedPermissions));
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
@@ -80,12 +150,11 @@ public sealed class HonuaMapPluginHost
             catch (Exception ex)
             {
                 var pluginId = plugin.GetType().FullName ?? plugin.GetType().Name;
-                _logger?.LogError(ex, "Map plugin {PluginId} failed during activation.", pluginId);
-                failures.Add(new HonuaMapPluginActivationFailure(pluginId, ex.Message, ex));
+                AddFailure(failures, pluginId, ex);
             }
         }
 
-        foreach (var (descriptor, plugin) in candidates.OrderBy(item => item.Descriptor.Priority))
+        foreach (var (descriptor, plugin, grantedPermissions) in candidates.OrderBy(item => item.Descriptor.Priority))
         {
             ct.ThrowIfCancellationRequested();
 
@@ -98,7 +167,11 @@ public sealed class HonuaMapPluginHost
                 }
 
                 var pluginContributions = new HonuaMapPluginContributionRegistry();
-                var context = new HonuaMapPluginContext(_services, descriptor, pluginContributions);
+                var context = new HonuaMapPluginContext(
+                    _services,
+                    descriptor,
+                    grantedPermissions,
+                    pluginContributions);
                 await plugin.ActivateAsync(context, ct).ConfigureAwait(false);
 
                 contributions.Merge(pluginContributions);
@@ -110,8 +183,7 @@ public sealed class HonuaMapPluginHost
             }
             catch (Exception ex)
             {
-                _logger?.LogError(ex, "Map plugin {PluginId} failed during activation.", descriptor.Id);
-                failures.Add(new HonuaMapPluginActivationFailure(descriptor.Id, ex.Message, ex));
+                AddFailure(failures, descriptor.Id, ex);
             }
         }
 
@@ -123,6 +195,88 @@ public sealed class HonuaMapPluginHost
         };
     }
 
+    private async ValueTask EnsureTrustedAsync(
+        HonuaMapPluginDescriptor descriptor,
+        CancellationToken ct)
+    {
+        var trust = await _trustService.EvaluateTrustAsync(descriptor, ct).ConfigureAwait(false);
+        if (!trust.CanLoad)
+        {
+            var reason = string.IsNullOrWhiteSpace(trust.Reason)
+                ? "plugin trust state is not approved"
+                : trust.Reason;
+            throw new InvalidOperationException(
+                $"Map plugin '{descriptor.Id}' cannot load because its trust state is {trust.State}: {reason}");
+        }
+    }
+
+    private async ValueTask<IReadOnlyList<HonuaPluginPermissionDeclaration>> RequestRequiredPermissionsAsync(
+        HonuaMapPluginDescriptor descriptor,
+        CancellationToken ct)
+    {
+        var requested = descriptor.SdkManifest?.Permissions ?? [];
+        if (requested.Count == 0)
+        {
+            return [];
+        }
+
+        var granted = new List<HonuaPluginPermissionDeclaration>();
+        foreach (var permission in requested)
+        {
+            ct.ThrowIfCancellationRequested();
+            var decision = await _permissionService.RequestPermissionAsync(
+                new HonuaMapPluginPermissionRequest
+                {
+                    Plugin = descriptor,
+                    Permission = permission,
+                },
+                ct).ConfigureAwait(false);
+
+            if (decision.Granted)
+            {
+                granted.Add(permission);
+                continue;
+            }
+
+            if (permission.Required)
+            {
+                var reason = string.IsNullOrWhiteSpace(decision.Reason)
+                    ? "permission was denied"
+                    : decision.Reason;
+                throw new InvalidOperationException(
+                    $"Map plugin '{descriptor.Id}' required permission '{FormatPermission(permission)}' was denied: {reason}");
+            }
+        }
+
+        return granted.ToArray();
+    }
+
+    private static string FormatPermission(HonuaPluginPermissionDeclaration permission)
+        => string.IsNullOrWhiteSpace(permission.Access)
+            ? permission.Permission ?? string.Empty
+            : $"{permission.Permission}:{permission.Access}";
+
+    private void AddFailure(
+        ICollection<HonuaMapPluginActivationFailure> failures,
+        string pluginId,
+        Exception exception)
+    {
+        var safePluginId = MobileExceptionRedactor.RedactText(
+            pluginId,
+            FailureRedactionOptions,
+            FailureRedactionOptions.MaxMessageLength) ?? "<unknown>";
+        var safeMessage = MobileExceptionRedactor.RedactText(
+            exception.Message,
+            FailureRedactionOptions,
+            FailureRedactionOptions.MaxMessageLength) ?? "Map plugin activation failed.";
+
+        _logger?.LogError(
+            "Map plugin {PluginId} failed during activation: {Message}",
+            safePluginId,
+            safeMessage);
+        failures.Add(new HonuaMapPluginActivationFailure(safePluginId, safeMessage, exception));
+    }
+
     private sealed class HonuaMapPluginContext : IHonuaMapPluginContext
     {
         private readonly HonuaMapPluginContributionRegistry _registry;
@@ -130,16 +284,30 @@ public sealed class HonuaMapPluginHost
         public HonuaMapPluginContext(
             IServiceProvider services,
             HonuaMapPluginDescriptor plugin,
+            IReadOnlyList<HonuaPluginPermissionDeclaration> grantedPermissions,
             HonuaMapPluginContributionRegistry registry)
         {
             Services = services ?? throw new ArgumentNullException(nameof(services));
             Plugin = plugin ?? throw new ArgumentNullException(nameof(plugin));
+            GrantedPermissions = grantedPermissions ?? throw new ArgumentNullException(nameof(grantedPermissions));
             _registry = registry ?? throw new ArgumentNullException(nameof(registry));
         }
 
         public IServiceProvider Services { get; }
 
         public HonuaMapPluginDescriptor Plugin { get; }
+
+        public IReadOnlyList<HonuaPluginPermissionDeclaration> GrantedPermissions { get; }
+
+        public bool HasPermission(string permission, string access)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(permission);
+            ArgumentException.ThrowIfNullOrWhiteSpace(access);
+
+            return GrantedPermissions.Any(grant =>
+                string.Equals(grant.Permission, permission, StringComparison.Ordinal) &&
+                string.Equals(grant.Access, access, StringComparison.Ordinal));
+        }
 
         public void AddToolbarButton(HonuaMapPluginToolbarButton button)
             => _registry.AddToolbarButton(Plugin.Id, button);

--- a/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginServiceCollectionExtensions.cs
@@ -14,9 +14,13 @@ public static class HonuaMapPluginServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
+        services.TryAddSingleton<IHonuaMapPluginTrustService, LocalHonuaMapPluginTrustService>();
+        services.TryAddSingleton<IHonuaMapPluginPermissionService, DenyByDefaultHonuaMapPluginPermissionService>();
         services.TryAddSingleton(sp => new HonuaMapPluginHost(
             sp.GetServices<IHonuaMapPlugin>(),
             sp,
+            sp.GetRequiredService<IHonuaMapPluginTrustService>(),
+            sp.GetRequiredService<IHonuaMapPluginPermissionService>(),
             sp.GetService<ILogger<HonuaMapPluginHost>>()));
         return services;
     }

--- a/tests/Honua.Mobile.Maui.Tests/HonuaMapPluginHostTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaMapPluginHostTests.cs
@@ -105,6 +105,41 @@ public sealed class HonuaMapPluginHostTests
     }
 
     [Fact]
+    public async Task ActivateAsync_SkipsDisabledPluginsForRuntimeUnload()
+    {
+        using var provider = new ServiceCollection()
+            .AddHonuaMapPlugin(new RecordingMapPlugin("first", priority: 1))
+            .AddHonuaMapPlugin(new RecordingMapPlugin("second", priority: 2))
+            .BuildServiceProvider();
+
+        var host = provider.GetRequiredService<HonuaMapPluginHost>();
+        var report = await host.ActivateAsync(new HonuaMapPluginActivationOptions
+        {
+            DisabledPluginIds = ["first"],
+        });
+
+        Assert.Equal("second", Assert.Single(report.ActivatedPlugins).Id);
+        Assert.Equal("second-action", Assert.Single(report.Contributions.ToolbarButtons).Contribution.Id);
+    }
+
+    [Fact]
+    public async Task ActivationReport_WithoutPlugin_RemovesContributionsWithoutRestart()
+    {
+        using var provider = new ServiceCollection()
+            .AddHonuaMapPlugin(new RecordingMapPlugin("first", priority: 1))
+            .AddHonuaMapPlugin(new RecordingMapPlugin("second", priority: 2))
+            .BuildServiceProvider();
+
+        var report = await provider.GetRequiredService<HonuaMapPluginHost>().ActivateAsync();
+        var unloaded = report.WithoutPlugin("first");
+
+        Assert.Equal("second", Assert.Single(unloaded.ActivatedPlugins).Id);
+        Assert.DoesNotContain(unloaded.Contributions.ToolbarButtons, item => item.PluginId == "first");
+        Assert.DoesNotContain(unloaded.Contributions.UiExtensions, item => item.PluginId == "first");
+        Assert.DoesNotContain(unloaded.Contributions.FeatureRenderers, item => item.PluginId == "first");
+    }
+
+    [Fact]
     public async Task AddHonuaMapPlugin_RegistersPluginTypeAndHost()
     {
         using var provider = new ServiceCollection()
@@ -152,6 +187,71 @@ public sealed class HonuaMapPluginHostTests
         Assert.Equal(typeof(ManifestBackedMapPlugin).FullName, failure.PluginId);
         Assert.Contains("mobile", failure.Message, StringComparison.Ordinal);
         Assert.Equal("healthy", Assert.Single(report.ActivatedPlugins).Id);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_BlocksUntrustedPluginBeforeActivation()
+    {
+        var trustService = new RecordingTrustService(
+            HonuaMapPluginTrustEvaluation.Untrusted("publisher not approved"));
+        using var provider = new ServiceCollection()
+            .AddSingleton<IHonuaMapPluginTrustService>(trustService)
+            .AddHonuaMapPlugin(new RecordingMapPlugin("blocked"))
+            .BuildServiceProvider();
+
+        var report = await provider.GetRequiredService<HonuaMapPluginHost>().ActivateAsync();
+
+        var failure = Assert.Single(report.Failures);
+        Assert.Equal("blocked", failure.PluginId);
+        Assert.Contains("trust state is Untrusted", failure.Message, StringComparison.Ordinal);
+        Assert.Empty(report.ActivatedPlugins);
+        Assert.Equal(["blocked"], trustService.EvaluatedPluginIds);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_BlocksRequiredPermissionWhenHostDeniesAndRedactsReason()
+    {
+        using var provider = new ServiceCollection()
+            .AddSingleton<IHonuaMapPluginPermissionService>(new RecordingPermissionService(
+                HonuaMapPluginPermissionDecision.Deny("apiKey=secret-value")))
+            .AddHonuaMapPlugin(new PermissionAwareMapPlugin(
+                CreateSdkManifest(
+                    "camera-plugin",
+                    "Camera Plugin",
+                    [HonuaPluginHostKinds.Mobile],
+                    CreatePermission("device.camera", HonuaPluginPermissionAccess.Read, required: true))))
+            .BuildServiceProvider();
+
+        var report = await provider.GetRequiredService<HonuaMapPluginHost>().ActivateAsync();
+
+        var failure = Assert.Single(report.Failures);
+        Assert.Equal("camera-plugin", failure.PluginId);
+        Assert.Contains("device.camera", failure.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret-value", failure.Message, StringComparison.Ordinal);
+        Assert.Contains("[redacted]", failure.Message, StringComparison.Ordinal);
+        Assert.Empty(report.ActivatedPlugins);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_ProvidesGrantedPermissionsToPluginContext()
+    {
+        var permission = CreatePermission("device.camera", HonuaPluginPermissionAccess.Read, required: true);
+        using var provider = new ServiceCollection()
+            .AddSingleton<IHonuaMapPluginPermissionService>(new RecordingPermissionService(
+                HonuaMapPluginPermissionDecision.Grant()))
+            .AddHonuaMapPlugin(new PermissionAwareMapPlugin(
+                CreateSdkManifest(
+                    "camera-plugin",
+                    "Camera Plugin",
+                    [HonuaPluginHostKinds.Mobile],
+                    permission)))
+            .BuildServiceProvider();
+
+        var report = await provider.GetRequiredService<HonuaMapPluginHost>().ActivateAsync();
+
+        Assert.False(report.HasFailures);
+        Assert.Equal("camera-plugin", Assert.Single(report.ActivatedPlugins).Id);
+        Assert.Equal("camera-plugin-action", Assert.Single(report.Contributions.ToolbarButtons).Contribution.Id);
     }
 
     [Fact]
@@ -291,6 +391,64 @@ public sealed class HonuaMapPluginHostTests
         }
     }
 
+    private sealed class PermissionAwareMapPlugin : IHonuaMapPlugin
+    {
+        public PermissionAwareMapPlugin(HonuaPluginManifest manifest)
+        {
+            Descriptor = manifest.ToMapPluginDescriptor();
+        }
+
+        public HonuaMapPluginDescriptor Descriptor { get; }
+
+        public ValueTask ActivateAsync(IHonuaMapPluginContext context, CancellationToken ct = default)
+        {
+            if (!context.HasPermission("device.camera", HonuaPluginPermissionAccess.Read))
+            {
+                throw new InvalidOperationException("Camera permission was not granted.");
+            }
+
+            context.AddToolbarButton(CreateToolbarButton($"{context.Plugin.Id}-action"));
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingTrustService : IHonuaMapPluginTrustService
+    {
+        private readonly HonuaMapPluginTrustEvaluation _evaluation;
+
+        public RecordingTrustService(HonuaMapPluginTrustEvaluation evaluation)
+        {
+            _evaluation = evaluation;
+        }
+
+        public List<string> EvaluatedPluginIds { get; } = [];
+
+        public ValueTask<HonuaMapPluginTrustEvaluation> EvaluateTrustAsync(
+            HonuaMapPluginDescriptor plugin,
+            CancellationToken ct = default)
+        {
+            EvaluatedPluginIds.Add(plugin.Id);
+            return ValueTask.FromResult(_evaluation);
+        }
+    }
+
+    private sealed class RecordingPermissionService : IHonuaMapPluginPermissionService
+    {
+        private readonly HonuaMapPluginPermissionDecision _decision;
+
+        public RecordingPermissionService(HonuaMapPluginPermissionDecision decision)
+        {
+            _decision = decision;
+        }
+
+        public ValueTask<HonuaMapPluginPermissionDecision> RequestPermissionAsync(
+            HonuaMapPluginPermissionRequest request,
+            CancellationToken ct = default)
+        {
+            return ValueTask.FromResult(_decision);
+        }
+    }
+
     private sealed class RecordingRenderer;
 
     private static HonuaMapPluginToolbarButton CreateToolbarButton(string id)
@@ -304,7 +462,8 @@ public sealed class HonuaMapPluginHostTests
     private static HonuaPluginManifest CreateSdkManifest(
         string pluginId,
         string displayName,
-        IReadOnlyList<string> hosts)
+        IReadOnlyList<string> hosts,
+        params HonuaPluginPermissionDeclaration[] permissions)
         => new()
         {
             SchemaVersion = HonuaPluginManifest.CurrentSchemaVersion,
@@ -316,6 +475,7 @@ public sealed class HonuaMapPluginHostTests
             {
                 SupportedHosts = hosts,
             },
+            Permissions = permissions,
             Extensions =
             [
                 new HonuaPluginExtensionPoint
@@ -327,5 +487,17 @@ public sealed class HonuaMapPluginHostTests
                     Order = 0,
                 },
             ],
+        };
+
+    private static HonuaPluginPermissionDeclaration CreatePermission(
+        string permission,
+        string access,
+        bool required)
+        => new()
+        {
+            Permission = permission,
+            Access = access,
+            Required = required,
+            Reason = "Needed for plugin tests.",
         };
 }


### PR DESCRIPTION
## Summary

Closes #226.

Hardens the mobile and web plugin host runtime without adding durable plugin manifests or SDK/server-owned contracts to this repo.

- Adds MAUI plugin trust and permission gate adapter points, with default local trust and deny-by-default required permissions.
- Adds runtime unload/reload support through disabled plugin activation options and filtered contribution snapshots.
- Redacts mobile plugin activation failure messages before they are exposed in activation reports/log messages.
- Adds `@honua-io/embed` registration policy options for trust and required permissions, permission-aware extension contexts, and command-click failure isolation.
- Updates plugin host docs to describe the mobile/web boundaries and runtime hardening behavior.

## Platform / Host Impact

- Mobile/MAUI: host runtime behavior changes only for plugins with SDK manifest permissions or a custom trust service. Existing code-registered plugins without requested permissions still load through the default local trust service.
- Web embed: registration options are additive. Existing extensions still register as approved with no required permissions.
- SDK/server contracts remain external; mobile consumes SDK `HonuaPluginManifest` and permission declarations when provided.

## Validation

- `dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --no-restore --verbosity minimal` - 95 passed
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore --verbosity minimal` - 103 passed
- `dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --no-restore --verbosity minimal` - 26 passed
- `npm test -- honua-extensions.test.ts` - 8 passed
- `npm run typecheck` - passed
- `npm test` - 184 passed; happy-dom printed a teardown `AbortError` after tests but exited 0
- `dotnet format Honua.Mobile.sln --verify-no-changes --no-restore --verbosity minimal` - passed with existing `Honua.Mobile.PlatformSmoke` reference-load warnings
- `git diff --cached --check` - passed