### PR TITLE
mobile: add AR field workflow shell

### DIFF
--- a/docs/guides/native-scene-anchoring-requirements.md
+++ b/docs/guides/native-scene-anchoring-requirements.md
@@ -52,6 +52,19 @@ may capture evidence, and `PrecisionInspection` requires survey-quality source
 data, enough confirmed control points, and a calibration residual under the
 configured threshold.
 
+`HonuaNativeArFieldWorkflow` is the first shared MAUI field workflow shell for
+[#225](https://github.com/honua-io/honua-mobile/issues/225). It wraps the
+anchoring controller with field record context, offline package behavior,
+user-visible degraded states, and evidence attachment helpers. The workflow can
+attach AR metadata to mobile photos, annotations, or report metadata under the
+mobile-owned `honua.arEvidence` key while keeping SDK field attachments free of
+host-local paths and AR-specific contracts.
+
+The workflow is not a platform-native AR renderer by itself. Apps still need to
+register an `IHonuaNativeArSceneAnchorAdapter` backed by ARCore or ARKit, plus
+the field UI that renders the user-visible state. Physical-device validation is
+still required before this workstream is treated as GA complete.
+
 ## Target Prototype
 
 | Decision | Requirement |
@@ -238,6 +251,16 @@ pass this checklist on physical devices:
   language.
 - Two-device validation covers at least one iOS ARKit target and one Android
   ARCore target before the workflow is promoted beyond prototype.
+
+For the shared field workflow shell, automated tests must cover:
+
+- Field context, scene id, scene revision, package id, and package state are
+  carried into the user-visible workflow state.
+- Offline package failures produce blocked/degraded UX text rather than silent
+  fallback.
+- AR evidence metadata can be attached to mobile photos, annotations, and report
+  metadata.
+- SDK field attachment conversion strips mobile-only evidence and local paths.
 
 ## Platform References
 

--- a/src/Honua.Mobile.Field/Capture/MobileFieldMediaAttachment.cs
+++ b/src/Honua.Mobile.Field/Capture/MobileFieldMediaAttachment.cs
@@ -35,6 +35,33 @@ public sealed record MobileFieldMediaAttachment
     public bool RequiresFaceBlur { get; init; }
 
     /// <summary>
+    /// Mobile-owned evidence metadata, such as AR scene anchoring context. This is
+    /// intentionally excluded from SDK attachment conversion until the SDK owns a
+    /// portable evidence contract.
+    /// </summary>
+    public IReadOnlyDictionary<string, object?> EvidenceMetadata { get; init; } =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Returns a copy with merged mobile evidence metadata.
+    /// </summary>
+    /// <param name="metadata">Metadata to merge into the attachment.</param>
+    /// <returns>A copy containing the merged metadata.</returns>
+    public MobileFieldMediaAttachment WithEvidenceMetadata(IReadOnlyDictionary<string, object?> metadata)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
+
+        var merged = new Dictionary<string, object?>(EvidenceMetadata, StringComparer.Ordinal);
+        foreach (var item in metadata)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(item.Key);
+            merged[item.Key] = item.Value;
+        }
+
+        return this with { EvidenceMetadata = merged };
+    }
+
+    /// <summary>
     /// Converts mobile capture metadata to the portable SDK attachment contract.
     /// </summary>
     /// <returns>SDK field media attachment without host-local file-system paths.</returns>

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -464,6 +464,7 @@ public static class HonuaMobileServiceCollectionExtensions
 
         services.AddSingleton(options ?? new HonuaNativeArSessionOptions());
         services.AddSingleton<HonuaNativeArSceneAnchoringController>();
+        services.AddSingleton<HonuaNativeArFieldWorkflow>();
         return services;
     }
 

--- a/src/Honua.Mobile.Maui/SceneAnchoring/HonuaNativeArFieldWorkflow.cs
+++ b/src/Honua.Mobile.Maui/SceneAnchoring/HonuaNativeArFieldWorkflow.cs
@@ -1,0 +1,341 @@
+using System.Globalization;
+using Honua.Mobile.Field.Capture;
+using Honua.Mobile.Maui.Annotations;
+
+namespace Honua.Mobile.Maui.SceneAnchoring;
+
+/// <summary>
+/// User-visible degraded state for a native AR field workflow.
+/// </summary>
+public enum HonuaNativeArFieldWorkflowDegradedMode
+{
+    None,
+    UnsupportedDevice,
+    Blocked,
+    OfflinePackageUnavailable,
+    CoarsePreviewOnly,
+    PrecisionUnavailable,
+}
+
+/// <summary>
+/// Field record context owned by the mobile workflow surface.
+/// </summary>
+public sealed record HonuaNativeArFieldContext
+{
+    public required string WorkflowId { get; init; }
+
+    public string? FormId { get; init; }
+
+    public string? RecordId { get; init; }
+
+    public string? LayerId { get; init; }
+
+    public string? FeatureId { get; init; }
+
+    public string Purpose { get; init; } = "field-ar-scene-review";
+
+    public IReadOnlyDictionary<string, object?> Metadata { get; init; } =
+        new Dictionary<string, object?>();
+
+    public void Validate()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(WorkflowId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(Purpose);
+        ArgumentNullException.ThrowIfNull(Metadata);
+
+        foreach (var key in Metadata.Keys)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        }
+    }
+}
+
+/// <summary>
+/// Request that starts an AR scene workflow for a field record or report.
+/// </summary>
+public sealed record HonuaNativeArFieldWorkflowRequest
+{
+    public required HonuaNativeArSceneAnchorRequest AnchorRequest { get; init; }
+
+    public required HonuaNativeArFieldContext FieldContext { get; init; }
+
+    public bool RequiresPrecisionEvidence { get; init; }
+
+    public void Validate()
+    {
+        ArgumentNullException.ThrowIfNull(AnchorRequest);
+        ArgumentNullException.ThrowIfNull(FieldContext);
+        AnchorRequest.Validate();
+        FieldContext.Validate();
+    }
+}
+
+/// <summary>
+/// Current user-facing state for an AR field workflow.
+/// </summary>
+public sealed record HonuaNativeArFieldWorkflowState
+{
+    public required HonuaNativeArFieldContext FieldContext { get; init; }
+
+    public required HonuaNativeArSceneAnchorRequest AnchorRequest { get; init; }
+
+    public required HonuaNativeArReadiness Readiness { get; init; }
+
+    public HonuaNativeArFieldWorkflowDegradedMode DegradedMode { get; init; }
+
+    public required string UserVisibleStatus { get; init; }
+
+    public required string OfflineBehavior { get; init; }
+
+    public bool CanRenderOverlay => Readiness.CanRenderOverlay;
+
+    public bool CanCaptureFieldEvidence => Readiness.CanCaptureEvidence;
+
+    public bool CanUsePrecisionTools => Readiness.CanUsePrecisionTools;
+}
+
+/// <summary>
+/// Evidence context attached to photos, annotations, or report metadata.
+/// </summary>
+public sealed record HonuaNativeArFieldEvidence
+{
+    public required HonuaNativeArFieldContext FieldContext { get; init; }
+
+    public required HonuaNativeArEvidenceContext ArContext { get; init; }
+
+    public required HonuaNativeArFieldWorkflowState WorkflowState { get; init; }
+
+    public IReadOnlyDictionary<string, object?> ToMetadata()
+    {
+        var metadata = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["kind"] = "honua.native-ar-field-evidence.v1",
+            ["workflowId"] = FieldContext.WorkflowId,
+            ["purpose"] = FieldContext.Purpose,
+            ["formId"] = FieldContext.FormId,
+            ["recordId"] = FieldContext.RecordId,
+            ["layerId"] = FieldContext.LayerId,
+            ["featureId"] = FieldContext.FeatureId,
+            ["sceneId"] = ArContext.SceneId,
+            ["sceneRevision"] = ArContext.SceneRevision,
+            ["packageId"] = ArContext.PackageId,
+            ["isOffline"] = ArContext.IsOffline,
+            ["isOnline"] = ArContext.IsOnline,
+            ["runtime"] = ArContext.Runtime.ToString(),
+            ["deviceModel"] = ArContext.DeviceModel,
+            ["readinessLevel"] = ArContext.ReadinessLevel.ToString(),
+            ["anchoringMode"] = ArContext.ActiveAnchoringMode.ToString(),
+            ["packageState"] = ArContext.PackageState.ToString(),
+            ["horizontalAccuracyMeters"] = ArContext.HorizontalAccuracyMeters,
+            ["verticalAccuracyMeters"] = ArContext.VerticalAccuracyMeters,
+            ["yawAccuracyDegrees"] = ArContext.YawAccuracyDegrees,
+            ["calibrationResidualMeters"] = ArContext.CalibrationResidualMeters,
+            ["confirmedControlPointCount"] = ArContext.ConfirmedControlPointCount,
+            ["controlPointIds"] = ArContext.ControlPointIds.ToArray(),
+            ["blockers"] = ArContext.Blockers.ToArray(),
+            ["warnings"] = ArContext.Warnings.ToArray(),
+            ["canAttachToFieldEvidence"] = ArContext.CanAttachToFieldEvidence,
+            ["canAttachToPrecisionEvidence"] = ArContext.CanAttachToPrecisionEvidence,
+            ["capturedAtUtc"] = ArContext.CapturedAt.ToString("O", CultureInfo.InvariantCulture),
+            ["degradedMode"] = WorkflowState.DegradedMode.ToString(),
+            ["userVisibleStatus"] = WorkflowState.UserVisibleStatus,
+            ["offlineBehavior"] = WorkflowState.OfflineBehavior,
+        };
+
+        foreach (var item in FieldContext.Metadata)
+        {
+            metadata[$"field.{item.Key}"] = item.Value;
+        }
+
+        return metadata;
+    }
+}
+
+/// <summary>
+/// Coordinates the first mobile-owned AR field workflow over scene anchoring,
+/// cached scene package state, and field capture context.
+/// </summary>
+public sealed class HonuaNativeArFieldWorkflow
+{
+    public const string EvidenceMetadataKey = "honua.arEvidence";
+
+    private readonly HonuaNativeArSceneAnchoringController _anchoringController;
+    private HonuaNativeArFieldWorkflowRequest? _activeRequest;
+    private HonuaNativeArFieldWorkflowState? _activeState;
+
+    public HonuaNativeArFieldWorkflow(HonuaNativeArSceneAnchoringController anchoringController)
+    {
+        _anchoringController = anchoringController ?? throw new ArgumentNullException(nameof(anchoringController));
+    }
+
+    public async ValueTask<HonuaNativeArFieldWorkflowState> StartAsync(
+        HonuaNativeArFieldWorkflowRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        request.Validate();
+
+        var readiness = await _anchoringController.StartAsync(request.AnchorRequest, ct).ConfigureAwait(false);
+        var state = CreateState(request, readiness);
+        _activeRequest = request;
+        _activeState = state;
+        return state;
+    }
+
+    public async ValueTask<HonuaNativeArFieldWorkflowState> RefreshAsync(CancellationToken ct = default)
+    {
+        var request = _activeRequest
+            ?? throw new InvalidOperationException("No native AR field workflow is active.");
+
+        var readiness = await _anchoringController.RefreshReadinessAsync(ct).ConfigureAwait(false);
+        var state = CreateState(request, readiness);
+        _activeState = state;
+        return state;
+    }
+
+    public async ValueTask<HonuaNativeArFieldEvidence> CreateEvidenceAsync(CancellationToken ct = default)
+    {
+        var request = _activeRequest
+            ?? throw new InvalidOperationException("No native AR field workflow is active.");
+
+        var state = _activeState
+            ?? throw new InvalidOperationException("No native AR field workflow state is active.");
+
+        var arContext = await _anchoringController.CreateEvidenceContextAsync(ct).ConfigureAwait(false);
+        return new HonuaNativeArFieldEvidence
+        {
+            FieldContext = request.FieldContext,
+            ArContext = arContext,
+            WorkflowState = state,
+        };
+    }
+
+    public MobileFieldMediaAttachment AttachEvidence(
+        MobileFieldMediaAttachment attachment,
+        HonuaNativeArFieldEvidence evidence)
+    {
+        ArgumentNullException.ThrowIfNull(attachment);
+        ArgumentNullException.ThrowIfNull(evidence);
+
+        return attachment.WithEvidenceMetadata(new Dictionary<string, object?>
+        {
+            [EvidenceMetadataKey] = evidence.ToMetadata(),
+        });
+    }
+
+    public HonuaAnnotation AttachEvidence(
+        HonuaAnnotation annotation,
+        HonuaNativeArFieldEvidence evidence)
+    {
+        ArgumentNullException.ThrowIfNull(annotation);
+        ArgumentNullException.ThrowIfNull(evidence);
+
+        var metadata = new Dictionary<string, object?>(annotation.Metadata, StringComparer.Ordinal)
+        {
+            [EvidenceMetadataKey] = evidence.ToMetadata(),
+        };
+
+        return annotation with
+        {
+            Metadata = metadata,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+    }
+
+    public IReadOnlyDictionary<string, object?> CreateReportMetadata(HonuaNativeArFieldEvidence evidence)
+    {
+        ArgumentNullException.ThrowIfNull(evidence);
+        return new Dictionary<string, object?>
+        {
+            [EvidenceMetadataKey] = evidence.ToMetadata(),
+        };
+    }
+
+    private static HonuaNativeArFieldWorkflowState CreateState(
+        HonuaNativeArFieldWorkflowRequest request,
+        HonuaNativeArReadiness readiness)
+    {
+        return new HonuaNativeArFieldWorkflowState
+        {
+            FieldContext = request.FieldContext,
+            AnchorRequest = request.AnchorRequest,
+            Readiness = readiness,
+            DegradedMode = DetermineDegradedMode(request, readiness),
+            UserVisibleStatus = BuildUserVisibleStatus(request, readiness),
+            OfflineBehavior = BuildOfflineBehavior(request.AnchorRequest, readiness),
+        };
+    }
+
+    private static HonuaNativeArFieldWorkflowDegradedMode DetermineDegradedMode(
+        HonuaNativeArFieldWorkflowRequest request,
+        HonuaNativeArReadiness readiness)
+    {
+        if (readiness.Level == HonuaNativeArReadinessLevel.Unsupported)
+        {
+            return HonuaNativeArFieldWorkflowDegradedMode.UnsupportedDevice;
+        }
+
+        if (readiness.Level == HonuaNativeArReadinessLevel.Blocked)
+        {
+            return request.AnchorRequest.IsOffline
+                && readiness.Blockers.Any(blocker => blocker.Contains("Offline scene package", StringComparison.Ordinal))
+                    ? HonuaNativeArFieldWorkflowDegradedMode.OfflinePackageUnavailable
+                    : HonuaNativeArFieldWorkflowDegradedMode.Blocked;
+        }
+
+        if (readiness.Level == HonuaNativeArReadinessLevel.CoarsePreview)
+        {
+            return HonuaNativeArFieldWorkflowDegradedMode.CoarsePreviewOnly;
+        }
+
+        if (request.RequiresPrecisionEvidence
+            && readiness.Level != HonuaNativeArReadinessLevel.PrecisionInspection)
+        {
+            return HonuaNativeArFieldWorkflowDegradedMode.PrecisionUnavailable;
+        }
+
+        return HonuaNativeArFieldWorkflowDegradedMode.None;
+    }
+
+    private static string BuildUserVisibleStatus(
+        HonuaNativeArFieldWorkflowRequest request,
+        HonuaNativeArReadiness readiness)
+    {
+        return readiness.Level switch
+        {
+            HonuaNativeArReadinessLevel.Unsupported =>
+                "AR is unavailable on this device. Continue with the 2D field workflow.",
+            HonuaNativeArReadinessLevel.Blocked =>
+                $"AR overlay is blocked: {FirstReason(readiness.Blockers)}",
+            HonuaNativeArReadinessLevel.CoarsePreview =>
+                "Coarse AR preview is available. Evidence capture and precision tools are disabled.",
+            HonuaNativeArReadinessLevel.SiteReview when request.RequiresPrecisionEvidence =>
+                "Site review is available. Precision evidence is disabled until survey-quality calibration is complete.",
+            HonuaNativeArReadinessLevel.SiteReview =>
+                "Site review is available. Captures will include AR scene, accuracy, and package metadata.",
+            HonuaNativeArReadinessLevel.PrecisionInspection =>
+                "Precision inspection is available. Captures will include calibration residual and control-point evidence.",
+            _ => "AR workflow state is unknown.",
+        };
+    }
+
+    private static string BuildOfflineBehavior(
+        HonuaNativeArSceneAnchorRequest request,
+        HonuaNativeArReadiness readiness)
+    {
+        if (!request.IsOffline)
+        {
+            return "Online scene metadata is active; evidence records online runtime state.";
+        }
+
+        if (readiness.Blockers.Any(blocker => blocker.Contains("Offline scene package", StringComparison.Ordinal)))
+        {
+            return "Offline scene package is not valid for AR rendering; use the 2D field workflow or refresh the package.";
+        }
+
+        return $"Using validated offline scene package '{request.PackageId}' for cached scene assets.";
+    }
+
+    private static string FirstReason(IReadOnlyList<string> reasons)
+        => reasons.Count == 0 ? "unknown reason" : reasons[0];
+}

--- a/tests/Honua.Mobile.Field.Tests/FormValidatorTests.cs
+++ b/tests/Honua.Mobile.Field.Tests/FormValidatorTests.cs
@@ -369,6 +369,29 @@ public sealed class FormValidatorTests
         Assert.True(sdkAttachment.RequiresFaceBlur);
     }
 
+    [Fact]
+    public void MobileMediaAttachment_WithEvidenceMetadata_MergesMobileOnlyEvidence()
+    {
+        var mobileAttachment = new MobileFieldMediaAttachment
+        {
+            AttachmentId = "a-local",
+            FieldId = "photos",
+            LocalPath = Path.Combine("offline", "captures", "asset.jpg"),
+            MediaType = FieldMediaType.Photo,
+            EvidenceMetadata = new Dictionary<string, object?> { ["existing"] = "kept" },
+        };
+
+        var updated = mobileAttachment.WithEvidenceMetadata(new Dictionary<string, object?>
+        {
+            ["honua.arEvidence"] = new Dictionary<string, object?> { ["sceneId"] = "downtown-honolulu" },
+        });
+        var sdkAttachment = updated.ToSdkAttachment();
+
+        Assert.Equal("kept", updated.EvidenceMetadata["existing"]);
+        Assert.True(updated.EvidenceMetadata.ContainsKey("honua.arEvidence"));
+        Assert.Equal("asset.jpg", sdkAttachment.FileName);
+    }
+
     private static MobileFieldCaptureWorkflow CreateWorkflow()
         => new(new DuplicateDetector());
 }

--- a/tests/Honua.Mobile.Maui.Tests/HonuaNativeSceneAnchoringTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/HonuaNativeSceneAnchoringTests.cs
@@ -1,5 +1,8 @@
 using Honua.Mobile.Maui;
+using Honua.Mobile.Field.Capture;
+using Honua.Mobile.Maui.Annotations;
 using Honua.Mobile.Maui.SceneAnchoring;
+using Honua.Sdk.Field.Records;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Honua.Mobile.Maui.Tests;
@@ -315,6 +318,141 @@ public sealed class HonuaNativeSceneAnchoringTests
     }
 
     [Fact]
+    public async Task FieldWorkflow_StartAsync_WhenOfflinePackageValid_MapsFieldContextAndOfflineBehavior()
+    {
+        var adapter = new RecordingNativeArSceneAnchorAdapter
+        {
+            StartStatus = CreateStatus(
+                activeAnchoringMode: HonuaNativeArAnchoringMode.PlatformGeospatial,
+                packageState: HonuaNativeArScenePackageState.Valid,
+                packageId: "pkg-2026-05",
+                horizontalAccuracyMeters: 1.2,
+                yawAccuracyDegrees: 8,
+                isOnline: false),
+        };
+        var workflow = new HonuaNativeArFieldWorkflow(new HonuaNativeArSceneAnchoringController(adapter));
+        var request = CreateFieldWorkflowRequest(
+            isOffline: true,
+            packageId: "pkg-2026-05",
+            metadata: new Dictionary<string, object?> { ["inspectionType"] = "utility" });
+
+        var state = await workflow.StartAsync(request);
+
+        Assert.Equal(HonuaNativeArReadinessLevel.SiteReview, state.Readiness.Level);
+        Assert.Equal(HonuaNativeArFieldWorkflowDegradedMode.None, state.DegradedMode);
+        Assert.True(state.CanRenderOverlay);
+        Assert.True(state.CanCaptureFieldEvidence);
+        Assert.False(state.CanUsePrecisionTools);
+        Assert.Equal("record-1", state.FieldContext.RecordId);
+        Assert.Contains("pkg-2026-05", state.OfflineBehavior, StringComparison.Ordinal);
+        Assert.Contains("Captures will include AR scene", state.UserVisibleStatus, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task FieldWorkflow_StartAsync_WhenOfflinePackageExpired_MakesDegradedBehaviorVisible()
+    {
+        var adapter = new RecordingNativeArSceneAnchorAdapter
+        {
+            StartStatus = CreateStatus(
+                activeAnchoringMode: HonuaNativeArAnchoringMode.PlatformGeospatial,
+                packageState: HonuaNativeArScenePackageState.Expired,
+                packageId: "pkg-2026-05",
+                horizontalAccuracyMeters: 1,
+                yawAccuracyDegrees: 6,
+                isOnline: false),
+        };
+        var workflow = new HonuaNativeArFieldWorkflow(new HonuaNativeArSceneAnchoringController(adapter));
+        var request = CreateFieldWorkflowRequest(isOffline: true, packageId: "pkg-2026-05");
+
+        var state = await workflow.StartAsync(request);
+
+        Assert.Equal(HonuaNativeArReadinessLevel.Blocked, state.Readiness.Level);
+        Assert.Equal(HonuaNativeArFieldWorkflowDegradedMode.OfflinePackageUnavailable, state.DegradedMode);
+        Assert.False(state.CanRenderOverlay);
+        Assert.False(state.CanCaptureFieldEvidence);
+        Assert.Contains("Offline scene package", state.UserVisibleStatus, StringComparison.Ordinal);
+        Assert.Contains("2D field workflow", state.OfflineBehavior, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task FieldWorkflow_CreateEvidenceAsync_AttachesArMetadataToMediaAnnotationsAndReports()
+    {
+        var capturedAt = new DateTimeOffset(2026, 5, 8, 9, 15, 0, TimeSpan.Zero);
+        var adapter = new RecordingNativeArSceneAnchorAdapter
+        {
+            StartStatus = CreateStatus(
+                activeAnchoringMode: HonuaNativeArAnchoringMode.ControlPointCalibration,
+                packageState: HonuaNativeArScenePackageState.Valid,
+                packageId: "pkg-2026-05",
+                horizontalAccuracyMeters: 0.4,
+                verticalAccuracyMeters: 0.6,
+                yawAccuracyDegrees: 3,
+                calibrationResidualMeters: 0.2,
+                confirmedControlPointCount: 3,
+                deviceModel: "Pixel 8 Pro",
+                isOnline: false,
+                updatedAt: capturedAt),
+            Status = CreateStatus(
+                activeAnchoringMode: HonuaNativeArAnchoringMode.ControlPointCalibration,
+                packageState: HonuaNativeArScenePackageState.Valid,
+                packageId: "pkg-2026-05",
+                horizontalAccuracyMeters: 0.4,
+                verticalAccuracyMeters: 0.6,
+                yawAccuracyDegrees: 3,
+                calibrationResidualMeters: 0.2,
+                confirmedControlPointCount: 3,
+                deviceModel: "Pixel 8 Pro",
+                isOnline: false,
+                updatedAt: capturedAt),
+        };
+        var workflow = new HonuaNativeArFieldWorkflow(new HonuaNativeArSceneAnchoringController(adapter));
+        var request = CreateFieldWorkflowRequest(
+            isOffline: true,
+            packageId: "pkg-2026-05",
+            requiresVerticalPlacement: true,
+            sourceDeclaresSurveyQuality: true,
+            requiresPrecisionEvidence: true,
+            controlPointIds: ["cp-a", "cp-b", "cp-c"]);
+
+        await workflow.StartAsync(request);
+        var evidence = await workflow.CreateEvidenceAsync();
+
+        var media = new MobileFieldMediaAttachment
+        {
+            AttachmentId = "photo-1",
+            FieldId = "photos",
+            LocalPath = Path.Combine("offline", "captures", "photo-1.jpg"),
+            MediaType = FieldMediaType.Photo,
+            EvidenceMetadata = new Dictionary<string, object?> { ["existing"] = "kept" },
+        };
+        var attachedMedia = workflow.AttachEvidence(media, evidence);
+        var sdkMedia = attachedMedia.ToSdkAttachment();
+        var mediaMetadata = AssertArEvidence(attachedMedia.EvidenceMetadata);
+
+        Assert.Equal("kept", attachedMedia.EvidenceMetadata["existing"]);
+        Assert.Equal("photo-1.jpg", sdkMedia.FileName);
+        Assert.Equal("record-1", mediaMetadata["recordId"]);
+        Assert.Equal("PrecisionInspection", mediaMetadata["readinessLevel"]);
+        Assert.Equal(["cp-a", "cp-b", "cp-c"], Assert.IsType<string[]>(mediaMetadata["controlPointIds"]));
+        Assert.Equal("2026-05-08T09:15:00.0000000+00:00", mediaMetadata["capturedAtUtc"]);
+
+        var annotation = new HonuaAnnotationLayer().DrawPoint(
+            new HonuaMapCoordinate(21.3069, -157.8583),
+            id: "note-1",
+            metadata: new Dictionary<string, object?> { ["source"] = "field-note" });
+        var attachedAnnotation = workflow.AttachEvidence(annotation, evidence);
+        var annotationMetadata = AssertArEvidence(attachedAnnotation.Metadata);
+
+        Assert.Equal("field-note", attachedAnnotation.Metadata["source"]);
+        Assert.Equal("pkg-2026-05", annotationMetadata["packageId"]);
+
+        var reportMetadata = AssertArEvidence(workflow.CreateReportMetadata(evidence));
+        Assert.Equal("honua.native-ar-field-evidence.v1", reportMetadata["kind"]);
+        Assert.Equal("field-ar-scene-review", reportMetadata["purpose"]);
+        Assert.Equal("utility-inspection", reportMetadata["field.inspectionType"]);
+    }
+
+    [Fact]
     public void AddHonuaNativeSceneAnchoring_RegistersControllerAndOptions()
     {
         var options = new HonuaNativeArSessionOptions
@@ -329,7 +467,43 @@ public sealed class HonuaNativeSceneAnchoringTests
 
         Assert.Same(options, provider.GetRequiredService<HonuaNativeArSessionOptions>());
         Assert.NotNull(provider.GetRequiredService<HonuaNativeArSceneAnchoringController>());
+        Assert.NotNull(provider.GetRequiredService<HonuaNativeArFieldWorkflow>());
     }
+
+    private static IReadOnlyDictionary<string, object?> AssertArEvidence(IReadOnlyDictionary<string, object?> metadata)
+    {
+        Assert.True(metadata.ContainsKey(HonuaNativeArFieldWorkflow.EvidenceMetadataKey));
+        return Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(
+            metadata[HonuaNativeArFieldWorkflow.EvidenceMetadataKey]);
+    }
+
+    private static HonuaNativeArFieldWorkflowRequest CreateFieldWorkflowRequest(
+        bool isOffline = false,
+        string? packageId = null,
+        bool requiresVerticalPlacement = false,
+        bool sourceDeclaresSurveyQuality = false,
+        bool requiresPrecisionEvidence = false,
+        IReadOnlyList<string>? controlPointIds = null,
+        IReadOnlyDictionary<string, object?>? metadata = null)
+        => new()
+        {
+            AnchorRequest = CreateRequest(
+                isOffline,
+                packageId,
+                requiresVerticalPlacement,
+                sourceDeclaresSurveyQuality,
+                controlPointIds),
+            FieldContext = new HonuaNativeArFieldContext
+            {
+                WorkflowId = "workflow-1",
+                FormId = "inspection",
+                RecordId = "record-1",
+                LayerId = "assets",
+                FeatureId = "asset-100",
+                Metadata = metadata ?? new Dictionary<string, object?> { ["inspectionType"] = "utility-inspection" },
+            },
+            RequiresPrecisionEvidence = requiresPrecisionEvidence,
+        };
 
     private static HonuaNativeArSceneAnchorRequest CreateRequest(
         bool isOffline = false,


### PR DESCRIPTION
## Summary

Part of #225.

Adds the shared MAUI field workflow shell for native AR scene anchoring without adding new SDK/server-owned contracts.

- Adds `HonuaNativeArFieldWorkflow` over the existing AR anchoring controller so mobile UI can bind field context, scene/package readiness, user-visible degraded states, and offline behavior.
- Adds mobile-only evidence metadata on `MobileFieldMediaAttachment` and helpers to attach AR evidence to photos, annotations, and report metadata under `honua.arEvidence`.
- Keeps SDK field attachment conversion portable by stripping local paths and AR-specific evidence from `FieldMediaAttachment`.
- Registers the field workflow through `AddHonuaNativeSceneAnchoring(...)` and documents the remaining native adapter / physical-device validation boundary.

## Platform / Host Impact

- Mobile/MAUI: adds shared workflow/adapters only. Apps still need an `IHonuaNativeArSceneAnchorAdapter` backed by ARCore or ARKit before a real camera/AR surface can run.
- Field capture: mobile attachments can carry host-owned evidence metadata; SDK attachment contracts are unchanged.
- Offline: expired/stale/invalid scene packages produce explicit blocked/degraded workflow text instead of silent fallback.

## Remaining #225 Evidence

This PR does not claim GA closure for #225. Physical-device AR validation evidence is still required before closing the issue.

## Validation

- `dotnet restore tests/Honua.Mobile.Field.Tests/Honua.Mobile.Field.Tests.csproj --verbosity minimal`
- `dotnet test tests/Honua.Mobile.Field.Tests/Honua.Mobile.Field.Tests.csproj --no-restore --verbosity minimal` - 12 passed
- `dotnet test tests/Honua.Mobile.Maui.Tests/Honua.Mobile.Maui.Tests.csproj --no-restore --verbosity minimal` - 98 passed
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore --verbosity minimal` - 103 passed
- `dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --no-restore --verbosity minimal` - 26 passed
- `dotnet restore tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj --verbosity minimal`
- `dotnet test tests/Honua.Mobile.Offline.Tests/Honua.Mobile.Offline.Tests.csproj --no-restore --verbosity minimal` - 81 passed
- `dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --no-restore --verbosity minimal` - 86 passed, 1 skipped
- `dotnet test Honua.Mobile.sln --no-restore --verbosity minimal` - non-platform suites passed; local `Honua.Mobile.PlatformSmoke` failed at Android SDK discovery (`XA5300`), matching this environment's missing local Android SDK
- `dotnet format Honua.Mobile.sln --verify-no-changes --no-restore --verbosity minimal` - passed with existing `Honua.Mobile.PlatformSmoke` reference-load warnings
- `git diff --cached --check` - passed