### PR TITLE
sdk: add embed governance adapters

### DIFF
--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -595,10 +595,59 @@ original error.
 
 `<honua-map>` provides the declarative, white-label web component shell, Shadow
 DOM encapsulation, theme hooks, generated snippets, host extension controls,
-accessible controls, iframe fallback packaging, search events, and identify
-events. Production map rendering should use the MapLibre/deck.gl adapter above
-until the custom element owns a full renderer lifecycle. Follow-on work can add
-feature loading, analytics, binary deck.gl attribute batches, admin embed-builder
-screens, and framework-specific wrappers.
+accessible controls, iframe fallback packaging, search events, identify events,
+and host-side governance adapters. Production map rendering should use the
+MapLibre/deck.gl adapter above until the custom element owns a full renderer
+lifecycle. Follow-on work can add feature loading, binary deck.gl attribute
+batches, and server-backed API-key/rate/CORS enforcement.
+
+## Embed Governance
+
+`@honua-io/embed` does not issue API keys, enforce authoritative rate limits, or
+own CORS/domain policy. Those remain server/admin responsibilities. The package
+does provide a thin host-side governance adapter so admin portals can apply
+server-provided policy decisions and record redacted analytics from the existing
+map events.
+
+```ts
+import { bindHonuaMapGovernance } from '@honua-io/embed';
+
+const map = document.querySelector('honua-map')!;
+const binding = bindHonuaMapGovernance(map, {
+  integrationId: 'city-work-orders',
+  origin: window.location.origin,
+  policy: {
+    requiredApiKey: true,
+    allowedOrigins: ['https://portal.example.com'],
+    allowedServiceOrigins: ['https://services.example.com'],
+    allowedLayerIds: ['assets', 'work-orders'],
+    rateLimit: {
+      remaining: 1200,
+      resetAt: '2026-05-23T18:00:00Z',
+    },
+  },
+  sink: async (event) => {
+    await fetch('/internal/embed-analytics', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(event),
+    });
+  },
+});
+
+map.addEventListener('honua-map-policy-denied', (event) => {
+  console.warn(event.detail.decision.reasons);
+});
+
+// Later, for tenant switch or component teardown:
+binding.disconnect();
+```
+
+Governance events include view, configuration-change, search, identify, and
+policy-denied records. They include service URL, service origin, selected layer
+ids, integration id, origin, API-key presence, and optional host metadata, but
+never include the API-key value. Policy evaluation is intentionally local and
+advisory; use it to mirror server decisions in the embed UI, not as the
+authoritative security boundary.
 
 For 3D Tiles and CesiumJS-based scenes, use the [`<honua-scene>` guide](3d-scene-embed.md).

--- a/src/Honua.Embed/README.md
+++ b/src/Honua.Embed/README.md
@@ -661,6 +661,32 @@ const angularIframeComponent = createHonuaSceneAngularIframeSnippet({
 });
 ```
 
+## Embed Governance
+
+```ts
+import { bindHonuaMapGovernance } from '@honua-io/embed';
+
+const binding = bindHonuaMapGovernance(document.querySelector('honua-map')!, {
+  integrationId: 'city-work-orders',
+  origin: window.location.origin,
+  policy: {
+    requiredApiKey: true,
+    allowedOrigins: ['https://portal.example.com'],
+    allowedServiceOrigins: ['https://services.example.com'],
+    allowedLayerIds: ['assets', 'work-orders'],
+  },
+  sink: (event) => {
+    console.log(event.type, event.layerIds, event.apiKeyPresent);
+  },
+});
+```
+
+The governance helper records redacted view, config-change, search, identify,
+and policy-denied analytics from existing map events. It can evaluate
+server-provided API-key/domain/layer/rate-limit policy state on the client, but
+authoritative issuance, CORS, rate limiting, and analytics ingestion remain
+server/admin responsibilities.
+
 ## Host Extensions
 
 ```ts

--- a/src/Honua.Embed/src/governance.ts
+++ b/src/Honua.Embed/src/governance.ts
@@ -1,0 +1,320 @@
+import type {
+  HonuaMapConfig,
+  HonuaMapElement,
+  HonuaMapIdentifyDetail,
+  HonuaMapSearchDetail,
+} from './map';
+
+export type HonuaMapGovernanceEventType =
+  | 'view'
+  | 'config-change'
+  | 'search'
+  | 'identify'
+  | 'policy-denied';
+
+export interface HonuaMapGovernanceEvent {
+  target: 'map';
+  type: HonuaMapGovernanceEventType;
+  occurredAt: string;
+  integrationId: string | null;
+  origin: string | null;
+  serviceUrl: string | null;
+  serviceOrigin: string | null;
+  layerIds: string[];
+  apiKeyPresent: boolean;
+  searchQuery?: string;
+  identifyPoint?: { x: number; y: number };
+  policyDecision?: HonuaMapPolicyDecision;
+  metadata?: Record<string, unknown>;
+}
+
+export interface HonuaMapAnalyticsSink {
+  record(event: HonuaMapGovernanceEvent): void | Promise<void>;
+}
+
+export interface HonuaMapRateLimitState {
+  remaining?: number | null;
+  resetAt?: string | null;
+}
+
+export interface HonuaMapEmbedPolicy {
+  requiredApiKey?: boolean | null;
+  allowedOrigins?: readonly string[] | null;
+  allowedServiceOrigins?: readonly string[] | null;
+  allowedLayerIds?: readonly string[] | null;
+  rateLimit?: HonuaMapRateLimitState | null;
+}
+
+export interface HonuaMapPolicyContext {
+  origin?: string | null;
+}
+
+export interface HonuaMapPolicyDecision {
+  allowed: boolean;
+  reasons: string[];
+  warnings: string[];
+}
+
+export interface HonuaMapGovernanceBindingOptions {
+  sink?: HonuaMapAnalyticsSink | ((event: HonuaMapGovernanceEvent) => void | Promise<void>) | null;
+  policy?: HonuaMapEmbedPolicy | null;
+  integrationId?: string | null;
+  origin?: string | null;
+  metadata?: Record<string, unknown> | null;
+  clock?: () => Date;
+}
+
+export interface HonuaMapGovernanceBinding {
+  evaluate(): HonuaMapPolicyDecision;
+  disconnect(): void;
+}
+
+export interface HonuaMapPolicyDeniedDetail {
+  decision: HonuaMapPolicyDecision;
+  event: HonuaMapGovernanceEvent;
+}
+
+export function bindHonuaMapGovernance(
+  element: HonuaMapElement,
+  options: HonuaMapGovernanceBindingOptions = {},
+): HonuaMapGovernanceBinding {
+  const sink = normalizeSink(options.sink);
+  const clock = options.clock ?? (() => new Date());
+  const context = { origin: normalizeOptionalString(options.origin) ?? currentOrigin() };
+  const metadata = options.metadata ? { ...options.metadata } : undefined;
+
+  const createEvent = (
+    type: HonuaMapGovernanceEventType,
+    detail?: HonuaMapSearchDetail | HonuaMapIdentifyDetail,
+    decision?: HonuaMapPolicyDecision,
+  ): HonuaMapGovernanceEvent => createHonuaMapGovernanceEvent(element.config, type, {
+    occurredAt: clock().toISOString(),
+    integrationId: normalizeOptionalString(options.integrationId),
+    origin: context.origin,
+    metadata,
+    searchQuery: isSearchDetail(detail) ? detail.query : undefined,
+    identifyPoint: isIdentifyDetail(detail) ? { x: detail.x, y: detail.y } : undefined,
+    policyDecision: decision,
+  });
+
+  const evaluate = (): HonuaMapPolicyDecision =>
+    evaluateHonuaMapPolicy(element.config, options.policy, context);
+
+  const recordIfAllowed = (
+    type: HonuaMapGovernanceEventType,
+    detail?: HonuaMapSearchDetail | HonuaMapIdentifyDetail,
+  ): void => {
+    const decision = evaluate();
+    if (!decision.allowed) {
+      const deniedEvent = createEvent('policy-denied', detail, decision);
+      safeRecord(sink, deniedEvent);
+      element.dispatchEvent(new CustomEvent<HonuaMapPolicyDeniedDetail>('honua-map-policy-denied', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          decision,
+          event: deniedEvent,
+        },
+      }));
+      return;
+    }
+
+    safeRecord(sink, createEvent(type, detail, decision));
+  };
+
+  let viewRecorded = false;
+  const ready = (): void => {
+    if (viewRecorded) {
+      return;
+    }
+
+    viewRecorded = true;
+    recordIfAllowed('view');
+  };
+  const configChange = (): void => recordIfAllowed('config-change');
+  const search = (event: Event): void =>
+    recordIfAllowed('search', (event as CustomEvent<HonuaMapSearchDetail>).detail);
+  const identify = (event: Event): void =>
+    recordIfAllowed('identify', (event as CustomEvent<HonuaMapIdentifyDetail>).detail);
+
+  element.addEventListener('honua-map-ready', ready);
+  element.addEventListener('honua-map-config-change', configChange);
+  element.addEventListener('honua-map-search', search);
+  element.addEventListener('honua-map-identify', identify);
+
+  if (element.isConnected) {
+    ready();
+  }
+
+  return {
+    evaluate,
+    disconnect(): void {
+      element.removeEventListener('honua-map-ready', ready);
+      element.removeEventListener('honua-map-config-change', configChange);
+      element.removeEventListener('honua-map-search', search);
+      element.removeEventListener('honua-map-identify', identify);
+    },
+  };
+}
+
+export function createHonuaMapGovernanceEvent(
+  config: HonuaMapConfig,
+  type: HonuaMapGovernanceEventType,
+  options: {
+    occurredAt?: string;
+    integrationId?: string | null;
+    origin?: string | null;
+    searchQuery?: string;
+    identifyPoint?: { x: number; y: number };
+    policyDecision?: HonuaMapPolicyDecision;
+    metadata?: Record<string, unknown>;
+  } = {},
+): HonuaMapGovernanceEvent {
+  return {
+    target: 'map',
+    type,
+    occurredAt: options.occurredAt ?? new Date().toISOString(),
+    integrationId: normalizeOptionalString(options.integrationId),
+    origin: normalizeOptionalString(options.origin),
+    serviceUrl: config.serviceUrl,
+    serviceOrigin: serviceOrigin(config.serviceUrl),
+    layerIds: [...config.layerIds],
+    apiKeyPresent: Boolean(config.apiKey),
+    searchQuery: normalizeOptionalString(options.searchQuery) ?? undefined,
+    identifyPoint: options.identifyPoint,
+    policyDecision: options.policyDecision,
+    metadata: options.metadata,
+  };
+}
+
+export function evaluateHonuaMapPolicy(
+  config: HonuaMapConfig,
+  policy: HonuaMapEmbedPolicy | null | undefined,
+  context: HonuaMapPolicyContext = {},
+): HonuaMapPolicyDecision {
+  const reasons: string[] = [];
+  const warnings: string[] = [];
+
+  if (!policy) {
+    return { allowed: true, reasons, warnings };
+  }
+
+  if (policy.requiredApiKey && !config.apiKey) {
+    reasons.push('API key is required for this embed.');
+  }
+
+  const origin = normalizeOptionalString(context.origin);
+  const allowedOrigins = normalizeSet(policy.allowedOrigins);
+  if (allowedOrigins.size > 0) {
+    if (!origin) {
+      reasons.push('Embed origin is unavailable for policy evaluation.');
+    } else if (!allowedOrigins.has(origin)) {
+      reasons.push('Embed origin is not allowed for this API key.');
+    }
+  }
+
+  const allowedServiceOrigins = normalizeSet(policy.allowedServiceOrigins);
+  const configServiceOrigin = serviceOrigin(config.serviceUrl);
+  if (allowedServiceOrigins.size > 0) {
+    if (!configServiceOrigin) {
+      reasons.push('Service URL origin is unavailable for policy evaluation.');
+    } else if (!allowedServiceOrigins.has(configServiceOrigin)) {
+      reasons.push('Service URL origin is not allowed for this API key.');
+    }
+  }
+
+  const allowedLayerIds = normalizeSet(policy.allowedLayerIds);
+  if (allowedLayerIds.size > 0) {
+    const deniedLayers = config.layerIds.filter((layerId) => !allowedLayerIds.has(layerId));
+    if (deniedLayers.length > 0) {
+      reasons.push(`Layer ids are not allowed for this API key: ${deniedLayers.join(', ')}`);
+    }
+  }
+
+  const remaining = policy.rateLimit?.remaining;
+  if (remaining !== undefined && remaining !== null) {
+    if (!Number.isFinite(remaining)) {
+      warnings.push('Rate limit remaining value is not finite.');
+    } else if (remaining <= 0) {
+      reasons.push(policy.rateLimit?.resetAt
+        ? `API key rate limit is exhausted until ${policy.rateLimit.resetAt}.`
+        : 'API key rate limit is exhausted.');
+    }
+  }
+
+  return {
+    allowed: reasons.length === 0,
+    reasons,
+    warnings,
+  };
+}
+
+function normalizeSink(
+  sink: HonuaMapGovernanceBindingOptions['sink'],
+): ((event: HonuaMapGovernanceEvent) => void | Promise<void>) | null {
+  if (!sink) {
+    return null;
+  }
+
+  if (typeof sink === 'function') {
+    return sink;
+  }
+
+  return (event) => sink.record(event);
+}
+
+function safeRecord(
+  sink: ((event: HonuaMapGovernanceEvent) => void | Promise<void>) | null,
+  event: HonuaMapGovernanceEvent,
+): void {
+  if (!sink) {
+    return;
+  }
+
+  try {
+    void Promise.resolve(sink(event)).catch(() => {
+      // Analytics sinks are host-owned and must not break embed interactions.
+    });
+  } catch {
+    // Analytics sinks are host-owned and must not break embed interactions.
+  }
+}
+
+function serviceOrigin(serviceUrl: string | null): string | null {
+  if (!serviceUrl) {
+    return null;
+  }
+
+  try {
+    return new URL(serviceUrl).origin;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeSet(values: readonly string[] | null | undefined): Set<string> {
+  return new Set((values ?? [])
+    .map((value) => value.trim())
+    .filter(Boolean));
+}
+
+function normalizeOptionalString(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function currentOrigin(): string | null {
+  return globalThis.location?.origin ?? null;
+}
+
+function isSearchDetail(
+  detail: HonuaMapSearchDetail | HonuaMapIdentifyDetail | undefined,
+): detail is HonuaMapSearchDetail {
+  return Boolean(detail && 'query' in detail);
+}
+
+function isIdentifyDetail(
+  detail: HonuaMapSearchDetail | HonuaMapIdentifyDetail | undefined,
+): detail is HonuaMapIdentifyDetail {
+  return Boolean(detail && 'x' in detail && 'y' in detail);
+}

--- a/src/Honua.Embed/src/index.ts
+++ b/src/Honua.Embed/src/index.ts
@@ -5,6 +5,7 @@ export * from './scene-package-cache';
 export * from './display-adapter';
 export * from './builder';
 export * from './builder-element';
+export * from './governance';
 export type {
   HonuaEmbedConfigByTarget,
   HonuaEmbedContribution,

--- a/src/Honua.Embed/tests/honua-governance.test.ts
+++ b/src/Honua.Embed/tests/honua-governance.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  bindHonuaMapGovernance,
+  createHonuaMapGovernanceEvent,
+  defineHonuaMapElement,
+  evaluateHonuaMapPolicy,
+  type HonuaMapConfig,
+  type HonuaMapElement,
+  type HonuaMapGovernanceEvent,
+} from '../src/index';
+
+describe('honua map governance', () => {
+  beforeEach(() => {
+    defineHonuaMapElement();
+    document.body.replaceChildren();
+  });
+
+  it('records redacted view and interaction analytics from map events', () => {
+    const events: HonuaMapGovernanceEvent[] = [];
+    const element = createConfiguredMap();
+    const binding = bindHonuaMapGovernance(element, {
+      sink: (event) => events.push(event),
+      integrationId: 'portal-embed',
+      origin: 'https://portal.example.test',
+      metadata: { tenantId: 'city' },
+      clock: () => new Date('2026-05-23T17:15:00Z'),
+    });
+
+    document.body.append(element);
+    const input = element.shadowRoot!.querySelector<HTMLInputElement>('input[type="search"]')!;
+    const form = element.shadowRoot!.querySelector<HTMLFormElement>('form')!;
+    input.value = 'hydrants';
+    form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }));
+    element.identifyAt(10, 20);
+    binding.disconnect();
+
+    expect(events.map((event) => event.type)).toEqual(['view', 'search', 'identify']);
+    expect(events[0]).toMatchObject({
+      integrationId: 'portal-embed',
+      origin: 'https://portal.example.test',
+      serviceOrigin: 'https://services.example.test',
+      layerIds: ['assets', 'work-orders'],
+      apiKeyPresent: true,
+      metadata: { tenantId: 'city' },
+      occurredAt: '2026-05-23T17:15:00.000Z',
+    });
+    expect(events[1].searchQuery).toBe('hydrants');
+    expect(events[2].identifyPoint).toEqual({ x: 10, y: 20 });
+    expect(JSON.stringify(events)).not.toContain('secret-browser-key');
+  });
+
+  it('emits policy-denied events when host-provided policy blocks the embed', () => {
+    const events: HonuaMapGovernanceEvent[] = [];
+    const denied = vi.fn();
+    const element = createConfiguredMap({ apiKey: null, layerIds: 'assets,restricted' });
+    element.addEventListener('honua-map-policy-denied', denied);
+
+    bindHonuaMapGovernance(element, {
+      sink: (event) => events.push(event),
+      origin: 'https://portal.example.test',
+      policy: {
+        requiredApiKey: true,
+        allowedOrigins: ['https://portal.example.test'],
+        allowedServiceOrigins: ['https://services.example.test'],
+        allowedLayerIds: ['assets'],
+      },
+    });
+    document.body.append(element);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('policy-denied');
+    expect(events[0].policyDecision?.allowed).toBe(false);
+    expect(events[0].policyDecision?.reasons).toEqual([
+      'API key is required for this embed.',
+      'Layer ids are not allowed for this API key: restricted',
+    ]);
+    expect(denied).toHaveBeenCalledOnce();
+    expect(denied.mock.calls[0][0].detail.decision.allowed).toBe(false);
+  });
+
+  it('records a single view when binding after the element is connected', () => {
+    const events: HonuaMapGovernanceEvent[] = [];
+    const element = createConfiguredMap();
+    document.body.append(element);
+
+    const binding = bindHonuaMapGovernance(element, {
+      sink: (event) => events.push(event),
+    });
+    element.dispatchEvent(new CustomEvent('honua-map-ready', {
+      bubbles: true,
+      composed: true,
+      detail: element.config,
+    }));
+    binding.disconnect();
+
+    expect(events.map((event) => event.type)).toEqual(['view']);
+  });
+
+  it('evaluates origin, service, layer, and rate-limit policy without server DTOs', () => {
+    const config = createConfig();
+
+    const decision = evaluateHonuaMapPolicy(config, {
+      requiredApiKey: true,
+      allowedOrigins: ['https://other.example.test'],
+      allowedServiceOrigins: ['https://services.example.test'],
+      allowedLayerIds: ['assets'],
+      rateLimit: {
+        remaining: 0,
+        resetAt: '2026-05-23T18:00:00Z',
+      },
+    }, {
+      origin: 'https://portal.example.test',
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasons).toEqual([
+      'Embed origin is not allowed for this API key.',
+      'Layer ids are not allowed for this API key: work-orders',
+      'API key rate limit is exhausted until 2026-05-23T18:00:00Z.',
+    ]);
+  });
+
+  it('creates safe analytics snapshots from config without carrying credentials', () => {
+    const event = createHonuaMapGovernanceEvent(createConfig(), 'config-change', {
+      occurredAt: '2026-05-23T17:20:00.000Z',
+      integrationId: 'builder-preview',
+      origin: 'https://portal.example.test',
+    });
+
+    expect(event).toMatchObject({
+      type: 'config-change',
+      integrationId: 'builder-preview',
+      apiKeyPresent: true,
+      serviceUrl: 'https://services.example.test/FeatureServer',
+      serviceOrigin: 'https://services.example.test',
+    });
+    expect(JSON.stringify(event)).not.toContain('secret-browser-key');
+  });
+});
+
+function createConfiguredMap(options: {
+  apiKey?: string | null;
+  layerIds?: string;
+} = {}): HonuaMapElement {
+  const element = document.createElement('honua-map') as HonuaMapElement;
+  element.setAttribute('service-url', 'https://services.example.test/FeatureServer');
+  element.setAttribute('layer-ids', options.layerIds ?? 'assets,work-orders');
+  if (options.apiKey !== null) {
+    element.setAttribute('api-key', options.apiKey ?? 'secret-browser-key');
+  }
+
+  element.setAttribute('search', '');
+  element.setAttribute('identify', '');
+  return element;
+}
+
+function createConfig(): HonuaMapConfig {
+  return {
+    serviceUrl: 'https://services.example.test/FeatureServer',
+    layerIds: ['assets', 'work-orders'],
+    apiKey: 'secret-browser-key',
+    center: null,
+    zoom: 10,
+    bounds: null,
+    basemap: 'streets',
+    interactive: true,
+    search: true,
+    identify: true,
+    attribution: null,
+    theme: 'light',
+    label: 'Embedded map',
+  };
+}


### PR DESCRIPTION
## Summary

Part of #10.

Adds host-side governance helpers for `@honua-io/embed` without adding server-owned API-key, rate-limit, analytics-ingestion, or CORS contracts to this repo.

- Adds `bindHonuaMapGovernance(...)` to record redacted view, config-change, search, identify, and policy-denied events from existing `<honua-map>` events.
- Adds `evaluateHonuaMapPolicy(...)` for host/server-provided API-key, allowed-origin, allowed-service-origin, allowed-layer, and rate-limit state.
- Keeps API key values out of analytics events; events only expose `apiKeyPresent` plus service/layer/origin metadata.
- Exports the governance module and documents the server/admin ownership boundary.

## Host Impact

- Web/embed only. No .NET mobile runtime changes.
- Existing `<honua-map>` behavior is unchanged unless a host explicitly binds governance helpers.
- The client-side policy helper is advisory. Authoritative API key issuance, domain/CORS enforcement, rate limiting, and analytics ingestion still belong in `honua-server` / admin surfaces.

## Validation

- `npm test -- honua-governance.test.ts` - 5 passed
- `npm run typecheck` - passed
- `npm test` - 189 passed; happy-dom printed a teardown `AbortError` after tests but exited 0
- `npm run build` - passed
- `git diff --cached --check` - passed