### PR TITLE
mobile: add no-cloud package lifecycle adapters

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Models/NoCloudFieldModels.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Models/NoCloudFieldModels.cs
@@ -1,0 +1,92 @@
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Field.Projects;
+using Honua.Sdk.Field.Records;
+
+namespace Honua.Mobile.FieldCollection.Models;
+
+public sealed class LocalFieldProjectPackageImportRequest
+{
+    public required string ManifestPath { get; init; }
+    public required string DestinationRootDirectory { get; init; }
+    public string? ImportSource { get; init; }
+    public bool OverwriteExisting { get; init; }
+}
+
+public sealed class LocalFieldProjectPackageImportResult
+{
+    public string? ProjectId { get; init; }
+    public bool Imported { get; init; }
+    public FieldProjectCatalogEntry? CatalogEntry { get; init; }
+    public IReadOnlyList<LocalFieldProjectPackageDiagnostic> Diagnostics { get; init; } = [];
+    public IReadOnlyList<LocalFieldProjectPackageImportedFile> ImportedFiles { get; init; } = [];
+    public IReadOnlyList<LayerInfo> Layers { get; init; } = [];
+    public long CopiedBytes { get; init; }
+    public string? InstalledManifestPath { get; init; }
+}
+
+public sealed class LocalFieldProjectPackageDiagnostic
+{
+    public required string Code { get; init; }
+    public required string Path { get; init; }
+    public required string Message { get; init; }
+    public LocalFieldProjectPackageDiagnosticSeverity Severity { get; init; } = LocalFieldProjectPackageDiagnosticSeverity.Error;
+}
+
+public enum LocalFieldProjectPackageDiagnosticSeverity
+{
+    Warning,
+    Error
+}
+
+public sealed class LocalFieldProjectPackageImportedFile
+{
+    public required string PackageId { get; init; }
+    public required string RelativePath { get; init; }
+    public required string DestinationPath { get; init; }
+    public long SizeBytes { get; init; }
+    public string? Sha256 { get; init; }
+}
+
+public sealed class LocalFieldRecordLifecycleTransitionResult
+{
+    public bool Succeeded { get; init; }
+    public string? ReasonCode { get; init; }
+    public string? Reason { get; init; }
+    public RecordStatus FromStatus { get; init; }
+    public RecordStatus ToStatus { get; init; }
+    public Feature? Feature { get; init; }
+}
+
+public sealed class LocalFieldAssignmentInfo
+{
+    public string AssignmentId { get; init; } = string.Empty;
+    public string TaskPacketId { get; init; } = string.Empty;
+    public string ProjectId { get; init; } = string.Empty;
+    public string BindingId { get; init; } = string.Empty;
+    public string? SourceId { get; init; }
+    public string? AssigneeUserId { get; init; }
+    public string? CrewId { get; init; }
+    public FieldAssignmentPriority Priority { get; init; } = FieldAssignmentPriority.Normal;
+    public FieldAssignmentStatus Status { get; init; } = FieldAssignmentStatus.NotStarted;
+    public DateTimeOffset? DueAtUtc { get; init; }
+    public SourceQuery? WorkQuery { get; init; }
+    public IReadOnlyList<string> RecordIds { get; init; } = [];
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    public DateTime ImportedAtUtc { get; init; }
+    public DateTime UpdatedAtUtc { get; init; }
+    public DateTime? CompletedAtUtc { get; init; }
+}
+
+public sealed class LocalFieldAssignmentFilter
+{
+    public string? ProjectId { get; init; }
+    public string? BindingId { get; init; }
+    public string? SourceId { get; init; }
+    public string? AssigneeUserId { get; init; }
+    public string? CrewId { get; init; }
+    public FieldAssignmentStatus? Status { get; init; }
+    public FieldAssignmentPriority? MinimumPriority { get; init; }
+    public DateTimeOffset? DueBeforeUtc { get; init; }
+    public FeatureBoundingBox? IntersectsExtent { get; init; }
+}

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Assignments/LocalFieldAssignmentService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Assignments/LocalFieldAssignmentService.cs
@@ -1,0 +1,44 @@
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Sdk.Field.Projects;
+
+namespace Honua.Mobile.FieldCollection.Services.Assignments;
+
+public interface ILocalFieldAssignmentService
+{
+    Task<IReadOnlyList<LocalFieldAssignmentInfo>> GetAssignmentsAsync(
+        LocalFieldAssignmentFilter? filter = null,
+        CancellationToken cancellationToken = default);
+
+    Task<bool> UpdateStatusAsync(
+        string assignmentId,
+        FieldAssignmentStatus status,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class LocalFieldAssignmentService : ILocalFieldAssignmentService
+{
+    private readonly GeoPackageStorageService _storage;
+
+    public LocalFieldAssignmentService(GeoPackageStorageService storage)
+    {
+        _storage = storage;
+    }
+
+    public async Task<IReadOnlyList<LocalFieldAssignmentInfo>> GetAssignmentsAsync(
+        LocalFieldAssignmentFilter? filter = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return await _storage.GetFieldAssignmentsAsync(filter).ConfigureAwait(false);
+    }
+
+    public async Task<bool> UpdateStatusAsync(
+        string assignmentId,
+        FieldAssignmentStatus status,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return await _storage.UpdateFieldAssignmentStatusAsync(assignmentId, status).ConfigureAwait(false);
+    }
+}

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Packages/LocalFieldProjectPackageImportService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Packages/LocalFieldProjectPackageImportService.cs
@@ -1,0 +1,467 @@
+using System.Security.Cryptography;
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Sdk.Field.Forms;
+using Honua.Sdk.Field.Projects;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Mobile.FieldCollection.Services.Packages;
+
+public sealed class LocalFieldProjectPackageImportService
+{
+    private const string InstalledManifestFileName = "field-project-package.json";
+
+    private readonly GeoPackageStorageService _storage;
+    private readonly ILogger<LocalFieldProjectPackageImportService>? _logger;
+
+    public LocalFieldProjectPackageImportService(
+        GeoPackageStorageService storage,
+        ILogger<LocalFieldProjectPackageImportService>? logger = null)
+    {
+        _storage = storage;
+        _logger = logger;
+    }
+
+    public async Task<LocalFieldProjectPackageImportResult> ImportAsync(
+        LocalFieldProjectPackageImportRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ManifestPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.DestinationRootDirectory);
+
+        var manifestPath = Path.GetFullPath(request.ManifestPath);
+        if (!File.Exists(manifestPath))
+        {
+            return Failed(null, Error("missing-manifest", "$.manifestPath", $"Manifest file '{manifestPath}' was not found."));
+        }
+
+        var packageRoot = Path.GetDirectoryName(manifestPath) ?? Directory.GetCurrentDirectory();
+        FieldProjectPackage package;
+        string manifestJson;
+        try
+        {
+            manifestJson = await File.ReadAllTextAsync(manifestPath, cancellationToken).ConfigureAwait(false);
+            package = FieldProjectPackage.ParseJson(manifestJson);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Text.Json.JsonException or ArgumentException)
+        {
+            _logger?.LogWarning(ex, "Failed to parse local field project package manifest {ManifestPath}", manifestPath);
+            return Failed(null, Error("invalid-manifest", "$", ex.Message));
+        }
+
+        var diagnostics = new List<LocalFieldProjectPackageDiagnostic>();
+        diagnostics.AddRange(package.Validate().Issues.Select(ToDiagnostic));
+        diagnostics.AddRange(ValidateMobileImportShape(package));
+        var fileDiagnostics = ValidateOfflinePackageFiles(packageRoot, package, out var offlineFiles);
+        diagnostics.AddRange(fileDiagnostics);
+
+        if (diagnostics.Any(IsError))
+        {
+            await UpsertInvalidCatalogEntryAsync(package, request, diagnostics, cancellationToken).ConfigureAwait(false);
+            return Failed(package.ProjectId, diagnostics);
+        }
+
+        var destinationDirectory = BuildDestinationDirectory(request.DestinationRootDirectory, package);
+        if (Directory.Exists(destinationDirectory))
+        {
+            if (!request.OverwriteExisting)
+            {
+                diagnostics.Add(Error(
+                    "project-already-installed",
+                    "$.projectId",
+                    $"Project '{package.ProjectId}' is already installed at the destination."));
+                await UpsertInvalidCatalogEntryAsync(package, request, diagnostics, cancellationToken).ConfigureAwait(false);
+                return Failed(package.ProjectId, diagnostics);
+            }
+
+            Directory.Delete(destinationDirectory, recursive: true);
+        }
+
+        Directory.CreateDirectory(destinationDirectory);
+        var installedManifestPath = Path.Combine(destinationDirectory, InstalledManifestFileName);
+        await File.WriteAllTextAsync(installedManifestPath, manifestJson, cancellationToken).ConfigureAwait(false);
+
+        var importedFiles = new List<LocalFieldProjectPackageImportedFile>();
+        foreach (var file in offlineFiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var destinationPath = ResolveDestinationPath(destinationDirectory, file.RelativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+            File.Copy(file.SourcePath, destinationPath, overwrite: true);
+            importedFiles.Add(new LocalFieldProjectPackageImportedFile
+            {
+                PackageId = file.PackageId,
+                RelativePath = file.RelativePath,
+                DestinationPath = destinationPath,
+                SizeBytes = file.SizeBytes,
+                Sha256 = file.Sha256
+            });
+        }
+
+        var layers = BuildLayers(package);
+        foreach (var layer in layers)
+        {
+            await _storage.CreateLayerAsync(layer).ConfigureAwait(false);
+        }
+
+        var bindingSourceIds = package.Bindings.ToDictionary(
+            binding => binding.BindingId,
+            binding => (string?)binding.SourceId,
+            StringComparer.Ordinal);
+        await _storage.DeleteFieldAssignmentsForProjectAsync(package.ProjectId).ConfigureAwait(false);
+        await _storage.UpsertFieldTaskPacketsAsync(package.ProjectId, package.TaskPackets, bindingSourceIds).ConfigureAwait(false);
+
+        var now = DateTime.UtcNow;
+        var catalogEntry = new FieldProjectCatalogEntry
+        {
+            ProjectId = package.ProjectId,
+            ServiceId = package.ProjectId,
+            PackageId = ResolveCatalogPackageId(package),
+            Version = package.Version,
+            Name = package.Name,
+            Description = package.Description ?? string.Empty,
+            State = FieldProjectCatalogState.Installed,
+            ValidationStatus = diagnostics.Any(diagnostic => diagnostic.Severity == LocalFieldProjectPackageDiagnosticSeverity.Warning)
+                ? FieldProjectValidationStatus.Warning
+                : FieldProjectValidationStatus.Valid,
+            ValidationIssueCount = diagnostics.Count,
+            LayerCount = layers.Count,
+            PackageSizeBytes = new FileInfo(installedManifestPath).Length + importedFiles.Sum(file => file.SizeBytes),
+            MediaSizeBytes = importedFiles
+                .Where(file => package.OfflinePackages.Any(offlinePackage =>
+                    string.Equals(offlinePackage.PackageId, file.PackageId, StringComparison.Ordinal) &&
+                    offlinePackage.Kind == FieldOfflinePackageKind.Media))
+                .Sum(file => file.SizeBytes),
+            LocalStoragePath = destinationDirectory,
+            ManifestPath = installedManifestPath,
+            ImportSource = request.ImportSource ?? manifestPath,
+            PackageDigest = $"sha256:{ComputeSha256(manifestPath)}",
+            ImportedAtUtc = now,
+            LastValidationAtUtc = now
+        };
+        await _storage.UpsertProjectCatalogEntryAsync(catalogEntry).ConfigureAwait(false);
+
+        return new LocalFieldProjectPackageImportResult
+        {
+            ProjectId = package.ProjectId,
+            Imported = true,
+            CatalogEntry = catalogEntry,
+            Diagnostics = diagnostics,
+            ImportedFiles = importedFiles,
+            Layers = layers,
+            CopiedBytes = importedFiles.Sum(file => file.SizeBytes),
+            InstalledManifestPath = installedManifestPath
+        };
+    }
+
+    private async Task UpsertInvalidCatalogEntryAsync(
+        FieldProjectPackage package,
+        LocalFieldProjectPackageImportRequest request,
+        IReadOnlyList<LocalFieldProjectPackageDiagnostic> diagnostics,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (string.IsNullOrWhiteSpace(package.ProjectId))
+        {
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        await _storage.UpsertProjectCatalogEntryAsync(new FieldProjectCatalogEntry
+        {
+            ProjectId = package.ProjectId,
+            ServiceId = package.ProjectId,
+            PackageId = ResolveCatalogPackageId(package),
+            Version = package.Version,
+            Name = string.IsNullOrWhiteSpace(package.Name) ? package.ProjectId : package.Name,
+            Description = package.Description ?? string.Empty,
+            State = FieldProjectCatalogState.Invalid,
+            ValidationStatus = FieldProjectValidationStatus.Error,
+            ValidationIssueCount = diagnostics.Count(IsError),
+            ImportSource = request.ImportSource ?? request.ManifestPath,
+            ImportedAtUtc = now,
+            LastValidationAtUtc = now
+        }).ConfigureAwait(false);
+    }
+
+    private static IReadOnlyList<LayerInfo> BuildLayers(FieldProjectPackage package)
+    {
+        var formsById = package.Forms.ToDictionary(form => form.FormId, StringComparer.Ordinal);
+        var sourcesById = package.Sources.ToDictionary(source => source.Id, StringComparer.Ordinal);
+        var usedLayerIds = new HashSet<int>();
+        var layers = new List<LayerInfo>(package.Bindings.Count);
+
+        foreach (var binding in package.Bindings)
+        {
+            if (!formsById.TryGetValue(binding.FormId, out var form) ||
+                !sourcesById.TryGetValue(binding.SourceId, out var source))
+            {
+                continue;
+            }
+
+            var layerId = ResolveLayerId(source.Locator.LayerId, usedLayerIds);
+            var layerForm = ApplyBindingMetadata(form, binding);
+            layers.Add(new LayerInfo
+            {
+                Id = layerId,
+                ServiceId = package.ProjectId,
+                SourceId = $"{package.ProjectId}/{binding.BindingId}",
+                Name = form.Name,
+                Description = package.Description ?? source.Attribution ?? string.Empty,
+                GeometryType = source.Schema?.GeometryType ?? Honua.Sdk.Abstractions.Features.FeatureSpatialGeometryType.Unspecified,
+                IsEditable = binding.Editable,
+                IsVisible = true,
+                Form = layerForm,
+                Schema = layerForm.Sections.SelectMany(section => section.Fields).ToList()
+            });
+        }
+
+        return layers;
+    }
+
+    private static FormDefinition ApplyBindingMetadata(FormDefinition form, FieldProjectBinding binding)
+    {
+        var metadata = new Dictionary<string, string>(form.Metadata, StringComparer.OrdinalIgnoreCase)
+        {
+            ["honua:bindingId"] = binding.BindingId,
+            ["honua:sourceId"] = binding.SourceId
+        };
+
+        if (!string.IsNullOrWhiteSpace(binding.OfflinePackageId))
+        {
+            metadata["honua:offlinePackageId"] = binding.OfflinePackageId;
+        }
+
+        if (!string.IsNullOrWhiteSpace(binding.DisplayFieldId))
+        {
+            metadata["honua:displayFieldId"] = binding.DisplayFieldId;
+        }
+
+        if (!string.IsNullOrWhiteSpace(binding.DuplicateKeyFieldId))
+        {
+            metadata["honua:duplicateKeyFieldId"] = binding.DuplicateKeyFieldId;
+        }
+
+        return form with { Metadata = metadata };
+    }
+
+    private static int ResolveLayerId(int? preferredLayerId, HashSet<int> usedLayerIds)
+    {
+        var layerId = preferredLayerId.GetValueOrDefault(usedLayerIds.Count + 1);
+        if (layerId <= 0)
+        {
+            layerId = usedLayerIds.Count + 1;
+        }
+
+        while (!usedLayerIds.Add(layerId))
+        {
+            layerId++;
+        }
+
+        return layerId;
+    }
+
+    private static IReadOnlyList<LocalFieldProjectPackageDiagnostic> ValidateMobileImportShape(
+        FieldProjectPackage package)
+    {
+        var diagnostics = new List<LocalFieldProjectPackageDiagnostic>();
+        if (package.Bindings.Count == 0)
+        {
+            diagnostics.Add(Error("missing-layer-binding", "$.bindings", "At least one form-to-source binding is required."));
+        }
+
+        var boundFormIds = package.Bindings
+            .Select(binding => binding.FormId)
+            .ToHashSet(StringComparer.Ordinal);
+        for (var i = 0; i < package.Forms.Count; i++)
+        {
+            if (!boundFormIds.Contains(package.Forms[i].FormId))
+            {
+                diagnostics.Add(Error(
+                    "missing-layer-binding",
+                    $"$.forms[{i}].formId",
+                    $"Form '{package.Forms[i].FormId}' is not bound to a source."));
+            }
+        }
+
+        return diagnostics;
+    }
+
+    private static IReadOnlyList<LocalFieldProjectPackageDiagnostic> ValidateOfflinePackageFiles(
+        string packageRoot,
+        FieldProjectPackage package,
+        out IReadOnlyList<OfflinePackageFile> files)
+    {
+        var diagnostics = new List<LocalFieldProjectPackageDiagnostic>();
+        var resolvedFiles = new List<OfflinePackageFile>();
+
+        for (var i = 0; i < package.OfflinePackages.Count; i++)
+        {
+            var offlinePackage = package.OfflinePackages[i];
+            if (string.IsNullOrWhiteSpace(offlinePackage.RelativePath))
+            {
+                diagnostics.Add(Error(
+                    "missing-offline-artifact",
+                    $"$.offlinePackages[{i}].relativePath",
+                    $"Offline package '{offlinePackage.PackageId}' must include a relativePath for local import."));
+                continue;
+            }
+
+            if (!TryResolvePackagePath(packageRoot, offlinePackage.RelativePath, out var sourcePath))
+            {
+                diagnostics.Add(Error(
+                    "unsafe-offline-artifact-path",
+                    $"$.offlinePackages[{i}].relativePath",
+                    $"Offline package '{offlinePackage.PackageId}' has an unsafe relative path."));
+                continue;
+            }
+
+            if (!File.Exists(sourcePath))
+            {
+                diagnostics.Add(Error(
+                    "missing-offline-artifact",
+                    $"$.offlinePackages[{i}].relativePath",
+                    $"Offline package artifact '{offlinePackage.RelativePath}' was not found."));
+                continue;
+            }
+
+            var sizeBytes = new FileInfo(sourcePath).Length;
+            if (offlinePackage.SizeBytes.HasValue && offlinePackage.SizeBytes.Value != sizeBytes)
+            {
+                diagnostics.Add(Error(
+                    "offline-artifact-size-mismatch",
+                    $"$.offlinePackages[{i}].sizeBytes",
+                    $"Offline package '{offlinePackage.PackageId}' declared {offlinePackage.SizeBytes.Value} bytes but found {sizeBytes} bytes."));
+            }
+
+            var sha256 = ComputeSha256(sourcePath);
+            if (!string.IsNullOrWhiteSpace(offlinePackage.Sha256) &&
+                !string.Equals(offlinePackage.Sha256, sha256, StringComparison.OrdinalIgnoreCase))
+            {
+                diagnostics.Add(Error(
+                    "offline-artifact-sha256-mismatch",
+                    $"$.offlinePackages[{i}].sha256",
+                    $"Offline package '{offlinePackage.PackageId}' SHA-256 did not match the manifest."));
+            }
+
+            resolvedFiles.Add(new OfflinePackageFile(
+                offlinePackage.PackageId,
+                offlinePackage.RelativePath,
+                sourcePath,
+                sizeBytes,
+                sha256));
+        }
+
+        files = resolvedFiles;
+        return diagnostics;
+    }
+
+    private static bool TryResolvePackagePath(string packageRoot, string relativePath, out string fullPath)
+    {
+        fullPath = string.Empty;
+        if (Path.IsPathRooted(relativePath))
+        {
+            return false;
+        }
+
+        var root = Path.GetFullPath(packageRoot);
+        var candidate = Path.GetFullPath(Path.Combine(root, relativePath));
+        var rootPrefix = root.EndsWith(Path.DirectorySeparatorChar)
+            ? root
+            : $"{root}{Path.DirectorySeparatorChar}";
+        if (!candidate.StartsWith(rootPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        fullPath = candidate;
+        return true;
+    }
+
+    private static string ResolveDestinationPath(string destinationDirectory, string relativePath)
+    {
+        if (!TryResolvePackagePath(destinationDirectory, relativePath, out var fullPath))
+        {
+            throw new InvalidOperationException($"Invalid package destination path '{relativePath}'.");
+        }
+
+        return fullPath;
+    }
+
+    private static string BuildDestinationDirectory(
+        string destinationRootDirectory,
+        FieldProjectPackage package)
+    {
+        var version = string.IsNullOrWhiteSpace(package.Version) ? "current" : package.Version;
+        return Path.Combine(
+            Path.GetFullPath(destinationRootDirectory),
+            SanitizePathSegment(package.ProjectId),
+            SanitizePathSegment(version));
+    }
+
+    private static string SanitizePathSegment(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars().ToHashSet();
+        var sanitized = new string(value
+            .Select(character => invalid.Contains(character) ? '-' : character)
+            .ToArray()).Trim();
+
+        return string.IsNullOrWhiteSpace(sanitized) ? "package" : sanitized;
+    }
+
+    private static string ResolveCatalogPackageId(FieldProjectPackage package)
+        => package.OfflinePackages.Count == 1 ? package.OfflinePackages[0].PackageId : package.ProjectId;
+
+    private static string ComputeSha256(string path)
+    {
+        using var stream = File.OpenRead(path);
+        var hash = SHA256.HashData(stream);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static LocalFieldProjectPackageImportResult Failed(
+        string? projectId,
+        params LocalFieldProjectPackageDiagnostic[] diagnostics)
+        => Failed(projectId, diagnostics.AsEnumerable());
+
+    private static LocalFieldProjectPackageImportResult Failed(
+        string? projectId,
+        IEnumerable<LocalFieldProjectPackageDiagnostic> diagnostics)
+        => new()
+        {
+            ProjectId = projectId,
+            Imported = false,
+            Diagnostics = diagnostics.ToList()
+        };
+
+    private static LocalFieldProjectPackageDiagnostic ToDiagnostic(FieldProjectPackageValidationIssue issue)
+        => new()
+        {
+            Code = issue.Code,
+            Path = issue.Path,
+            Message = issue.Message,
+            Severity = issue.Severity == FieldProjectPackageValidationSeverity.Error
+                ? LocalFieldProjectPackageDiagnosticSeverity.Error
+                : LocalFieldProjectPackageDiagnosticSeverity.Warning
+        };
+
+    private static LocalFieldProjectPackageDiagnostic Error(string code, string path, string message)
+        => new()
+        {
+            Code = code,
+            Path = path,
+            Message = message,
+            Severity = LocalFieldProjectPackageDiagnosticSeverity.Error
+        };
+
+    private static bool IsError(LocalFieldProjectPackageDiagnostic diagnostic)
+        => diagnostic.Severity == LocalFieldProjectPackageDiagnosticSeverity.Error;
+
+    private sealed record OfflinePackageFile(
+        string PackageId,
+        string RelativePath,
+        string SourcePath,
+        long SizeBytes,
+        string Sha256);
+}

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
@@ -8,6 +8,9 @@ using Honua.Mobile.FieldCollection.Services.Ai;
 using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using Honua.Mobile.FieldCollection.Services.Metadata;
 using Honua.Mobile.FieldCollection.Services.Storage.Models;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Field.Forms;
+using Honua.Sdk.Field.Projects;
 using ChangeOperation = Honua.Mobile.FieldCollection.Services.Storage.Models.ChangeOperation;
 using CoreModels = Honua.Mobile.FieldCollection.Models;
 using StorageConflictResolution = Honua.Mobile.FieldCollection.Services.Storage.Models.ConflictResolution;
@@ -133,6 +136,7 @@ public class GeoPackageStorageService : IDisposable
         await _connection.CreateTableAsync<LayerMetadata>();
         await EnsureLayerMetadataTableAsync();
         await EnsureProjectCatalogTableAsync();
+        await EnsureFieldAssignmentsTableAsync();
         await EnsureLocalAttachmentsTableAsync();
     }
 
@@ -183,6 +187,12 @@ public class GeoPackageStorageService : IDisposable
             columnNames.Add("source_id");
         }
 
+        if (!columnNames.Contains("form_json"))
+        {
+            await _connection.ExecuteAsync("ALTER TABLE layer_metadata ADD COLUMN form_json TEXT");
+            columnNames.Add("form_json");
+        }
+
         if (!columnNames.Contains("storage_key"))
         {
             await MigrateLayerMetadataTableAsync();
@@ -228,6 +238,23 @@ public class GeoPackageStorageService : IDisposable
             "CREATE INDEX IF NOT EXISTS idx_field_project_catalog_state ON field_project_catalog(state)");
     }
 
+    private async Task EnsureFieldAssignmentsTableAsync()
+    {
+        await _connection.CreateTableAsync<LocalFieldAssignmentEntry>();
+        await _connection.ExecuteAsync(
+            "CREATE INDEX IF NOT EXISTS idx_field_assignments_project_id ON field_assignments(project_id)");
+        await _connection.ExecuteAsync(
+            "CREATE INDEX IF NOT EXISTS idx_field_assignments_binding_id ON field_assignments(binding_id)");
+        await _connection.ExecuteAsync(
+            "CREATE INDEX IF NOT EXISTS idx_field_assignments_source_id ON field_assignments(source_id)");
+        await _connection.ExecuteAsync(
+            "CREATE INDEX IF NOT EXISTS idx_field_assignments_status ON field_assignments(status)");
+        await _connection.ExecuteAsync(
+            "CREATE INDEX IF NOT EXISTS idx_field_assignments_assignee ON field_assignments(assignee_user_id)");
+        await _connection.ExecuteAsync(
+            "CREATE INDEX IF NOT EXISTS idx_field_assignments_due_at ON field_assignments(due_at_utc)");
+    }
+
     private async Task MigrateLayerMetadataTableAsync()
     {
         const string migrationTable = "layer_metadata_migration";
@@ -240,7 +267,7 @@ public class GeoPackageStorageService : IDisposable
             await _connection.ExecuteAsync($@"
                 INSERT OR REPLACE INTO {migrationTable}
                     (storage_key, id, service_id, source_id, name, description, geometry_type, spatial_reference,
-                     is_editable, schema, server_url, created_at, last_sync, sync_enabled)
+                     is_editable, schema, form_json, server_url, created_at, last_sync, sync_enabled)
                 SELECT
                     COALESCE(NULLIF(source_id, ''), COALESCE(NULLIF(service_id, ''), 'mobile_offline_demo') || '/FeatureServer/' || id),
                     id,
@@ -252,6 +279,7 @@ public class GeoPackageStorageService : IDisposable
                     spatial_reference,
                     is_editable,
                     schema,
+                    NULL,
                     server_url,
                     created_at,
                     last_sync,
@@ -282,6 +310,7 @@ public class GeoPackageStorageService : IDisposable
                 spatial_reference TEXT NOT NULL,
                 is_editable INTEGER NOT NULL,
                 schema TEXT,
+                form_json TEXT,
                 server_url TEXT,
                 created_at TEXT NOT NULL,
                 last_sync TEXT,
@@ -1559,6 +1588,226 @@ public class GeoPackageStorageService : IDisposable
 
     #endregion
 
+    #region Field Assignments
+
+    public async Task UpsertFieldTaskPacketsAsync(
+        string projectId,
+        IReadOnlyList<FieldTaskPacket> taskPackets,
+        IReadOnlyDictionary<string, string?> bindingSourceIds)
+    {
+        projectId = NormalizeProjectId(projectId);
+        ArgumentNullException.ThrowIfNull(taskPackets);
+        ArgumentNullException.ThrowIfNull(bindingSourceIds);
+
+        var now = DateTime.UtcNow;
+        var rows = taskPackets
+            .SelectMany(packet => packet.Assignments.Select(assignment =>
+                ToLocalFieldAssignmentEntry(projectId, packet.TaskPacketId, assignment, bindingSourceIds, now)))
+            .ToList();
+
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            await ExecuteInImmediateTransactionAsync(async () =>
+            {
+                foreach (var row in rows)
+                {
+                    await _connection.InsertOrReplaceAsync(row);
+                }
+            });
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<LocalFieldAssignmentInfo>> GetFieldAssignmentsAsync(
+        LocalFieldAssignmentFilter? filter = null)
+    {
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            var rows = await _connection.Table<LocalFieldAssignmentEntry>().ToListAsync();
+            return rows
+                .Select(ToFieldAssignmentInfo)
+                .Where(assignment => MatchesAssignmentFilter(assignment, filter))
+                .OrderBy(assignment => assignment.DueAtUtc ?? DateTimeOffset.MaxValue)
+                .ThenByDescending(assignment => assignment.Priority)
+                .ThenBy(assignment => assignment.AssignmentId, StringComparer.Ordinal)
+                .ToList();
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    public async Task<bool> UpdateFieldAssignmentStatusAsync(
+        string assignmentId,
+        FieldAssignmentStatus status,
+        DateTime? updatedAtUtc = null)
+    {
+        if (string.IsNullOrWhiteSpace(assignmentId))
+        {
+            throw new ArgumentException("Assignment ID is required.", nameof(assignmentId));
+        }
+
+        var updatedAt = updatedAtUtc ?? DateTime.UtcNow;
+        var completedAt = status == FieldAssignmentStatus.Complete ? updatedAt : (DateTime?)null;
+
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            return await _connection.ExecuteAsync(
+                """
+                UPDATE field_assignments
+                SET status = ?,
+                    updated_at_utc = ?,
+                    completed_at_utc = ?
+                WHERE assignment_id = ?
+                """,
+                status,
+                updatedAt,
+                completedAt,
+                assignmentId.Trim()) > 0;
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    public async Task<int> DeleteFieldAssignmentsForProjectAsync(string projectId)
+    {
+        projectId = NormalizeProjectId(projectId);
+
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            return await _connection.Table<LocalFieldAssignmentEntry>()
+                .DeleteAsync(row => row.ProjectId == projectId);
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    private static LocalFieldAssignmentEntry ToLocalFieldAssignmentEntry(
+        string projectId,
+        string taskPacketId,
+        FieldAssignment assignment,
+        IReadOnlyDictionary<string, string?> bindingSourceIds,
+        DateTime now)
+    {
+        bindingSourceIds.TryGetValue(assignment.BindingId, out var sourceId);
+
+        return new LocalFieldAssignmentEntry
+        {
+            AssignmentId = assignment.AssignmentId.Trim(),
+            TaskPacketId = taskPacketId.Trim(),
+            ProjectId = projectId,
+            BindingId = assignment.BindingId.Trim(),
+            SourceId = string.IsNullOrWhiteSpace(sourceId) ? null : sourceId.Trim(),
+            AssigneeUserId = string.IsNullOrWhiteSpace(assignment.AssigneeUserId) ? null : assignment.AssigneeUserId.Trim(),
+            CrewId = string.IsNullOrWhiteSpace(assignment.CrewId) ? null : assignment.CrewId.Trim(),
+            Priority = assignment.Priority,
+            Status = assignment.Status,
+            DueAtUtc = assignment.DueAtUtc?.UtcDateTime,
+            WorkQueryJson = assignment.WorkQuery is null ? null : JsonSerializer.Serialize(assignment.WorkQuery, SchemaJsonOptions),
+            RecordIdsJson = JsonSerializer.Serialize(assignment.RecordIds, SchemaJsonOptions),
+            MetadataJson = JsonSerializer.Serialize(assignment.Metadata, SchemaJsonOptions),
+            ImportedAtUtc = now,
+            UpdatedAtUtc = now,
+            CompletedAtUtc = assignment.Status == FieldAssignmentStatus.Complete ? now : null
+        };
+    }
+
+    private static LocalFieldAssignmentInfo ToFieldAssignmentInfo(LocalFieldAssignmentEntry row)
+        => new()
+        {
+            AssignmentId = row.AssignmentId,
+            TaskPacketId = row.TaskPacketId,
+            ProjectId = row.ProjectId,
+            BindingId = row.BindingId,
+            SourceId = row.SourceId,
+            AssigneeUserId = row.AssigneeUserId,
+            CrewId = row.CrewId,
+            Priority = row.Priority,
+            Status = row.Status,
+            DueAtUtc = row.DueAtUtc.HasValue
+                ? new DateTimeOffset(DateTime.SpecifyKind(row.DueAtUtc.Value, DateTimeKind.Utc))
+                : null,
+            WorkQuery = DeserializeJson<SourceQuery>(row.WorkQueryJson),
+            RecordIds = DeserializeJson<IReadOnlyList<string>>(row.RecordIdsJson) ?? [],
+            Metadata = DeserializeJson<IReadOnlyDictionary<string, string>>(row.MetadataJson) ??
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            ImportedAtUtc = row.ImportedAtUtc,
+            UpdatedAtUtc = row.UpdatedAtUtc,
+            CompletedAtUtc = row.CompletedAtUtc
+        };
+
+    private static bool MatchesAssignmentFilter(
+        LocalFieldAssignmentInfo assignment,
+        LocalFieldAssignmentFilter? filter)
+    {
+        if (filter is null)
+        {
+            return true;
+        }
+
+        return Matches(filter.ProjectId, assignment.ProjectId) &&
+            Matches(filter.BindingId, assignment.BindingId) &&
+            Matches(filter.SourceId, assignment.SourceId) &&
+            Matches(filter.AssigneeUserId, assignment.AssigneeUserId) &&
+            Matches(filter.CrewId, assignment.CrewId) &&
+            (!filter.Status.HasValue || assignment.Status == filter.Status.Value) &&
+            (!filter.MinimumPriority.HasValue || (int)assignment.Priority >= (int)filter.MinimumPriority.Value) &&
+            (!filter.DueBeforeUtc.HasValue || assignment.DueAtUtc <= filter.DueBeforeUtc.Value) &&
+            Intersects(assignment.WorkQuery?.Bbox, filter.IntersectsExtent);
+
+        static bool Matches(string? expected, string? actual)
+            => string.IsNullOrWhiteSpace(expected) ||
+                string.Equals(expected.Trim(), actual?.Trim(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool Intersects(FeatureBoundingBox? assignmentExtent, FeatureBoundingBox? filterExtent)
+    {
+        if (filterExtent is null || assignmentExtent is null)
+        {
+            return true;
+        }
+
+        return assignmentExtent.MinX <= filterExtent.MaxX &&
+            assignmentExtent.MaxX >= filterExtent.MinX &&
+            assignmentExtent.MinY <= filterExtent.MaxY &&
+            assignmentExtent.MaxY >= filterExtent.MinY;
+    }
+
+    private static T? DeserializeJson<T>(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return default;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<T>(json, SchemaJsonOptions);
+        }
+        catch (JsonException)
+        {
+            return default;
+        }
+    }
+
+    #endregion
+
     #region Layer Management
 
     public async Task<bool> CreateLayerAsync(LayerInfo layer)
@@ -1578,7 +1827,8 @@ public class GeoPackageStorageService : IDisposable
                 GeometryType = layer.GeometryType.ToString(),
                 SpatialReference = "EPSG:4326",
                 IsEditable = layer.IsEditable,
-                Schema = JsonSerializer.Serialize(layer.Schema, SchemaJsonOptions),
+                Schema = JsonSerializer.Serialize(GetLayerSchema(layer), SchemaJsonOptions),
+                FormJson = layer.Form is null ? null : JsonSerializer.Serialize(layer.Form, SchemaJsonOptions),
                 CreatedAt = DateTime.UtcNow,
                 LastSync = DateTime.UtcNow
             };
@@ -1656,8 +1906,20 @@ public class GeoPackageStorageService : IDisposable
             Schema = DeserializeLayerSchema(metadata.Schema)
         };
 
-        layer.Form = FieldCollectionMetadataMapper.CreateFormDefinition(layer);
+        layer.Form = DeserializeFormDefinition(metadata.FormJson) ?? FieldCollectionMetadataMapper.CreateFormDefinition(layer);
         return layer;
+    }
+
+    private static IReadOnlyList<FormField> GetLayerSchema(LayerInfo layer)
+    {
+        if (layer.Schema.Count > 0)
+        {
+            return layer.Schema;
+        }
+
+        return layer.Form?.Sections
+            .SelectMany(section => section.Fields)
+            .ToList() ?? [];
     }
 
     private static string GetLayerMetadataStorageKey(LayerInfo layer)
@@ -1701,6 +1963,23 @@ public class GeoPackageStorageService : IDisposable
         catch (JsonException)
         {
             return DeserializeLegacyLayerSchema(schema);
+        }
+    }
+
+    private static FormDefinition? DeserializeFormDefinition(string? formJson)
+    {
+        if (string.IsNullOrWhiteSpace(formJson))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<FormDefinition>(formJson, SchemaJsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
         }
     }
 

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/Models/StorageModels.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/Models/StorageModels.cs
@@ -288,6 +288,9 @@ public class LayerMetadata
     [Column("schema")]
     public string? Schema { get; set; }
 
+    [Column("form_json")]
+    public string? FormJson { get; set; }
+
     [Column("server_url")]
     public string? ServerUrl { get; set; }
 
@@ -376,6 +379,73 @@ public class LocalFieldProjectCatalogEntry
 
     [Column("last_export_at_utc")]
     public DateTime? LastExportAtUtc { get; set; }
+}
+
+/// <summary>
+/// Locally persisted no-cloud assignment state imported from SDK task packets.
+/// </summary>
+[Table("field_assignments")]
+public class LocalFieldAssignmentEntry
+{
+    [PrimaryKey]
+    [Column("assignment_id")]
+    public string AssignmentId { get; set; } = string.Empty;
+
+    [Column("task_packet_id")]
+    [Indexed]
+    public string TaskPacketId { get; set; } = string.Empty;
+
+    [Column("project_id")]
+    [Indexed]
+    public string ProjectId { get; set; } = string.Empty;
+
+    [Column("binding_id")]
+    [Indexed]
+    public string BindingId { get; set; } = string.Empty;
+
+    [Column("source_id")]
+    [Indexed]
+    public string? SourceId { get; set; }
+
+    [Column("assignee_user_id")]
+    [Indexed]
+    public string? AssigneeUserId { get; set; }
+
+    [Column("crew_id")]
+    [Indexed]
+    public string? CrewId { get; set; }
+
+    [Column("priority")]
+    [Indexed]
+    public Honua.Sdk.Field.Projects.FieldAssignmentPriority Priority { get; set; } =
+        Honua.Sdk.Field.Projects.FieldAssignmentPriority.Normal;
+
+    [Column("status")]
+    [Indexed]
+    public Honua.Sdk.Field.Projects.FieldAssignmentStatus Status { get; set; } =
+        Honua.Sdk.Field.Projects.FieldAssignmentStatus.NotStarted;
+
+    [Column("due_at_utc")]
+    [Indexed]
+    public DateTime? DueAtUtc { get; set; }
+
+    [Column("work_query_json")]
+    public string? WorkQueryJson { get; set; }
+
+    [Column("record_ids_json")]
+    public string? RecordIdsJson { get; set; }
+
+    [Column("metadata_json")]
+    public string? MetadataJson { get; set; }
+
+    [Column("imported_at_utc")]
+    public DateTime ImportedAtUtc { get; set; }
+
+    [Column("updated_at_utc")]
+    public DateTime UpdatedAtUtc { get; set; }
+
+    [Column("completed_at_utc")]
+    public DateTime? CompletedAtUtc { get; set; }
 }
 
 /// <summary>

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Workflow/LocalFieldRecordLifecycleService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Workflow/LocalFieldRecordLifecycleService.cs
@@ -1,0 +1,250 @@
+using System.Globalization;
+using System.Text.Json;
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Sdk.Field.Projects;
+using Honua.Sdk.Field.Records;
+
+namespace Honua.Mobile.FieldCollection.Services.Workflow;
+
+public sealed class LocalFieldRecordLifecycleService
+{
+    public const string StatusAttribute = "honua_record_status";
+    public const string SubmittedAtAttribute = "honua_submitted_at_utc";
+    public const string CompletedAtAttribute = "honua_completed_at_utc";
+    public const string LifecycleUpdatedAtAttribute = "honua_lifecycle_updated_at_utc";
+    public const string LifecycleActorIdAttribute = "honua_lifecycle_actor_id";
+    public const string LifecycleActorRoleAttribute = "honua_lifecycle_actor_role";
+    public const string LifecycleNoteAttribute = "honua_lifecycle_note";
+
+    private readonly GeoPackageStorageService _storage;
+
+    public LocalFieldRecordLifecycleService(GeoPackageStorageService storage)
+    {
+        _storage = storage;
+    }
+
+    public async Task<LocalFieldRecordLifecycleTransitionResult> TransitionAsync(
+        int layerId,
+        string featureId,
+        RecordStatus targetStatus,
+        FieldRecordLifecyclePolicy? policy = null,
+        string? actorId = null,
+        string? actorRole = null,
+        string? note = null,
+        DateTimeOffset? transitionTimeUtc = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var feature = await _storage.GetFeatureAsync(featureId, layerId).ConfigureAwait(false);
+        if (feature is null)
+        {
+            return new LocalFieldRecordLifecycleTransitionResult
+            {
+                Succeeded = false,
+                ReasonCode = "record-not-found",
+                Reason = $"Record '{featureId}' was not found in layer {layerId}.",
+                FromStatus = RecordStatus.Draft,
+                ToStatus = targetStatus
+            };
+        }
+
+        var fromStatus = GetStatus(feature);
+        var transition = FindTransition(fromStatus, targetStatus, policy);
+        if (transition is null || !RoleMatches(transition, actorRole) || !RecordWorkflow.CanTransition(fromStatus, targetStatus))
+        {
+            return new LocalFieldRecordLifecycleTransitionResult
+            {
+                Succeeded = false,
+                ReasonCode = "invalid-transition",
+                Reason = $"Transition from {fromStatus} to {targetStatus} is not allowed by the lifecycle policy.",
+                FromStatus = fromStatus,
+                ToStatus = targetStatus,
+                Feature = feature
+            };
+        }
+
+        var timestamp = transitionTimeUtc ?? DateTimeOffset.UtcNow;
+        var record = ToFieldRecord(feature, fromStatus);
+        RecordWorkflow.Transition(record, targetStatus, timestamp);
+        ApplyLifecycleAttributes(feature, record, timestamp, actorId, actorRole, note);
+        await _storage.UpdateFeatureAsync(feature).ConfigureAwait(false);
+
+        return new LocalFieldRecordLifecycleTransitionResult
+        {
+            Succeeded = true,
+            FromStatus = fromStatus,
+            ToStatus = targetStatus,
+            Feature = feature
+        };
+    }
+
+    public static bool CanEdit(Feature feature, FieldRecordLifecyclePolicy? policy = null)
+        => CanEdit(GetStatus(feature), policy);
+
+    public static bool CanEdit(RecordStatus status, FieldRecordLifecyclePolicy? policy = null)
+    {
+        policy ??= FieldRecordLifecyclePolicy.Default;
+        return status switch
+        {
+            RecordStatus.Draft or RecordStatus.ReadyToSubmit or RecordStatus.Reopened => true,
+            RecordStatus.Rejected => policy.AllowRejectedEdit,
+            RecordStatus.Submitted or RecordStatus.Approved => !policy.ProtectSubmittedRecords,
+            RecordStatus.Deleted => false,
+            _ => false
+        };
+    }
+
+    public static RecordStatus GetStatus(Feature feature)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+        return TryGetAttribute(feature.Attributes, StatusAttribute, out var value) &&
+            Enum.TryParse<RecordStatus>(ReadString(value), ignoreCase: true, out var status)
+                ? status
+                : RecordStatus.Draft;
+    }
+
+    public static bool CanTransition(
+        RecordStatus from,
+        RecordStatus to,
+        FieldRecordLifecyclePolicy? policy = null,
+        string? actorRole = null)
+        => FindTransition(from, to, policy) is { } transition &&
+            RoleMatches(transition, actorRole) &&
+            RecordWorkflow.CanTransition(from, to);
+
+    private static FieldRecordLifecycleTransition? FindTransition(
+        RecordStatus from,
+        RecordStatus to,
+        FieldRecordLifecyclePolicy? policy)
+    {
+        policy ??= FieldRecordLifecyclePolicy.Default;
+        if (policy.AllowedStatuses.Count > 0 &&
+            (!policy.AllowedStatuses.Contains(from) || !policy.AllowedStatuses.Contains(to)))
+        {
+            return null;
+        }
+
+        return policy.AllowedTransitions.FirstOrDefault(transition =>
+            transition.From == from && transition.To == to) ??
+            (RecordWorkflow.CanTransition(from, to) && policy.AllowedTransitions.Count == 0
+                ? new FieldRecordLifecycleTransition { From = from, To = to }
+                : null);
+    }
+
+    private static bool RoleMatches(FieldRecordLifecycleTransition transition, string? actorRole)
+        => string.IsNullOrWhiteSpace(transition.RequiredActorRole) ||
+            string.Equals(transition.RequiredActorRole, actorRole, StringComparison.OrdinalIgnoreCase);
+
+    private static FieldRecord ToFieldRecord(Feature feature, RecordStatus status)
+        => new()
+        {
+            RecordId = feature.Id,
+            FormId = feature.LayerId.ToString(CultureInfo.InvariantCulture),
+            Values = new Dictionary<string, object?>(feature.Attributes, StringComparer.OrdinalIgnoreCase),
+            Status = status,
+            CreatedAtUtc = feature.CreatedAt == default
+                ? DateTimeOffset.UtcNow
+                : new DateTimeOffset(DateTime.SpecifyKind(feature.CreatedAt, DateTimeKind.Utc)),
+            SubmittedAtUtc = TryReadDateTimeOffset(feature.Attributes, SubmittedAtAttribute, out var submittedAt)
+                ? submittedAt
+                : null,
+            CompletedAtUtc = TryReadDateTimeOffset(feature.Attributes, CompletedAtAttribute, out var completedAt)
+                ? completedAt
+                : null
+        };
+
+    private static void ApplyLifecycleAttributes(
+        Feature feature,
+        FieldRecord record,
+        DateTimeOffset updatedAtUtc,
+        string? actorId,
+        string? actorRole,
+        string? note)
+    {
+        feature.Attributes[StatusAttribute] = record.Status.ToString();
+        feature.Attributes[LifecycleUpdatedAtAttribute] = FormatDateTimeOffset(updatedAtUtc);
+        SetOptional(feature.Attributes, SubmittedAtAttribute, record.SubmittedAtUtc);
+        SetOptional(feature.Attributes, CompletedAtAttribute, record.CompletedAtUtc);
+        SetOptional(feature.Attributes, LifecycleActorIdAttribute, actorId);
+        SetOptional(feature.Attributes, LifecycleActorRoleAttribute, actorRole);
+        SetOptional(feature.Attributes, LifecycleNoteAttribute, note);
+        feature.UpdatedAt = updatedAtUtc.UtcDateTime;
+        feature.ModifiedAt = updatedAtUtc.UtcDateTime;
+    }
+
+    private static void SetOptional(
+        IDictionary<string, object?> attributes,
+        string key,
+        DateTimeOffset? value)
+    {
+        if (value.HasValue)
+        {
+            attributes[key] = FormatDateTimeOffset(value.Value);
+        }
+        else
+        {
+            attributes.Remove(key);
+        }
+    }
+
+    private static void SetOptional(
+        IDictionary<string, object?> attributes,
+        string key,
+        string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            attributes.Remove(key);
+        }
+        else
+        {
+            attributes[key] = value.Trim();
+        }
+    }
+
+    private static bool TryGetAttribute(
+        IReadOnlyDictionary<string, object?> attributes,
+        string key,
+        out object? value)
+    {
+        foreach (var attribute in attributes)
+        {
+            if (string.Equals(attribute.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                value = attribute.Value;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static bool TryReadDateTimeOffset(
+        IReadOnlyDictionary<string, object?> attributes,
+        string key,
+        out DateTimeOffset value)
+    {
+        value = default;
+        return TryGetAttribute(attributes, key, out var raw) &&
+            DateTimeOffset.TryParse(
+                ReadString(raw),
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out value);
+    }
+
+    private static string? ReadString(object? value)
+        => value switch
+        {
+            null => null,
+            string text => text,
+            JsonElement { ValueKind: JsonValueKind.String } element => element.GetString(),
+            JsonElement element => element.ToString(),
+            _ => Convert.ToString(value, CultureInfo.InvariantCulture)
+        };
+
+    private static string FormatDateTimeOffset(DateTimeOffset value)
+        => value.UtcDateTime.ToString("O", CultureInfo.InvariantCulture);
+}

--- a/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
+++ b/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
@@ -1,13 +1,16 @@
 using CommunityToolkit.Maui;
 using Honua.Mobile.FieldCollection.Services;
 using Honua.Mobile.FieldCollection.Services.Ai;
+using Honua.Mobile.FieldCollection.Services.Assignments;
 using Honua.Mobile.FieldCollection.Services.Configuration;
 using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using Honua.Mobile.FieldCollection.Services.Features;
 using Honua.Mobile.FieldCollection.Services.Forms;
 using Honua.Mobile.FieldCollection.Services.Metadata;
+using Honua.Mobile.FieldCollection.Services.Packages;
 using Honua.Mobile.FieldCollection.Services.Storage;
 using Honua.Mobile.FieldCollection.Services.Sync;
+using Honua.Mobile.FieldCollection.Services.Workflow;
 using Honua.Mobile.Maui;
 using Honua.Mobile.Maui.Diagnostics;
 using Honua.Mobile.FieldCollection.ViewModels;
@@ -161,6 +164,23 @@ public static class MauiProgram
             return new LocalRecordExportService(
                 databaseService.GetStorageService(),
                 logger: provider.GetService<ILogger<LocalRecordExportService>>());
+        });
+        services.AddSingleton(provider =>
+        {
+            var databaseService = provider.GetRequiredService<DatabaseService>();
+            return new LocalFieldProjectPackageImportService(
+                databaseService.GetStorageService(),
+                provider.GetService<ILogger<LocalFieldProjectPackageImportService>>());
+        });
+        services.AddSingleton(provider =>
+        {
+            var databaseService = provider.GetRequiredService<DatabaseService>();
+            return new LocalFieldRecordLifecycleService(databaseService.GetStorageService());
+        });
+        services.AddSingleton<ILocalFieldAssignmentService>(provider =>
+        {
+            var databaseService = provider.GetRequiredService<DatabaseService>();
+            return new LocalFieldAssignmentService(databaseService.GetStorageService());
         });
         services.AddSingleton<IMobileAiCaptureProvider, NullMobileAiCaptureProvider>();
         services.AddSingleton<IMobileAiCaptureQueue, SettingsMobileAiCaptureQueue>();

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -719,6 +719,53 @@ public sealed class GeoPackageSyncServiceTests
         Assert.Equal(1, diagnostics.Operations.AttachmentPendingCount);
     }
 
+    [Fact]
+    public async Task LocalFieldConflictReplayHarness_WithRemoteDeleteCanDeferForManualReview()
+    {
+        var databasePath = CreateDatabasePath();
+        var evidenceDirectory = Path.Combine(Path.GetTempPath(), $"honua-conflict-delete-replay-{Guid.NewGuid():N}");
+        await using var cleanup = new DatabaseCleanup(databasePath, evidenceDirectory);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var plan = new LocalFieldConflictReplayPlan
+        {
+            RunId = "local-delete-conflict-replay-test",
+            Layer = CreateLayer(),
+            FeatureId = "asset-delete-conflict",
+            LocalVersion = 3,
+            ServerVersion = 2,
+            LocalAttributes = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["name"] = "local survivor",
+                ["status"] = "field-updated"
+            },
+            ServerAttributes = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["name"] = "server deleted"
+            },
+            Resolution = ConflictResolution.Manual
+        };
+        var peer = new LocalReplayFieldSyncPeer([LocalFieldConflictReplayHarness.CreateServerDelete(plan)]);
+        using var sync = CreateSyncService(storage, uploader: peer, puller: peer, attachmentSynchronizer: peer);
+        var harness = new LocalFieldConflictReplayHarness(storage, sync, evidenceDirectory);
+
+        var result = await harness.RunAsync(plan);
+
+        Assert.True(result.PullResult.IsSuccess);
+        Assert.NotNull(result.Conflict);
+        Assert.True(result.ResolutionApplied);
+        Assert.NotNull(result.FinalFeature);
+        Assert.Equal("local survivor", result.FinalFeature.Attributes["name"]?.ToString());
+        Assert.Equal(1, result.Diagnostics.Operations.ConflictCount);
+
+        var evidenceJson = await File.ReadAllTextAsync(result.EvidencePath!);
+        using var evidence = JsonDocument.Parse(evidenceJson);
+        Assert.Equal("Manual", evidence.RootElement.GetProperty("selectedResolution").GetString());
+        Assert.True(evidence.RootElement.GetProperty("resolutionApplied").GetBoolean());
+        Assert.True(evidence.RootElement.GetProperty("finalState").GetProperty("featureExists").GetBoolean());
+        Assert.Equal(1, evidence.RootElement.GetProperty("finalState").GetProperty("conflictCount").GetInt32());
+        Assert.Equal(4, evidence.RootElement.GetProperty("events").GetArrayLength());
+    }
+
     private static GeoPackageSyncService CreateSyncService(
         GeoPackageStorageService storage,
         IFieldCollectionChangeUploader? uploader = null,

--- a/tests/Honua.Mobile.FieldCollection.Tests/LocalFieldProjectPackageImportServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/LocalFieldProjectPackageImportServiceTests.cs
@@ -1,0 +1,470 @@
+using System.Security.Cryptography;
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services.Assignments;
+using Honua.Mobile.FieldCollection.Services.Packages;
+using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Field.Forms;
+using Honua.Sdk.Field.Projects;
+using Honua.Sdk.Field.Records;
+
+namespace Honua.Mobile.FieldCollection.Tests;
+
+public sealed class LocalFieldProjectPackageImportServiceTests : IDisposable
+{
+    private readonly string _databasePath;
+    private readonly string _packageRoot;
+    private readonly string _installRoot;
+
+    public LocalFieldProjectPackageImportServiceTests()
+    {
+        SQLitePCL.Batteries_V2.Init();
+        _databasePath = Path.Combine(Path.GetTempPath(), $"honua-package-import-{Guid.NewGuid():N}.gpkg");
+        _packageRoot = Path.Combine(Path.GetTempPath(), $"honua-package-source-{Guid.NewGuid():N}");
+        _installRoot = Path.Combine(Path.GetTempPath(), $"honua-package-install-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_packageRoot);
+        Directory.CreateDirectory(_installRoot);
+    }
+
+    [Fact]
+    public async Task ImportAsync_WithValidPackage_CopiesArtifactsCreatesCatalogLayersAndAssignments()
+    {
+        using var storage = new GeoPackageStorageService(_databasePath);
+        var manifestPath = await WritePackageAsync(CreatePackage());
+        var result = await new LocalFieldProjectPackageImportService(storage).ImportAsync(new LocalFieldProjectPackageImportRequest
+        {
+            ManifestPath = manifestPath,
+            DestinationRootDirectory = _installRoot,
+            ImportSource = "usb",
+            OverwriteExisting = true
+        });
+
+        Assert.True(result.Imported, string.Join(" | ", result.Diagnostics.Select(diagnostic => diagnostic.Message)));
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Severity == LocalFieldProjectPackageDiagnosticSeverity.Error);
+        Assert.Equal("local-inspection-demo", result.ProjectId);
+        Assert.True(File.Exists(result.InstalledManifestPath));
+        var importedFile = Assert.Single(result.ImportedFiles);
+        Assert.Equal("data/assets.gpkg", importedFile.RelativePath);
+        Assert.True(File.Exists(importedFile.DestinationPath));
+
+        var catalogEntry = await storage.GetProjectCatalogEntryAsync("local-inspection-demo");
+        Assert.NotNull(catalogEntry);
+        Assert.Equal(FieldProjectCatalogState.Installed, catalogEntry.State);
+        Assert.Equal(FieldProjectValidationStatus.Valid, catalogEntry.ValidationStatus);
+        Assert.Equal("pkg-assets", catalogEntry.PackageId);
+        Assert.Equal(2, catalogEntry.LayerCount);
+        Assert.Equal("usb", catalogEntry.ImportSource);
+
+        var layers = await storage.GetLayersAsync();
+        Assert.Equal(2, layers.Count);
+        Assert.All(layers, layer => Assert.Equal("local-inspection-demo", layer.ServiceId));
+        Assert.Contains(layers, layer => layer.Form?.FormId == "asset-inspection");
+        Assert.Contains(layers, layer => layer.Form?.Metadata["honua:bindingId"] == "incident-assets");
+
+        var assignmentService = new LocalFieldAssignmentService(storage);
+        var fieldUserAssignments = await assignmentService.GetAssignmentsAsync(new LocalFieldAssignmentFilter
+        {
+            AssigneeUserId = "field-user-1",
+            Status = FieldAssignmentStatus.NotStarted,
+            MinimumPriority = FieldAssignmentPriority.High,
+            DueBeforeUtc = new DateTimeOffset(2026, 5, 24, 4, 0, 0, TimeSpan.Zero),
+            SourceId = "assets",
+            IntersectsExtent = new FeatureBoundingBox
+            {
+                MinX = -158,
+                MinY = 21,
+                MaxX = -157,
+                MaxY = 22,
+                Crs = "EPSG:4326"
+            }
+        });
+        var assignment = Assert.Single(fieldUserAssignments);
+        Assert.Equal("task-asset-100", assignment.AssignmentId);
+        Assert.Equal("asset-100", Assert.Single(assignment.RecordIds));
+
+        Assert.True(await assignmentService.UpdateStatusAsync("task-asset-100", FieldAssignmentStatus.Complete));
+        var completed = Assert.Single(await assignmentService.GetAssignmentsAsync(new LocalFieldAssignmentFilter
+        {
+            Status = FieldAssignmentStatus.Complete
+        }));
+        Assert.Equal("task-asset-100", completed.AssignmentId);
+        Assert.NotNull(completed.CompletedAtUtc);
+
+        using var restartedStorage = new GeoPackageStorageService(_databasePath);
+        var restartedAssignments = await restartedStorage.GetFieldAssignmentsAsync(new LocalFieldAssignmentFilter
+        {
+            Status = FieldAssignmentStatus.Complete
+        });
+        Assert.Single(restartedAssignments);
+    }
+
+    [Fact]
+    public async Task ImportAsync_WithInvalidPackages_ReturnsDeterministicDiagnostics()
+    {
+        using var storage = new GeoPackageStorageService(_databasePath);
+        var validPackage = CreatePackage();
+        var cases = new[]
+        {
+            (
+                Name: "unsupported schema",
+                Package: validPackage with { SchemaVersion = "honua.field-project-package.v0" },
+                Code: FieldProjectPackageValidationCodes.UnsupportedSchemaVersion),
+            (
+                Name: "missing form",
+                Package: validPackage with
+                {
+                    Bindings =
+                    [
+                        validPackage.Bindings[0] with { FormId = "missing-form" }
+                    ]
+                },
+                Code: FieldProjectPackageValidationCodes.MissingReference),
+            (
+                Name: "missing layer binding",
+                Package: validPackage with { Bindings = [] },
+                Code: "missing-layer-binding"),
+            (
+                Name: "invalid media policy",
+                Package: validPackage with
+                {
+                    MediaPolicy = new FieldProjectMediaPolicy
+                    {
+                        Requirements =
+                        [
+                            new FieldMediaRequirement
+                            {
+                                FormId = "asset-inspection",
+                                FieldId = "photos",
+                                MediaType = FieldMediaType.Photo,
+                                MinCount = 3,
+                                MaxCount = 1
+                            }
+                        ]
+                    }
+                },
+                Code: FieldProjectPackageValidationCodes.InvalidValue)
+        };
+
+        foreach (var testCase in cases)
+        {
+            var manifestPath = await WritePackageAsync(testCase.Package, testCase.Name.Replace(' ', '-'));
+            var result = await new LocalFieldProjectPackageImportService(storage).ImportAsync(new LocalFieldProjectPackageImportRequest
+            {
+                ManifestPath = manifestPath,
+                DestinationRootDirectory = _installRoot,
+                OverwriteExisting = true
+            });
+
+            Assert.False(result.Imported);
+            Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == testCase.Code);
+        }
+
+        var catalogEntry = await storage.GetProjectCatalogEntryAsync("local-inspection-demo");
+        Assert.NotNull(catalogEntry);
+        Assert.Equal(FieldProjectCatalogState.Invalid, catalogEntry.State);
+        Assert.Equal(FieldProjectValidationStatus.Error, catalogEntry.ValidationStatus);
+    }
+
+    public void Dispose()
+    {
+        DeleteIfExists(_databasePath);
+        DeleteIfExists($"{_databasePath}-wal");
+        DeleteIfExists($"{_databasePath}-shm");
+
+        if (Directory.Exists(_packageRoot))
+        {
+            Directory.Delete(_packageRoot, recursive: true);
+        }
+
+        if (Directory.Exists(_installRoot))
+        {
+            Directory.Delete(_installRoot, recursive: true);
+        }
+    }
+
+    private async Task<string> WritePackageAsync(FieldProjectPackage package, string directoryName = "valid")
+    {
+        var packageDirectory = Path.Combine(_packageRoot, directoryName);
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "data"));
+        var artifactPath = Path.Combine(packageDirectory, "data", "assets.gpkg");
+        await File.WriteAllTextAsync(artifactPath, "offline feature data");
+        package = package with
+        {
+            OfflinePackages =
+            [
+                package.OfflinePackages[0] with
+                {
+                    SizeBytes = new FileInfo(artifactPath).Length,
+                    Sha256 = ComputeSha256(artifactPath)
+                }
+            ]
+        };
+
+        var manifestPath = Path.Combine(packageDirectory, "field-project-package.json");
+        await File.WriteAllTextAsync(manifestPath, package.ToJson());
+        return manifestPath;
+    }
+
+    internal static FieldProjectPackage CreatePackage()
+        => new()
+        {
+            SchemaVersion = FieldProjectPackage.CurrentSchemaVersion,
+            ProjectId = "local-inspection-demo",
+            Name = "Local Inspection Demo",
+            Version = "2026.05",
+            Description = "No-cloud local package fixture.",
+            Sources =
+            [
+                new SourceDescriptor
+                {
+                    Id = "assets",
+                    Protocol = "FeatureServer",
+                    Locator = new SourceLocator
+                    {
+                        ServiceId = "mobile_offline_demo",
+                        LayerId = 68910
+                    },
+                    Capabilities = ["query", "edit", "attachments"],
+                    Schema = new SourceSchema
+                    {
+                        PrimaryKey = "globalid",
+                        ObjectIdField = "objectid",
+                        GlobalIdField = "globalid",
+                        GeometryType = FeatureSpatialGeometryType.Point,
+                        SpatialReference = "EPSG:4326"
+                    }
+                }
+            ],
+            Forms =
+            [
+                CreateInspectionForm(),
+                CreateIncidentForm()
+            ],
+            Bindings =
+            [
+                new FieldProjectBinding
+                {
+                    BindingId = "asset-inspection-assets",
+                    FormId = "asset-inspection",
+                    SourceId = "assets",
+                    OfflinePackageId = "pkg-assets",
+                    Editable = true,
+                    DisplayFieldId = "asset_id",
+                    SourceQuery = new SourceQuery
+                    {
+                        Where = "1=1",
+                        ReturnGeometry = true,
+                        Bbox = new FeatureBoundingBox
+                        {
+                            MinX = -158,
+                            MinY = 21,
+                            MaxX = -157,
+                            MaxY = 22,
+                            Crs = "EPSG:4326"
+                        }
+                    }
+                },
+                new FieldProjectBinding
+                {
+                    BindingId = "incident-assets",
+                    FormId = "incident-report",
+                    SourceId = "assets",
+                    OfflinePackageId = "pkg-assets",
+                    Editable = true,
+                    DisplayFieldId = "summary"
+                }
+            ],
+            OfflinePackages =
+            [
+                new FieldOfflinePackageReference
+                {
+                    PackageId = "pkg-assets",
+                    Kind = FieldOfflinePackageKind.FeatureData,
+                    RelativePath = "data/assets.gpkg",
+                    ContentType = "application/geopackage+sqlite3",
+                    SourceIds = ["assets"]
+                }
+            ],
+            MediaPolicy = new FieldProjectMediaPolicy
+            {
+                AllowedContentTypes = ["image/jpeg", "image/png", "audio/mp4"],
+                MaxAttachmentBytes = 52_428_800,
+                RequiresFaceBlurByDefault = true,
+                Requirements =
+                [
+                    new FieldMediaRequirement
+                    {
+                        FormId = "asset-inspection",
+                        FieldId = "photos",
+                        MediaType = FieldMediaType.Photo,
+                        MinCount = 1,
+                        MaxCount = 12,
+                        AllowedContentTypes = ["image/jpeg", "image/png"]
+                    }
+                ]
+            },
+            LifecyclePolicy = FieldRecordLifecyclePolicy.Default,
+            TaskPackets =
+            [
+                new FieldTaskPacket
+                {
+                    TaskPacketId = "crew-a-day-1",
+                    Name = "Crew A day 1",
+                    Assignments =
+                    [
+                        new FieldAssignment
+                        {
+                            AssignmentId = "task-asset-100",
+                            BindingId = "asset-inspection-assets",
+                            AssigneeUserId = "field-user-1",
+                            Priority = FieldAssignmentPriority.High,
+                            Status = FieldAssignmentStatus.NotStarted,
+                            DueAtUtc = new DateTimeOffset(2026, 5, 24, 3, 0, 0, TimeSpan.Zero),
+                            RecordIds = ["asset-100"],
+                            WorkQuery = new SourceQuery
+                            {
+                                ReturnGeometry = true,
+                                Bbox = new FeatureBoundingBox
+                                {
+                                    MinX = -158,
+                                    MinY = 21,
+                                    MaxX = -157,
+                                    MaxY = 22,
+                                    Crs = "EPSG:4326"
+                                }
+                            },
+                            Metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                            {
+                                ["route"] = "north"
+                            }
+                        },
+                        new FieldAssignment
+                        {
+                            AssignmentId = "task-incident-sweep",
+                            BindingId = "incident-assets",
+                            CrewId = "crew-a",
+                            Priority = FieldAssignmentPriority.Normal,
+                            Status = FieldAssignmentStatus.NotStarted,
+                            WorkQuery = new SourceQuery
+                            {
+                                Where = "priority IN ('normal','urgent')",
+                                ReturnGeometry = true
+                            }
+                        }
+                    ]
+                }
+            ]
+        };
+
+    private static FormDefinition CreateInspectionForm()
+        => new()
+        {
+            FormId = "asset-inspection",
+            Name = "Asset Inspection",
+            Version = "2026.05",
+            Target = new FormTarget
+            {
+                SourceId = "assets",
+                ServiceId = "mobile_offline_demo",
+                LayerId = 68910
+            },
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "main",
+                    Label = "Main",
+                    Fields =
+                    [
+                        Field("asset_id", "Asset ID", FormFieldType.Text, required: true),
+                        new FormField
+                        {
+                            FieldId = "condition",
+                            Label = "Condition",
+                            Type = FormFieldType.SingleChoice,
+                            Required = true,
+                            ChoiceSetId = "asset-condition",
+                            Choices =
+                            [
+                                new FieldChoice { Value = "good", Label = "Good" },
+                                new FieldChoice { Value = "needsRepair", Label = "Needs repair" }
+                            ]
+                        },
+                        new FormField
+                        {
+                            FieldId = "photos",
+                            Label = "Photos",
+                            Type = FormFieldType.Photo,
+                            Required = true,
+                            Validation = new FieldValidationRule { MinMediaCount = 1 },
+                            MediaPolicy = new FieldMediaCapturePolicy
+                            {
+                                AllowedContentTypes = ["image/jpeg", "image/png"],
+                                CaptureLocation = true
+                            }
+                        }
+                    ]
+                }
+            ]
+        };
+
+    private static FormDefinition CreateIncidentForm()
+        => new()
+        {
+            FormId = "incident-report",
+            Name = "Incident Report",
+            Version = "2026.05",
+            Target = new FormTarget
+            {
+                SourceId = "assets",
+                ServiceId = "mobile_offline_demo",
+                LayerId = 68910
+            },
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "main",
+                    Label = "Main",
+                    Fields =
+                    [
+                        Field("summary", "Summary", FormFieldType.Text, required: true),
+                        new FormField
+                        {
+                            FieldId = "linked_asset",
+                            Label = "Linked asset",
+                            Type = FormFieldType.RecordLink,
+                            ReferencedFormId = "asset-inspection"
+                        }
+                    ]
+                }
+            ]
+        };
+
+    private static FormField Field(
+        string fieldId,
+        string label,
+        FormFieldType type,
+        bool required = false)
+        => new()
+        {
+            FieldId = fieldId,
+            Label = label,
+            Type = type,
+            Required = required
+        };
+
+    private static string ComputeSha256(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
+    }
+
+    private static void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/Honua.Mobile.FieldCollection.Tests/LocalFieldRecordLifecycleServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/LocalFieldRecordLifecycleServiceTests.cs
@@ -1,0 +1,176 @@
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Mobile.FieldCollection.Services.Workflow;
+using Honua.Sdk.Field.Projects;
+using Honua.Sdk.Field.Records;
+
+namespace Honua.Mobile.FieldCollection.Tests;
+
+public sealed class LocalFieldRecordLifecycleServiceTests : IDisposable
+{
+    private readonly string _databasePath;
+    private readonly string _artifactRoot;
+
+    public LocalFieldRecordLifecycleServiceTests()
+    {
+        SQLitePCL.Batteries_V2.Init();
+        _databasePath = Path.Combine(Path.GetTempPath(), $"honua-lifecycle-{Guid.NewGuid():N}.gpkg");
+        _artifactRoot = Path.Combine(Path.GetTempPath(), $"honua-lifecycle-export-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_artifactRoot);
+    }
+
+    [Fact]
+    public async Task TransitionAsync_EnforcesPolicyAndPersistsLifecycleMetadata()
+    {
+        using (var storage = new GeoPackageStorageService(_databasePath))
+        {
+            await storage.CreateLayerAsync(CreateLayer());
+            await storage.StoreFeatureAsync(CreateFeature("asset-1"));
+            var service = new LocalFieldRecordLifecycleService(storage);
+            var submittedAt = new DateTimeOffset(2026, 5, 24, 8, 0, 0, TimeSpan.Zero);
+
+            var ready = await service.TransitionAsync(
+                1,
+                "asset-1",
+                RecordStatus.ReadyToSubmit,
+                transitionTimeUtc: submittedAt.AddMinutes(-5));
+            var submitted = await service.TransitionAsync(
+                1,
+                "asset-1",
+                RecordStatus.Submitted,
+                actorId: "field-user-1",
+                actorRole: "inspector",
+                note: "ready for review",
+                transitionTimeUtc: submittedAt);
+            var invalid = await service.TransitionAsync(1, "asset-1", RecordStatus.Draft);
+
+            Assert.True(ready.Succeeded);
+            Assert.True(submitted.Succeeded);
+            Assert.False(invalid.Succeeded);
+            Assert.Equal("invalid-transition", invalid.ReasonCode);
+
+            var feature = await storage.GetFeatureAsync("asset-1", 1);
+            Assert.NotNull(feature);
+            Assert.Equal(RecordStatus.Submitted, LocalFieldRecordLifecycleService.GetStatus(feature));
+            Assert.False(LocalFieldRecordLifecycleService.CanEdit(feature));
+            Assert.Equal("field-user-1", feature.Attributes[LocalFieldRecordLifecycleService.LifecycleActorIdAttribute]?.ToString());
+            Assert.Contains("2026-05-24T08:00:00", feature.Attributes[LocalFieldRecordLifecycleService.SubmittedAtAttribute]?.ToString());
+        }
+
+        using (var restartedStorage = new GeoPackageStorageService(_databasePath))
+        {
+            var feature = await restartedStorage.GetFeatureAsync("asset-1", 1);
+            Assert.NotNull(feature);
+            Assert.Equal(RecordStatus.Submitted, LocalFieldRecordLifecycleService.GetStatus(feature));
+        }
+    }
+
+    [Fact]
+    public async Task LifecyclePolicy_ProtectsSubmittedRecordsAndAllowsRejectedOrReopenedEditing()
+    {
+        using var storage = new GeoPackageStorageService(_databasePath);
+        await storage.CreateLayerAsync(CreateLayer());
+        await storage.StoreFeatureAsync(CreateFeature("asset-2"));
+        var service = new LocalFieldRecordLifecycleService(storage);
+
+        Assert.True(LocalFieldRecordLifecycleService.CanEdit(RecordStatus.Draft));
+        Assert.True(LocalFieldRecordLifecycleService.CanEdit(RecordStatus.Rejected));
+        Assert.False(LocalFieldRecordLifecycleService.CanEdit(RecordStatus.Submitted));
+        Assert.False(LocalFieldRecordLifecycleService.CanEdit(RecordStatus.Approved));
+
+        Assert.True(await TransitionSucceeded(service, "asset-2", RecordStatus.Submitted));
+        Assert.True(await TransitionSucceeded(service, "asset-2", RecordStatus.Rejected));
+        var rejected = await storage.GetFeatureAsync("asset-2", 1);
+        Assert.NotNull(rejected);
+        Assert.True(LocalFieldRecordLifecycleService.CanEdit(rejected));
+
+        Assert.True(await TransitionSucceeded(service, "asset-2", RecordStatus.Reopened));
+        var reopened = await storage.GetFeatureAsync("asset-2", 1);
+        Assert.NotNull(reopened);
+        Assert.True(LocalFieldRecordLifecycleService.CanEdit(reopened));
+
+        var protectedPolicy = FieldRecordLifecyclePolicy.Default with { AllowRejectedEdit = false };
+        Assert.False(LocalFieldRecordLifecycleService.CanEdit(RecordStatus.Rejected, protectedPolicy));
+    }
+
+    [Fact]
+    public async Task LocalExport_IncludesLifecycleMetadata()
+    {
+        using var storage = new GeoPackageStorageService(_databasePath);
+        var layer = CreateLayer();
+        await storage.CreateLayerAsync(layer);
+        await storage.UpsertProjectCatalogEntryAsync(new FieldProjectCatalogEntry
+        {
+            ProjectId = "lifecycle-demo",
+            ServiceId = "lifecycle-demo",
+            PackageId = "pkg-lifecycle",
+            Name = "Lifecycle Demo",
+            State = FieldProjectCatalogState.Installed,
+            ValidationStatus = FieldProjectValidationStatus.Valid,
+            LayerCount = 1
+        });
+        await storage.StoreFeatureAsync(CreateFeature("asset-3"));
+        var service = new LocalFieldRecordLifecycleService(storage);
+        Assert.True((await service.TransitionAsync(1, "asset-3", RecordStatus.Submitted)).Succeeded);
+
+        var result = await new LocalRecordExportService(storage, _artifactRoot).ExportLayerAsync(layer);
+        var csv = await File.ReadAllTextAsync(result.CsvPath);
+        var geoJson = await File.ReadAllTextAsync(result.GeoJsonPath);
+
+        Assert.Contains("attribute_honua_record_status", csv);
+        Assert.Contains("Submitted", csv);
+        Assert.Contains(LocalFieldRecordLifecycleService.StatusAttribute, geoJson);
+        Assert.Contains("Submitted", geoJson);
+    }
+
+    public void Dispose()
+    {
+        DeleteIfExists(_databasePath);
+        DeleteIfExists($"{_databasePath}-wal");
+        DeleteIfExists($"{_databasePath}-shm");
+
+        if (Directory.Exists(_artifactRoot))
+        {
+            Directory.Delete(_artifactRoot, recursive: true);
+        }
+    }
+
+    private static async Task<bool> TransitionSucceeded(
+        LocalFieldRecordLifecycleService service,
+        string featureId,
+        RecordStatus status)
+        => (await service.TransitionAsync(1, featureId, status)).Succeeded;
+
+    private static LayerInfo CreateLayer()
+        => new()
+        {
+            Id = 1,
+            ServiceId = "lifecycle-demo",
+            SourceId = "lifecycle-demo/assets",
+            Name = "Lifecycle Assets",
+            GeometryType = GeometryType.Point,
+            IsEditable = true
+        };
+
+    private static Feature CreateFeature(string id)
+        => new()
+        {
+            Id = id,
+            LayerId = 1,
+            Geometry = new Point(21.3, -157.8),
+            CreatedAt = new DateTime(2026, 5, 24, 7, 30, 0, DateTimeKind.Utc),
+            Attributes = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["asset_id"] = id
+            }
+        };
+
+    private static void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/Honua.Mobile.FieldCollection.Tests/LocalFormParityGoldenFixtureTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/LocalFormParityGoldenFixtureTests.cs
@@ -95,9 +95,7 @@ public sealed class LocalFormParityGoldenFixtureTests : IDisposable
             summaries,
             UnsupportedFollowUps:
             [
-                "SDK follow-up honua-sdk-dotnet#161: shared choice-set ids, record-link target metadata, and media capture policy fields require the newer SDK package.",
-                "SDK follow-up honua-sdk-dotnet#161: full XLSForm/Arcade expression parity beyond supported concat/default/visibility rules.",
-                "Mobile follow-up honua-mobile#254: broader rejected-media and nested-repeat scenario fixtures."
+                "Mobile follow-up: full XLSForm/Arcade expression parity beyond supported concat/default/visibility rules remains a broader runtime slice."
             ]);
         var evidencePath = Path.Combine(_artifactDirectory, "local-form-parity-golden-fixtures.evidence.json");
         await File.WriteAllTextAsync(evidencePath, JsonSerializer.Serialize(evidence, JsonOptions));
@@ -120,7 +118,34 @@ public sealed class LocalFormParityGoldenFixtureTests : IDisposable
         Assert.Contains(summaries.SelectMany(summary => summary.Capabilities), capability => capability == "Media constraints");
         Assert.Contains(summaries.SelectMany(summary => summary.Capabilities), capability => capability == "Record links");
         Assert.Contains(summaries.SelectMany(summary => summary.Capabilities), capability => capability == "Barcode capture");
+        Assert.Contains(summaries.SelectMany(summary => summary.Capabilities), capability => capability == "Shared choice-set ids");
+        Assert.Contains(summaries.SelectMany(summary => summary.Capabilities), capability => capability == "Record-link target metadata");
+        Assert.Contains(summaries.SelectMany(summary => summary.Capabilities), capability => capability == "Media capture policy");
         Assert.True(File.Exists(evidencePath));
+    }
+
+    [Fact]
+    public async Task GoldenFixture_RejectedMediaProducesDeterministicValidationError()
+    {
+        var fixture = CreateInspectionFixture();
+        var values = MobileFormRuleRuntime.ApplyDefaultValues(
+            fixture.Form,
+            fixture.Values,
+            fixture.InitialRepeatCount);
+        values = MobileFormRuleRuntime.ApplyCalculatedValues(fixture.Form, values);
+        var formData = new FormData
+        {
+            LayerId = fixture.LayerId,
+            FeatureId = "inspection-rejected-media",
+            Values = values,
+            Media = []
+        };
+
+        var valid = await new FormService().ValidateFormAsync(formData, fixture.Form);
+
+        Assert.False(valid);
+        Assert.Contains("photos", formData.ValidationErrors.Keys);
+        Assert.Contains("required", formData.ValidationErrors["photos"], StringComparison.OrdinalIgnoreCase);
     }
 
     public void Dispose()
@@ -159,7 +184,10 @@ public sealed class LocalFormParityGoldenFixtureTests : IDisposable
                     Fields =
                     [
                         Field("asset_id", "Asset ID", FormFieldType.Text, required: true),
-                        ChoiceField("status", "Status", required: true, choices: ["open", "closed"]),
+                        ChoiceField("status", "Status", required: true, choices: ["open", "closed"]) with
+                        {
+                            ChoiceSetId = "inspection-statuses"
+                        },
                         new FormField
                         {
                             FieldId = "display_name",
@@ -189,7 +217,8 @@ public sealed class LocalFormParityGoldenFixtureTests : IDisposable
                             Validation = new FieldValidationRule
                             {
                                 MinMediaCount = 1
-                            }
+                            },
+                            MediaPolicy = PhotoMediaPolicy()
                         }
                     ]
                 }
@@ -222,6 +251,8 @@ public sealed class LocalFormParityGoldenFixtureTests : IDisposable
                 "Conditional visibility",
                 "Calculated values",
                 "Media constraints",
+                "Media capture policy",
+                "Shared choice-set ids",
                 "Choice sets",
                 "Draft restore"
             ]);
@@ -242,13 +273,17 @@ public sealed class LocalFormParityGoldenFixtureTests : IDisposable
                     Fields =
                     [
                         Field("asset_tag", "Asset tag", FormFieldType.Barcode, required: true),
-                        ChoiceField("asset_type", "Asset type", required: true, choices: ["pump", "valve", "meter"]),
+                        ChoiceField("asset_type", "Asset type", required: true, choices: ["pump", "valve", "meter"]) with
+                        {
+                            ChoiceSetId = "asset-types"
+                        },
                         new FormField
                         {
                             FieldId = "condition_codes",
                             Label = "Condition codes",
                             Type = FormFieldType.MultipleChoice,
                             Required = true,
+                            ChoiceSetId = "condition-codes",
                             Choices =
                             [
                                 new FieldChoice { Value = "working", Label = "Working" },
@@ -261,7 +296,8 @@ public sealed class LocalFormParityGoldenFixtureTests : IDisposable
                             FieldId = "linked_work_order",
                             Label = "Linked work order",
                             Type = FormFieldType.RecordLink,
-                            Required = true
+                            Required = true,
+                            ReferencedFormId = "work_order"
                         },
                         new FormField
                         {
@@ -298,6 +334,8 @@ public sealed class LocalFormParityGoldenFixtureTests : IDisposable
             [
                 "Barcode capture",
                 "Record links",
+                "Record-link target metadata",
+                "Shared choice-set ids",
                 "Choice sets",
                 "Required rules",
                 "Draft restore"
@@ -318,7 +356,10 @@ public sealed class LocalFormParityGoldenFixtureTests : IDisposable
                     Label = "Incident",
                     Fields =
                     [
-                        ChoiceField("severity", "Severity", required: true, choices: ["low", "medium", "high"]),
+                        ChoiceField("severity", "Severity", required: true, choices: ["low", "medium", "high"]) with
+                        {
+                            ChoiceSetId = "incident-severity"
+                        },
                         new FormField
                         {
                             FieldId = "description",
@@ -352,7 +393,12 @@ public sealed class LocalFormParityGoldenFixtureTests : IDisposable
                             Label = "Signature",
                             Type = FormFieldType.Signature,
                             Required = true,
-                            Validation = new FieldValidationRule { MinMediaCount = 1 }
+                            Validation = new FieldValidationRule { MinMediaCount = 1 },
+                            MediaPolicy = new FieldMediaCapturePolicy
+                            {
+                                AllowedContentTypes = ["image/png"],
+                                CaptureLocation = true
+                            }
                         }
                     ]
                 }
@@ -387,6 +433,8 @@ public sealed class LocalFormParityGoldenFixtureTests : IDisposable
                 "Conditional visibility",
                 "Location capture",
                 "Media constraints",
+                "Media capture policy",
+                "Shared choice-set ids",
                 "Draft restore"
             ]);
     }
@@ -400,7 +448,10 @@ public sealed class LocalFormParityGoldenFixtureTests : IDisposable
             Repeatable = true,
             Fields =
             [
-                ChoiceField("condition", "Condition", required: true, choices: ["ok", "damaged"]),
+                ChoiceField("condition", "Condition", required: true, choices: ["ok", "damaged"]) with
+                {
+                    ChoiceSetId = "observation-condition"
+                },
                 new FormField
                 {
                     FieldId = "quantity",
@@ -439,7 +490,8 @@ public sealed class LocalFormParityGoldenFixtureTests : IDisposable
                     Label = "Photos",
                     Type = FormFieldType.Photo,
                     Required = true,
-                    Validation = new FieldValidationRule { MinMediaCount = 1 }
+                    Validation = new FieldValidationRule { MinMediaCount = 1 },
+                    MediaPolicy = PhotoMediaPolicy()
                 }
             ]
         };
@@ -507,6 +559,8 @@ public sealed class LocalFormParityGoldenFixtureTests : IDisposable
                 "Conditional visibility",
                 "Calculated values",
                 "Media constraints",
+                "Media capture policy",
+                "Shared choice-set ids",
                 "Draft restore"
             ]);
     }
@@ -550,6 +604,15 @@ public sealed class LocalFormParityGoldenFixtureTests : IDisposable
             ContentType = mediaType == FieldMediaType.Photo ? "image/jpeg" : "application/octet-stream",
             MediaType = mediaType,
             SizeBytes = 128
+        };
+
+    private static FieldMediaCapturePolicy PhotoMediaPolicy()
+        => new()
+        {
+            AllowedContentTypes = ["image/jpeg", "image/png"],
+            MaxAttachmentBytes = 10_485_760,
+            CaptureLocation = true,
+            RequiresFaceBlur = true
         };
 
     private sealed record GoldenFixture(

--- a/tests/Honua.Mobile.FieldCollection.Tests/NoCloudFieldDayAcceptanceHarnessTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/NoCloudFieldDayAcceptanceHarnessTests.cs
@@ -1,10 +1,15 @@
 using System.Text.Json;
+using System.Security.Cryptography;
 using Honua.Mobile.FieldCollection.Models;
 using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.FieldCollection.Services.Assignments;
 using Honua.Mobile.FieldCollection.Services.Forms;
+using Honua.Mobile.FieldCollection.Services.Packages;
 using Honua.Mobile.FieldCollection.Services.Sync;
 using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Mobile.FieldCollection.Services.Workflow;
 using Honua.Sdk.Field.Forms;
+using Honua.Sdk.Field.Projects;
 using Honua.Sdk.Field.Records;
 
 namespace Honua.Mobile.FieldCollection.Tests;
@@ -19,6 +24,8 @@ public sealed class NoCloudFieldDayAcceptanceHarnessTests : IDisposable
     private readonly string _databasePath;
     private readonly string _artifactRoot;
     private readonly string _mediaRoot;
+    private readonly string _packageRoot;
+    private readonly string _installRoot;
 
     public NoCloudFieldDayAcceptanceHarnessTests()
     {
@@ -26,34 +33,46 @@ public sealed class NoCloudFieldDayAcceptanceHarnessTests : IDisposable
         _databasePath = Path.Combine(Path.GetTempPath(), $"honua-field-day-{Guid.NewGuid():N}.gpkg");
         _artifactRoot = Path.Combine(Path.GetTempPath(), $"honua-field-day-artifacts-{Guid.NewGuid():N}");
         _mediaRoot = Path.Combine(Path.GetTempPath(), $"honua-field-day-media-{Guid.NewGuid():N}");
+        _packageRoot = Path.Combine(Path.GetTempPath(), $"honua-field-day-package-{Guid.NewGuid():N}");
+        _installRoot = Path.Combine(Path.GetTempPath(), $"honua-field-day-install-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_artifactRoot);
         Directory.CreateDirectory(_mediaRoot);
+        Directory.CreateDirectory(_packageRoot);
+        Directory.CreateDirectory(_installRoot);
     }
 
     [Fact]
     public async Task FieldDayHarness_RunsNoCloudWorkflowAndWritesEvidence()
     {
         using var storage = new GeoPackageStorageService(_databasePath);
-        var layer = CreateLayer();
-        await storage.CreateLayerAsync(layer);
-        await storage.UpsertProjectCatalogEntryAsync(new FieldProjectCatalogEntry
+        var package = LocalFieldProjectPackageImportServiceTests.CreatePackage();
+        var manifestPath = await WritePackageAsync(package);
+        var importResult = await new LocalFieldProjectPackageImportService(storage).ImportAsync(new LocalFieldProjectPackageImportRequest
         {
-            ProjectId = "field-day",
-            ServiceId = "field-day",
-            PackageId = "field-day-local-package",
-            Version = "2026.05.23",
-            Name = "Field Day Local Package",
-            Description = "No-cloud acceptance fixture",
-            State = FieldProjectCatalogState.Installed,
-            ValidationStatus = FieldProjectValidationStatus.Valid,
-            LayerCount = 1,
-            ImportedAtUtc = DateTime.UtcNow.AddHours(-1),
-            PackageDigest = "sha256:field-day-fixture"
+            ManifestPath = manifestPath,
+            DestinationRootDirectory = _installRoot,
+            ImportSource = "field-day-fixture",
+            OverwriteExisting = true
         });
-        await storage.MarkProjectCatalogEntryOpenedAsync("field-day");
+        Assert.True(importResult.Imported, string.Join(" | ", importResult.Diagnostics.Select(diagnostic => diagnostic.Message)));
+
+        var layer = (await storage.GetLayersAsync())
+            .Single(importedLayer => importedLayer.Form?.FormId == "asset-inspection");
+        await storage.MarkProjectCatalogEntryOpenedAsync(package.ProjectId);
+
+        var assignmentService = new LocalFieldAssignmentService(storage);
+        var assignments = await assignmentService.GetAssignmentsAsync(new LocalFieldAssignmentFilter
+        {
+            AssigneeUserId = "field-user-1",
+            Status = FieldAssignmentStatus.NotStarted,
+            SourceId = "assets"
+        });
+        var assignment = Assert.Single(assignments);
+        Assert.True(await assignmentService.UpdateStatusAsync(assignment.AssignmentId, FieldAssignmentStatus.InProgress));
 
         var form = layer.Form!;
         var formData = CreateCapturedFormData(form);
+        formData.LayerId = layer.Id;
         var formValid = await new FormService().ValidateFormAsync(formData, form);
         Assert.True(formValid, string.Join(" | ", formData.ValidationErrors.Select(error => $"{error.Key}: {error.Value}")));
         Assert.Empty(formData.ValidationErrors);
@@ -70,6 +89,16 @@ public sealed class NoCloudFieldDayAcceptanceHarnessTests : IDisposable
             Attributes = new Dictionary<string, object?>(formData.Values, StringComparer.Ordinal)
         };
         await storage.StoreFeatureAsync(capturedFeature);
+        var lifecycleService = new LocalFieldRecordLifecycleService(storage);
+        Assert.True((await lifecycleService.TransitionAsync(layer.Id, capturedFeature.Id, RecordStatus.ReadyToSubmit)).Succeeded);
+        Assert.True((await lifecycleService.TransitionAsync(
+            layer.Id,
+            capturedFeature.Id,
+            RecordStatus.Submitted,
+            actorId: "field-user-1",
+            actorRole: "inspector",
+            note: "field day complete")).Succeeded);
+        Assert.True(await assignmentService.UpdateStatusAsync(assignment.AssignmentId, FieldAssignmentStatus.Complete));
 
         var localPhotoPath = Path.Combine(_mediaRoot, "capture", "field-day-photo.jpg");
         Directory.CreateDirectory(Path.GetDirectoryName(localPhotoPath)!);
@@ -124,7 +153,7 @@ public sealed class NoCloudFieldDayAcceptanceHarnessTests : IDisposable
 
         var exportRoot = Path.Combine(_artifactRoot, "exports");
         var exportResult = await new LocalRecordExportService(storage, exportRoot).ExportLayerAsync(layer);
-        var catalogEntry = await storage.GetProjectCatalogEntryAsync("field-day");
+        var catalogEntry = await storage.GetProjectCatalogEntryAsync(package.ProjectId);
         var diagnostics = await storage.GetOfflineCacheDiagnosticsAsync();
         var evidencePath = Path.Combine(_artifactRoot, "field-day.evidence.json");
         var evidence = new FieldDayEvidence(
@@ -134,16 +163,18 @@ public sealed class NoCloudFieldDayAcceptanceHarnessTests : IDisposable
             GeneratedAtUtc: DateTime.UtcNow,
             Steps:
             [
-                Step("package-catalog", "passed", "field_project_catalog row installed and opened", "field-day"),
-                Step("assignment-packet", "follow-up", "portable task packet adapters remain in honua-mobile#252", null),
+                Step("package-import", importResult.Imported ? "passed" : "failed", "SDK package manifest validated and installed locally", Path.GetFileName(importResult.InstalledManifestPath)),
+                Step("package-catalog", catalogEntry?.LastOpenedAtUtc is not null ? "passed" : "failed", "field_project_catalog row installed and opened", package.ProjectId),
+                Step("assignment-packet", "passed", "SDK task packet imported and completed locally", assignment.AssignmentId),
                 Step("record-collection", "passed", "form values validated and stored in GeoPackage", capturedFeature.Id),
                 Step("media-attachment", "passed", "local photo metadata stored and exported from device path", "field-day-photo-1"),
-                Step("lifecycle-transition", "follow-up", "formal lifecycle runtime remains in honua-mobile#251", null),
+                Step("lifecycle-transition", "passed", "record moved through ready-to-submit and submitted lifecycle states", capturedFeature.Id),
                 Step("conflict-replay", conflictResult.ResolutionApplied ? "passed" : "failed", "local peer replayed conflict and selected resolution", Path.GetFileName(conflictResult.EvidencePath)),
                 Step("export", File.Exists(exportResult.EvidenceManifestPath) ? "passed" : "failed", "local export package written", Path.GetFileName(exportResult.EvidenceManifestPath))
             ],
             Artifacts: new Dictionary<string, string?>(StringComparer.Ordinal)
             {
+                ["installedManifest"] = Path.GetFileName(importResult.InstalledManifestPath),
                 ["conflictEvidence"] = Path.GetFileName(conflictResult.EvidencePath),
                 ["exportDirectory"] = Path.GetFileName(exportResult.ExportDirectory),
                 ["exportEvidence"] = Path.GetFileName(exportResult.EvidenceManifestPath),
@@ -153,6 +184,7 @@ public sealed class NoCloudFieldDayAcceptanceHarnessTests : IDisposable
             Counts: new Dictionary<string, int>(StringComparer.Ordinal)
             {
                 ["records"] = exportResult.RecordCount,
+                ["assignments"] = (await assignmentService.GetAssignmentsAsync()).Count,
                 ["attachments"] = exportResult.AttachmentCount,
                 ["copiedMediaFiles"] = exportResult.MediaFileCount,
                 ["pendingOperations"] = diagnostics.Operations.PendingCount,
@@ -176,8 +208,10 @@ public sealed class NoCloudFieldDayAcceptanceHarnessTests : IDisposable
             parsed.RootElement.GetProperty("schemaVersion").GetString());
         Assert.True(parsed.RootElement.GetProperty("noCloud").GetBoolean());
         Assert.False(parsed.RootElement.GetProperty("cloudUploadIncluded").GetBoolean());
-        Assert.Equal(7, parsed.RootElement.GetProperty("steps").GetArrayLength());
-        Assert.Contains("\"status\": \"follow-up\"", evidenceJson);
+        Assert.Equal(8, parsed.RootElement.GetProperty("steps").GetArrayLength());
+        Assert.DoesNotContain("\"status\": \"follow-up\"", evidenceJson);
+        Assert.Contains("\"assignment-packet\"", evidenceJson);
+        Assert.Contains("\"lifecycle-transition\"", evidenceJson);
         Assert.DoesNotContain(_artifactRoot, evidenceJson);
         Assert.DoesNotContain(_mediaRoot, evidenceJson);
         Assert.DoesNotContain(localPhotoPath, evidenceJson);
@@ -197,6 +231,16 @@ public sealed class NoCloudFieldDayAcceptanceHarnessTests : IDisposable
         if (Directory.Exists(_mediaRoot))
         {
             Directory.Delete(_mediaRoot, recursive: true);
+        }
+
+        if (Directory.Exists(_packageRoot))
+        {
+            Directory.Delete(_packageRoot, recursive: true);
+        }
+
+        if (Directory.Exists(_installRoot))
+        {
+            Directory.Delete(_installRoot, recursive: true);
         }
     }
 
@@ -261,6 +305,7 @@ public sealed class NoCloudFieldDayAcceptanceHarnessTests : IDisposable
         var values = MobileFormRuleRuntime.ApplyDefaultValues(form, new Dictionary<string, object?>
         {
             ["asset_id"] = "asset-field-day-1",
+            ["condition"] = "good",
             ["location"] = new FieldGeoPoint(21.3, -157.8, 3)
         });
         values = MobileFormRuleRuntime.ApplyCalculatedValues(form, values);
@@ -315,6 +360,34 @@ public sealed class NoCloudFieldDayAcceptanceHarnessTests : IDisposable
 
     private static FieldDayStep Step(string name, string status, string detail, string? artifact)
         => new(name, status, detail, artifact);
+
+    private async Task<string> WritePackageAsync(FieldProjectPackage package)
+    {
+        Directory.CreateDirectory(Path.Combine(_packageRoot, "data"));
+        var artifactPath = Path.Combine(_packageRoot, "data", "assets.gpkg");
+        await File.WriteAllTextAsync(artifactPath, "field day offline data");
+        package = package with
+        {
+            OfflinePackages =
+            [
+                package.OfflinePackages[0] with
+                {
+                    SizeBytes = new FileInfo(artifactPath).Length,
+                    Sha256 = ComputeSha256(artifactPath)
+                }
+            ]
+        };
+
+        var manifestPath = Path.Combine(_packageRoot, "field-project-package.json");
+        await File.WriteAllTextAsync(manifestPath, package.ToJson());
+        return manifestPath;
+    }
+
+    private static string ComputeSha256(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
+    }
 
     private static void DeleteIfExists(string path)
     {


### PR DESCRIPTION
## Summary

- adds SDK-backed local field project package import and validation, including artifact copy, manifest/file diagnostics, catalog/layer registration, and task packet ingestion
- adds mobile-owned lifecycle and assignment adapters over the SDK field contracts, with persisted record status metadata and service-level assignment filtering/completion
- hardens no-cloud parity evidence for media policy, record-link metadata, choice-set ids, rejected media, remote-delete conflict replay, and the field-day harness

Closes #249
Closes #251
Closes #252
Closes #253
Closes #255
Closes #257
Closes #258

## Validation

- `dotnet build tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true --no-restore --verbosity minimal`
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --configuration Release --no-build --verbosity minimal` (121 passed)
- `dotnet format tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore --verify-no-changes --verbosity minimal`
- `dotnet build apps/Honua.Mobile.FieldCollection.Core/Honua.Mobile.FieldCollection.Core.csproj --configuration Release /p:TreatWarningsAsErrors=true --no-restore --verbosity minimal`
- `git diff --check`

Local MAUI Android app build could not run because this machine has no Android SDK (`XA5300`). CI should cover the MAUI targets.
