### PR TITLE
mobile: use SDK FeatureServer edit conversion

### DIFF
--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs
@@ -6,6 +6,7 @@ using Honua.Sdk.GeoServices.FeatureServer;
 using Honua.Sdk.GeoServices.FeatureServer.Exceptions;
 using Honua.Sdk.Grpc;
 using Honua.Sdk.OgcFeatures.Exceptions;
+using FeatureServerRequestConverters = Honua.Sdk.GeoServices.FeatureServer.Conversion.RequestConverters;
 
 namespace Honua.Mobile.Sdk;
 
@@ -437,7 +438,7 @@ public sealed partial class HonuaMobileClient
             HttpMethod.Post,
             path,
             query: null,
-            new FormUrlEncodedContent(BuildFeatureServerEditFormParameters(editRequest)),
+            new FormUrlEncodedContent(FeatureServerRequestConverters.ToFeatureServerEditFormParameters(editRequest)),
             ct).ConfigureAwait(false);
     }
 

--- a/tests/Honua.Mobile.Sdk.Tests/HonuaMobileSdkFeatureClientTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/HonuaMobileSdkFeatureClientTests.cs
@@ -126,13 +126,7 @@ public sealed class HonuaMobileSdkFeatureClientTests
         Assert.Equal(7, result.DeleteResults[0].ObjectId);
     }
 
-    // GeoJSON Point -> {"x":,"y":} translation now lives in Honua.Sdk.GeoServices'
-    // FeatureServer converters. The 0.1.17-alpha.1 train surfaces FeatureEditFeature
-    // attributes/geometry verbatim through ToFeatureServerEditFormParameters; the
-    // explicit x/y projection that mobile previously performed before assembling
-    // the form payload is no longer mobile-owned. Re-enable once
-    // honua-sdk-dotnet adds the GeoJSON->FeatureServer geometry projection.
-    [Fact(Skip = "Tracked at honua-io/honua-mobile#199 — SDK 0.1.17-alpha.1 emits GeoJSON in adds payload; pending Honua.Sdk.GeoServices geometry projection.")]
+    [Fact]
     public async Task ApplyEditsAsync_FeatureServerRequest_AcceptsSparseLiveImageEditResponse()
     {
         string? capturedBody = null;

--- a/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
@@ -128,14 +128,6 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
             });
             AssertEditSucceeded(update, "updateResults");
 
-            // Tracked at https://github.com/honua-io/honua-mobile/issues/199 -- the SDK
-            // provider-neutral ApplyEdits.Adds path sends GeoJSON-shaped geometry that
-            // the FeatureServer rejects with "Invalid GeoServices JSON geometry format"
-            // (error code 1000). Skip just this branch (the REST overload above is
-            // exercised, and the trunk server contract is verified) until the
-            // GeoServices request-converter shape divergence is resolved.
-            Skip.If(true, "Tracked at #199 -- SDK ApplyEdits.Adds geometry shape divergence (GeoJSON vs GeoServices x/y).");
-
             var sdkEdit = await client.ApplyEditsAsync(new FeatureEditRequest
             {
                 Source = FeatureSource(),


### PR DESCRIPTION
## Summary
- routes provider-neutral FeatureServer edits through the published Honua.Sdk.GeoServices request converter
- re-enables the sparse live-image edit response unit test
- removes the #199 live-test skip around SDK ApplyEdits adds

## Root cause
Mobile had already consumed the SDK train with GeoJSON-to-GeoServices projection, but the provider-neutral FeatureServer REST edit path was still assembling the form payload locally. That bypassed the SDK converter and preserved the old GeoJSON geometry shape.

## Validation
- `dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj`
- `HONUA_MOBILE_LIVE_SERVER_TESTS=1 HONUA_MOBILE_LIVE_SERVER_IMAGE=honuaio/honua-server:nightly HONUA_MOBILE_LIVE_SERVER_FIXTURE_SQL=/home/makani/honua-mobile/tests/seed/mobile-offline-demo-v1.sql dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --filter "FullyQualifiedName~LiveHonuaServerInteractionTests.LiveImage_FeatureServerRestAndSdkFeatureContracts_RoundTrip" --logger "console;verbosity=normal"`

Closes #199