### PR TITLE
test: activate live grpc stream validation

### DIFF
--- a/docs/guides/validation-strategy.md
+++ b/docs/guides/validation-strategy.md
@@ -75,7 +75,7 @@ honest gaps; the parenthesised reason indicates why.
 | Sync engine (queue, claim/lease, retry) | `OfflineSyncEngineTests.cs` (7), `HonuaApiOfflineOperationUploaderTests.cs` (10) | `OfflineServerIntegrationTests.cs` (3) | covered by `LiveHonuaServerInteractionTests.cs` | covered by cloud acceptance suite | N/A (deferred) | covered |
 | FeatureServer REST | `HonuaMobileClientHttpTests.cs` (17), `HonuaMobileSdkFeatureClientTests.cs` (5) | `SdkServerIntegrationTests.cs` (3) | covered by `LiveHonuaServerInteractionTests.cs` | covered by cloud acceptance suite | N/A (deferred) | covered |
 | OGC Features | `HonuaMobileClientHttpTests.cs` (subset of 17) | `SdkServerIntegrationTests.cs` (3) | covered by `LiveHonuaServerInteractionTests.cs` | N/A (manual) | N/A (deferred) | covered |
-| gRPC transport | `HonuaMobileClientHttpTests.cs` (subset), `HonuaMobileClientTransportSecurityTests.cs` (7), `grpc-validation` job in `ci.yml` | N/A (loopback uses REST) | `LiveHonuaServerInteractionTests.LiveImage_GrpcFeatureQueryAndEdit_RoundTrip` (unary RPC + ApplyEdits add, active) and `LiveImage_GrpcFeatureQueryStream_RoundTrip` (server-streaming RPC, tracked-Skip pending #202: server-side streaming validator rejects fields the unary RPC accepts), both wired against the testcontainers gRPC endpoint (port 8081 / `HONUA_MOBILE_LIVE_SERVER_GRPC_URL`) with `allowRestFallbackOnGrpcFailure: false` | N/A (manual) | N/A (deferred) | unit + live (unary); streaming live tracked-Skip |
+| gRPC transport | `HonuaMobileClientHttpTests.cs` (subset), `HonuaMobileClientTransportSecurityTests.cs` (7), `grpc-validation` job in `ci.yml` | N/A (loopback uses REST) | `LiveHonuaServerInteractionTests.LiveImage_GrpcFeatureQueryAndEdit_RoundTrip` (unary RPC + ApplyEdits add) and `LiveImage_GrpcFeatureQueryStream_RoundTrip` (server-streaming RPC), both wired against the testcontainers gRPC endpoint (port 8081 / `HONUA_MOBILE_LIVE_SERVER_GRPC_URL`) with `allowRestFallbackOnGrpcFailure: false` | N/A (manual) | N/A (deferred) | unit + live |
 | Replica sync (delta, cursors) | `ReplicaSyncClientTests.cs` (12), `DeltaDownloadEngineTests.cs` (7) | N/A (future) | covered by `LiveHonuaServerInteractionTests.cs` | N/A (manual) | N/A (deferred) | unit + live |
 | Offline diagnostics / cache governance | `BackgroundPrefetchSchedulerTests.cs` (1), `GeoPackageSyncServiceTests.cs` (15) | N/A (future) | N/A (future) | N/A (manual) | N/A (deferred) | unit-only |
 | Field collection workflow | `FormValidatorTests.cs` (8), `RecordWorkflowTests.cs` (3), `FieldWorkflowOfflineAdapterTests.cs` (1), `FieldCollectionSdkContractMigrationTests.cs` (5) | `FieldCollectionServerIntegrationTests.cs` (3) | covered by `LiveHonuaServerInteractionTests.cs` | covered by `DisconnectedFieldWorkflowAcceptanceTests.cs` | N/A (deferred) | covered |
@@ -127,17 +127,13 @@ Known coverage gaps, with the owner ticket where one exists:
   postgres container and the dotnet test step as a hard gate (no
   `continue-on-error`). Adding the workflow to branch-protection required
   checks is a separate maintainer call.
-- **gRPC live transport** -- unary covered.
+- **gRPC live transport** -- covered.
   `LiveHonuaServerInteractionTests.LiveImage_GrpcFeatureQueryAndEdit_RoundTrip`
   exercises the unary RPC + `ApplyEdits` against the testcontainers
   honua-server image with `preferGrpc: true, allowRestFallbackOnGrpcFailure:
-  false`. Server-streaming coverage is wired
-  (`LiveImage_GrpcFeatureQueryStream_RoundTrip`) but currently
-  tracked-`Skip` pending honua-io/honua-mobile#202: the server's
-  streaming-RPC validator rejects `Where`/`OutFields`/`ReturnGeometry`
-  even though the unary RPC accepts the same shape from the same
-  `GrpcRequestConverters.ToGrpcQueryRequest` output. The test's
-  assertion is preserved so it activates as soon as #202 lands.
+  false`. `LiveImage_GrpcFeatureQueryStream_RoundTrip` exercises the
+  server-streaming RPC with `Where`, `OutFields`, and `ReturnGeometry` so
+  the live suite covers the mobile query path used by paginated gRPC reads.
 - **Background sync and connectivity-aware sync end-to-end** -- only
   unit-tested today (`BackgroundSyncOrchestratorTests.cs`,
   `BackgroundPrefetchSchedulerTests.cs`). No integration or live fixture

--- a/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
@@ -225,16 +225,6 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
         // than being silently masked by the unary REST path.
         using var client = CreateMobileClient(preferGrpc: true, allowRestFallbackOnGrpcFailure: false);
 
-        // Tracked at https://github.com/honua-io/honua-mobile/issues/202 -- the live
-        // server-streaming RPC currently rejects this request with
-        // "InvalidArgument: Invalid request parameters" even though the unary RPC
-        // accepts the same shape (see LiveImage_GrpcFeatureQueryAndEdit_RoundTrip).
-        // The mobile-side converter (GrpcRequestConverters.ToGrpcQueryRequest) is
-        // identical for both paths, so the divergence is in the server's request
-        // validation. Skip narrowly until the streaming contract is reconciled; the
-        // assertion below is preserved so it activates as soon as #202 lands.
-        Skip.If(true, "Tracked at #202 -- live gRPC streaming RPC rejects Where/OutFields/ReturnGeometry that unary accepts.");
-
         JsonDocument? page = null;
         await foreach (var streamed in client.QueryFeaturesStreamAsync(new QueryFeaturesRequest
         {


### PR DESCRIPTION
Closes #202.

## Summary
- remove the tracked skip from `LiveImage_GrpcFeatureQueryStream_RoundTrip` now that server streaming validation is fixed
- update the validation strategy to mark gRPC server-streaming live coverage active

## Validation
- `dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --filter "FullyQualifiedName~LiveHonuaServerInteractionTests.LiveImage_GrpcFeatureQueryStream_RoundTrip" --logger "console;verbosity=normal"` (env-gated local compile run; skipped because live env was unset)
- `dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --filter "FullyQualifiedName~MobileParityBacklogDocsTests" --logger "console;verbosity=normal"`
- `HONUA_MOBILE_LIVE_SERVER_TESTS=1 HONUA_MOBILE_LIVE_SERVER_IMAGE=honuaio/honua-server:nightly HONUA_MOBILE_LIVE_SERVER_FIXTURE_SQL=/home/makani/honua-mobile/tests/seed/mobile-offline-demo-v1.sql dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --filter "FullyQualifiedName~LiveHonuaServerInteractionTests.LiveImage_GrpcFeatureQueryStream_RoundTrip" --logger "console;verbosity=normal"`
- `HONUA_MOBILE_LIVE_SERVER_TESTS=1 HONUA_MOBILE_LIVE_SERVER_IMAGE=honuaio/honua-server:nightly HONUA_MOBILE_LIVE_SERVER_FIXTURE_SQL=/home/makani/honua-mobile/tests/seed/mobile-offline-demo-v1.sql dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --filter "FullyQualifiedName~LiveHonuaServerInteractionTests" --logger "console;verbosity=normal"` (11/11 passed)

## Notes
- server dependency honua-io/honua-server#1161 was closed by honua-io/honua-server#1177
- manually refreshed `honuaio/honua-server:nightly` from server trunk commit `a04ee5409a89df8129c87f4f5bfedf7bed062326`; local pull resolved digest `sha256:203b18cab1ae6b2c018ea714b0bc2960b22849bf7fd3f8d801062bde0723d7ec`