### PR TITLE
mobile: add field operations work surface

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Export/LocalRecordExportShareService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Export/LocalRecordExportShareService.cs
@@ -1,0 +1,16 @@
+namespace Honua.Mobile.FieldCollection.Services;
+
+public interface ILocalRecordExportShareService
+{
+    Task ShareExportAsync(LocalRecordExportResult export, CancellationToken cancellationToken = default);
+}
+
+public sealed class NoOpLocalRecordExportShareService : ILocalRecordExportShareService
+{
+    public Task ShareExportAsync(LocalRecordExportResult export, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(export);
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
+    }
+}

--- a/apps/Honua.Mobile.FieldCollection.Core/ViewModels/FieldOperationsViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/ViewModels/FieldOperationsViewModel.cs
@@ -1,0 +1,357 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.FieldCollection.Services.Assignments;
+using Honua.Mobile.FieldCollection.Services.Packages;
+using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Sdk.Field.Projects;
+
+namespace Honua.Mobile.FieldCollection.ViewModels;
+
+public partial class FieldOperationsViewModel : BaseViewModel
+{
+    private readonly GeoPackageStorageService _storage;
+    private readonly ILocalFieldAssignmentService _assignmentService;
+    private readonly LocalFieldProjectPackageImportService _packageImportService;
+    private readonly ILocalRecordExportService _recordExportService;
+    private readonly ILocalRecordExportShareService _exportShareService;
+
+    [ObservableProperty]
+    private FieldProjectCatalogEntry? selectedPackage;
+
+    [ObservableProperty]
+    private LocalFieldAssignmentInfo? selectedAssignment;
+
+    [ObservableProperty]
+    private LayerInfo? selectedLayer;
+
+    [ObservableProperty]
+    private string packageManifestPath = string.Empty;
+
+    [ObservableProperty]
+    private string packageDestinationRoot = string.Empty;
+
+    [ObservableProperty]
+    private bool includeArchivedPackages;
+
+    [ObservableProperty]
+    private string statusMessage = string.Empty;
+
+    [ObservableProperty]
+    private string lastImportSummary = string.Empty;
+
+    [ObservableProperty]
+    private string lastExportSummary = string.Empty;
+
+    [ObservableProperty]
+    private string lastExportDirectory = string.Empty;
+
+    [ObservableProperty]
+    private bool hasImportDiagnostics;
+
+    [ObservableProperty]
+    private bool hasLastExport;
+
+    private LocalRecordExportResult? _lastExport;
+
+    public ObservableCollection<FieldProjectCatalogEntry> Packages { get; } = [];
+    public ObservableCollection<LocalFieldAssignmentInfo> Assignments { get; } = [];
+    public ObservableCollection<LayerInfo> AvailableLayers { get; } = [];
+    public ObservableCollection<LocalFieldProjectPackageDiagnostic> ImportDiagnostics { get; } = [];
+    public ObservableCollection<string> ExportArtifacts { get; } = [];
+
+    public FieldOperationsViewModel(
+        INavigationService navigationService,
+        GeoPackageStorageService storage,
+        ILocalFieldAssignmentService assignmentService,
+        LocalFieldProjectPackageImportService packageImportService,
+        ILocalRecordExportService recordExportService,
+        ILocalRecordExportShareService exportShareService)
+        : base(navigationService)
+    {
+        _storage = storage;
+        _assignmentService = assignmentService;
+        _packageImportService = packageImportService;
+        _recordExportService = recordExportService;
+        _exportShareService = exportShareService;
+        Title = "Work";
+    }
+
+    protected override Task OnRefresh() => LoadWorkspace();
+
+    partial void OnSelectedPackageChanged(FieldProjectCatalogEntry? value)
+    {
+        _ = LoadAssignments();
+    }
+
+    partial void OnIncludeArchivedPackagesChanged(bool value)
+    {
+        _ = LoadWorkspace();
+    }
+
+    [RelayCommand]
+    private async Task LoadWorkspace()
+    {
+        await ExecuteAsync(RefreshWorkspaceCoreAsync);
+    }
+
+    [RelayCommand]
+    private async Task LoadAssignments()
+    {
+        await ExecuteAsync(LoadAssignmentsCoreAsync);
+    }
+
+    [RelayCommand]
+    private async Task ImportPackage()
+    {
+        if (string.IsNullOrWhiteSpace(PackageManifestPath))
+        {
+            await ShowError("Package Required", "Enter a field-project-package.json path before importing.");
+            return;
+        }
+
+        var manifestPath = PackageManifestPath.Trim();
+        var destinationRoot = string.IsNullOrWhiteSpace(PackageDestinationRoot)
+            ? Path.Combine(Path.GetDirectoryName(manifestPath) ?? Environment.CurrentDirectory, "installed")
+            : PackageDestinationRoot.Trim();
+
+        await ExecuteAsync(async () =>
+        {
+            var result = await _packageImportService.ImportAsync(new LocalFieldProjectPackageImportRequest
+            {
+                ManifestPath = manifestPath,
+                DestinationRootDirectory = destinationRoot,
+                ImportSource = manifestPath,
+                OverwriteExisting = true
+            });
+
+            ImportDiagnostics.Clear();
+            foreach (var diagnostic in result.Diagnostics)
+            {
+                ImportDiagnostics.Add(diagnostic);
+            }
+
+            HasImportDiagnostics = ImportDiagnostics.Count > 0;
+            LastImportSummary = result.Imported
+                ? $"Imported {result.ProjectId} with {result.ImportedFiles.Count} artifact(s), {result.CopiedBytes} byte(s)."
+                : $"Package import failed for {result.ProjectId ?? Path.GetFileName(manifestPath)}.";
+            StatusMessage = LastImportSummary;
+
+            await RefreshWorkspaceCoreAsync();
+        });
+    }
+
+    [RelayCommand]
+    private async Task MarkPackageOpened()
+    {
+        if (SelectedPackage is null)
+        {
+            return;
+        }
+
+        var projectId = SelectedPackage.ProjectId;
+        await ExecuteAsync(async () =>
+        {
+            await _storage.MarkProjectCatalogEntryOpenedAsync(projectId);
+            StatusMessage = $"Opened {SelectedPackage.Name}.";
+            await RefreshWorkspaceCoreAsync();
+        });
+    }
+
+    [RelayCommand]
+    private async Task ArchivePackage()
+    {
+        if (SelectedPackage is null)
+        {
+            return;
+        }
+
+        var projectId = SelectedPackage.ProjectId;
+        await ExecuteAsync(async () =>
+        {
+            await _storage.UpdateProjectCatalogStateAsync(projectId, FieldProjectCatalogState.Archived);
+            StatusMessage = $"Archived {SelectedPackage.Name}.";
+            await RefreshWorkspaceCoreAsync();
+        });
+    }
+
+    [RelayCommand]
+    private async Task StartAssignment(LocalFieldAssignmentInfo assignment)
+    {
+        await UpdateAssignmentStatusAsync(assignment, FieldAssignmentStatus.InProgress);
+    }
+
+    [RelayCommand]
+    private async Task CompleteAssignment(LocalFieldAssignmentInfo assignment)
+    {
+        await UpdateAssignmentStatusAsync(assignment, FieldAssignmentStatus.Complete);
+    }
+
+    [RelayCommand]
+    private async Task ReopenAssignment(LocalFieldAssignmentInfo assignment)
+    {
+        await UpdateAssignmentStatusAsync(assignment, FieldAssignmentStatus.NotStarted);
+    }
+
+    [RelayCommand]
+    private async Task OpenAssignmentRecord(LocalFieldAssignmentInfo assignment)
+    {
+        if (assignment.RecordIds.Count == 0)
+        {
+            StatusMessage = "Assignment has no bound record.";
+            return;
+        }
+
+        var layer = FindLayerForAssignment(assignment);
+        if (layer is null)
+        {
+            StatusMessage = $"No local layer found for assignment {assignment.AssignmentId}.";
+            return;
+        }
+
+        await NavigationService.NavigateToAsync(
+            "record-detail",
+            new Dictionary<string, object>
+            {
+                ["layerId"] = layer.Id,
+                ["featureId"] = assignment.RecordIds[0]
+            });
+    }
+
+    [RelayCommand]
+    private async Task ExportSelectedLayer()
+    {
+        if (SelectedLayer is null)
+        {
+            await ShowError("Layer Required", "Select a local layer before exporting.");
+            return;
+        }
+
+        var layer = SelectedLayer;
+        await ExecuteAsync(async () =>
+        {
+            _lastExport = await _recordExportService.ExportLayerAsync(layer);
+            HasLastExport = true;
+            LastExportDirectory = _lastExport.ExportDirectory;
+            LastExportSummary = $"Exported {_lastExport.RecordCount} record(s), {_lastExport.AttachmentCount} attachment(s).";
+
+            ExportArtifacts.Clear();
+            ExportArtifacts.Add(_lastExport.CsvPath);
+            ExportArtifacts.Add(_lastExport.GeoJsonPath);
+            ExportArtifacts.Add(_lastExport.AttachmentManifestPath);
+            ExportArtifacts.Add(_lastExport.EvidenceManifestPath);
+
+            StatusMessage = LastExportSummary;
+            await RefreshWorkspaceCoreAsync();
+        });
+    }
+
+    [RelayCommand]
+    private async Task ShareLastExport()
+    {
+        if (_lastExport is null)
+        {
+            await ShowError("Export Required", "Export a layer before sharing.");
+            return;
+        }
+
+        await ExecuteAsync(async () =>
+        {
+            await _exportShareService.ShareExportAsync(_lastExport);
+            StatusMessage = $"Shared export for {_lastExport.LayerName}.";
+        });
+    }
+
+    private async Task UpdateAssignmentStatusAsync(LocalFieldAssignmentInfo? assignment, FieldAssignmentStatus status)
+    {
+        if (assignment is null)
+        {
+            return;
+        }
+
+        await ExecuteAsync(async () =>
+        {
+            if (!await _assignmentService.UpdateStatusAsync(assignment.AssignmentId, status))
+            {
+                StatusMessage = $"Assignment {assignment.AssignmentId} was not found.";
+                return;
+            }
+
+            StatusMessage = $"Assignment {assignment.AssignmentId} is {status}.";
+            await LoadAssignmentsCoreAsync();
+        });
+    }
+
+    private async Task RefreshWorkspaceCoreAsync()
+    {
+        var previousPackageId = SelectedPackage?.ProjectId;
+        var previousLayerId = SelectedLayer?.Id;
+        var packages = await _storage.GetProjectCatalogEntriesAsync(IncludeArchivedPackages);
+        var layers = await _storage.GetLayersAsync();
+
+        Packages.Clear();
+        foreach (var package in packages)
+        {
+            Packages.Add(package);
+        }
+
+        AvailableLayers.Clear();
+        foreach (var layer in layers.OrderBy(layer => layer.Name, StringComparer.OrdinalIgnoreCase))
+        {
+            AvailableLayers.Add(layer);
+        }
+
+        SelectedPackage = Packages.FirstOrDefault(package =>
+                string.Equals(package.ProjectId, previousPackageId, StringComparison.OrdinalIgnoreCase)) ??
+            Packages.FirstOrDefault();
+        SelectedLayer = AvailableLayers.FirstOrDefault(layer => layer.Id == previousLayerId) ??
+            AvailableLayers.FirstOrDefault();
+
+        await LoadAssignmentsCoreAsync();
+        StatusMessage = Packages.Count == 0
+            ? "No local field packages installed."
+            : $"{Packages.Count} package(s), {Assignments.Count} assignment(s).";
+    }
+
+    private async Task LoadAssignmentsCoreAsync()
+    {
+        var projectId = SelectedPackage?.ProjectId;
+        var assignments = await _assignmentService.GetAssignmentsAsync(
+            string.IsNullOrWhiteSpace(projectId)
+                ? null
+                : new LocalFieldAssignmentFilter { ProjectId = projectId });
+
+        var selectedAssignmentId = SelectedAssignment?.AssignmentId;
+        Assignments.Clear();
+        foreach (var assignment in assignments
+            .OrderBy(assignment => assignment.DueAtUtc ?? DateTimeOffset.MaxValue)
+            .ThenByDescending(assignment => assignment.Priority)
+            .ThenBy(assignment => assignment.AssignmentId, StringComparer.OrdinalIgnoreCase))
+        {
+            Assignments.Add(assignment);
+        }
+
+        SelectedAssignment = Assignments.FirstOrDefault(assignment =>
+                string.Equals(assignment.AssignmentId, selectedAssignmentId, StringComparison.OrdinalIgnoreCase)) ??
+            Assignments.FirstOrDefault();
+    }
+
+    private LayerInfo? FindLayerForAssignment(LocalFieldAssignmentInfo assignment)
+    {
+        return AvailableLayers.FirstOrDefault(layer =>
+                string.Equals(layer.ServiceId, assignment.ProjectId, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(ReadBindingId(layer), assignment.BindingId, StringComparison.OrdinalIgnoreCase)) ??
+            AvailableLayers.FirstOrDefault(layer =>
+                string.Equals(layer.ServiceId, assignment.ProjectId, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(layer.SourceId, $"{assignment.ProjectId}/{assignment.BindingId}", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string? ReadBindingId(LayerInfo layer)
+    {
+        return layer.Form?.Metadata.TryGetValue("honua:bindingId", out var bindingId) == true
+            ? bindingId
+            : null;
+    }
+}

--- a/apps/Honua.Mobile.FieldCollection/AppShell.xaml
+++ b/apps/Honua.Mobile.FieldCollection/AppShell.xaml
@@ -31,6 +31,13 @@
             Route="map"
             ContentTemplate="{DataTemplate views:MapPage}" />
 
+        <!-- Work Tab -->
+        <ShellContent
+            Title="Work"
+            Icon="list_icon.png"
+            Route="work"
+            ContentTemplate="{DataTemplate views:FieldOperationsPage}" />
+
         <!-- Records Tab -->
         <Tab Title="Records" Icon="list_icon.png">
             <ShellContent

--- a/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
+++ b/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
@@ -8,6 +8,7 @@ using Honua.Mobile.FieldCollection.Services.Features;
 using Honua.Mobile.FieldCollection.Services.Forms;
 using Honua.Mobile.FieldCollection.Services.Metadata;
 using Honua.Mobile.FieldCollection.Services.Packages;
+using Honua.Mobile.FieldCollection.Services.Sharing;
 using Honua.Mobile.FieldCollection.Services.Storage;
 using Honua.Mobile.FieldCollection.Services.Sync;
 using Honua.Mobile.FieldCollection.Services.Workflow;
@@ -58,6 +59,8 @@ public static class MauiProgram
     {
         // Database and Storage Services
         services.AddSingleton<DatabaseService>();
+        services.AddSingleton<GeoPackageStorageService>(provider =>
+            provider.GetRequiredService<DatabaseService>().GetStorageService());
 
         services.AddSingleton<IStorageService, StorageService>();
 
@@ -160,27 +163,24 @@ public static class MauiProgram
         });
         services.AddSingleton<ILocalRecordExportService>(provider =>
         {
-            var databaseService = provider.GetRequiredService<DatabaseService>();
             return new LocalRecordExportService(
-                databaseService.GetStorageService(),
+                provider.GetRequiredService<GeoPackageStorageService>(),
                 logger: provider.GetService<ILogger<LocalRecordExportService>>());
         });
+        services.AddSingleton<ILocalRecordExportShareService, MauiLocalRecordExportShareService>();
         services.AddSingleton(provider =>
         {
-            var databaseService = provider.GetRequiredService<DatabaseService>();
             return new LocalFieldProjectPackageImportService(
-                databaseService.GetStorageService(),
+                provider.GetRequiredService<GeoPackageStorageService>(),
                 provider.GetService<ILogger<LocalFieldProjectPackageImportService>>());
         });
         services.AddSingleton(provider =>
         {
-            var databaseService = provider.GetRequiredService<DatabaseService>();
-            return new LocalFieldRecordLifecycleService(databaseService.GetStorageService());
+            return new LocalFieldRecordLifecycleService(provider.GetRequiredService<GeoPackageStorageService>());
         });
         services.AddSingleton<ILocalFieldAssignmentService>(provider =>
         {
-            var databaseService = provider.GetRequiredService<DatabaseService>();
-            return new LocalFieldAssignmentService(databaseService.GetStorageService());
+            return new LocalFieldAssignmentService(provider.GetRequiredService<GeoPackageStorageService>());
         });
         services.AddSingleton<IMobileAiCaptureProvider, NullMobileAiCaptureProvider>();
         services.AddSingleton<IMobileAiCaptureQueue, SettingsMobileAiCaptureQueue>();
@@ -219,6 +219,7 @@ public static class MauiProgram
     {
         services.AddTransient<MainViewModel>();
         services.AddTransient<MapViewModel>();
+        services.AddTransient<FieldOperationsViewModel>();
         services.AddTransient<RecordsViewModel>();
         services.AddTransient<SyncCenterViewModel>();
         services.AddTransient<SettingsViewModel>();
@@ -239,6 +240,7 @@ public static class MauiProgram
     {
         services.AddTransient<MainPage>();
         services.AddTransient<MapPage>();
+        services.AddTransient<FieldOperationsPage>();
         services.AddTransient<RecordsPage>();
         services.AddTransient<SyncCenterPage>();
         services.AddTransient<SettingsPage>();

--- a/apps/Honua.Mobile.FieldCollection/Services/Sharing/MauiLocalRecordExportShareService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Sharing/MauiLocalRecordExportShareService.cs
@@ -1,0 +1,35 @@
+using Honua.Mobile.FieldCollection.Services;
+using Microsoft.Maui.ApplicationModel.DataTransfer;
+
+namespace Honua.Mobile.FieldCollection.Services.Sharing;
+
+public sealed class MauiLocalRecordExportShareService : ILocalRecordExportShareService
+{
+    public async Task ShareExportAsync(LocalRecordExportResult export, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(export);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var files = new[]
+            {
+                export.CsvPath,
+                export.GeoJsonPath,
+                export.AttachmentManifestPath,
+                export.EvidenceManifestPath
+            }
+            .Where(File.Exists)
+            .Select(path => new ShareFile(path))
+            .ToList();
+
+        if (files.Count == 0)
+        {
+            throw new FileNotFoundException("No export artifacts are available to share.", export.ExportDirectory);
+        }
+
+        await Share.Default.RequestAsync(new ShareMultipleFilesRequest
+        {
+            Title = $"Honua export - {export.LayerName}",
+            Files = files
+        });
+    }
+}

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/BaseViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/BaseViewModel.cs
@@ -96,6 +96,12 @@ public partial class MainViewModel : BaseViewModel
     }
 
     [RelayCommand]
+    private async Task NavigateToWork()
+    {
+        await NavigationService.NavigateToAsync("//work");
+    }
+
+    [RelayCommand]
     private async Task NavigateToSync()
     {
         await NavigationService.NavigateToAsync("//sync");

--- a/apps/Honua.Mobile.FieldCollection/ViewModels/WorkflowViewModels.cs
+++ b/apps/Honua.Mobile.FieldCollection/ViewModels/WorkflowViewModels.cs
@@ -9,6 +9,7 @@ using Honua.Mobile.FieldCollection.Services.Configuration;
 using Honua.Mobile.FieldCollection.Services.Diagnostics;
 using Honua.Mobile.FieldCollection.Services.Forms;
 using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Mobile.FieldCollection.Services.Workflow;
 using Honua.Sdk.Field.Forms;
 using Honua.Sdk.Field.Records;
 using Microsoft.Maui.Devices.Sensors;
@@ -409,6 +410,7 @@ public partial class RecordDetailViewModel : BaseViewModel, IRouteAwareViewModel
 {
     private readonly IFeatureService _featureService;
     private readonly IAttachmentService _attachmentService;
+    private readonly LocalFieldRecordLifecycleService _lifecycleService;
 
     [ObservableProperty]
     private string featureId = string.Empty;
@@ -422,19 +424,42 @@ public partial class RecordDetailViewModel : BaseViewModel, IRouteAwareViewModel
     [ObservableProperty]
     private string geometrySummary = "No geometry";
 
+    [ObservableProperty]
+    private string lifecycleStatusText = RecordStatus.Draft.ToString();
+
+    [ObservableProperty]
+    private bool canMarkReadyToSubmit;
+
+    [ObservableProperty]
+    private bool canSubmitRecord;
+
+    [ObservableProperty]
+    private bool canReopenRecord;
+
     public ObservableCollection<AttributeDisplayItem> Attributes { get; } = [];
     public ObservableCollection<AttachmentInfo> Attachments { get; } = [];
 
     public RecordDetailViewModel(
         INavigationService navigationService,
         IFeatureService featureService,
-        IAttachmentService attachmentService)
+        IAttachmentService attachmentService,
+        LocalFieldRecordLifecycleService lifecycleService)
         : base(navigationService)
     {
         _featureService = featureService;
         _attachmentService = attachmentService;
+        _lifecycleService = lifecycleService;
         Title = "Record Detail";
     }
+
+    partial void OnCanMarkReadyToSubmitChanged(bool value)
+        => MarkReadyToSubmitCommand.NotifyCanExecuteChanged();
+
+    partial void OnCanSubmitRecordChanged(bool value)
+        => SubmitRecordCommand.NotifyCanExecuteChanged();
+
+    partial void OnCanReopenRecordChanged(bool value)
+        => ReopenRecordCommand.NotifyCanExecuteChanged();
 
     public virtual void ApplyQueryAttributes(IDictionary<string, object> query)
     {
@@ -461,19 +486,11 @@ public partial class RecordDetailViewModel : BaseViewModel, IRouteAwareViewModel
             if (Feature == null)
             {
                 GeometrySummary = "Record not found";
+                UpdateLifecycleState();
                 return;
             }
 
-            foreach (var attribute in Feature.Attributes.OrderBy(attribute => attribute.Key, StringComparer.OrdinalIgnoreCase))
-            {
-                Attributes.Add(new AttributeDisplayItem
-                {
-                    Key = attribute.Key,
-                    Value = FormatValue(attribute.Value)
-                });
-            }
-
-            GeometrySummary = FormatGeometry(Feature.Geometry);
+            RenderFeatureDetails(Feature);
 
             foreach (var attachment in await _attachmentService.GetAttachmentsAsync(Feature.Id))
             {
@@ -526,6 +543,44 @@ public partial class RecordDetailViewModel : BaseViewModel, IRouteAwareViewModel
         });
     }
 
+    [RelayCommand(CanExecute = nameof(CanMarkReadyToSubmit))]
+    private Task MarkReadyToSubmit()
+        => TransitionRecord(RecordStatus.ReadyToSubmit);
+
+    [RelayCommand(CanExecute = nameof(CanSubmitRecord))]
+    private Task SubmitRecord()
+        => TransitionRecord(RecordStatus.Submitted);
+
+    [RelayCommand(CanExecute = nameof(CanReopenRecord))]
+    private Task ReopenRecord()
+        => TransitionRecord(RecordStatus.Reopened);
+
+    private async Task TransitionRecord(RecordStatus targetStatus)
+    {
+        if (Feature == null)
+        {
+            return;
+        }
+
+        var layerId = Feature.LayerId;
+        var featureId = Feature.Id;
+        await ExecuteAsync(async () =>
+        {
+            var result = await _lifecycleService.TransitionAsync(layerId, featureId, targetStatus);
+            if (!result.Succeeded)
+            {
+                await ShowError("Status Not Changed", result.Reason ?? "The record status could not be changed.");
+                return;
+            }
+
+            Feature = result.Feature;
+            if (Feature is not null)
+            {
+                RenderFeatureDetails(Feature);
+            }
+        });
+    }
+
     [RelayCommand]
     private async Task OpenAttachment(AttachmentInfo attachment)
     {
@@ -540,6 +595,37 @@ public partial class RecordDetailViewModel : BaseViewModel, IRouteAwareViewModel
             new Microsoft.Maui.ApplicationModel.OpenFileRequest(
                 attachment.FileName,
                 new Microsoft.Maui.Storage.ReadOnlyFile(attachment.LocalPath, attachment.ContentType)));
+    }
+
+    private void RenderFeatureDetails(Feature feature)
+    {
+        Attributes.Clear();
+        foreach (var attribute in feature.Attributes.OrderBy(attribute => attribute.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            Attributes.Add(new AttributeDisplayItem
+            {
+                Key = attribute.Key,
+                Value = FormatValue(attribute.Value)
+            });
+        }
+
+        GeometrySummary = FormatGeometry(feature.Geometry);
+        UpdateLifecycleState();
+    }
+
+    private void UpdateLifecycleState()
+    {
+        var status = Feature is null
+            ? RecordStatus.Draft
+            : LocalFieldRecordLifecycleService.GetStatus(Feature);
+
+        LifecycleStatusText = status.ToString();
+        CanMarkReadyToSubmit = Feature is not null &&
+            LocalFieldRecordLifecycleService.CanTransition(status, RecordStatus.ReadyToSubmit);
+        CanSubmitRecord = Feature is not null &&
+            LocalFieldRecordLifecycleService.CanTransition(status, RecordStatus.Submitted);
+        CanReopenRecord = Feature is not null &&
+            LocalFieldRecordLifecycleService.CanTransition(status, RecordStatus.Reopened);
     }
 
     private static string FormatGeometry(Geometry? geometry)
@@ -572,8 +658,9 @@ public sealed partial class FeatureDetailViewModel : RecordDetailViewModel
     public FeatureDetailViewModel(
         INavigationService navigationService,
         IFeatureService featureService,
-        IAttachmentService attachmentService)
-        : base(navigationService, featureService, attachmentService)
+        IAttachmentService attachmentService,
+        LocalFieldRecordLifecycleService lifecycleService)
+        : base(navigationService, featureService, attachmentService, lifecycleService)
     {
         Title = "Feature Detail";
     }

--- a/apps/Honua.Mobile.FieldCollection/Views/FieldOperationsPage.xaml
+++ b/apps/Honua.Mobile.FieldCollection/Views/FieldOperationsPage.xaml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:models="clr-namespace:Honua.Mobile.FieldCollection.Models;assembly=Honua.Mobile.FieldCollection.Core"
+             xmlns:vm="clr-namespace:Honua.Mobile.FieldCollection.ViewModels;assembly=Honua.Mobile.FieldCollection.Core"
+             x:Class="Honua.Mobile.FieldCollection.Views.FieldOperationsPage"
+             Title="{Binding Title}"
+             x:DataType="vm:FieldOperationsViewModel">
+
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Refresh"
+                     Command="{Binding LoadWorkspaceCommand}" />
+    </ContentPage.ToolbarItems>
+
+    <RefreshView IsRefreshing="{Binding IsRefreshing}"
+                 Command="{Binding RefreshCommand}">
+        <ScrollView>
+            <VerticalStackLayout Spacing="16" Padding="16">
+
+                <Frame Style="{StaticResource CardFrameStyle}">
+                    <VerticalStackLayout Spacing="10">
+                        <Label Text="Packages" Style="{StaticResource SectionHeaderStyle}" />
+
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                            <Picker Grid.Column="0"
+                                    ItemsSource="{Binding Packages}"
+                                    SelectedItem="{Binding SelectedPackage}"
+                                    ItemDisplayBinding="{Binding Name}"
+                                    Title="Installed package" />
+                            <HorizontalStackLayout Grid.Column="1" Spacing="8">
+                                <CheckBox IsChecked="{Binding IncludeArchivedPackages}" />
+                                <Label Text="Archived"
+                                       VerticalOptions="Center" />
+                            </HorizontalStackLayout>
+                        </Grid>
+
+                        <Label Text="{Binding SelectedPackage.Description}"
+                               FontSize="13"
+                               TextColor="{StaticResource Gray600}"
+                               LineBreakMode="WordWrap" />
+
+                        <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                            <Button Grid.Column="0"
+                                    Text="Open"
+                                    Style="{StaticResource BaseButtonStyle}"
+                                    Command="{Binding MarkPackageOpenedCommand}" />
+                            <Button Grid.Column="1"
+                                    Text="Archive"
+                                    Style="{StaticResource SecondaryButtonStyle}"
+                                    Command="{Binding ArchivePackageCommand}" />
+                        </Grid>
+                    </VerticalStackLayout>
+                </Frame>
+
+                <Frame Style="{StaticResource CardFrameStyle}">
+                    <VerticalStackLayout Spacing="10">
+                        <Label Text="Import Package" Style="{StaticResource SectionHeaderStyle}" />
+                        <Entry Text="{Binding PackageManifestPath}"
+                               Placeholder="field-project-package.json path" />
+                        <Entry Text="{Binding PackageDestinationRoot}"
+                               Placeholder="install destination folder" />
+                        <Button Text="Import"
+                                Style="{StaticResource BaseButtonStyle}"
+                                Command="{Binding ImportPackageCommand}" />
+                        <Label Text="{Binding LastImportSummary}"
+                               FontSize="13"
+                               TextColor="{StaticResource Gray600}" />
+
+                        <CollectionView ItemsSource="{Binding ImportDiagnostics}"
+                                        IsVisible="{Binding HasImportDiagnostics}">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="models:LocalFieldProjectPackageDiagnostic">
+                                    <Grid Padding="0,4"
+                                          RowDefinitions="Auto,Auto"
+                                          ColumnDefinitions="Auto,*"
+                                          ColumnSpacing="8">
+                                        <Label Grid.Row="0"
+                                               Grid.Column="0"
+                                               Text="{Binding Severity}"
+                                               FontAttributes="Bold" />
+                                        <Label Grid.Row="0"
+                                               Grid.Column="1"
+                                               Text="{Binding Code}" />
+                                        <Label Grid.Row="1"
+                                               Grid.Column="1"
+                                               Text="{Binding Message}"
+                                               FontSize="12"
+                                               TextColor="{StaticResource Gray600}"
+                                               LineBreakMode="WordWrap" />
+                                    </Grid>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Frame>
+
+                <Frame Style="{StaticResource CardFrameStyle}">
+                    <VerticalStackLayout Spacing="10">
+                        <Label Text="Assignments" Style="{StaticResource SectionHeaderStyle}" />
+                        <CollectionView ItemsSource="{Binding Assignments}"
+                                        SelectionMode="Single"
+                                        SelectedItem="{Binding SelectedAssignment}">
+                            <CollectionView.EmptyView>
+                                <Label Text="No assignments in this package."
+                                       TextColor="{StaticResource Gray600}" />
+                            </CollectionView.EmptyView>
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="models:LocalFieldAssignmentInfo">
+                                    <Frame Style="{StaticResource CardFrameStyle}" Margin="0,5">
+                                        <Grid RowDefinitions="Auto,Auto,Auto"
+                                              RowSpacing="6">
+                                            <Grid Grid.Row="0"
+                                                  ColumnDefinitions="*,Auto"
+                                                  ColumnSpacing="10">
+                                                <Label Grid.Column="0"
+                                                       Text="{Binding AssignmentId}"
+                                                       FontAttributes="Bold" />
+                                                <Label Grid.Column="1"
+                                                       Text="{Binding Status}"
+                                                       FontSize="12"
+                                                       TextColor="{StaticResource Gray600}" />
+                                            </Grid>
+
+                                            <Label Grid.Row="1"
+                                                   Text="{Binding BindingId}"
+                                                   FontSize="12"
+                                                   TextColor="{StaticResource Gray600}" />
+
+                                            <Grid Grid.Row="2"
+                                                  ColumnDefinitions="*,*,*,*"
+                                                  ColumnSpacing="6">
+                                                <Button Grid.Column="0"
+                                                        Text="Open"
+                                                        FontSize="12"
+                                                        Style="{StaticResource SecondaryButtonStyle}"
+                                                        Command="{Binding Source={RelativeSource AncestorType={x:Type vm:FieldOperationsViewModel}}, Path=OpenAssignmentRecordCommand}"
+                                                        CommandParameter="{Binding .}" />
+                                                <Button Grid.Column="1"
+                                                        Text="Start"
+                                                        FontSize="12"
+                                                        Style="{StaticResource BaseButtonStyle}"
+                                                        Command="{Binding Source={RelativeSource AncestorType={x:Type vm:FieldOperationsViewModel}}, Path=StartAssignmentCommand}"
+                                                        CommandParameter="{Binding .}" />
+                                                <Button Grid.Column="2"
+                                                        Text="Done"
+                                                        FontSize="12"
+                                                        Style="{StaticResource BaseButtonStyle}"
+                                                        Command="{Binding Source={RelativeSource AncestorType={x:Type vm:FieldOperationsViewModel}}, Path=CompleteAssignmentCommand}"
+                                                        CommandParameter="{Binding .}" />
+                                                <Button Grid.Column="3"
+                                                        Text="Reset"
+                                                        FontSize="12"
+                                                        Style="{StaticResource SecondaryButtonStyle}"
+                                                        Command="{Binding Source={RelativeSource AncestorType={x:Type vm:FieldOperationsViewModel}}, Path=ReopenAssignmentCommand}"
+                                                        CommandParameter="{Binding .}" />
+                                            </Grid>
+                                        </Grid>
+                                    </Frame>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Frame>
+
+                <Frame Style="{StaticResource CardFrameStyle}">
+                    <VerticalStackLayout Spacing="10">
+                        <Label Text="Export" Style="{StaticResource SectionHeaderStyle}" />
+                        <Picker ItemsSource="{Binding AvailableLayers}"
+                                SelectedItem="{Binding SelectedLayer}"
+                                ItemDisplayBinding="{Binding Name}"
+                                Title="Layer" />
+                        <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                            <Button Grid.Column="0"
+                                    Text="Export"
+                                    Style="{StaticResource BaseButtonStyle}"
+                                    Command="{Binding ExportSelectedLayerCommand}" />
+                            <Button Grid.Column="1"
+                                    Text="Share"
+                                    Style="{StaticResource SecondaryButtonStyle}"
+                                    Command="{Binding ShareLastExportCommand}"
+                                    IsEnabled="{Binding HasLastExport}" />
+                        </Grid>
+                        <Label Text="{Binding LastExportSummary}"
+                               FontSize="13"
+                               TextColor="{StaticResource Gray600}" />
+                        <Label Text="{Binding LastExportDirectory}"
+                               FontSize="12"
+                               TextColor="{StaticResource Gray600}"
+                               LineBreakMode="WordWrap" />
+                    </VerticalStackLayout>
+                </Frame>
+
+                <Label Text="{Binding StatusMessage}"
+                       FontSize="13"
+                       TextColor="{StaticResource Gray600}"
+                       LineBreakMode="WordWrap" />
+            </VerticalStackLayout>
+        </ScrollView>
+    </RefreshView>
+
+    <ActivityIndicator IsRunning="{Binding IsBusy}"
+                       IsVisible="{Binding IsBusy}"
+                       Color="{StaticResource Primary}"
+                       HorizontalOptions="Center"
+                       VerticalOptions="Center" />
+</ContentPage>

--- a/apps/Honua.Mobile.FieldCollection/Views/FieldOperationsPage.xaml.cs
+++ b/apps/Honua.Mobile.FieldCollection/Views/FieldOperationsPage.xaml.cs
@@ -1,0 +1,21 @@
+using Honua.Mobile.FieldCollection.ViewModels;
+
+namespace Honua.Mobile.FieldCollection.Views;
+
+public partial class FieldOperationsPage : ContentPage
+{
+    private readonly FieldOperationsViewModel _viewModel;
+
+    public FieldOperationsPage(FieldOperationsViewModel viewModel)
+    {
+        InitializeComponent();
+        _viewModel = viewModel;
+        BindingContext = viewModel;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        await _viewModel.LoadWorkspaceCommand.ExecuteAsync(null);
+    }
+}

--- a/apps/Honua.Mobile.FieldCollection/Views/MainPage.xaml
+++ b/apps/Honua.Mobile.FieldCollection/Views/MainPage.xaml
@@ -54,24 +54,30 @@
                 <!-- Quick Actions -->
                 <Label Text="Quick Actions" Style="{StaticResource SectionHeaderStyle}" />
 
-                <Grid ColumnDefinitions="*,*" RowDefinitions="*,*" ColumnSpacing="15" RowSpacing="15">
+                <Grid ColumnDefinitions="*,*" RowDefinitions="*,*,*" ColumnSpacing="15" RowSpacing="15">
                     <Button Grid.Row="0" Grid.Column="0"
                             Text="📍 Map"
                             Style="{StaticResource BaseButtonStyle}"
                             Command="{Binding NavigateToMapCommand}" />
 
                     <Button Grid.Row="0" Grid.Column="1"
+                            Text="Work"
+                            Style="{StaticResource BaseButtonStyle}"
+                            Command="{Binding NavigateToWorkCommand}" />
+
+                    <Button Grid.Row="1" Grid.Column="0"
                             Text="📋 Records"
                             Style="{StaticResource BaseButtonStyle}"
                             Command="{Binding NavigateToRecordsCommand}" />
 
-                    <Button Grid.Row="1" Grid.Column="0"
+                    <Button Grid.Row="1" Grid.Column="1"
                             Text="🔄 Sync"
                             Style="{StaticResource SecondaryButtonStyle}"
                             Command="{Binding QuickSyncCommand}"
                             IsEnabled="{Binding IsOnline}" />
 
-                    <Button Grid.Row="1" Grid.Column="1"
+                    <Button Grid.Row="2" Grid.Column="0"
+                            Grid.ColumnSpan="2"
                             Text="⚙️ Settings"
                             Style="{StaticResource SecondaryButtonStyle}"
                             Command="{Binding NavigateToSettingsCommand}" />

--- a/apps/Honua.Mobile.FieldCollection/Views/WorkflowPages.cs
+++ b/apps/Honua.Mobile.FieldCollection/Views/WorkflowPages.cs
@@ -237,10 +237,15 @@ internal static class WorkflowPageContent
             BoundHeader("Feature.DisplayTitle", "Record"),
             BoundLabel("Feature.Id", "Record ID"),
             BoundLabel("GeometrySummary", "Geometry"),
+            BoundLabel("LifecycleStatusText", "Status"),
             SectionTitle("Attributes"),
             attributes,
             SectionTitle("Attachments"),
             attachments,
+            ButtonRow(
+                CommandButton("Ready", "MarkReadyToSubmitCommand"),
+                CommandButton("Submit", "SubmitRecordCommand"),
+                CommandButton("Reopen", "ReopenRecordCommand")),
             ButtonRow(
                 CommandButton("Edit", "EditRecordCommand"),
                 CommandButton("Delete", "DeleteRecordCommand")));

--- a/tests/Honua.Mobile.FieldCollection.Tests/FieldOperationsViewModelTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/FieldOperationsViewModelTests.cs
@@ -1,0 +1,230 @@
+using System.Security.Cryptography;
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.FieldCollection.Services.Assignments;
+using Honua.Mobile.FieldCollection.Services.Packages;
+using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Mobile.FieldCollection.ViewModels;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Field.Projects;
+
+namespace Honua.Mobile.FieldCollection.Tests;
+
+public sealed class FieldOperationsViewModelTests : IDisposable
+{
+    private readonly string _databasePath;
+    private readonly string _packageRoot;
+    private readonly string _installRoot;
+    private readonly string _exportRoot;
+
+    public FieldOperationsViewModelTests()
+    {
+        SQLitePCL.Batteries_V2.Init();
+        _databasePath = Path.Combine(Path.GetTempPath(), $"honua-workspace-{Guid.NewGuid():N}.gpkg");
+        _packageRoot = Path.Combine(Path.GetTempPath(), $"honua-workspace-package-{Guid.NewGuid():N}");
+        _installRoot = Path.Combine(Path.GetTempPath(), $"honua-workspace-install-{Guid.NewGuid():N}");
+        _exportRoot = Path.Combine(Path.GetTempPath(), $"honua-workspace-export-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_packageRoot);
+        Directory.CreateDirectory(_installRoot);
+        Directory.CreateDirectory(_exportRoot);
+    }
+
+    [Fact]
+    public async Task WorkCommands_ImportPackageManageAssignmentsOpenRecordAndShareExport()
+    {
+        using var storage = new GeoPackageStorageService(_databasePath);
+        var navigation = new RecordingNavigationService();
+        var share = new RecordingExportShareService();
+        var viewModel = CreateViewModel(storage, navigation, share);
+        viewModel.PackageManifestPath = await WritePackageAsync(LocalFieldProjectPackageImportServiceTests.CreatePackage());
+        viewModel.PackageDestinationRoot = _installRoot;
+
+        await viewModel.ImportPackageCommand.ExecuteAsync(null);
+
+        Assert.Single(viewModel.Packages);
+        Assert.Equal("local-inspection-demo", viewModel.SelectedPackage?.ProjectId);
+        Assert.Equal(2, viewModel.AvailableLayers.Count);
+        Assert.Equal(2, viewModel.Assignments.Count);
+        Assert.False(viewModel.HasImportDiagnostics);
+        Assert.Contains("Imported local-inspection-demo", viewModel.LastImportSummary, StringComparison.Ordinal);
+
+        var assignment = viewModel.Assignments.Single(item => item.AssignmentId == "task-asset-100");
+        await viewModel.StartAssignmentCommand.ExecuteAsync(assignment);
+        Assert.Equal(FieldAssignmentStatus.InProgress, viewModel.Assignments.Single(item => item.AssignmentId == assignment.AssignmentId).Status);
+
+        await viewModel.CompleteAssignmentCommand.ExecuteAsync(viewModel.Assignments.Single(item => item.AssignmentId == assignment.AssignmentId));
+        Assert.Equal(FieldAssignmentStatus.Complete, viewModel.Assignments.Single(item => item.AssignmentId == assignment.AssignmentId).Status);
+
+        await viewModel.ReopenAssignmentCommand.ExecuteAsync(viewModel.Assignments.Single(item => item.AssignmentId == assignment.AssignmentId));
+        Assert.Equal(FieldAssignmentStatus.NotStarted, viewModel.Assignments.Single(item => item.AssignmentId == assignment.AssignmentId).Status);
+
+        await viewModel.OpenAssignmentRecordCommand.ExecuteAsync(viewModel.Assignments.Single(item => item.AssignmentId == assignment.AssignmentId));
+        Assert.Equal("record-detail", navigation.LastRoute);
+        Assert.Equal("asset-100", navigation.LastParameters["featureId"]);
+        Assert.Equal(viewModel.AvailableLayers.Single(layer =>
+            layer.Form?.Metadata.TryGetValue("honua:bindingId", out var bindingId) == true &&
+            bindingId == "asset-inspection-assets").Id, navigation.LastParameters["layerId"]);
+
+        viewModel.SelectedLayer = viewModel.AvailableLayers.Single(layer =>
+            layer.Form?.Metadata.TryGetValue("honua:bindingId", out var bindingId) == true &&
+            bindingId == "asset-inspection-assets");
+        await storage.StoreFeatureAsync(new Feature
+        {
+            Id = "asset-100",
+            LayerId = viewModel.SelectedLayer.Id,
+            Geometry = new Point(21.3, -157.8),
+            CreatedAt = new DateTime(2026, 5, 24, 8, 0, 0, DateTimeKind.Utc),
+            Attributes = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["asset_id"] = "asset-100"
+            }
+        });
+
+        await viewModel.ExportSelectedLayerCommand.ExecuteAsync(null);
+        Assert.True(viewModel.HasLastExport);
+        Assert.Contains("Exported 1 record", viewModel.LastExportSummary, StringComparison.Ordinal);
+        Assert.All(viewModel.ExportArtifacts, path => Assert.True(File.Exists(path), path));
+
+        await viewModel.ShareLastExportCommand.ExecuteAsync(null);
+        Assert.NotNull(share.SharedExport);
+        Assert.Equal(viewModel.SelectedLayer.Id, share.SharedExport.LayerId);
+    }
+
+    [Fact]
+    public async Task ImportPackageCommand_WithInvalidPackage_RendersDeterministicDiagnostics()
+    {
+        using var storage = new GeoPackageStorageService(_databasePath);
+        var viewModel = CreateViewModel(storage);
+        var invalidPackage = LocalFieldProjectPackageImportServiceTests.CreatePackage() with
+        {
+            SchemaVersion = "honua.field-project-package.v0"
+        };
+        viewModel.PackageManifestPath = await WritePackageAsync(invalidPackage);
+        viewModel.PackageDestinationRoot = _installRoot;
+
+        await viewModel.ImportPackageCommand.ExecuteAsync(null);
+
+        Assert.True(viewModel.HasImportDiagnostics);
+        Assert.Contains(viewModel.ImportDiagnostics, diagnostic => diagnostic.Code == FieldProjectPackageValidationCodes.UnsupportedSchemaVersion);
+        Assert.Contains("failed", viewModel.LastImportSummary, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(FieldProjectCatalogState.Invalid, viewModel.Packages.Single().State);
+    }
+
+    private FieldOperationsViewModel CreateViewModel(
+        GeoPackageStorageService storage,
+        RecordingNavigationService? navigation = null,
+        ILocalRecordExportShareService? share = null)
+    {
+        return new FieldOperationsViewModel(
+            navigation ?? new RecordingNavigationService(),
+            storage,
+            new LocalFieldAssignmentService(storage),
+            new LocalFieldProjectPackageImportService(storage),
+            new LocalRecordExportService(storage, _exportRoot),
+            share ?? new RecordingExportShareService());
+    }
+
+    private async Task<string> WritePackageAsync(FieldProjectPackage package, string directoryName = "package")
+    {
+        var packageDirectory = Path.Combine(_packageRoot, directoryName);
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "data"));
+        var artifactPath = Path.Combine(packageDirectory, "data", "assets.gpkg");
+        await File.WriteAllTextAsync(artifactPath, "offline feature data");
+        package = package with
+        {
+            OfflinePackages =
+            [
+                package.OfflinePackages[0] with
+                {
+                    SizeBytes = new FileInfo(artifactPath).Length,
+                    Sha256 = ComputeSha256(artifactPath)
+                }
+            ]
+        };
+
+        var manifestPath = Path.Combine(packageDirectory, "field-project-package.json");
+        await File.WriteAllTextAsync(manifestPath, package.ToJson());
+        return manifestPath;
+    }
+
+    private static string ComputeSha256(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
+    }
+
+    public void Dispose()
+    {
+        DeleteFile(_databasePath);
+        DeleteDirectory(_packageRoot);
+        DeleteDirectory(_installRoot);
+        DeleteDirectory(_exportRoot);
+    }
+
+    private static void DeleteFile(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static void DeleteDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+
+    private sealed class RecordingNavigationService : INavigationService
+    {
+        public string LastRoute { get; private set; } = string.Empty;
+        public Dictionary<string, object> LastParameters { get; private set; } = [];
+
+        public Task NavigateToAsync(string route)
+        {
+            LastRoute = route;
+            LastParameters = [];
+            return Task.CompletedTask;
+        }
+
+        public Task NavigateToAsync(string route, IDictionary<string, object> parameters)
+        {
+            LastRoute = route;
+            LastParameters = new Dictionary<string, object>(parameters);
+            return Task.CompletedTask;
+        }
+
+        public Task GoBackAsync() => Task.CompletedTask;
+
+        public Task PopToRootAsync() => Task.CompletedTask;
+
+        public Task DisplayAlert(string title, string message, string cancel) => Task.CompletedTask;
+
+        public Task<bool> DisplayAlert(string title, string message, string accept, string cancel) => Task.FromResult(true);
+
+        public Task<string> DisplayActionSheet(string title, string cancel, string destruction, params string[] buttons) =>
+            Task.FromResult(buttons.FirstOrDefault() ?? cancel);
+
+        public Task<string> DisplayPromptAsync(
+            string title,
+            string message,
+            string accept = "OK",
+            string cancel = "Cancel",
+            string placeholder = "",
+            int maxLength = -1,
+            string initialValue = "") => Task.FromResult(initialValue);
+    }
+
+    private sealed class RecordingExportShareService : ILocalRecordExportShareService
+    {
+        public LocalRecordExportResult? SharedExport { get; private set; }
+
+        public Task ShareExportAsync(LocalRecordExportResult export, CancellationToken cancellationToken = default)
+        {
+            SharedExport = export;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Related to #92.

Adds a mobile field operations surface for the no-cloud parity path:

- adds a Work tab/page for local package catalog state, package import diagnostics, assignment inbox actions, layer export, and export sharing
- adds a core `FieldOperationsViewModel` so package import, assignment status transitions, open-record routing, and export/share behavior are unit-testable without booting MAUI
- wires a MAUI share implementation for generated CSV, GeoJSON, attachment manifest, and evidence manifest artifacts
- adds record detail lifecycle status plus Ready, Submit, and Reopen commands backed by the local record lifecycle service

## Why

This moves the Survey123/Fulcrum parity work beyond backend services by giving field users an app-level workflow for installed packages, assigned work, record lifecycle, and offline export handoff while cloud DNS/TLS remains blocked.

## Platform Impact

MAUI app registration and Shell navigation now include a Work tab. The new platform-specific code is limited to the export share adapter, which uses MAUI Essentials sharing APIs for the generated export artifacts.

## Offline Impact

This is intentionally no-cloud capable. Package import, assignment status changes, lifecycle transitions, and exports operate against the local GeoPackage/catalog services; cloud package download/publish remains outside this slice and still depends on server/cloud readiness.

## Testing

- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --configuration Release --filter "FieldOperationsViewModelTests|LocalFieldRecordLifecycleServiceTests|LocalFieldProjectPackageImportServiceTests|LocalRecordExportServiceTests"`
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --configuration Release`
- `dotnet build apps/Honua.Mobile.FieldCollection.Core/Honua.Mobile.FieldCollection.Core.csproj --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet format apps/Honua.Mobile.FieldCollection.Core/Honua.Mobile.FieldCollection.Core.csproj --no-restore --verify-no-changes --verbosity minimal`
- `dotnet format tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore --verify-no-changes --verbosity minimal`
- `git diff --check`

Local MAUI Android app build could not complete because this machine does not have an Android SDK configured: `XA5300: The Android SDK directory could not be found.` CI should validate the XAML/app target on a configured runner.
