### PR TITLE
mobile: add field package download intake

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Models/NoCloudFieldModels.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Models/NoCloudFieldModels.cs
@@ -47,6 +47,38 @@ public sealed class LocalFieldProjectPackageImportedFile
     public string? Sha256 { get; init; }
 }
 
+public sealed class LocalFieldProjectPackageDownloadRequest
+{
+    public required Uri ManifestUri { get; init; }
+    public required string DownloadRootDirectory { get; init; }
+    public required string DestinationRootDirectory { get; init; }
+    public Uri? ArtifactBaseUri { get; init; }
+    public bool OverwriteExisting { get; init; }
+    public bool CleanupPartialDownloadOnFailure { get; init; } = true;
+}
+
+public sealed class LocalFieldProjectPackageDownloadResult
+{
+    public string? ProjectId { get; init; }
+    public bool Downloaded { get; init; }
+    public bool Imported => ImportResult?.Imported == true;
+    public string? DownloadedManifestPath { get; init; }
+    public string? DownloadDirectory { get; init; }
+    public LocalFieldProjectPackageImportResult? ImportResult { get; init; }
+    public IReadOnlyList<LocalFieldProjectPackageDiagnostic> Diagnostics { get; init; } = [];
+    public IReadOnlyList<LocalFieldProjectPackageDownloadedFile> DownloadedFiles { get; init; } = [];
+    public long DownloadedBytes { get; init; }
+}
+
+public sealed class LocalFieldProjectPackageDownloadedFile
+{
+    public required string PackageId { get; init; }
+    public required Uri SourceUri { get; init; }
+    public required string RelativePath { get; init; }
+    public required string LocalPath { get; init; }
+    public long SizeBytes { get; init; }
+}
+
 public sealed class LocalFieldRecordLifecycleTransitionResult
 {
     public bool Succeeded { get; init; }

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Packages/LocalFieldProjectPackageDownloadService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Packages/LocalFieldProjectPackageDownloadService.cs
@@ -1,0 +1,415 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services;
+using Honua.Mobile.Sdk.Auth;
+using Honua.Sdk.Field.Projects;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Mobile.FieldCollection.Services.Packages;
+
+public interface IFieldProjectPackageDownloadRequestCustomizer
+{
+    ValueTask CustomizeAsync(HttpRequestMessage request, CancellationToken cancellationToken = default);
+}
+
+public sealed class LocalFieldProjectPackageDownloadService
+{
+    private const string ManifestFileName = "field-project-package.json";
+
+    private readonly HttpClient _httpClient;
+    private readonly LocalFieldProjectPackageImportService _importService;
+    private readonly IReadOnlyList<IFieldProjectPackageDownloadRequestCustomizer> _requestCustomizers;
+    private readonly ILogger<LocalFieldProjectPackageDownloadService>? _logger;
+
+    public LocalFieldProjectPackageDownloadService(
+        HttpClient httpClient,
+        LocalFieldProjectPackageImportService importService,
+        IEnumerable<IFieldProjectPackageDownloadRequestCustomizer>? requestCustomizers = null,
+        ILogger<LocalFieldProjectPackageDownloadService>? logger = null)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _importService = importService ?? throw new ArgumentNullException(nameof(importService));
+        _requestCustomizers = requestCustomizers?.ToList() ?? [];
+        _logger = logger;
+    }
+
+    public async Task<LocalFieldProjectPackageDownloadResult> DownloadAndImportAsync(
+        LocalFieldProjectPackageDownloadRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.ManifestUri);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.DownloadRootDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.DestinationRootDirectory);
+
+        if (!request.ManifestUri.IsAbsoluteUri)
+        {
+            return Failed(null, Error("invalid-manifest-uri", "$.manifestUri", "Package manifest URI must be absolute."));
+        }
+
+        var downloadRoot = Path.GetFullPath(request.DownloadRootDirectory);
+        var partialDirectory = Path.Combine(downloadRoot, ".partial", Guid.NewGuid().ToString("N"));
+        var manifestPath = Path.Combine(partialDirectory, ManifestFileName);
+        Directory.CreateDirectory(partialDirectory);
+
+        FieldProjectPackage? package = null;
+        var downloadedFiles = new List<LocalFieldProjectPackageDownloadedFile>();
+        var diagnostics = new List<LocalFieldProjectPackageDiagnostic>();
+        var downloadedBytes = 0L;
+
+        try
+        {
+            var manifestBytes = await DownloadFileAsync(
+                request.ManifestUri,
+                manifestPath,
+                "$.manifestUri",
+                "Package manifest",
+                cancellationToken).ConfigureAwait(false);
+            downloadedBytes += manifestBytes;
+
+            try
+            {
+                var manifestJson = await File.ReadAllTextAsync(manifestPath, cancellationToken).ConfigureAwait(false);
+                package = FieldProjectPackage.ParseJson(manifestJson);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Text.Json.JsonException or ArgumentException)
+            {
+                _logger?.LogWarning(ex, "Failed to parse downloaded field project package manifest {ManifestUri}", request.ManifestUri);
+                diagnostics.Add(Error("invalid-manifest", "$", ex.Message));
+                return Failed(null, diagnostics, downloadedBytes: downloadedBytes);
+            }
+
+            var artifactBaseUri = request.ArtifactBaseUri is null
+                ? ResolveManifestDirectoryUri(request.ManifestUri)
+                : EnsureDirectoryUri(request.ArtifactBaseUri);
+            for (var i = 0; i < package.OfflinePackages.Count; i++)
+            {
+                var offlinePackage = package.OfflinePackages[i];
+                if (!TryNormalizeRelativePath(offlinePackage.RelativePath, out var relativePath))
+                {
+                    diagnostics.Add(Error(
+                        "unsafe-offline-artifact-path",
+                        $"$.offlinePackages[{i}].relativePath",
+                        $"Offline package '{offlinePackage.PackageId}' has an unsafe relative path."));
+                    continue;
+                }
+
+                var artifactUri = new Uri(artifactBaseUri, relativePath);
+                var localPath = ResolvePackageFilePath(partialDirectory, relativePath);
+                var artifactBytes = await DownloadFileAsync(
+                    artifactUri,
+                    localPath,
+                    $"$.offlinePackages[{i}].relativePath",
+                    $"Offline package '{offlinePackage.PackageId}'",
+                    cancellationToken).ConfigureAwait(false);
+
+                downloadedBytes += artifactBytes;
+                downloadedFiles.Add(new LocalFieldProjectPackageDownloadedFile
+                {
+                    PackageId = offlinePackage.PackageId,
+                    SourceUri = artifactUri,
+                    RelativePath = relativePath,
+                    LocalPath = localPath,
+                    SizeBytes = artifactBytes
+                });
+            }
+
+            if (diagnostics.Any(IsError))
+            {
+                return Failed(package.ProjectId, diagnostics, downloadedBytes: downloadedBytes, downloadedFiles: downloadedFiles);
+            }
+
+            var downloadDirectory = BuildDownloadDirectory(downloadRoot, package);
+            if (Directory.Exists(downloadDirectory))
+            {
+                if (!request.OverwriteExisting)
+                {
+                    diagnostics.Add(Error(
+                        "download-already-exists",
+                        "$.projectId",
+                        $"Project '{package.ProjectId}' is already downloaded at the destination."));
+                    return Failed(package.ProjectId, diagnostics, downloadedBytes: downloadedBytes, downloadedFiles: downloadedFiles);
+                }
+
+                Directory.Delete(downloadDirectory, recursive: true);
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(downloadDirectory)!);
+            Directory.Move(partialDirectory, downloadDirectory);
+            partialDirectory = string.Empty;
+
+            var downloadedManifestPath = Path.Combine(downloadDirectory, ManifestFileName);
+            var importResult = await _importService.ImportAsync(new LocalFieldProjectPackageImportRequest
+            {
+                ManifestPath = downloadedManifestPath,
+                DestinationRootDirectory = request.DestinationRootDirectory,
+                ImportSource = request.ManifestUri.AbsoluteUri,
+                OverwriteExisting = request.OverwriteExisting
+            }, cancellationToken).ConfigureAwait(false);
+
+            diagnostics.AddRange(importResult.Diagnostics);
+
+            return new LocalFieldProjectPackageDownloadResult
+            {
+                ProjectId = package.ProjectId,
+                Downloaded = true,
+                DownloadedManifestPath = downloadedManifestPath,
+                DownloadDirectory = downloadDirectory,
+                ImportResult = importResult,
+                Diagnostics = diagnostics,
+                DownloadedFiles = downloadedFiles,
+                DownloadedBytes = downloadedBytes
+            };
+        }
+        catch (Exception ex) when (ex is HttpRequestException or IOException or UnauthorizedAccessException)
+        {
+            _logger?.LogWarning(ex, "Failed to download field project package {ManifestUri}", request.ManifestUri);
+            diagnostics.Add(ToDownloadDiagnostic(ex));
+            return Failed(package?.ProjectId, diagnostics, downloadedBytes: downloadedBytes, downloadedFiles: downloadedFiles);
+        }
+        finally
+        {
+            if (request.CleanupPartialDownloadOnFailure && !string.IsNullOrWhiteSpace(partialDirectory))
+            {
+                DeleteDirectoryIfExists(partialDirectory);
+            }
+        }
+    }
+
+    private async Task<long> DownloadFileAsync(
+        Uri uri,
+        string destinationPath,
+        string diagnosticPath,
+        string description,
+        CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+        var partialPath = destinationPath + ".partial";
+        using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+        foreach (var customizer in _requestCustomizers)
+        {
+            await customizer.CustomizeAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        using var response = await _httpClient.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new FieldProjectPackageDownloadException(
+                "download-http-error",
+                diagnosticPath,
+                $"{description} download failed with HTTP {(int)response.StatusCode} {response.ReasonPhrase ?? response.StatusCode.ToString()}.");
+        }
+
+        await using (var input = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false))
+        await using (var output = new FileStream(partialPath, FileMode.Create, FileAccess.Write, FileShare.None))
+        {
+            await input.CopyToAsync(output, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (File.Exists(destinationPath))
+        {
+            File.Delete(destinationPath);
+        }
+
+        File.Move(partialPath, destinationPath);
+        return new FileInfo(destinationPath).Length;
+    }
+
+    private static Uri EnsureDirectoryUri(Uri uri)
+    {
+        if (!uri.IsAbsoluteUri)
+        {
+            throw new FieldProjectPackageDownloadException(
+                "invalid-artifact-base-uri",
+                "$.artifactBaseUri",
+                "Package artifact base URI must be absolute.");
+        }
+
+        return uri.AbsoluteUri.EndsWith("/", StringComparison.Ordinal)
+            ? uri
+            : new Uri(uri.AbsoluteUri + "/");
+    }
+
+    private static Uri ResolveManifestDirectoryUri(Uri manifestUri)
+    {
+        if (!manifestUri.IsAbsoluteUri)
+        {
+            throw new FieldProjectPackageDownloadException(
+                "invalid-manifest-uri",
+                "$.manifestUri",
+                "Package manifest URI must be absolute.");
+        }
+
+        return manifestUri.AbsoluteUri.EndsWith("/", StringComparison.Ordinal)
+            ? manifestUri
+            : new Uri(manifestUri.AbsoluteUri[..(manifestUri.AbsoluteUri.LastIndexOf('/') + 1)]);
+    }
+
+    private static bool TryNormalizeRelativePath(string? relativePath, out string normalized)
+    {
+        normalized = string.Empty;
+        if (string.IsNullOrWhiteSpace(relativePath) ||
+            relativePath.Contains('\\', StringComparison.Ordinal) ||
+            relativePath.StartsWith("/", StringComparison.Ordinal) ||
+            Uri.TryCreate(relativePath, UriKind.Absolute, out _))
+        {
+            return false;
+        }
+
+        var segments = relativePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0 || segments.Any(segment => segment is "." or ".."))
+        {
+            return false;
+        }
+
+        normalized = string.Join('/', segments);
+        return true;
+    }
+
+    private static string ResolvePackageFilePath(string packageDirectory, string relativePath)
+    {
+        var fullPath = Path.GetFullPath(Path.Combine(packageDirectory, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var root = Path.GetFullPath(packageDirectory);
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        var rootPrefix = Path.EndsInDirectorySeparator(root)
+            ? root
+            : root + Path.DirectorySeparatorChar;
+        if (!fullPath.StartsWith(rootPrefix, comparison))
+        {
+            throw new FieldProjectPackageDownloadException(
+                "unsafe-offline-artifact-path",
+                "$.offlinePackages",
+                "Resolved offline artifact path is outside the package directory.");
+        }
+
+        return fullPath;
+    }
+
+    private static string BuildDownloadDirectory(
+        string downloadRootDirectory,
+        FieldProjectPackage package)
+    {
+        var version = string.IsNullOrWhiteSpace(package.Version) ? "current" : package.Version;
+        return Path.Combine(
+            downloadRootDirectory,
+            SanitizePathSegment(package.ProjectId),
+            SanitizePathSegment(version));
+    }
+
+    private static string SanitizePathSegment(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars().ToHashSet();
+        var sanitized = new string(value
+            .Select(character => invalid.Contains(character) ? '-' : character)
+            .ToArray()).Trim();
+
+        return string.IsNullOrWhiteSpace(sanitized) ? "package" : sanitized;
+    }
+
+    private static LocalFieldProjectPackageDownloadResult Failed(
+        string? projectId,
+        IEnumerable<LocalFieldProjectPackageDiagnostic> diagnostics,
+        IReadOnlyList<LocalFieldProjectPackageDownloadedFile>? downloadedFiles = null,
+        long downloadedBytes = 0)
+        => new()
+        {
+            ProjectId = projectId,
+            Downloaded = false,
+            Diagnostics = diagnostics.ToList(),
+            DownloadedFiles = downloadedFiles ?? [],
+            DownloadedBytes = downloadedBytes
+        };
+
+    private static LocalFieldProjectPackageDownloadResult Failed(
+        string? projectId,
+        params LocalFieldProjectPackageDiagnostic[] diagnostics)
+        => Failed(projectId, diagnostics.AsEnumerable());
+
+    private static LocalFieldProjectPackageDiagnostic ToDownloadDiagnostic(Exception exception)
+        => exception is FieldProjectPackageDownloadException downloadException
+            ? Error(downloadException.Code, downloadException.Path, downloadException.Message)
+            : Error("download-failed", "$.manifestUri", exception.Message);
+
+    private static LocalFieldProjectPackageDiagnostic Error(string code, string path, string message)
+        => new()
+        {
+            Code = code,
+            Path = path,
+            Message = message,
+            Severity = LocalFieldProjectPackageDiagnosticSeverity.Error
+        };
+
+    private static bool IsError(LocalFieldProjectPackageDiagnostic diagnostic)
+        => diagnostic.Severity == LocalFieldProjectPackageDiagnosticSeverity.Error;
+
+    private static void DeleteDirectoryIfExists(string? path)
+    {
+        if (!string.IsNullOrWhiteSpace(path) && Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+
+    private sealed class FieldProjectPackageDownloadException : HttpRequestException
+    {
+        public FieldProjectPackageDownloadException(string code, string path, string message)
+            : base(message)
+        {
+            Code = code;
+            Path = path;
+        }
+
+        public string Code { get; }
+
+        public string Path { get; }
+    }
+}
+
+public sealed class FieldProjectPackageDownloadAuthHeader : IFieldProjectPackageDownloadRequestCustomizer
+{
+    private readonly IAuthenticationService _authService;
+
+    public FieldProjectPackageDownloadAuthHeader(IAuthenticationService authService)
+    {
+        _authService = authService ?? throw new ArgumentNullException(nameof(authService));
+    }
+
+    public async ValueTask CustomizeAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (!ShouldAttachCredentials(request.RequestUri))
+        {
+            return;
+        }
+
+        await _authService.EnsureValidSessionAsync(cancellationToken).ConfigureAwait(false);
+        var token = await _authService.GetAuthTokenAsync(cancellationToken).ConfigureAwait(false);
+        switch (token?.Scheme)
+        {
+            case HonuaAuthScheme.ApiKey when !string.IsNullOrWhiteSpace(token.AccessToken):
+                request.Headers.TryAddWithoutValidation("X-API-Key", token.AccessToken);
+                break;
+            case HonuaAuthScheme.Bearer when !string.IsNullOrWhiteSpace(token.AccessToken):
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.AccessToken);
+                break;
+        }
+    }
+
+    private bool ShouldAttachCredentials(Uri? endpoint)
+    {
+        return endpoint is not null &&
+            Uri.TryCreate(_authService.ServerUrl, UriKind.Absolute, out var serverUri) &&
+            Uri.Compare(
+                endpoint,
+                serverUri,
+                UriComponents.SchemeAndServer,
+                UriFormat.SafeUnescaped,
+                StringComparison.OrdinalIgnoreCase) == 0;
+    }
+}

--- a/apps/Honua.Mobile.FieldCollection.Core/ViewModels/FieldOperationsViewModel.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/ViewModels/FieldOperationsViewModel.cs
@@ -15,6 +15,7 @@ public partial class FieldOperationsViewModel : BaseViewModel
     private readonly GeoPackageStorageService _storage;
     private readonly ILocalFieldAssignmentService _assignmentService;
     private readonly LocalFieldProjectPackageImportService _packageImportService;
+    private readonly LocalFieldProjectPackageDownloadService _packageDownloadService;
     private readonly ILocalRecordExportService _recordExportService;
     private readonly ILocalRecordExportShareService _exportShareService;
 
@@ -29,6 +30,12 @@ public partial class FieldOperationsViewModel : BaseViewModel
 
     [ObservableProperty]
     private string packageManifestPath = string.Empty;
+
+    [ObservableProperty]
+    private string packageManifestUrl = string.Empty;
+
+    [ObservableProperty]
+    private string packageDownloadRoot = string.Empty;
 
     [ObservableProperty]
     private string packageDestinationRoot = string.Empty;
@@ -67,6 +74,7 @@ public partial class FieldOperationsViewModel : BaseViewModel
         GeoPackageStorageService storage,
         ILocalFieldAssignmentService assignmentService,
         LocalFieldProjectPackageImportService packageImportService,
+        LocalFieldProjectPackageDownloadService packageDownloadService,
         ILocalRecordExportService recordExportService,
         ILocalRecordExportShareService exportShareService)
         : base(navigationService)
@@ -74,6 +82,7 @@ public partial class FieldOperationsViewModel : BaseViewModel
         _storage = storage;
         _assignmentService = assignmentService;
         _packageImportService = packageImportService;
+        _packageDownloadService = packageDownloadService;
         _recordExportService = recordExportService;
         _exportShareService = exportShareService;
         Title = "Work";
@@ -137,6 +146,57 @@ public partial class FieldOperationsViewModel : BaseViewModel
             LastImportSummary = result.Imported
                 ? $"Imported {result.ProjectId} with {result.ImportedFiles.Count} artifact(s), {result.CopiedBytes} byte(s)."
                 : $"Package import failed for {result.ProjectId ?? Path.GetFileName(manifestPath)}.";
+            StatusMessage = LastImportSummary;
+
+            await RefreshWorkspaceCoreAsync();
+        });
+    }
+
+    [RelayCommand]
+    private async Task DownloadPackage()
+    {
+        if (string.IsNullOrWhiteSpace(PackageManifestUrl))
+        {
+            await ShowError("Package Required", "Enter a field project package manifest URL before downloading.");
+            return;
+        }
+
+        if (!Uri.TryCreate(PackageManifestUrl.Trim(), UriKind.Absolute, out var manifestUri))
+        {
+            await ShowError("Package URL Invalid", "Enter an absolute field project package manifest URL.");
+            return;
+        }
+
+        var downloadRoot = string.IsNullOrWhiteSpace(PackageDownloadRoot)
+            ? Path.Combine(GetLocalAppDataDirectory(), "Honua", "field-package-downloads")
+            : PackageDownloadRoot.Trim();
+        var destinationRoot = string.IsNullOrWhiteSpace(PackageDestinationRoot)
+            ? Path.Combine(GetLocalAppDataDirectory(), "Honua", "field-packages")
+            : PackageDestinationRoot.Trim();
+
+        await ExecuteAsync(async () =>
+        {
+            var result = await _packageDownloadService.DownloadAndImportAsync(new LocalFieldProjectPackageDownloadRequest
+            {
+                ManifestUri = manifestUri,
+                DownloadRootDirectory = downloadRoot,
+                DestinationRootDirectory = destinationRoot,
+                OverwriteExisting = true
+            });
+
+            ImportDiagnostics.Clear();
+            foreach (var diagnostic in result.Diagnostics)
+            {
+                ImportDiagnostics.Add(diagnostic);
+            }
+
+            HasImportDiagnostics = ImportDiagnostics.Count > 0;
+            PackageManifestPath = result.DownloadedManifestPath ?? PackageManifestPath;
+            LastImportSummary = result.Imported
+                ? $"Downloaded and imported {result.ProjectId} with {result.DownloadedFiles.Count} artifact(s), {result.DownloadedBytes} byte(s)."
+                : result.Downloaded
+                    ? $"Package downloaded but import failed for {result.ProjectId ?? manifestUri.Host}."
+                    : $"Package download failed for {result.ProjectId ?? manifestUri.Host}.";
             StatusMessage = LastImportSummary;
 
             await RefreshWorkspaceCoreAsync();
@@ -353,5 +413,13 @@ public partial class FieldOperationsViewModel : BaseViewModel
         return layer.Form?.Metadata.TryGetValue("honua:bindingId", out var bindingId) == true
             ? bindingId
             : null;
+    }
+
+    private static string GetLocalAppDataDirectory()
+    {
+        var directory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        return string.IsNullOrWhiteSpace(directory)
+            ? Environment.CurrentDirectory
+            : directory;
     }
 }

--- a/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
+++ b/apps/Honua.Mobile.FieldCollection/MauiProgram.cs
@@ -168,11 +168,22 @@ public static class MauiProgram
                 logger: provider.GetService<ILogger<LocalRecordExportService>>());
         });
         services.AddSingleton<ILocalRecordExportShareService, MauiLocalRecordExportShareService>();
+        services.AddHttpClient("HonuaFieldPackageDownload");
+        services.AddSingleton<IFieldProjectPackageDownloadRequestCustomizer, FieldProjectPackageDownloadAuthHeader>();
         services.AddSingleton(provider =>
         {
             return new LocalFieldProjectPackageImportService(
                 provider.GetRequiredService<GeoPackageStorageService>(),
                 provider.GetService<ILogger<LocalFieldProjectPackageImportService>>());
+        });
+        services.AddSingleton(provider =>
+        {
+            var httpClientFactory = provider.GetRequiredService<IHttpClientFactory>();
+            return new LocalFieldProjectPackageDownloadService(
+                httpClientFactory.CreateClient("HonuaFieldPackageDownload"),
+                provider.GetRequiredService<LocalFieldProjectPackageImportService>(),
+                provider.GetServices<IFieldProjectPackageDownloadRequestCustomizer>(),
+                provider.GetService<ILogger<LocalFieldProjectPackageDownloadService>>());
         });
         services.AddSingleton(provider =>
         {

--- a/apps/Honua.Mobile.FieldCollection/Views/FieldOperationsPage.xaml
+++ b/apps/Honua.Mobile.FieldCollection/Views/FieldOperationsPage.xaml
@@ -54,14 +54,25 @@
 
                 <Frame Style="{StaticResource CardFrameStyle}">
                     <VerticalStackLayout Spacing="10">
-                        <Label Text="Import Package" Style="{StaticResource SectionHeaderStyle}" />
+                        <Label Text="Package Intake" Style="{StaticResource SectionHeaderStyle}" />
+                        <Entry Text="{Binding PackageManifestUrl}"
+                               Placeholder="field project package manifest URL" />
                         <Entry Text="{Binding PackageManifestPath}"
                                Placeholder="field-project-package.json path" />
+                        <Entry Text="{Binding PackageDownloadRoot}"
+                               Placeholder="download cache folder" />
                         <Entry Text="{Binding PackageDestinationRoot}"
                                Placeholder="install destination folder" />
-                        <Button Text="Import"
-                                Style="{StaticResource BaseButtonStyle}"
-                                Command="{Binding ImportPackageCommand}" />
+                        <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                            <Button Grid.Column="0"
+                                    Text="Download"
+                                    Style="{StaticResource BaseButtonStyle}"
+                                    Command="{Binding DownloadPackageCommand}" />
+                            <Button Grid.Column="1"
+                                    Text="Import"
+                                    Style="{StaticResource SecondaryButtonStyle}"
+                                    Command="{Binding ImportPackageCommand}" />
+                        </Grid>
                         <Label Text="{Binding LastImportSummary}"
                                FontSize="13"
                                TextColor="{StaticResource Gray600}" />

--- a/tests/Honua.Mobile.FieldCollection.Tests/FieldOperationsViewModelTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/FieldOperationsViewModelTests.cs
@@ -14,6 +14,7 @@ public sealed class FieldOperationsViewModelTests : IDisposable
 {
     private readonly string _databasePath;
     private readonly string _packageRoot;
+    private readonly string _downloadRoot;
     private readonly string _installRoot;
     private readonly string _exportRoot;
 
@@ -22,9 +23,11 @@ public sealed class FieldOperationsViewModelTests : IDisposable
         SQLitePCL.Batteries_V2.Init();
         _databasePath = Path.Combine(Path.GetTempPath(), $"honua-workspace-{Guid.NewGuid():N}.gpkg");
         _packageRoot = Path.Combine(Path.GetTempPath(), $"honua-workspace-package-{Guid.NewGuid():N}");
+        _downloadRoot = Path.Combine(Path.GetTempPath(), $"honua-workspace-download-{Guid.NewGuid():N}");
         _installRoot = Path.Combine(Path.GetTempPath(), $"honua-workspace-install-{Guid.NewGuid():N}");
         _exportRoot = Path.Combine(Path.GetTempPath(), $"honua-workspace-export-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_packageRoot);
+        Directory.CreateDirectory(_downloadRoot);
         Directory.CreateDirectory(_installRoot);
         Directory.CreateDirectory(_exportRoot);
     }
@@ -91,6 +94,55 @@ public sealed class FieldOperationsViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task DownloadPackageCommand_WithManifestUrl_DownloadsImportsAndSelectsPackage()
+    {
+        using var storage = new GeoPackageStorageService(_databasePath);
+        var artifactBytes = "offline feature data"u8.ToArray();
+        var basePackage = LocalFieldProjectPackageImportServiceTests.CreatePackage();
+        var package = basePackage with
+        {
+            OfflinePackages =
+            [
+                basePackage.OfflinePackages[0] with
+                {
+                    SizeBytes = artifactBytes.Length,
+                    Sha256 = ComputeSha256(artifactBytes)
+                }
+            ]
+        };
+
+        var requestedPaths = new List<string>();
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(request =>
+        {
+            requestedPaths.Add(request.RequestUri?.AbsolutePath ?? string.Empty);
+            return request.RequestUri?.AbsolutePath switch
+            {
+                "/packages/day-1/field-project-package.json" => JsonResponse(package.ToJson()),
+                "/packages/day-1/data/assets.gpkg" => BytesResponse(artifactBytes),
+                _ => new HttpResponseMessage(System.Net.HttpStatusCode.NotFound)
+            };
+        }));
+        var importService = new LocalFieldProjectPackageImportService(storage);
+        var downloadService = new LocalFieldProjectPackageDownloadService(httpClient, importService);
+        var viewModel = CreateViewModel(storage, packageDownloadService: downloadService);
+        viewModel.PackageManifestUrl = "https://packages.honua.test/packages/day-1/field-project-package.json";
+        viewModel.PackageDownloadRoot = _downloadRoot;
+        viewModel.PackageDestinationRoot = _installRoot;
+
+        await viewModel.DownloadPackageCommand.ExecuteAsync(null);
+
+        Assert.Equal(
+            new[] { "/packages/day-1/field-project-package.json", "/packages/day-1/data/assets.gpkg" },
+            requestedPaths);
+        Assert.Single(viewModel.Packages);
+        Assert.Equal("local-inspection-demo", viewModel.SelectedPackage?.ProjectId);
+        Assert.Equal(2, viewModel.Assignments.Count);
+        Assert.False(viewModel.HasImportDiagnostics);
+        Assert.Contains("Downloaded and imported local-inspection-demo", viewModel.LastImportSummary, StringComparison.Ordinal);
+        Assert.True(File.Exists(viewModel.PackageManifestPath));
+    }
+
+    [Fact]
     public async Task ImportPackageCommand_WithInvalidPackage_RendersDeterministicDiagnostics()
     {
         using var storage = new GeoPackageStorageService(_databasePath);
@@ -113,13 +165,18 @@ public sealed class FieldOperationsViewModelTests : IDisposable
     private FieldOperationsViewModel CreateViewModel(
         GeoPackageStorageService storage,
         RecordingNavigationService? navigation = null,
-        ILocalRecordExportShareService? share = null)
+        ILocalRecordExportShareService? share = null,
+        LocalFieldProjectPackageDownloadService? packageDownloadService = null)
     {
+        var importService = new LocalFieldProjectPackageImportService(storage);
         return new FieldOperationsViewModel(
             navigation ?? new RecordingNavigationService(),
             storage,
             new LocalFieldAssignmentService(storage),
-            new LocalFieldProjectPackageImportService(storage),
+            importService,
+            packageDownloadService ?? new LocalFieldProjectPackageDownloadService(
+                new HttpClient(new StubHttpMessageHandler(_ => new HttpResponseMessage(System.Net.HttpStatusCode.NotFound))),
+                importService),
             new LocalRecordExportService(storage, _exportRoot),
             share ?? new RecordingExportShareService());
     }
@@ -153,10 +210,26 @@ public sealed class FieldOperationsViewModelTests : IDisposable
         return Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
     }
 
+    private static string ComputeSha256(byte[] bytes)
+        => Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+    private static HttpResponseMessage JsonResponse(string json)
+        => new(System.Net.HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+        };
+
+    private static HttpResponseMessage BytesResponse(byte[] bytes)
+        => new(System.Net.HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(bytes)
+        };
+
     public void Dispose()
     {
         DeleteFile(_databasePath);
         DeleteDirectory(_packageRoot);
+        DeleteDirectory(_downloadRoot);
         DeleteDirectory(_installRoot);
         DeleteDirectory(_exportRoot);
     }

--- a/tests/Honua.Mobile.FieldCollection.Tests/LocalFieldProjectPackageDownloadServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/LocalFieldProjectPackageDownloadServiceTests.cs
@@ -1,0 +1,289 @@
+using System.Net;
+using System.Security.Cryptography;
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services.Packages;
+using Honua.Mobile.FieldCollection.Services.Storage;
+using Honua.Sdk.Field.Projects;
+
+namespace Honua.Mobile.FieldCollection.Tests;
+
+public sealed class LocalFieldProjectPackageDownloadServiceTests : IDisposable
+{
+    private readonly string _databasePath;
+    private readonly string _downloadRoot;
+    private readonly string _installRoot;
+
+    public LocalFieldProjectPackageDownloadServiceTests()
+    {
+        SQLitePCL.Batteries_V2.Init();
+        _databasePath = Path.Combine(Path.GetTempPath(), $"honua-package-download-{Guid.NewGuid():N}.gpkg");
+        _downloadRoot = Path.Combine(Path.GetTempPath(), $"honua-package-download-cache-{Guid.NewGuid():N}");
+        _installRoot = Path.Combine(Path.GetTempPath(), $"honua-package-download-install-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_downloadRoot);
+        Directory.CreateDirectory(_installRoot);
+    }
+
+    [Fact]
+    public async Task DownloadAndImportAsync_WithValidManifest_DownloadsArtifactsAndCreatesCatalog()
+    {
+        using var storage = new GeoPackageStorageService(_databasePath);
+        var artifactBytes = "offline feature data"u8.ToArray();
+        var package = PackageWithArtifact(artifactBytes);
+        var requestedPaths = new List<string>();
+        using var httpClient = CreateHttpClient(request =>
+        {
+            requestedPaths.Add(request.RequestUri?.AbsolutePath ?? string.Empty);
+            return request.RequestUri?.AbsolutePath switch
+            {
+                "/packages/day-1/field-project-package.json" => JsonResponse(package.ToJson()),
+                "/packages/day-1/data/assets.gpkg" => BytesResponse(artifactBytes),
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound)
+            };
+        });
+
+        var result = await CreateService(storage, httpClient).DownloadAndImportAsync(new LocalFieldProjectPackageDownloadRequest
+        {
+            ManifestUri = new Uri("https://packages.honua.test/packages/day-1/field-project-package.json"),
+            DownloadRootDirectory = _downloadRoot,
+            DestinationRootDirectory = _installRoot,
+            OverwriteExisting = true
+        });
+
+        Assert.True(result.Downloaded, string.Join(" | ", result.Diagnostics.Select(diagnostic => diagnostic.Message)));
+        Assert.True(result.Imported, string.Join(" | ", result.Diagnostics.Select(diagnostic => diagnostic.Message)));
+        Assert.Equal(
+            new[] { "/packages/day-1/field-project-package.json", "/packages/day-1/data/assets.gpkg" },
+            requestedPaths);
+        Assert.Equal("local-inspection-demo", result.ProjectId);
+        Assert.True(File.Exists(result.DownloadedManifestPath));
+        Assert.True(File.Exists(Path.Combine(result.DownloadDirectory!, "data", "assets.gpkg")));
+        var downloadedFile = Assert.Single(result.DownloadedFiles);
+        Assert.Equal("pkg-assets", downloadedFile.PackageId);
+        Assert.Equal("data/assets.gpkg", downloadedFile.RelativePath);
+        Assert.Equal(artifactBytes.Length, downloadedFile.SizeBytes);
+        Assert.True(result.DownloadedBytes > artifactBytes.Length);
+
+        var catalogEntry = await storage.GetProjectCatalogEntryAsync("local-inspection-demo");
+        Assert.NotNull(catalogEntry);
+        Assert.Equal(FieldProjectCatalogState.Installed, catalogEntry.State);
+        Assert.Equal("https://packages.honua.test/packages/day-1/field-project-package.json", catalogEntry.ImportSource);
+    }
+
+    [Fact]
+    public async Task DownloadAndImportAsync_WithArtifactHttpError_ReturnsDownloadDiagnosticWithoutImporting()
+    {
+        using var storage = new GeoPackageStorageService(_databasePath);
+        var artifactBytes = "offline feature data"u8.ToArray();
+        var package = PackageWithArtifact(artifactBytes);
+        using var httpClient = CreateHttpClient(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/packages/day-1/field-project-package.json" => JsonResponse(package.ToJson()),
+            "/packages/day-1/data/assets.gpkg" => new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                ReasonPhrase = "Not Found"
+            },
+            _ => new HttpResponseMessage(HttpStatusCode.NotFound)
+        });
+
+        var result = await CreateService(storage, httpClient).DownloadAndImportAsync(new LocalFieldProjectPackageDownloadRequest
+        {
+            ManifestUri = new Uri("https://packages.honua.test/packages/day-1/field-project-package.json"),
+            DownloadRootDirectory = _downloadRoot,
+            DestinationRootDirectory = _installRoot,
+            OverwriteExisting = true
+        });
+
+        Assert.False(result.Downloaded);
+        Assert.False(result.Imported);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "download-http-error");
+        Assert.Null(await storage.GetProjectCatalogEntryAsync("local-inspection-demo"));
+    }
+
+    [Fact]
+    public async Task DownloadAndImportAsync_WithUnsafeArtifactPath_DoesNotRequestArtifact()
+    {
+        using var storage = new GeoPackageStorageService(_databasePath);
+        var package = PackageWithArtifact("offline feature data"u8.ToArray()) with
+        {
+            OfflinePackages =
+            [
+                PackageWithArtifact("offline feature data"u8.ToArray()).OfflinePackages[0] with
+                {
+                    RelativePath = "../escape.gpkg"
+                }
+            ]
+        };
+        var artifactRequested = false;
+        using var httpClient = CreateHttpClient(request =>
+        {
+            if (request.RequestUri?.AbsolutePath != "/packages/day-1/field-project-package.json")
+            {
+                artifactRequested = true;
+            }
+
+            return request.RequestUri?.AbsolutePath == "/packages/day-1/field-project-package.json"
+                ? JsonResponse(package.ToJson())
+                : BytesResponse("unexpected"u8.ToArray());
+        });
+
+        var result = await CreateService(storage, httpClient).DownloadAndImportAsync(new LocalFieldProjectPackageDownloadRequest
+        {
+            ManifestUri = new Uri("https://packages.honua.test/packages/day-1/field-project-package.json"),
+            DownloadRootDirectory = _downloadRoot,
+            DestinationRootDirectory = _installRoot,
+            OverwriteExisting = true
+        });
+
+        Assert.False(result.Downloaded);
+        Assert.False(result.Imported);
+        Assert.False(artifactRequested);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "unsafe-offline-artifact-path");
+    }
+
+    [Fact]
+    public async Task DownloadAndImportAsync_WithChecksumMismatch_DownloadsThenReturnsImportDiagnostics()
+    {
+        using var storage = new GeoPackageStorageService(_databasePath);
+        var artifactBytes = "offline feature data"u8.ToArray();
+        var package = PackageWithArtifact(artifactBytes) with
+        {
+            OfflinePackages =
+            [
+                PackageWithArtifact(artifactBytes).OfflinePackages[0] with
+                {
+                    Sha256 = new string('0', 64)
+                }
+            ]
+        };
+        using var httpClient = CreateHttpClient(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/packages/day-1/field-project-package.json" => JsonResponse(package.ToJson()),
+            "/packages/day-1/data/assets.gpkg" => BytesResponse(artifactBytes),
+            _ => new HttpResponseMessage(HttpStatusCode.NotFound)
+        });
+
+        var result = await CreateService(storage, httpClient).DownloadAndImportAsync(new LocalFieldProjectPackageDownloadRequest
+        {
+            ManifestUri = new Uri("https://packages.honua.test/packages/day-1/field-project-package.json"),
+            DownloadRootDirectory = _downloadRoot,
+            DestinationRootDirectory = _installRoot,
+            OverwriteExisting = true
+        });
+
+        Assert.True(result.Downloaded);
+        Assert.False(result.Imported);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "offline-artifact-sha256-mismatch");
+        var catalogEntry = await storage.GetProjectCatalogEntryAsync("local-inspection-demo");
+        Assert.NotNull(catalogEntry);
+        Assert.Equal(FieldProjectCatalogState.Invalid, catalogEntry.State);
+    }
+
+    [Fact]
+    public async Task DownloadAndImportAsync_WithAuthCustomizer_AttachesApiKeyToSameOriginRequests()
+    {
+        using var storage = new GeoPackageStorageService(_databasePath);
+        var artifactBytes = "offline feature data"u8.ToArray();
+        var package = PackageWithArtifact(artifactBytes);
+        var apiKeys = new List<string?>();
+        using var httpClient = CreateHttpClient(request =>
+        {
+            apiKeys.Add(request.Headers.TryGetValues("X-API-Key", out var values) ? values.Single() : null);
+            return request.RequestUri?.AbsolutePath switch
+            {
+                "/packages/day-1/field-project-package.json" => JsonResponse(package.ToJson()),
+                "/packages/day-1/data/assets.gpkg" => BytesResponse(artifactBytes),
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound)
+            };
+        });
+        var auth = new TestAuthenticationService
+        {
+            ServerUrl = "https://packages.honua.test",
+            ApiKey = "package-api-key"
+        };
+
+        var result = await CreateService(
+            storage,
+            httpClient,
+            new FieldProjectPackageDownloadAuthHeader(auth)).DownloadAndImportAsync(new LocalFieldProjectPackageDownloadRequest
+            {
+                ManifestUri = new Uri("https://packages.honua.test/packages/day-1/field-project-package.json"),
+                DownloadRootDirectory = _downloadRoot,
+                DestinationRootDirectory = _installRoot,
+                OverwriteExisting = true
+            });
+
+        Assert.True(result.Imported, string.Join(" | ", result.Diagnostics.Select(diagnostic => diagnostic.Message)));
+        Assert.Equal(new[] { "package-api-key", "package-api-key" }, apiKeys);
+        Assert.Equal(2, auth.EnsureValidSessionCalls);
+    }
+
+    private static FieldProjectPackage PackageWithArtifact(byte[] artifactBytes)
+    {
+        var package = LocalFieldProjectPackageImportServiceTests.CreatePackage();
+        return package with
+        {
+            OfflinePackages =
+            [
+                package.OfflinePackages[0] with
+                {
+                    SizeBytes = artifactBytes.Length,
+                    Sha256 = ComputeSha256(artifactBytes)
+                }
+            ]
+        };
+    }
+
+    private static LocalFieldProjectPackageDownloadService CreateService(
+        GeoPackageStorageService storage,
+        HttpClient httpClient,
+        params IFieldProjectPackageDownloadRequestCustomizer[] customizers)
+    {
+        return new LocalFieldProjectPackageDownloadService(
+            httpClient,
+            new LocalFieldProjectPackageImportService(storage),
+            customizers);
+    }
+
+    private static HttpClient CreateHttpClient(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        => new(new StubHttpMessageHandler(handler));
+
+    private static HttpResponseMessage JsonResponse(string json)
+        => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+        };
+
+    private static HttpResponseMessage BytesResponse(byte[] bytes)
+        => new(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(bytes)
+        };
+
+    private static string ComputeSha256(byte[] bytes)
+        => Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+    public void Dispose()
+    {
+        DeleteIfExists(_databasePath);
+        DeleteIfExists($"{_databasePath}-wal");
+        DeleteIfExists($"{_databasePath}-shm");
+        DeleteDirectoryIfExists(_downloadRoot);
+        DeleteDirectoryIfExists(_installRoot);
+    }
+
+    private static void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static void DeleteDirectoryIfExists(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a mobile-owned field project package downloader that fetches an SDK `FieldProjectPackage` manifest and relative offline artifacts into local cache before handing off to the existing import service
- add same-origin package download auth customization, Work tab download command wiring, and DI registration
- cover successful download/import plus HTTP failure, unsafe paths, checksum mismatch, auth headers, and viewmodel command behavior

Related to #92. This does not add a mobile-local Honua Server package API client; it consumes direct manifest/artifact URIs and SDK package contracts.

## Testing
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --configuration Release --logger "console;verbosity=minimal"`
- `dotnet test tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --configuration Release --no-restore --logger "console;verbosity=minimal"`
- `dotnet format apps/Honua.Mobile.FieldCollection.Core/Honua.Mobile.FieldCollection.Core.csproj --no-restore --verify-no-changes --verbosity minimal`
- `dotnet format tests/Honua.Mobile.FieldCollection.Tests/Honua.Mobile.FieldCollection.Tests.csproj --no-restore --verify-no-changes --verbosity minimal`
- `git diff --check`

## Local gap
- `dotnet build apps/Honua.Mobile.FieldCollection/Honua.Mobile.FieldCollection.csproj --configuration Release --framework net10.0-android --no-restore` is blocked locally by missing Android SDK (`XA5300`) before app-specific compilation.