### PR TITLE
docs: refresh mobile parity backlog status

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -7,11 +7,12 @@ This repository owns mobile SDK packages, MAUI integration, offline field workfl
 - `Honua.Mobile.Sdk`: transport, auth, gRPC-first feature queries, REST fallback, routing, scene metadata adapter, and secure transport checks.
 - `Honua.Mobile.Field`: SDK-backed field form validation, calculated fields, duplicate detection, media attachment metadata conversion, and record workflow.
 - Field collection reference workflow: opt-in AI capture adapter hooks for field suggestions, media redaction state, provider-unavailable queueing, and sanitized diagnostics.
+- FieldCollection local Work tab: SDK field package manifest import, direct manifest/artifact URL download, local project catalog state, package diagnostics, assignment inbox/actions, record open routing, lifecycle buttons, local export, and native share handoff.
 - `Honua.Mobile.Offline`: GeoPackage storage, sync queue, pull/push sync, conflicts, map area download, delta cursors, TTL/cache governance, and R-tree bbox lookup.
 - `Honua.Mobile.Maui`: DI registration, native display boundaries, map annotations, secure auth token storage, device location, background location, and geofencing contracts.
 - `@honua/embed`: framework-agnostic `<honua-map>` and `<honua-scene>` components with display adapters, scene package caching, snippets, and DOM behavior tests.
 - Reference MAUI applications, field collection example, embed example, scene example, AR utility visualization example, and field collector template.
-- Integration and smoke tests for loopback server paths, offline sync, MAUI helpers, embed components, and optional live Honua query.
+- Integration and smoke tests for loopback server paths, offline sync, no-cloud field-day acceptance, local package import/download, MAUI helpers, embed components, and optional live Honua query.
 
 ## Source Evidence
 
@@ -20,6 +21,7 @@ This repository owns mobile SDK packages, MAUI integration, offline field workfl
 - Apps and examples: `apps/`, `examples/`, `templates/`
 - Tests: `tests/`, `src/Honua.Embed/tests/`
 - 3D/offline/capture docs: `docs/guides/3d-scene-embed.md`, `docs/guides/offline-3d-scene-packages.md`, `docs/guides/protected-3d-scene-auth.md`, `docs/guides/field-ai-assisted-capture.md`
+- No-cloud field parity docs: `docs/guides/no-cloud-field-parity-information-model.md`
 
 ## 3D Status
 

--- a/docs/guides/mobile-sdk-backlog-roadmap.md
+++ b/docs/guides/mobile-sdk-backlog-roadmap.md
@@ -1,11 +1,14 @@
 # Mobile SDK Backlog Roadmap
 
-Last reviewed: 2026-05-23.
+Last reviewed: 2026-05-24.
 
 This roadmap integrates the remaining non-Flutter backlog for #1, the mobile SDK
-epic. It covers open children #10, #12, #16, #23, #38, #42, #50, #51, and #57.
-It intentionally excludes #22, which owns Flutter and broader platform parity
-expansion.
+epic. The historical child issues #12, #16, #23, #38, #42, #50, #51, and #57
+are now closed; #10 remains open for embeddable map packaging. The current open
+mobile-owned parity items are #92 for final hosted cloud acceptance and #225 for
+AR/3D GA physical-device validation. Mobile DevOps/store-release work remains
+tracked separately in #82 and #85. This roadmap intentionally excludes #22,
+which owns Flutter and broader platform parity expansion.
 
 This page is a sequencing and closure matrix. It also indexes the current
 Fulcrum/Survey123 parity backlog. It does not replace the detailed
@@ -46,23 +49,28 @@ Survey123, or other field collection platforms:
 |-------|--------|-------------------|
 | Phase 0 foundation | Complete as a planning baseline. | Keeps #1 anchored to parity, innovation, and test gates instead of reopening broad discovery. |
 | SDK contract alignment | Baseline documented and partially migrated to published `Honua.Sdk.*` packages. | New portable contracts should land in `honua-sdk-dotnet`; mobile should stay limited to adapters, DI, native storage, renderer integration, and lifecycle behavior. |
-| Offline mobile runtime | Mobile-owned runtime behavior is established around GeoPackage/SQLite, queueing, file placement, and app lifecycle. | Remaining work should extend the runtime through SDK contracts instead of adding provider-neutral clients here. |
-| Display and embed | Active work is split between map embedding, web display adapters, scene rendering, and native display evaluation. | #10, #50, and #57 should remain separate so product packaging, web rendering, and native .NET evaluation do not block each other unnecessarily. |
-| 3D, offline scene, and AR/VR | Policy and dependency order are documented; implementation depends on server, SDK, browser/WebView, and native platform decisions. | #12 remains the umbrella. #42 and #38 are immediate prerequisites for production offline scenes and native AR/VR work. |
-| Field location behavior | Geofencing acquisition remains a mobile-owned runtime slice once SDK evaluation contracts are available. | #51 should not define portable geofence rules; it should consume the SDK and own permissions, sensors, background behavior, and battery policy. |
-| Plugins | Mobile/web hosts own runtime loading and UI integration; non-UI manifests and permission contracts belong in shared SDK/server work. | #16 can consume SDK manifests from `Honua.Sdk.Abstractions`; server plugin APIs remain tracked in honua-io/honua-server#347. |
+| Offline mobile runtime | Mobile-owned runtime behavior is established around GeoPackage/SQLite, queueing, file placement, app lifecycle, local package intake, assignment packets, lifecycle transitions, and export evidence. | Remaining work should extend the runtime through SDK contracts instead of adding provider-neutral clients here. #92 stays open only for hosted cloud acceptance after honua-server#965. |
+| Display and embed | Web display adapter and native .NET evaluation slices are closed; embeddable map product packaging remains #10. | #10 should close over the closed #50 adapter foundation without reopening #57 native display evaluation. |
+| 3D, offline scene, and AR/VR | Scene, browser offline cache, and anchoring decision slices are closed; first AR/3D workflow GA validation remains #225. | #225 should attach ARCore/ARKit adapter and physical-device evidence before GA closure. |
+| Field location behavior | Geofencing acquisition/background location is closed as a mobile-owned runtime slice. | Future geofence work should continue consuming SDK contracts while mobile owns permissions, sensors, background behavior, and battery policy. |
+| Plugins | Mobile/web host runtime scope is closed; non-UI manifests and permission contracts remain shared SDK/server concerns. | Server plugin APIs remain tracked in honua-io/honua-server#347 and should not be redefined in mobile. |
 
 ## Fulcrum/Survey123 Parity Backlog Index
 
-These issues are the current execution backlog for closing the gap between the
-historical Phase 0 parity targets and source-backed shipped status.
+The focused competitive parity sprint is no longer an open execution backlog.
+The local/no-cloud and no-design slices are closed, including #208 through
+#224, #226, and the no-cloud child backlog #249 through #258. Those closures
+cover local form runtime, validation, rules/calculations, repeat fixtures,
+metadata-driven project/form loading, local package import/download, assignment
+packets, lifecycle transitions, media metadata/export, conflict replay, device
+diagnostics, sync health, and the field-day acceptance harness.
 
-| Priority | Issues | Closure signal |
-|----------|--------|----------------|
-| P0 | [#208](https://github.com/honua-io/honua-mobile/issues/208) restore green validation; [#209](https://github.com/honua-io/honua-mobile/issues/209) reconcile parity docs. | Agents and reviewers can trust the local/CI baseline and source-backed docs. |
-| P1 | [#210](https://github.com/honua-io/honua-mobile/issues/210) functional FieldCollection workflows; [#211](https://github.com/honua-io/honua-mobile/issues/211) metadata-driven projects/layers/forms; [#212](https://github.com/honua-io/honua-mobile/issues/212) remote sync transports; [#213](https://github.com/honua-io/honua-mobile/issues/213) attachment storage/sync; [#214](https://github.com/honua-io/honua-mobile/issues/214) pilot field-type controls; [#215](https://github.com/honua-io/honua-mobile/issues/215) rules/calculations/conditional visibility/repeats; [#216](https://github.com/honua-io/honua-mobile/issues/216) real map workflow surface. | MVP field workflow is usable end to end from metadata load through capture, validation, map context, offline storage, and sync. |
-| P2 | [#217](https://github.com/honua-io/honua-mobile/issues/217) product acceptance suite; [#218](https://github.com/honua-io/honua-mobile/issues/218) auth/session hardening; [#219](https://github.com/honua-io/honua-mobile/issues/219) server/admin dependencies; [#220](https://github.com/honua-io/honua-mobile/issues/220) local record export; [#221](https://github.com/honua-io/honua-mobile/issues/221) diagnostics and sync health. | Beta hardening covers acceptance evidence, operational support, auth robustness, admin dependencies, and field troubleshooting. |
-| P3 | [#222](https://github.com/honua-io/honua-mobile/issues/222) external GNSS metadata; [#223](https://github.com/honua-io/honua-mobile/issues/223) geofence/proximity workflows; [#224](https://github.com/honua-io/honua-mobile/issues/224) AI-assisted capture hooks; [#225](https://github.com/honua-io/honua-mobile/issues/225) first AR/3D field workflow; [#226](https://github.com/honua-io/honua-mobile/issues/226) mobile/web plugin host hardening. | GA-oriented differentiators are implemented only after SDK/server dependencies and MVP/Beta workflow gaps are stable. |
+| Status | Issues | Closure signal |
+|--------|--------|----------------|
+| Closed local parity sprint | [#208](https://github.com/honua-io/honua-mobile/issues/208)-[#224](https://github.com/honua-io/honua-mobile/issues/224), [#226](https://github.com/honua-io/honua-mobile/issues/226), [#249](https://github.com/honua-io/honua-mobile/issues/249)-[#258](https://github.com/honua-io/honua-mobile/issues/258) | Source-backed docs, green validation, functional FieldCollection workflows, local package/catalog/assignment/lifecycle/export coverage, and no-cloud acceptance evidence are in place. |
+| Open cloud acceptance | [#92](https://github.com/honua-io/honua-mobile/issues/92), blocked by [honua-server#965](https://github.com/honua-io/honua-server/issues/965) | Re-dispatch `Cloud Acceptance` on `main` after `staging-api.honua.io` DNS/TLS is fixed, then attach the uploaded `cloud-acceptance-evidence` artifact to #92. |
+| Open AR/3D GA | [#225](https://github.com/honua-io/honua-mobile/issues/225) | Add ARCore/ARKit adapter evidence and physical-device validation for the first field workflow. |
+| Outside mobile/no-cloud scope | hosted designer/admin, supervisor review, hosted reports, tenancy, RBAC, audit, and hosted package catalog/publish | Owned by `honua-server`, admin UI, and SDK packages; mobile consumes published contracts through adapters, DI, local cache, UX, and tests. |
 
 ## Back-Office Dependency Handoff
 
@@ -93,14 +101,14 @@ contract/acceptance tests.
 | Issue | Role in #1 | Closure criteria | Dependencies and source docs | Disposition |
 |-------|------------|------------------|------------------------------|-------------|
 | #10 Embeddable map component | Beta product/API packaging for a white-label `<honua-map>` integration surface. | Drop-in component exposes theming, camera/options, events, auth/cache boundaries, and a working sample over the approved display adapter. | Depends on #50 for web display architecture; see [Embeddable Map](embeddable-map.md). | Current slice. Keep product packaging separate from #50's adapter internals. |
-| #12 3D / Scene services | GA umbrella for 3D visualization, terrain, building layers, CesiumJS, and related scene service capability. | Close only after server 3D serving/registry/terrain/elevation/generation/I3S decisions and client SDK/render/offline hooks are complete or explicitly split into follow-up epics. | Depends on honua-io/honua-server#837 through #844, SDK scene contracts, #42, #38, and #23; see [Mobile 3D and AR Dependency Matrix](mobile-3d-ar-dependency-matrix.md). | Remains epic scope. Do not close from mobile docs alone. |
-| #16 Plugin client SDK | GA host/runtime plugin framework for mobile and web. | Hosts can load/register approved plugins, surface UI extension points, enforce sandbox/signing/permission rules, and consume shared non-UI manifests from SDK/server contracts. | Consumes SDK-owned plugin manifests from `Honua.Sdk.Abstractions`; server plugin API dependency remains honua-io/honua-server#347. See [Mobile Contract Harmonization](mobile-contract-harmonization.md). | Host/runtime slice closeable when mobile/web adapters and docs are linked; avoid defining stable plugin contracts locally. |
-| #23 AR/VR field workflow enablement | GA field overlay workflow over scene, device pose, camera, and field context. | Native or WebXR prototype uses the selected #38 anchoring strategy, documents platform support and calibration limits, and has sample/test coverage for the first field workflow. | Depends on #38, #12 scene foundations, protected scene auth, and offline scene policy where disconnected AR is in scope. | Remaining implementation stream. Start after #38 closes. |
-| #38 Native scene anchoring spike | Decision spike for ARKit, ARCore, WebXR, and MAUI anchoring strategy. | Device capability requirements, anchoring comparison, accuracy/calibration risks, and first prototype target are documented and accepted. | Feeds #23; see [Mobile 3D and AR Dependency Matrix](mobile-3d-ar-dependency-matrix.md). | Closure-friendly decision slice. Close before AR/VR implementation begins. |
-| #42 Browser offline 3D scene cache adapter | Browser/WebView package-local asset resolution for `<honua-scene>`. | Adapter strategy is selected, package-local URLs resolve 3D Tiles/terrain/textures/metadata, stale/expired/revoked states match policy, and browser/WebView tests or fixtures cover cache behavior. | Depends on #36, #40, and #41; see [Offline 3D Scene Packages](offline-3d-scene-packages.md). | Current implementation slice owned separately. Reference here, but do not duplicate detailed cache design. |
-| #50 Web display adapter | P1 web display adapter using MapLibre GL JS and deck.gl over SDK feature data. | `FeatureQueryResult` pages or streams render through the adapter with base map, camera, picking/highlighting, overlays, and DOM/test coverage. | Feeds #10 and informs display scope in [Mobile Contract Harmonization](mobile-contract-harmonization.md). | Current implementation slice owned separately. This roadmap only sequences it. |
-| #51 Geofencing acquisition and background location | Mobile-owned device location acquisition, permissions, and battery-aware background behavior. | Mobile maps location streams into SDK geofence/event contracts, handles iOS/Android permission/background lifecycle, and includes enter/exit/proximity sample or fixture coverage. | Depends on SDK geofence evaluation contracts; mobile owns sensors and lifecycle behavior. | Remaining mobile runtime stream. Start when SDK contracts are available. |
-| #57 Mapsui-inspired native .NET display evaluation | Decision spike for native .NET display adapter direction. | Decision record states whether to use Mapsui, borrow architecture patterns, or reject it; follow-up adapter scope and prototype/test criteria are clear. | Informs future native display after #50/#10; see display ownership in [Mobile Contract Harmonization](mobile-contract-harmonization.md). | Closure-friendly evaluation slice. It should not block web display work. |
+| #12 3D / Scene services | GA umbrella for 3D visualization, terrain, building layers, CesiumJS, and related scene service capability. | Close only after server 3D serving/registry/terrain/elevation/generation/I3S decisions and client SDK/render/offline hooks are complete or explicitly split into follow-up epics. | Depends on honua-io/honua-server#837 through #844, SDK scene contracts, #42, #38, and #23; see [Mobile 3D and AR Dependency Matrix](mobile-3d-ar-dependency-matrix.md). | Closed. Remaining AR/3D GA evidence is tracked by #225. |
+| #16 Plugin client SDK | GA host/runtime plugin framework for mobile and web. | Hosts can load/register approved plugins, surface UI extension points, enforce sandbox/signing/permission rules, and consume shared non-UI manifests from SDK/server contracts. | Consumes SDK-owned plugin manifests from `Honua.Sdk.Abstractions`; server plugin API dependency remains honua-io/honua-server#347. See [Mobile Contract Harmonization](mobile-contract-harmonization.md). | Closed for mobile/web host runtime scope; server plugin behavior remains outside this repo. |
+| #23 AR/VR field workflow enablement | GA field overlay workflow over scene, device pose, camera, and field context. | Native or WebXR prototype uses the selected #38 anchoring strategy, documents platform support and calibration limits, and has sample/test coverage for the first field workflow. | Depends on #38, #12 scene foundations, protected scene auth, and offline scene policy where disconnected AR is in scope. | Closed as enablement. GA physical-device evidence remains #225. |
+| #38 Native scene anchoring spike | Decision spike for ARKit, ARCore, WebXR, and MAUI anchoring strategy. | Device capability requirements, anchoring comparison, accuracy/calibration risks, and first prototype target are documented and accepted. | Feeds #23; see [Mobile 3D and AR Dependency Matrix](mobile-3d-ar-dependency-matrix.md). | Closed decision slice. |
+| #42 Browser offline 3D scene cache adapter | Browser/WebView package-local asset resolution for `<honua-scene>`. | Adapter strategy is selected, package-local URLs resolve 3D Tiles/terrain/textures/metadata, stale/expired/revoked states match policy, and browser/WebView tests or fixtures cover cache behavior. | Depends on #36, #40, and #41; see [Offline 3D Scene Packages](offline-3d-scene-packages.md). | Closed browser/WebView offline scene slice. |
+| #50 Web display adapter | P1 web display adapter using MapLibre GL JS and deck.gl over SDK feature data. | `FeatureQueryResult` pages or streams render through the adapter with base map, camera, picking/highlighting, overlays, and DOM/test coverage. | Feeds #10 and informs display scope in [Mobile Contract Harmonization](mobile-contract-harmonization.md). | Closed adapter foundation; #10 remains the packaging/product surface. |
+| #51 Geofencing acquisition and background location | Mobile-owned device location acquisition, permissions, and battery-aware background behavior. | Mobile maps location streams into SDK geofence/event contracts, handles iOS/Android permission/background lifecycle, and includes enter/exit/proximity sample or fixture coverage. | Depends on SDK geofence evaluation contracts; mobile owns sensors and lifecycle behavior. | Closed mobile runtime slice. |
+| #57 Mapsui-inspired native .NET display evaluation | Decision spike for native .NET display adapter direction. | Decision record states whether to use Mapsui, borrow architecture patterns, or reject it; follow-up adapter scope and prototype/test criteria are clear. | Informs future native display after #50/#10; see display ownership in [Mobile Contract Harmonization](mobile-contract-harmonization.md). | Closed evaluation slice. |
 
 ## Dependency Map
 
@@ -113,29 +121,28 @@ contract/acceptance tests.
 
 ## Recommended Closure Sequence
 
-1. Stabilize the web display foundation: complete #50, then close #10 when the
-   embeddable component is packaged and documented over that adapter.
-2. Finish the browser/WebView offline scene path in #42 after the shared package
-   policy and .NET package pieces are stable.
-3. Close #38 as a decision spike before starting #23 implementation.
-4. Keep #12 open as the 3D umbrella until server, SDK, renderer, offline, and
-   AR/VR scope is either delivered or explicitly split into follow-up epics.
-5. Start #51 only after the SDK geofence/event evaluation contracts are ready to
-   consume from published `Honua.Sdk.*` packages.
-6. Keep #16 scoped to host/runtime adapters now that SDK-owned non-UI plugin
-   manifests are available; link server-side plugin behavior to
-   honua-io/honua-server#347.
-7. Close #1 only when every non-Flutter child in this matrix is closed or
+1. Close #10 when the embeddable map product surface is packaged and documented
+   over the closed web display adapter foundation.
+2. Keep #92 open until honua-server#965 is fixed, then re-dispatch `Cloud
+   Acceptance` on `main` and attach the evidence artifact to #92.
+3. Close #225 only after ARCore/ARKit adapter evidence and physical-device
+   validation are attached for the first AR/3D field workflow.
+4. Keep #82 and #85 in the DevOps/store-release lane rather than counting them
+   as mobile product parity gaps.
+5. Close #1 only when every non-Flutter child in this matrix is closed or
    intentionally deferred with a linked follow-up. Do not count #22 toward this
    workstream's closure.
 
 ## Closure Readiness Summary
 
-The foundation is documented enough for #1 coordination: Phase 0, contract
-harmonization, offline sync ownership, 3D/AR dependencies, offline scene policy,
-and protected scene auth are already present.
+The no-cloud/no-design Fulcrum and Survey123 parity backlog is closed for the
+mobile-owned local runtime. The remaining competitive-parity risks are now clear
+and narrower:
 
-The nearest closeable items are decision or narrow implementation slices: #38
-and #57 as spikes, and #42/#50 after their active implementation work lands.
-#10 can close after #50 provides the display adapter foundation. #12, #16, #23,
-#51, and #1 remain broader epic or implementation scope.
+- hosted cloud acceptance for #92 is blocked by honua-server#965 DNS/TLS;
+- #10 still needs the embeddable map product surface closure over the already
+  closed display adapter foundation;
+- #225 still needs physical-device AR/3D validation before GA closure;
+- hosted designer/admin/supervisor/reporting/tenancy/RBAC/audit parity remains
+  outside this repo and should be consumed through published SDK/server
+  contracts.

--- a/docs/guides/no-cloud-field-parity-information-model.md
+++ b/docs/guides/no-cloud-field-parity-information-model.md
@@ -1,12 +1,12 @@
 # No-Cloud Field Parity Information Model
 
-Last reviewed: 2026-05-23.
+Last reviewed: 2026-05-24.
 
 This handoff describes the information model needed to design Honua field
 collection UI without requiring hosted cloud services or new visual design work.
 The model is intentionally data-first: UI can be designed from these entities
-while SDK and mobile engineers continue implementing import, catalog, lifecycle,
-assignment, media, conflict simulation, and export behavior.
+now that package intake, catalog state, lifecycle, assignment, media, conflict
+simulation, export, and Work tab behavior have mobile-owned local coverage.
 
 Authoritative portable contracts belong in `honua-sdk-dotnet`. Mobile consumes
 those contracts and owns native storage, local file placement, permissions,
@@ -16,17 +16,19 @@ capture adapters, diagnostics, and runtime state.
 
 In scope:
 
-- Local project package import.
+- Local project package import and direct manifest/artifact download.
 - Offline project and survey catalog.
 - Local form/runtime state.
 - Record lifecycle, assignments, media metadata, validation, conflicts, and
   export evidence.
+- Mobile Work tab integration for local package intake, assignment actions,
+  record open routing, lifecycle actions, export, and native share handoff.
 - Local fixtures and acceptance evidence that run without external services.
 
 Out of scope:
 
 - Hosted form designer or admin UI.
-- Cloud publish/download/sync.
+- Hosted package catalog, publish APIs, and full cloud sync.
 - Store release setup.
 - New visual system or screen layouts.
 
@@ -51,6 +53,27 @@ Core fields:
 
 UI implication: the first screen can be a local project/survey catalog sourced
 from imported `FieldProjectPackage` records. It does not need cloud discovery.
+
+## Direct Package Intake
+
+Mobile supports two local-first package intake paths:
+
+- `LocalFieldProjectPackageImportService` imports an SDK
+  `FieldProjectPackage`, validates bindings and artifacts, copies package
+  artifacts into device-local storage, creates local catalog/layer state, and
+  stores task packets for local assignments.
+- `LocalFieldProjectPackageDownloadService` downloads a manifest URI plus
+  package-relative offline artifacts into a local download cache, applies
+  same-origin auth headers through `FieldProjectPackageDownloadAuthHeader`, and
+  then hands off to the import service.
+
+The downloader intentionally does not define a mobile-local Honua Server package
+API client. Hosted package catalog and publish semantics remain server/SDK
+work; mobile owns direct URI intake, safe relative artifact resolution, local
+cache placement, diagnostics, and app wiring.
+
+UI implication: a no-cloud Work tab can offer file import and direct manifest
+URL download without waiting on hosted cloud package discovery.
 
 ## Sources And Bindings
 
@@ -223,8 +246,8 @@ current fixtures cover:
 
 Unsupported or package-version-gated fixture capabilities are explicitly listed
 in the evidence as follow-ups, currently shared choice-set ids, record-link
-target metadata, media capture policy fields, full XLSForm/Arcade expression
-parity, rejected-media fixtures, and nested-repeat scenario coverage.
+target metadata, richer media capture policy fields, full XLSForm/Arcade
+expression parity, rejected-media fixtures, and nested-repeat scenario coverage.
 
 UI implication: form design can treat these fixture records as no-cloud parity
 examples, while unsupported fixture items remain visible as SDK/mobile backlog
@@ -282,28 +305,31 @@ The no-cloud product acceptance harness is represented by
 from an empty GeoPackage and covers:
 
 - local project catalog install/open state;
+- package import diagnostics and local package handoff;
+- assignment packet import, inbox filtering, and local status completion;
+- record lifecycle transition and lifecycle metadata export;
 - form validation and calculated field application;
 - local record collection into GeoPackage storage;
 - local media metadata plus exportable device media content;
 - deterministic conflict replay through `LocalReplayFieldSyncPeer`;
 - local export package generation and catalog export timestamp marking.
 
-The evidence includes step-level status and artifact names. Assignment packets
-and formal lifecycle transitions are currently recorded as `follow-up` steps
-linked to honua-mobile#252 and honua-mobile#251 because those adapters depend on
-the SDK package work and are not silently treated as complete.
+The evidence includes step-level status and artifact names. Current field-day
+evidence should not contain `follow-up` steps for assignment packets or record
+lifecycle transitions; those local adapters are now covered by package import,
+assignment, lifecycle, Work tab, and export tests.
 
 UI implication: a field-day review screen can be designed around step status,
-artifact links, counts, and follow-up markers without requiring hosted
-acceptance infrastructure.
+artifact links, counts, and local evidence without requiring hosted acceptance
+infrastructure.
 
 ## Current Implementation Readiness
 
 This table is the practical UI-design handoff for the current mobile branch.
 `Ready` means the data shape exists in mobile code and has local automated
-coverage. `SDK-gated` means the UI information model is defined here and in
-honua-sdk-dotnet#162, but the mobile app should wait for a published SDK package
-instead of adding duplicate contracts locally.
+coverage. `SDK-gated` now applies only to remaining package-version or hosted
+contract gaps; mobile should wait for published SDK/server contracts instead of
+adding duplicate DTOs locally.
 
 | Area | UI-facing data source | Current status | Automated evidence |
 | --- | --- | --- | --- |
@@ -312,10 +338,12 @@ instead of adding duplicate contracts locally.
 | Media metadata | `AttachmentInfo`, `AttachmentPayloadKind`, SDK `FieldMediaAttachment` | Ready for local metadata, required counts, payload kind, export, and retry evidence; capture policy fields are SDK-gated | `FieldCollectionAttachmentServiceTests`, `LocalRecordExportServiceTests`, `GeoPackageSyncServiceTests` |
 | Conflict review | `ConflictInfo`, `OfflineConflictReviewItem`, `LocalFieldConflictReplayResult` | Ready for local replay, manual/deferred state, accept-server resolution, retryable media failure evidence | `GeoPackageSyncServiceTests` |
 | Export preview | `LocalRecordExportResult`, `attachments-manifest.json`, `honua-evidence.json` | Ready | `LocalRecordExportServiceTests` |
-| Field-day acceptance | `honua.mobile.no-cloud-field-day.evidence.v1` | Ready as local acceptance harness; assignment/lifecycle steps are explicit follow-ups | `NoCloudFieldDayAcceptanceHarnessTests` |
-| Package import | SDK `FieldProjectPackage` and validation result | SDK-gated | honua-sdk-dotnet#162, honua-mobile#249 |
-| Lifecycle transitions | SDK `FieldRecordLifecyclePolicy` and `RecordStatus` | SDK-gated for policy; current harness marks step as follow-up | honua-sdk-dotnet#162, honua-mobile#251 |
-| Assignment/task packets | SDK `FieldTaskPacket`, `FieldAssignment` | SDK-gated | honua-sdk-dotnet#162, honua-mobile#252 |
+| Field-day acceptance | `honua.mobile.no-cloud-field-day.evidence.v1` | Ready as local acceptance harness with package, assignment, lifecycle, media, conflict, and export steps | `NoCloudFieldDayAcceptanceHarnessTests` |
+| Package import | SDK `FieldProjectPackage` and validation result | Ready for local manifest import and diagnostics | `LocalFieldProjectPackageImportServiceTests`, `FieldOperationsViewModelTests` |
+| Package download | `LocalFieldProjectPackageDownloadRequest`, downloaded manifest/artifact cache, import result | Ready for direct manifest URI intake and safe relative artifact download | `LocalFieldProjectPackageDownloadServiceTests`, `FieldOperationsViewModelTests` |
+| Lifecycle transitions | SDK `FieldRecordLifecyclePolicy` and `RecordStatus` | Ready for local transition policy, edit affordances, lifecycle metadata, and export evidence | `LocalFieldRecordLifecycleServiceTests`, `NoCloudFieldDayAcceptanceHarnessTests` |
+| Assignment/task packets | SDK `FieldTaskPacket`, `FieldAssignment` | Ready for local task packet import, filtering, status updates, record routing, and Work tab actions | `LocalFieldProjectPackageImportServiceTests`, `FieldOperationsViewModelTests`, `NoCloudFieldDayAcceptanceHarnessTests` |
+| Work tab | `FieldOperationsViewModel`, `FieldOperationsPage` | Ready for package import/download, assignment actions, record open routing, export, and share handoff | `FieldOperationsViewModelTests` |
 
 UI design can proceed now for:
 
@@ -325,33 +353,51 @@ UI design can proceed now for:
 - media galleries and export/media count previews;
 - conflict review lists and resolution evidence;
 - export preview/details;
-- field-day evidence review, including follow-up markers.
-
-UI design should model these as upcoming contract-backed surfaces, but avoid
-assuming mobile-local DTOs until the SDK package is published:
-
-- package import diagnostics;
+- field-day evidence review;
+- package import/download diagnostics;
 - assignment inbox and assignment completion state;
 - lifecycle badges, transition actions, and lifecycle-gated edit affordances;
+- Work tab flows for local package intake, assignments, record routing, export,
+  and share handoff.
+
+UI design should model these as upcoming contract-backed surfaces, but avoid
+assuming mobile-local DTOs or hosted APIs until the owning repo ships them:
+
+- hosted cloud package catalogs, package publish, and supervisor/admin package
+  workflows;
 - richer media capture policy controls;
 - shared choice-set and record-link target metadata.
 
 ## Implementation Backlog
 
-Local parity backlog:
+Closed local parity backlog:
 
 - honua-mobile#249: local package import and validation.
 - honua-mobile#250: local project/survey catalog lifecycle.
 - honua-mobile#251: offline record lifecycle state machine.
 - honua-mobile#252: local assignment/task packets.
 - honua-mobile#253: local media parity adapters.
-- honua-mobile#254: local parity golden fixtures.
-- honua-mobile#255: local conflict simulation and sync replay.
-- honua-mobile#256: local export/evidence packages.
-- honua-mobile#257: no-cloud field day acceptance harness.
-- honua-mobile#258: parent tracker.
+- honua-mobile#254: local form parity golden fixtures.
+- honua-mobile#255: local conflict simulation and sync replay harness.
+- honua-mobile#256: local export/evidence package generation.
+- honua-mobile#257: no-cloud field day product acceptance harness.
+- honua-mobile#258: no-cloud/no-design parity parent tracker.
 
-SDK model dependencies:
+Current remaining parity blockers are outside this no-cloud/no-design local
+scope:
+
+- honua-mobile#92 remains open for final hosted cloud acceptance and is blocked
+  on honua-server#965 DNS/TLS remediation for `staging-api.honua.io`.
+- honua-mobile#225 remains open for AR/3D GA closure until ARCore/ARKit adapter
+  evidence and physical-device validation are attached.
+- Hosted designer, admin, supervisor review, hosted export/reporting, tenancy,
+  and RBAC parity remain server/admin/SDK-owned work consumed by mobile through
+  published contracts.
+
+Closed SDK contract inputs:
 
 - honua-sdk-dotnet#160: local field project package contracts.
 - honua-sdk-dotnet#161: non-cloud form/media/value parity contracts.
+- honua-sdk-dotnet#162: SDK PR that landed the local project package contracts
+  consumed by mobile package import/download, assignment, and lifecycle
+  adapters.


### PR DESCRIPTION
## Summary
- refresh the no-cloud parity information model to show package import/download, assignment packets, lifecycle transitions, Work tab flows, export/share, and field-day evidence as landed local/mobile capability
- update the mobile SDK backlog roadmap so the closed parity sprint is not presented as active backlog
- keep remaining parity risks explicit: #92 is blocked on honua-server#965 DNS/TLS, #225 still needs AR/3D physical-device validation, and hosted designer/admin/cloud surfaces remain outside mobile
- add the Work tab and no-cloud parity docs to the feature map

Related to #209, #258, #92, #225.

## Testing
- `git diff --check`
- stale-reference grep for old open-backlog/follow-up wording
- GitHub issue-state audit for #208-#226, #249-#258, #92, #225, honua-server#965, and honua-sdk-dotnet#160-#162
