### PR TITLE
feat(embed): add governance transport adapters

### DIFF
--- a/docs/guides/embeddable-map.md
+++ b/docs/guides/embeddable-map.md
@@ -605,34 +605,28 @@ batches, and server-backed API-key/rate/CORS enforcement.
 
 `@honua-io/embed` does not issue API keys, enforce authoritative rate limits, or
 own CORS/domain policy. Those remain server/admin responsibilities. The package
-does provide a thin host-side governance adapter so admin portals can apply
+does provide thin host-side governance adapters so admin portals can fetch
 server-provided policy decisions and record redacted analytics from the existing
 map events.
 
 ```ts
-import { bindHonuaMapGovernance } from '@honua-io/embed';
+import {
+  bindHonuaMapGovernance,
+  createHonuaMapGovernanceHttpSink,
+  fetchHonuaMapEmbedPolicy,
+} from '@honua-io/embed';
 
 const map = document.querySelector('honua-map')!;
+const policy = await fetchHonuaMapEmbedPolicy({
+  url: '/internal/embed-policy/city-work-orders',
+});
 const binding = bindHonuaMapGovernance(map, {
   integrationId: 'city-work-orders',
   origin: window.location.origin,
-  policy: {
-    requiredApiKey: true,
-    allowedOrigins: ['https://portal.example.com'],
-    allowedServiceOrigins: ['https://services.example.com'],
-    allowedLayerIds: ['assets', 'work-orders'],
-    rateLimit: {
-      remaining: 1200,
-      resetAt: '2026-05-23T18:00:00Z',
-    },
-  },
-  sink: async (event) => {
-    await fetch('/internal/embed-analytics', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(event),
-    });
-  },
+  policy,
+  sink: createHonuaMapGovernanceHttpSink({
+    url: '/internal/embed-analytics',
+  }),
 });
 
 map.addEventListener('honua-map-policy-denied', (event) => {
@@ -641,6 +635,36 @@ map.addEventListener('honua-map-policy-denied', (event) => {
 
 // Later, for tenant switch or component teardown:
 binding.disconnect();
+```
+
+For the common remote-only path, `bindHonuaMapRemoteGovernance(...)` fetches the
+same policy payload before binding map events and posts analytics to the
+configured ingest URL:
+
+```ts
+import { bindHonuaMapRemoteGovernance } from '@honua-io/embed';
+
+const binding = await bindHonuaMapRemoteGovernance(map, {
+  integrationId: 'city-work-orders',
+  origin: window.location.origin,
+  policyUrl: '/internal/embed-policy/city-work-orders',
+  analyticsUrl: '/internal/embed-analytics',
+});
+```
+
+The fetched policy payload uses the existing client-owned policy shape:
+
+```json
+{
+  "requiredApiKey": true,
+  "allowedOrigins": ["https://portal.example.com"],
+  "allowedServiceOrigins": ["https://services.example.com"],
+  "allowedLayerIds": ["assets", "work-orders"],
+  "rateLimit": {
+    "remaining": 1200,
+    "resetAt": "2026-05-23T18:00:00Z"
+  }
+}
 ```
 
 Governance events include view, configuration-change, search, identify, and

--- a/docs/guides/mobile-sdk-backlog-roadmap.md
+++ b/docs/guides/mobile-sdk-backlog-roadmap.md
@@ -72,6 +72,26 @@ diagnostics, sync health, and the field-day acceptance harness.
 | Open AR/3D GA | [#225](https://github.com/honua-io/honua-mobile/issues/225) | Add ARCore/ARKit adapter evidence and physical-device validation for the first field workflow. |
 | Outside mobile/no-cloud scope | hosted designer/admin, supervisor review, hosted reports, tenancy, RBAC, audit, and hosted package catalog/publish | Owned by `honua-server`, admin UI, and SDK packages; mobile consumes published contracts through adapters, DI, local cache, UX, and tests. |
 
+Closed local parity issue links:
+[#208](https://github.com/honua-io/honua-mobile/issues/208),
+[#209](https://github.com/honua-io/honua-mobile/issues/209),
+[#210](https://github.com/honua-io/honua-mobile/issues/210),
+[#211](https://github.com/honua-io/honua-mobile/issues/211),
+[#212](https://github.com/honua-io/honua-mobile/issues/212),
+[#213](https://github.com/honua-io/honua-mobile/issues/213),
+[#214](https://github.com/honua-io/honua-mobile/issues/214),
+[#215](https://github.com/honua-io/honua-mobile/issues/215),
+[#216](https://github.com/honua-io/honua-mobile/issues/216),
+[#217](https://github.com/honua-io/honua-mobile/issues/217),
+[#218](https://github.com/honua-io/honua-mobile/issues/218),
+[#219](https://github.com/honua-io/honua-mobile/issues/219),
+[#220](https://github.com/honua-io/honua-mobile/issues/220),
+[#221](https://github.com/honua-io/honua-mobile/issues/221),
+[#222](https://github.com/honua-io/honua-mobile/issues/222),
+[#223](https://github.com/honua-io/honua-mobile/issues/223),
+[#224](https://github.com/honua-io/honua-mobile/issues/224), and
+[#226](https://github.com/honua-io/honua-mobile/issues/226).
+
 ## Back-Office Dependency Handoff
 
 #219 is a dependency-tracking issue, not a request to add server/admin clients to

--- a/src/Honua.Embed/src/governance.ts
+++ b/src/Honua.Embed/src/governance.ts
@@ -64,6 +64,46 @@ export interface HonuaMapGovernanceBindingOptions {
   clock?: () => Date;
 }
 
+export type HonuaMapGovernanceFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface HonuaMapGovernanceHttpSinkOptions {
+  url: string | URL;
+  fetch?: HonuaMapGovernanceFetch;
+  headers?: HeadersInit | ((event: HonuaMapGovernanceEvent) => HeadersInit);
+  credentials?: RequestCredentials;
+  keepalive?: boolean;
+  signal?: AbortSignal | null;
+  onError?: (error: unknown, event: HonuaMapGovernanceEvent) => void;
+}
+
+export interface HonuaMapEmbedPolicyFetchOptions {
+  url: string | URL;
+  fetch?: HonuaMapGovernanceFetch;
+  headers?: HeadersInit;
+  credentials?: RequestCredentials;
+  signal?: AbortSignal | null;
+}
+
+export interface HonuaMapRemoteGovernanceBindingOptions
+  extends Omit<HonuaMapGovernanceBindingOptions, 'policy' | 'sink'> {
+  policy?: HonuaMapEmbedPolicy | null;
+  policyUrl?: string | URL | null;
+  policyHeaders?: HeadersInit;
+  analyticsUrl?: string | URL | null;
+  analyticsHeaders?: HeadersInit | ((event: HonuaMapGovernanceEvent) => HeadersInit);
+  sink?: HonuaMapGovernanceBindingOptions['sink'];
+  fetch?: HonuaMapGovernanceFetch;
+  credentials?: RequestCredentials;
+  policyCredentials?: RequestCredentials;
+  analyticsCredentials?: RequestCredentials;
+  signal?: AbortSignal | null;
+  keepalive?: boolean;
+  onAnalyticsError?: (error: unknown, event: HonuaMapGovernanceEvent) => void;
+}
+
 export interface HonuaMapGovernanceBinding {
   evaluate(): HonuaMapPolicyDecision;
   disconnect(): void;
@@ -157,6 +197,93 @@ export function bindHonuaMapGovernance(
   };
 }
 
+export function createHonuaMapGovernanceHttpSink(
+  options: HonuaMapGovernanceHttpSinkOptions,
+): HonuaMapAnalyticsSink {
+  const fetchImpl = resolveFetch(options.fetch);
+  const url = normalizeRequiredUrl(options.url, 'Analytics URL');
+
+  return {
+    async record(event: HonuaMapGovernanceEvent): Promise<void> {
+      try {
+        const response = await fetchImpl(url, {
+          method: 'POST',
+          headers: createJsonHeaders(resolveHeaders(options.headers, event)),
+          body: JSON.stringify(event),
+          credentials: options.credentials,
+          keepalive: options.keepalive,
+          signal: options.signal ?? undefined,
+        });
+
+        if (!response.ok) {
+          throw new Error(`Honua map analytics request failed with HTTP ${response.status}.`);
+        }
+      } catch (error) {
+        options.onError?.(error, event);
+      }
+    },
+  };
+}
+
+export async function fetchHonuaMapEmbedPolicy(
+  options: HonuaMapEmbedPolicyFetchOptions,
+): Promise<HonuaMapEmbedPolicy | null> {
+  const fetchImpl = resolveFetch(options.fetch);
+  const url = normalizeRequiredUrl(options.url, 'Policy URL');
+  const response = await fetchImpl(url, {
+    method: 'GET',
+    headers: options.headers,
+    credentials: options.credentials,
+    signal: options.signal ?? undefined,
+  });
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Honua map policy request failed with HTTP ${response.status}.`);
+  }
+
+  return normalizeHonuaMapEmbedPolicy(await response.json());
+}
+
+export async function bindHonuaMapRemoteGovernance(
+  element: HonuaMapElement,
+  options: HonuaMapRemoteGovernanceBindingOptions = {},
+): Promise<HonuaMapGovernanceBinding> {
+  const policy = options.policyUrl !== undefined && options.policyUrl !== null
+    ? await fetchHonuaMapEmbedPolicy({
+      url: options.policyUrl,
+      fetch: options.fetch,
+      headers: options.policyHeaders,
+      credentials: options.policyCredentials ?? options.credentials,
+      signal: options.signal,
+    })
+    : options.policy ?? null;
+
+  const analyticsSink = options.analyticsUrl !== undefined && options.analyticsUrl !== null
+    ? createHonuaMapGovernanceHttpSink({
+      url: options.analyticsUrl,
+      fetch: options.fetch,
+      headers: options.analyticsHeaders,
+      credentials: options.analyticsCredentials ?? options.credentials,
+      keepalive: options.keepalive,
+      signal: options.signal,
+      onError: options.onAnalyticsError,
+    })
+    : null;
+
+  return bindHonuaMapGovernance(element, {
+    sink: combineSinks(options.sink, analyticsSink),
+    policy,
+    integrationId: options.integrationId,
+    origin: options.origin,
+    metadata: options.metadata,
+    clock: options.clock,
+  });
+}
+
 export function createHonuaMapGovernanceEvent(
   config: HonuaMapConfig,
   type: HonuaMapGovernanceEventType,
@@ -185,6 +312,40 @@ export function createHonuaMapGovernanceEvent(
     policyDecision: options.policyDecision,
     metadata: options.metadata,
   };
+}
+
+export function normalizeHonuaMapEmbedPolicy(value: unknown): HonuaMapEmbedPolicy | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const policy: HonuaMapEmbedPolicy = {};
+
+  if (typeof value.requiredApiKey === 'boolean' || value.requiredApiKey === null) {
+    policy.requiredApiKey = value.requiredApiKey;
+  }
+
+  const allowedOrigins = normalizeStringArray(value.allowedOrigins);
+  if (allowedOrigins) {
+    policy.allowedOrigins = allowedOrigins;
+  }
+
+  const allowedServiceOrigins = normalizeStringArray(value.allowedServiceOrigins);
+  if (allowedServiceOrigins) {
+    policy.allowedServiceOrigins = allowedServiceOrigins;
+  }
+
+  const allowedLayerIds = normalizeStringArray(value.allowedLayerIds);
+  if (allowedLayerIds) {
+    policy.allowedLayerIds = allowedLayerIds;
+  }
+
+  const rateLimit = normalizeRateLimit(value.rateLimit);
+  if (rateLimit) {
+    policy.rateLimit = rateLimit;
+  }
+
+  return policy;
 }
 
 export function evaluateHonuaMapPolicy(
@@ -263,6 +424,27 @@ function normalizeSink(
   return (event) => sink.record(event);
 }
 
+function combineSinks(
+  first: HonuaMapGovernanceBindingOptions['sink'],
+  second: HonuaMapGovernanceBindingOptions['sink'],
+): HonuaMapGovernanceBindingOptions['sink'] {
+  const sinks = [normalizeSink(first), normalizeSink(second)].filter(isNonNull);
+
+  if (sinks.length === 0) {
+    return null;
+  }
+
+  if (sinks.length === 1) {
+    return sinks[0];
+  }
+
+  return (event) => {
+    for (const sink of sinks) {
+      safeRecord(sink, event);
+    }
+  };
+}
+
 function safeRecord(
   sink: ((event: HonuaMapGovernanceEvent) => void | Promise<void>) | null,
   event: HonuaMapGovernanceEvent,
@@ -278,6 +460,40 @@ function safeRecord(
   } catch {
     // Analytics sinks are host-owned and must not break embed interactions.
   }
+}
+
+function resolveFetch(fetchImpl: HonuaMapGovernanceFetch | undefined): HonuaMapGovernanceFetch {
+  const resolved = fetchImpl ?? globalThis.fetch?.bind(globalThis);
+  if (!resolved) {
+    throw new Error('Honua map governance fetch API is not available.');
+  }
+
+  return resolved;
+}
+
+function normalizeRequiredUrl(url: string | URL, label: string): string {
+  const normalized = String(url).trim();
+  if (!normalized) {
+    throw new Error(`${label} is required for Honua map governance.`);
+  }
+
+  return normalized;
+}
+
+function resolveHeaders(
+  headers: HeadersInit | ((event: HonuaMapGovernanceEvent) => HeadersInit) | undefined,
+  event: HonuaMapGovernanceEvent,
+): HeadersInit | undefined {
+  return typeof headers === 'function' ? headers(event) : headers;
+}
+
+function createJsonHeaders(headers: HeadersInit | undefined): Headers {
+  const normalized = new Headers(headers);
+  if (!normalized.has('content-type')) {
+    normalized.set('content-type', 'application/json');
+  }
+
+  return normalized;
 }
 
 function serviceOrigin(serviceUrl: string | null): string | null {
@@ -298,9 +514,49 @@ function normalizeSet(values: readonly string[] | null | undefined): Set<string>
     .filter(Boolean));
 }
 
+function normalizeStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
 function normalizeOptionalString(value: string | null | undefined): string | null {
   const normalized = value?.trim();
   return normalized ? normalized : null;
+}
+
+function normalizeRateLimit(value: unknown): HonuaMapRateLimitState | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const rateLimit: HonuaMapRateLimitState = {};
+  if (typeof value.remaining === 'number' && Number.isFinite(value.remaining)) {
+    rateLimit.remaining = value.remaining;
+  } else if (value.remaining === null) {
+    rateLimit.remaining = null;
+  }
+
+  if (typeof value.resetAt === 'string') {
+    rateLimit.resetAt = normalizeOptionalString(value.resetAt);
+  } else if (value.resetAt === null) {
+    rateLimit.resetAt = null;
+  }
+
+  return Object.keys(rateLimit).length > 0 ? rateLimit : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonNull<T>(value: T | null): value is T {
+  return value !== null;
 }
 
 function currentOrigin(): string | null {

--- a/src/Honua.Embed/tests/honua-governance.test.ts
+++ b/src/Honua.Embed/tests/honua-governance.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   bindHonuaMapGovernance,
+  bindHonuaMapRemoteGovernance,
+  createHonuaMapGovernanceHttpSink,
   createHonuaMapGovernanceEvent,
   defineHonuaMapElement,
   evaluateHonuaMapPolicy,
+  fetchHonuaMapEmbedPolicy,
   type HonuaMapConfig,
   type HonuaMapElement,
   type HonuaMapGovernanceEvent,
@@ -135,6 +138,125 @@ describe('honua map governance', () => {
       serviceOrigin: 'https://services.example.test',
     });
     expect(JSON.stringify(event)).not.toContain('secret-browser-key');
+  });
+
+  it('posts redacted governance events to a configured analytics endpoint', async () => {
+    const fetchSpy = vi.fn(async () => new Response(null, { status: 204 }));
+    const event = createHonuaMapGovernanceEvent(createConfig(), 'view', {
+      occurredAt: '2026-05-23T17:20:00.000Z',
+      integrationId: 'city-work-orders',
+      origin: 'https://portal.example.test',
+      metadata: { tenantId: 'city' },
+    });
+    const sink = createHonuaMapGovernanceHttpSink({
+      url: 'https://admin.example.test/embed-analytics',
+      fetch: fetchSpy,
+      headers: { 'x-tenant': 'city' },
+    });
+
+    await sink.record(event);
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://admin.example.test/embed-analytics');
+    expect(init?.method).toBe('POST');
+    expect(init?.headers).toBeInstanceOf(Headers);
+    expect((init?.headers as Headers).get('content-type')).toBe('application/json');
+    expect((init?.headers as Headers).get('x-tenant')).toBe('city');
+
+    const payload = JSON.parse(init?.body as string) as HonuaMapGovernanceEvent;
+    expect(payload).toMatchObject({
+      type: 'view',
+      integrationId: 'city-work-orders',
+      apiKeyPresent: true,
+      metadata: { tenantId: 'city' },
+    });
+    expect(JSON.stringify(payload)).not.toContain('secret-browser-key');
+  });
+
+  it('fetches and normalizes server-provided embed policy without carrying credentials', async () => {
+    const fetchSpy = vi.fn(async () => new Response(JSON.stringify({
+      requiredApiKey: true,
+      allowedOrigins: [' https://portal.example.test ', '', 42],
+      allowedServiceOrigins: ['https://services.example.test'],
+      allowedLayerIds: ['assets'],
+      rateLimit: {
+        remaining: 0,
+        resetAt: ' 2026-05-23T18:00:00Z ',
+      },
+      apiKey: 'secret-browser-key',
+      unknownServerField: 'ignored',
+    }), {
+      headers: { 'content-type': 'application/json' },
+    }));
+
+    const policy = await fetchHonuaMapEmbedPolicy({
+      url: 'https://admin.example.test/embed-policy/city-work-orders',
+      fetch: fetchSpy,
+      headers: { 'x-integration': 'city-work-orders' },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith('https://admin.example.test/embed-policy/city-work-orders', {
+      method: 'GET',
+      headers: { 'x-integration': 'city-work-orders' },
+      credentials: undefined,
+      signal: undefined,
+    });
+    expect(policy).toEqual({
+      requiredApiKey: true,
+      allowedOrigins: ['https://portal.example.test'],
+      allowedServiceOrigins: ['https://services.example.test'],
+      allowedLayerIds: ['assets'],
+      rateLimit: {
+        remaining: 0,
+        resetAt: '2026-05-23T18:00:00Z',
+      },
+    });
+    expect(JSON.stringify(policy)).not.toContain('secret-browser-key');
+  });
+
+  it('binds remote policy and analytics before recording map events', async () => {
+    const posts: RequestInit[] = [];
+    const fetchSpy = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      if (String(url).includes('/embed-policy/')) {
+        return new Response(JSON.stringify({
+          requiredApiKey: true,
+          allowedOrigins: ['https://portal.example.test'],
+          allowedServiceOrigins: ['https://services.example.test'],
+          allowedLayerIds: ['assets'],
+        }), {
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
+      posts.push(init ?? {});
+      return new Response(null, { status: 204 });
+    });
+    const denied = vi.fn();
+    const element = createConfiguredMap({ layerIds: 'assets,restricted' });
+    element.addEventListener('honua-map-policy-denied', denied);
+
+    const binding = await bindHonuaMapRemoteGovernance(element, {
+      policyUrl: 'https://admin.example.test/embed-policy/city-work-orders',
+      analyticsUrl: 'https://admin.example.test/embed-analytics',
+      fetch: fetchSpy,
+      origin: 'https://portal.example.test',
+      integrationId: 'city-work-orders',
+    });
+    document.body.append(element);
+
+    expect(fetchSpy.mock.calls[0][0]).toBe('https://admin.example.test/embed-policy/city-work-orders');
+    expect(posts).toHaveLength(1);
+    const payload = JSON.parse(posts[0].body as string) as HonuaMapGovernanceEvent;
+    expect(payload.type).toBe('policy-denied');
+    expect(payload.policyDecision?.reasons).toEqual([
+      'Layer ids are not allowed for this API key: restricted',
+    ]);
+    expect(payload.integrationId).toBe('city-work-orders');
+    expect(JSON.stringify(payload)).not.toContain('secret-browser-key');
+    expect(denied).toHaveBeenCalledOnce();
+
+    binding.disconnect();
   });
 });
 

--- a/src/Honua.Embed/tests/honua-ssr.test.ts
+++ b/src/Honua.Embed/tests/honua-ssr.test.ts
@@ -12,7 +12,7 @@ describe('server-side package imports', () => {
     expect(embed.HonuaSceneElement).toBeTypeOf('function');
     expect(embed.defineHonuaMapElement).toBeTypeOf('function');
     expect(embed.defineHonuaSceneElement).toBeTypeOf('function');
-  });
+  }, 15000);
 
   it('reports a clear error when defining elements without a custom element registry', async () => {
     const { defineHonuaMapElement } = await import('../src/map');


### PR DESCRIPTION
## Summary

- add remote governance transport helpers for <honua-map>: redacted analytics POST sink, server-provided policy fetch/normalization, and an async remote binding convenience
- document the remote policy/analytics path while keeping API-key issuance, CORS, rate limiting, and hosted admin ownership outside this repo
- restore explicit mobile parity roadmap issue links so the smoke docs gate passes after the Dependabot merges
- give the SSR root-import test enough timeout headroom under the full local embed suite

Closes #10.

## Validation

- npm test -- --run tests/honua-governance.test.ts tests/honua-ssr.test.ts
- npm run typecheck
- npm run build
- npm test
- dotnet test tests/Honua.Mobile.Smoke.Tests/Honua.Mobile.Smoke.Tests.csproj --configuration Release --logger "console;verbosity=minimal"
