### PR TITLE
test: wire Live Server Integration suite to shared conformance fixtures and train drift gate (#273)

### DIFF
--- a/.github/workflows/live-server-integration.yml
+++ b/.github/workflows/live-server-integration.yml
@@ -42,8 +42,17 @@ env:
   DOTNET_VERSION: "10.0.x"
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
   DOTNET_NOLOGO: "true"
+  # Pinned honua-server image. `:nightly` tracks current trunk so the vendored
+  # seed schema (tests/seed/mobile-offline-demo-v1.sql) matches; it is the
+  # version the Compatibility-Train conformance checks run against. Recorded
+  # explicitly here and echoed in the run (see "Record pinned versions").
   HONUA_SERVER_IMAGE: ${{ inputs.honua_server_image || 'honuaio/honua-server:nightly' }}
   HONUA_POSTGIS_IMAGE: "postgis/postgis:17-3.5-alpine"
+  # Pinned geospatial-grpc conformance fixtures version (Compatibility Train,
+  # epic geospatial-grpc#18). Mirror of <HonuaConformanceFixturesVersion> in
+  # Directory.Build.props; provenance recorded in tests/conformance/UPSTREAM.md.
+  HONUA_CONFORMANCE_FIXTURES_VERSION: "0.1.0-alpha.1"
+  HONUA_CONFORMANCE_FIXTURES_REPO: "honua-io/geospatial-grpc"
 
 jobs:
   live-server-integration:
@@ -57,6 +66,26 @@ jobs:
       HONUA_MOBILE_ACCEPTANCE_EVIDENCE_DIR: ${{ github.workspace }}/CloudAcceptanceEvidence
     steps:
       - uses: actions/checkout@v6
+
+      # Make the pinned versions this run gates against explicit in the log and
+      # the job summary, so a reviewer can see exactly which honua-server image
+      # and which geospatial-grpc conformance fixture version produced the result.
+      - name: Record pinned versions
+        run: |
+          set -e
+          server_digest="$(docker manifest inspect "${HONUA_SERVER_IMAGE}" 2>/dev/null \
+            | sha256sum | awk '{print $1}' || echo 'unavailable')"
+          {
+            echo "### Live Server Integration — pinned versions"
+            echo ""
+            echo "| Anchor | Value |"
+            echo "| --- | --- |"
+            echo "| honua-server image | \`${HONUA_SERVER_IMAGE}\` |"
+            echo "| PostGIS image | \`${HONUA_POSTGIS_IMAGE}\` |"
+            echo "| geospatial-grpc conformance fixtures | \`${HONUA_CONFORMANCE_FIXTURES_VERSION}\` (repo \`${HONUA_CONFORMANCE_FIXTURES_REPO}\`) |"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "Pinned honua-server image: ${HONUA_SERVER_IMAGE}"
+          echo "Pinned conformance fixtures: ${HONUA_CONFORMANCE_FIXTURES_VERSION} from ${HONUA_CONFORMANCE_FIXTURES_REPO}"
 
       - name: Verify Docker available
         run: |
@@ -119,6 +148,29 @@ jobs:
           mkdir -p TestResults
           mkdir -p "${HONUA_MOBILE_ACCEPTANCE_EVIDENCE_DIR}"
 
+      # Pull the pinned, published geospatial-grpc conformance fixtures
+      # (Compatibility Train, epic geospatial-grpc#18). The helper downloads the
+      # conformance-fixtures-<version>.tar.gz release asset, verifies its SHA-256,
+      # extracts it, re-verifies every file against the in-tarball SHA256SUMS, and
+      # asserts the embedded VERSION equals the pin. The live suite asserts live
+      # FeatureServer/OGC responses against these canonical contracts. GITHUB_TOKEN
+      # has read scope for `gh release download` from the same org.
+      - name: Fetch pinned conformance fixtures
+        id: conformance-fixtures
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          dest="${{ github.workspace }}/conformance-fixtures"
+          tests/conformance/fetch-fixtures.sh \
+            --version "${HONUA_CONFORMANCE_FIXTURES_VERSION}" \
+            --repo "${HONUA_CONFORMANCE_FIXTURES_REPO}" \
+            --dest "${dest}"
+          test -d "${dest}/fixtures"
+          test -s "${dest}/VERSION"
+          echo "fixtures_dir=${dest}" >> "$GITHUB_OUTPUT"
+          echo "Fetched conformance fixtures $(cat "${dest}/VERSION") into ${dest}"
+
       # The seed SQL is vendored at tests/seed/mobile-offline-demo-v1.sql
       # (see tests/seed/UPSTREAM.md for upstream provenance). PR-trigger runs
       # consume the vendored copy directly, so the live suite is fully seeded
@@ -158,6 +210,11 @@ jobs:
       # ref to be exercised.
       - name: Run LiveHonuaServerInteractionTests
         id: live-tests
+        env:
+          # Point the suite at the verified, pinned conformance fixtures so its
+          # FeatureServer/OGC contract checks assert against the shared canonical
+          # geospatial.v1 payloads (not hand-written shapes).
+          HONUA_MOBILE_CONFORMANCE_FIXTURES_DIR: ${{ steps.conformance-fixtures.outputs.fixtures_dir }}
         run: |
           dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj \
             --no-build --no-restore --configuration Release \

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,5 +16,18 @@
     <HonuaSdkDotNetTrainReleaseCommit>6db17ed</HonuaSdkDotNetTrainReleaseCommit>
     <HonuaSdkDotNetTrainReleasePublishedAt>2026-05-24T00:55:47Z</HonuaSdkDotNetTrainReleasePublishedAt>
     <MauiVersion>10.0.70</MauiVersion>
+
+    <!--
+      geospatial-grpc conformance fixtures — pinned source of truth for the
+      Live Server Integration contract checks (Compatibility Train, epic
+      geospatial-grpc#18). The Live Server Integration workflow pulls this exact
+      fixture version via tests/conformance/fetch-fixtures.sh from the
+      v$(HonuaConformanceFixturesVersion) GitHub Release of
+      honua-io/geospatial-grpc; the version maps 1:1 to a geospatial.v1 schema
+      release. Provenance is recorded in tests/conformance/UPSTREAM.md. Bump this
+      pin (and UPSTREAM.md) in lockstep when adopting a newer fixture release.
+    -->
+    <HonuaConformanceFixturesVersion>0.1.0-alpha.1</HonuaConformanceFixturesVersion>
+    <HonuaConformanceFixturesRepository>honua-io/geospatial-grpc</HonuaConformanceFixturesRepository>
   </PropertyGroup>
 </Project>

--- a/tests/Honua.Mobile.ServerIntegration.Tests/ConformanceContractRunner.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/ConformanceContractRunner.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Mobile.Sdk;
+using Xunit;
+
+namespace Honua.Mobile.ServerIntegration.Tests;
+
+/// <summary>
+/// Executes a Compatibility-Train contract conformance check against a live
+/// response and applies the <b>known-tracked-xfail</b> policy: a structural or
+/// transport drift that matches a registered <see cref="KnownServerGaps"/> entry
+/// is reported as a visible skip (xfail) carrying the tracking issue, so the
+/// <c>Live Server Integration</c> job stays green while the harness is wired; any
+/// new / untracked drift fails the test.
+/// </summary>
+/// <remarks>
+/// The runner is the single choke point that turns an opaque
+/// <see cref="HonuaMobileApiException"/> (e.g. the <c>honua-server#1238</c>
+/// 400/500) into a <see cref="ContractDriftException"/> attributed to a named
+/// <c>geospatial.v1</c> contract, so triage reads as
+/// "<c>FeatureService.QueryFeatures response contract drift</c>" rather than a
+/// bare HTTP error.
+/// </remarks>
+public static class ConformanceContractRunner
+{
+    /// <summary>
+    /// Runs <paramref name="check"/> (a contract assertion that throws
+    /// <see cref="ContractDriftException"/> on drift), wrapping a live transport
+    /// failure for <paramref name="transportContract"/> into attributed drift,
+    /// then applies the known-gap xfail policy.
+    /// </summary>
+    /// <param name="transportContract">
+    /// The contract name to attribute a hard transport failure (HTTP 4xx/5xx) to,
+    /// for the case where the live call throws before any body can be validated.
+    /// </param>
+    /// <param name="check">The conformance assertion to execute.</param>
+    public static async Task RunAsync(string transportContract, Func<Task> check)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+
+        ContractDriftException? drift = null;
+        try
+        {
+            await check().ConfigureAwait(false);
+        }
+        catch (ContractDriftException ex)
+        {
+            drift = ex;
+        }
+        catch (HonuaMobileApiException ex)
+        {
+            // A hard transport failure (the #1238 400/500 class) — attribute it to
+            // the named contract and the HTTP status so it can be matched against a
+            // tracked gap instead of surfacing as a raw HTTP error.
+            drift = new ContractDriftException(
+                transportContract,
+                $"live request failed with HTTP {(int)ex.StatusCode} ({ex.StatusCode}) before a "
+                + $"conforming response body could be validated. Server detail: {Summarize(ex)}",
+                transportStatus: ex.StatusCode,
+                inner: ex);
+        }
+
+        if (drift is null)
+        {
+            return;
+        }
+
+        ApplyPolicy(drift);
+    }
+
+    /// <summary>
+    /// Synchronous overload for validating an already-materialized response.
+    /// </summary>
+    public static void Run(string transportContract, Action check)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+        RunAsync(transportContract, () =>
+        {
+            check();
+            return Task.CompletedTask;
+        }).GetAwaiter().GetResult();
+    }
+
+    private static void ApplyPolicy(ContractDriftException drift)
+    {
+        var gap = KnownServerGaps.Match(drift);
+        if (gap is not null)
+        {
+            // KNOWN, ALREADY-TRACKED gap: mark known-expected-failing (xfail) with an
+            // explicit issue reference. Visible in the test report, never silent.
+            Skip.If(
+                true,
+                $"KNOWN-EXPECTED-FAILING ({gap.Issue}): {gap.Summary}. "
+                + $"Tracked at {gap.IssueUrl}. Attributed drift: {drift.Message} "
+                + "When the server fix lands, remove this gap from KnownServerGaps so the xfail flips to required.");
+            return;
+        }
+
+        // NEW / UNTRACKED drift: fail with the contract-attributed message so a
+        // future regression is pinned to a named contract + field, not a bare error.
+        throw new ContractConformanceException(drift);
+    }
+
+    private static string Summarize(HonuaMobileApiException ex)
+    {
+        var body = ex.ResponseBody;
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return ex.Message;
+        }
+
+        body = body.Trim();
+        const int max = 400;
+        return body.Length <= max ? body : body[..max] + "…";
+    }
+}
+
+/// <summary>
+/// Failure raised for an untracked contract drift. Wraps the attributed
+/// <see cref="ContractDriftException"/> so the assertion failure clearly names the
+/// drifted contract and field (and is not mistaken for an infrastructure error).
+/// </summary>
+public sealed class ContractConformanceException : Xunit.Sdk.XunitException
+{
+    public ContractConformanceException(ContractDriftException drift)
+        : base(BuildMessage(drift), drift)
+    {
+    }
+
+    private static string BuildMessage(ContractDriftException drift)
+        => "UNTRACKED contract drift detected by the Compatibility-Train conformance check. "
+           + $"{drift.Message} "
+           + "This is a NEW drift (no matching KnownServerGaps entry). If it is a real, "
+           + "expected server gap, file a honua-server issue and register it in KnownServerGaps "
+           + "with an explicit issue reference; do not silence it.";
+}

--- a/tests/Honua.Mobile.ServerIntegration.Tests/ConformanceContractTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/ConformanceContractTests.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using Honua.Mobile.Sdk;
+
+namespace Honua.Mobile.ServerIntegration.Tests;
+
+/// <summary>
+/// Unit coverage for the Compatibility-Train conformance harness itself: the
+/// contract validators, the known-tracked-xfail policy, and the attribution of an
+/// opaque HTTP failure to a named contract. These run without Docker so they guard
+/// the harness on every PR (not only on a live run), proving the checks are
+/// effective — conforming responses pass, tracked drift xfails (visibly,
+/// attributed), and new/untracked drift fails.
+/// </summary>
+public sealed class ConformanceContractTests
+{
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+
+    [Fact]
+    public void FeatureQuery_conforming_response_passes()
+    {
+        var live = Parse(
+            """
+            {
+              "objectIdFieldName": "OBJECTID",
+              "fields": [{ "name": "globalid", "type": "esriFieldTypeString" }],
+              "features": [
+                { "attributes": { "globalid": "abc", "site_name": "Site" }, "geometry": { "x": -158, "y": 21 } }
+              ]
+            }
+            """);
+
+        FeatureContractConformance.AssertFeatureQueryResponse(live, canonical: default, requireFeature: true);
+    }
+
+    [Fact]
+    public void FeatureQuery_missing_features_is_attributed_drift()
+    {
+        var live = Parse("""{ "objectIdFieldName": "OBJECTID" }""");
+
+        var ex = Assert.Throws<ContractDriftException>(
+            () => FeatureContractConformance.AssertFeatureQueryResponse(live, canonical: default, requireFeature: true));
+
+        Assert.Equal(FeatureContractConformance.FeatureQueryContract, ex.Contract);
+        Assert.Contains("features", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FeatureQuery_feature_missing_attributes_names_the_field()
+    {
+        var live = Parse("""{ "features": [ { "geometry": { "x": 1, "y": 2 } } ] }""");
+
+        var ex = Assert.Throws<ContractDriftException>(
+            () => FeatureContractConformance.AssertFeatureQueryResponse(live, canonical: default, requireFeature: true));
+
+        Assert.Contains("attributes", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void OgcItems_non_feature_collection_is_attributed_drift()
+    {
+        var live = Parse("""{ "type": "Something", "features": [] }""");
+
+        var ex = Assert.Throws<ContractDriftException>(
+            () => FeatureContractConformance.AssertOgcItemsResponse(live, requireFeature: false));
+
+        Assert.Equal(FeatureContractConformance.OgcItemsContract, ex.Contract);
+        Assert.Contains("FeatureCollection", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ApplyEdits_missing_all_result_arrays_is_attributed_drift()
+    {
+        var live = Parse("""{ "somethingElse": true }""");
+
+        var ex = Assert.Throws<ContractDriftException>(
+            () => FeatureContractConformance.AssertApplyEditsResponse(live));
+
+        Assert.Equal(FeatureContractConformance.FeatureApplyEditsContract, ex.Contract);
+    }
+
+    [Fact]
+    public void KnownGaps_match_1238_featureserver_400_and_ogc_500()
+    {
+        var featureServer = new ContractDriftException(
+            FeatureContractConformance.FeatureQueryContract,
+            "live request failed with HTTP 400",
+            transportStatus: HttpStatusCode.BadRequest);
+        var ogc = new ContractDriftException(
+            FeatureContractConformance.OgcItemsContract,
+            "live request failed with HTTP 500",
+            transportStatus: HttpStatusCode.InternalServerError);
+
+        Assert.Equal("honua-server#1238", KnownServerGaps.Match(featureServer)?.Issue);
+        Assert.Equal("honua-server#1238", KnownServerGaps.Match(ogc)?.Issue);
+    }
+
+    [Fact]
+    public void KnownGaps_do_not_match_unrelated_query_drift()
+    {
+        // A structural drift in an otherwise-200 query response is NOT a tracked
+        // gap (no transport status) and must surface as a real failure.
+        var structuralDrift = new ContractDriftException(
+            FeatureContractConformance.FeatureQueryContract,
+            "missing required `features` array");
+
+        Assert.Null(KnownServerGaps.Match(structuralDrift));
+    }
+
+    [Fact]
+    public void Runner_xfails_tracked_transport_failure_with_attribution()
+    {
+        // A #1238-class transport failure becomes a visible Skip (xfail), not a
+        // pass and not a hard failure.
+        var skip = Assert.Throws<Xunit.SkipException>(() =>
+            ConformanceContractRunner.Run(
+                FeatureContractConformance.FeatureQueryContract,
+                () => throw new HonuaMobileApiException(
+                    HttpStatusCode.BadRequest,
+                    "Bad Request",
+                    """{"error":{"code":400,"message":"Invalid query parameters"}}""")));
+
+        Assert.Contains("KNOWN-EXPECTED-FAILING", skip.Message, StringComparison.Ordinal);
+        Assert.Contains("honua-server#1238", skip.Message, StringComparison.Ordinal);
+        Assert.Contains(FeatureContractConformance.FeatureQueryContract, skip.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Runner_fails_untracked_structural_drift()
+    {
+        // New/untracked drift must FAIL (the regression-detection guarantee), with
+        // a message that names the contract — not a silent pass.
+        var ex = Assert.Throws<ContractConformanceException>(() =>
+            ConformanceContractRunner.Run(
+                FeatureContractConformance.FeatureQueryContract,
+                () => throw new ContractDriftException(
+                    FeatureContractConformance.FeatureQueryContract,
+                    "`features[0].attributes` must be an object")));
+
+        Assert.Contains("UNTRACKED", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(FeatureContractConformance.FeatureQueryContract, ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Runner_fails_untracked_transport_failure()
+    {
+        // An unexpected transport status (e.g. 404 on a query) is not a tracked gap
+        // and must fail, attributed to the contract.
+        var ex = Assert.Throws<ContractConformanceException>(() =>
+            ConformanceContractRunner.Run(
+                FeatureContractConformance.FeatureQueryContract,
+                () => throw new HonuaMobileApiException(HttpStatusCode.NotFound, "Not Found")));
+
+        Assert.Contains("UNTRACKED", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("404", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Runner_passes_conforming_response()
+    {
+        // No throw == conforming == pass.
+        ConformanceContractRunner.Run(
+            FeatureContractConformance.FeatureQueryContract,
+            () => FeatureContractConformance.AssertFeatureQueryResponse(
+                Parse("""{ "objectIdFieldName": "OBJECTID", "features": [ { "attributes": {} } ] }"""),
+                canonical: default,
+                requireFeature: true));
+    }
+}

--- a/tests/Honua.Mobile.ServerIntegration.Tests/ConformanceFixtures.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/ConformanceFixtures.cs
@@ -1,0 +1,153 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+
+namespace Honua.Mobile.ServerIntegration.Tests;
+
+/// <summary>
+/// Loads and exposes the shared, versioned <c>geospatial-grpc</c> conformance
+/// fixtures (Compatibility Train, epic <c>geospatial-grpc#18</c>) and validates
+/// live <c>honua-server</c> FeatureServer/OGC responses against the canonical
+/// <c>geospatial.v1</c> contracts they describe.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The fixtures are <b>not vendored</b>. CI pulls a pinned release artifact with
+/// <c>tests/conformance/fetch-fixtures.sh</c> and points the suite at the
+/// extracted directory via the <c>HONUA_MOBILE_CONFORMANCE_FIXTURES_DIR</c>
+/// environment variable. Provenance is recorded in
+/// <c>tests/conformance/UPSTREAM.md</c>.
+/// </para>
+/// <para>
+/// The canonical fixtures use the protobuf JSON mapping (camelCase fields, enum
+/// names as strings, <c>int64</c> as strings) — see
+/// <c>geospatial-grpc/conformance/README.md</c>. The mobile-relevant subset is
+/// <c>FeatureService.QueryFeatures</c> / <c>FeatureService.ApplyEdits</c> and the
+/// OGC Features read/CRUD paths exercised against the <c>mobile_offline_demo</c>
+/// seed (layer <c>68910</c>).
+/// </para>
+/// <para>
+/// When a live response does not conform, the assertion fails with a message that
+/// names the drifted contract and the specific field, so a future
+/// <c>honua-server#1238</c>-class regression reads as
+/// "<c>FeatureService.QueryFeatures response contract drift on field X</c>"
+/// rather than a bare HTTP 400/500 or a generic <c>JsonValueKind</c> mismatch.
+/// </para>
+/// </remarks>
+public sealed class ConformanceFixtures
+{
+    /// <summary>Environment variable naming the directory of fetched, verified fixtures.</summary>
+    public const string FixturesDirEnvVar = "HONUA_MOBILE_CONFORMANCE_FIXTURES_DIR";
+
+    private static readonly Lazy<ConformanceFixtures> LazyInstance = new(Load);
+
+    private ConformanceFixtures(
+        string? root,
+        string? version,
+        IReadOnlyDictionary<string, JsonDocument> fixtures,
+        string? unavailableReason)
+    {
+        Root = root;
+        Version = version;
+        _fixtures = fixtures;
+        UnavailableReason = unavailableReason;
+    }
+
+    private readonly IReadOnlyDictionary<string, JsonDocument> _fixtures;
+
+    /// <summary>Shared instance loaded once per test run.</summary>
+    public static ConformanceFixtures Instance => LazyInstance.Value;
+
+    /// <summary>Directory the fixtures were loaded from, or <c>null</c> when unavailable.</summary>
+    public string? Root { get; }
+
+    /// <summary>Pinned fixture-set version (the bundle's <c>VERSION</c>), or <c>null</c>.</summary>
+    public string? Version { get; }
+
+    /// <summary><c>true</c> when fixtures were located and loaded.</summary>
+    public bool Available => Root is not null && _fixtures.Count > 0;
+
+    /// <summary>Human-readable reason the fixtures are unavailable (for <c>Skip.If</c>).</summary>
+    public string? UnavailableReason { get; }
+
+    /// <summary>Canonical <c>geospatial.v1.QueryFeaturesResponse</c> fixture.</summary>
+    public JsonElement FeatureQueryResponse => Fixture("feature_query_response.json").RootElement;
+
+    /// <summary>Canonical <c>geospatial.v1.ApplyEditsResponse</c> fixture.</summary>
+    public JsonElement FeatureApplyEditsResponse => Fixture("feature_apply_edits_response.json").RootElement;
+
+    private JsonDocument Fixture(string name)
+        => _fixtures.TryGetValue(name, out var doc)
+            ? doc
+            : throw new InvalidOperationException(
+                $"Conformance fixture '{name}' was not found under '{Root}'. "
+                + "The fetched fixture bundle is incomplete; check tests/conformance/fetch-fixtures.sh output.");
+
+    private static ConformanceFixtures Load()
+    {
+        var root = Environment.GetEnvironmentVariable(FixturesDirEnvVar);
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            return Unavailable(
+                $"{FixturesDirEnvVar} not set; run tests/conformance/fetch-fixtures.sh "
+                + "and point it at the extracted fixtures directory.");
+        }
+
+        root = root.Trim();
+
+        // Accept either the bundle root (contains fixtures/, golden/, VERSION) or
+        // its parent containing the conformance-fixtures-<version>/ directory.
+        var fixturesDir = Path.Combine(root, "fixtures");
+        if (!Directory.Exists(fixturesDir))
+        {
+            var nested = Directory.Exists(root)
+                ? Directory.GetDirectories(root, "conformance-fixtures-*").FirstOrDefault()
+                : null;
+            if (nested is not null && Directory.Exists(Path.Combine(nested, "fixtures")))
+            {
+                root = nested;
+                fixturesDir = Path.Combine(root, "fixtures");
+            }
+        }
+
+        if (!Directory.Exists(fixturesDir))
+        {
+            return Unavailable(
+                $"{FixturesDirEnvVar}='{root}' does not contain a fixtures/ directory; "
+                + "the fixture bundle was not fetched/extracted correctly.");
+        }
+
+        string? version = null;
+        var versionFile = Path.Combine(root, "VERSION");
+        if (File.Exists(versionFile))
+        {
+            version = File.ReadAllText(versionFile).Trim();
+        }
+
+        var fixtures = new Dictionary<string, JsonDocument>(StringComparer.Ordinal);
+        foreach (var file in Directory.EnumerateFiles(fixturesDir, "*.json"))
+        {
+            try
+            {
+                fixtures[Path.GetFileName(file)] = JsonDocument.Parse(File.ReadAllBytes(file));
+            }
+            catch (JsonException ex)
+            {
+                return Unavailable($"conformance fixture '{file}' is not valid JSON: {ex.Message}");
+            }
+        }
+
+        if (fixtures.Count == 0)
+        {
+            return Unavailable($"no conformance fixtures found under '{fixturesDir}'.");
+        }
+
+        return new ConformanceFixtures(root, version, fixtures, unavailableReason: null);
+    }
+
+    private static ConformanceFixtures Unavailable(string reason)
+        => new(root: null, version: null, new Dictionary<string, JsonDocument>(StringComparer.Ordinal), reason);
+}

--- a/tests/Honua.Mobile.ServerIntegration.Tests/FeatureContractConformance.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/FeatureContractConformance.cs
@@ -1,0 +1,388 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+namespace Honua.Mobile.ServerIntegration.Tests;
+
+/// <summary>
+/// Thrown when a live <c>honua-server</c> response fails to conform to a canonical
+/// <c>geospatial.v1</c> conformance contract. The message names the drifted
+/// contract/workflow and the specific field, so triage does not require tracing
+/// an opaque HTTP error back to a contract by hand (the <c>honua-server#1238</c>
+/// failure mode).
+/// </summary>
+public sealed class ContractDriftException : Exception
+{
+    public ContractDriftException(string contract, string detail, HttpStatusCode? transportStatus = null, Exception? inner = null)
+        : base($"{contract} contract drift: {detail}", inner)
+    {
+        Contract = contract;
+        Detail = detail;
+        TransportStatus = transportStatus;
+    }
+
+    /// <summary>The named contract/workflow that drifted, e.g. <c>FeatureService.QueryFeatures response</c>.</summary>
+    public string Contract { get; }
+
+    /// <summary>The specific mismatch detail (missing/typed field, HTTP status, parse failure).</summary>
+    public string Detail { get; }
+
+    /// <summary>
+    /// The HTTP status of the underlying transport failure, when the drift was a
+    /// hard error (e.g. the <c>honua-server#1238</c> 400/500) rather than a
+    /// structural mismatch in an otherwise-200 body.
+    /// </summary>
+    public HttpStatusCode? TransportStatus { get; }
+
+    /// <summary>True when the drift was an underlying transport failure with the given status.</summary>
+    public bool IsTransportStatus(HttpStatusCode status) => TransportStatus == status;
+
+    /// <summary>True when the contract or detail text mentions any of the given (case-insensitive) tokens.</summary>
+    public bool MentionsAny(params string[] tokens)
+    {
+        foreach (var token in tokens)
+        {
+            if (Contract.Contains(token, StringComparison.OrdinalIgnoreCase)
+                || Detail.Contains(token, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+/// <summary>
+/// Validates live FeatureServer/OGC responses against the shared, pinned
+/// <c>geospatial-grpc</c> conformance fixtures. Each check is named after the
+/// canonical contract it enforces and, on mismatch, throws
+/// <see cref="ContractDriftException"/> with the offending field, extending the
+/// existing <c>FormatFeatureEditDiagnostic</c> attribution pattern across the
+/// FeatureServer (REST + gRPC), SDK, and OGC read/query paths.
+/// </summary>
+/// <remarks>
+/// The canonical fixtures use the protobuf JSON mapping for the gRPC
+/// <c>geospatial.v1</c> messages (camelCase fields, enum names as strings,
+/// <c>int64</c> as strings). The live FeatureServer REST/SDK and OGC Features
+/// paths return GeoServices-style JSON / GeoJSON. These checks therefore assert
+/// the <b>structural contract</b> the fixtures describe — the presence and JSON
+/// kind of the canonical envelope, field-descriptor, feature, attribute, and
+/// geometry elements, and the attribute fields the fixture declares — rather than
+/// a byte-identical match. That is exactly the surface a <c>#1238</c>-class
+/// JSONB-projection regression breaks (it returns no parseable
+/// feature-collection envelope at all), so it is caught and attributed here.
+/// </remarks>
+public static class FeatureContractConformance
+{
+    /// <summary>Canonical FeatureService query response contract name.</summary>
+    public const string FeatureQueryContract = "FeatureService.QueryFeatures response";
+
+    /// <summary>Canonical FeatureService apply-edits response contract name.</summary>
+    public const string FeatureApplyEditsContract = "FeatureService.ApplyEdits response";
+
+    /// <summary>Canonical OGC Features items collection contract name.</summary>
+    public const string OgcItemsContract = "OGC Features items collection (FeatureService query)";
+
+    /// <summary>
+    /// Asserts a live FeatureServer/SDK query response conforms to the canonical
+    /// <c>geospatial.v1.QueryFeaturesResponse</c> envelope described by
+    /// <c>feature_query_response.json</c>: a feature-collection object exposing a
+    /// <c>features</c> array whose members carry an <c>attributes</c> object, plus
+    /// the structural descriptors (object-id field name, field list) the contract
+    /// declares. Throws <see cref="ContractDriftException"/> naming the field on
+    /// any mismatch.
+    /// </summary>
+    public static void AssertFeatureQueryResponse(JsonElement live, JsonElement canonical, bool requireFeature)
+    {
+        const string contract = FeatureQueryContract;
+
+        // When the shared canonical fixture was fetched, first confirm the live
+        // response carries the same canonical envelope keys the fixture declares
+        // (objectIdFieldName / fields / features). This ties the check to the
+        // shared, pinned geospatial.v1 fixture rather than a hand-written shape:
+        // if the fixture envelope changes, this set changes with it.
+        if (canonical.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var canonicalProp in canonical.EnumerateObject())
+            {
+                // Only the structural feature-collection envelope keys are required
+                // of every transport (REST/gRPC/SDK projection). Optional descriptors
+                // such as geometryType/spatialReference/exceededTransferLimit are not
+                // mandated of all transports, so we require only the load-bearing
+                // envelope keys the fixture declares.
+                if (canonicalProp.Name is "features" or "objectIdFieldName"
+                    && live.ValueKind == JsonValueKind.Object
+                    && !live.TryGetProperty(canonicalProp.Name, out _))
+                {
+                    throw new ContractDriftException(
+                        contract,
+                        $"missing `{canonicalProp.Name}` required by the canonical "
+                        + $"geospatial.v1.QueryFeaturesResponse fixture. "
+                        + $"Response keys present: {DescribeKeys(live)}.");
+                }
+            }
+        }
+
+        if (live.ValueKind != JsonValueKind.Object)
+        {
+            throw new ContractDriftException(
+                contract,
+                $"expected the response root to be a JSON object (per the canonical "
+                + $"QueryFeaturesResponse envelope), got {live.ValueKind}.");
+        }
+
+        // The canonical contract carries a `features` array; the live FeatureServer
+        // REST/SDK response uses the same key. A #1238-class projection failure
+        // never reaches here (it 400/500s before producing a body), but a drifted
+        // success body that drops `features` is named precisely.
+        if (!TryGetArray(live, "features", out var liveFeatures))
+        {
+            throw new ContractDriftException(
+                contract,
+                "missing required `features` array (canonical "
+                + "geospatial.v1.QueryFeaturesResponse.features). "
+                + $"Response keys present: {DescribeKeys(live)}.");
+        }
+
+        // Object-id field name is part of the canonical envelope; assert it is a
+        // string when the live response advertises it (FeatureServer always does).
+        if (live.TryGetProperty("objectIdFieldName", out var oidField)
+            && oidField.ValueKind is not (JsonValueKind.String or JsonValueKind.Null))
+        {
+            throw new ContractDriftException(
+                contract,
+                $"`objectIdFieldName` should be a string per the canonical contract, got {oidField.ValueKind}.");
+        }
+
+        // Field descriptors: the canonical contract describes `fields[]` entries
+        // each with a `name`. FeatureServer REST mirrors this; assert the shape
+        // when present so a descriptor-shape regression is attributed.
+        if (live.TryGetProperty("fields", out var liveFields))
+        {
+            if (liveFields.ValueKind != JsonValueKind.Array)
+            {
+                throw new ContractDriftException(
+                    contract,
+                    $"`fields` should be an array of field descriptors per the canonical contract, got {liveFields.ValueKind}.");
+            }
+
+            foreach (var field in liveFields.EnumerateArray())
+            {
+                if (field.ValueKind != JsonValueKind.Object || !field.TryGetProperty("name", out var fieldName)
+                    || fieldName.ValueKind != JsonValueKind.String)
+                {
+                    throw new ContractDriftException(
+                        contract,
+                        "each `fields[]` descriptor must be an object with a string `name` "
+                        + $"per the canonical contract; offending descriptor: {Truncate(field)}.");
+                }
+            }
+        }
+
+        if (requireFeature && liveFeatures.GetArrayLength() == 0)
+        {
+            throw new ContractDriftException(
+                contract,
+                "expected at least one feature for the seeded layer but `features` was empty "
+                + "(seeded mobile_offline_demo layer should return rows).");
+        }
+
+        // Per-feature shape: each member must expose an `attributes` object, the
+        // canonical geospatial.v1.Feature.attributes map.
+        var index = 0;
+        foreach (var feature in liveFeatures.EnumerateArray())
+        {
+            AssertFeatureShape(contract, feature, index);
+            index++;
+        }
+    }
+
+    /// <summary>
+    /// Asserts a live OGC Features items response conforms to the GeoJSON
+    /// FeatureCollection contract the canonical FeatureService query fixture maps
+    /// onto the OGC read path: a <c>FeatureCollection</c> with a <c>features</c>
+    /// array whose members are GeoJSON <c>Feature</c> objects carrying
+    /// <c>properties</c>. Throws <see cref="ContractDriftException"/> naming the
+    /// field on any mismatch.
+    /// </summary>
+    public static void AssertOgcItemsResponse(JsonElement live, bool requireFeature)
+    {
+        const string contract = OgcItemsContract;
+
+        if (live.ValueKind != JsonValueKind.Object)
+        {
+            throw new ContractDriftException(
+                contract,
+                $"expected the OGC items root to be a JSON object, got {live.ValueKind}.");
+        }
+
+        if (!live.TryGetProperty("type", out var type) || type.ValueKind != JsonValueKind.String)
+        {
+            throw new ContractDriftException(
+                contract,
+                $"missing string `type` (expected \"FeatureCollection\"). Response keys present: {DescribeKeys(live)}.");
+        }
+
+        if (!string.Equals(type.GetString(), "FeatureCollection", StringComparison.Ordinal))
+        {
+            throw new ContractDriftException(
+                contract,
+                $"`type` must be \"FeatureCollection\", got \"{type.GetString()}\".");
+        }
+
+        if (!TryGetArray(live, "features", out var liveFeatures))
+        {
+            throw new ContractDriftException(
+                contract,
+                $"missing required `features` array. Response keys present: {DescribeKeys(live)}.");
+        }
+
+        if (requireFeature && liveFeatures.GetArrayLength() == 0)
+        {
+            throw new ContractDriftException(
+                contract,
+                "expected at least one feature for the seeded collection but `features` was empty.");
+        }
+
+        var index = 0;
+        foreach (var feature in liveFeatures.EnumerateArray())
+        {
+            if (feature.ValueKind != JsonValueKind.Object)
+            {
+                throw new ContractDriftException(
+                    contract,
+                    $"`features[{index}]` must be a GeoJSON Feature object, got {feature.ValueKind}.");
+            }
+
+            if (!feature.TryGetProperty("type", out var ft) || ft.ValueKind != JsonValueKind.String
+                || !string.Equals(ft.GetString(), "Feature", StringComparison.Ordinal))
+            {
+                throw new ContractDriftException(
+                    contract,
+                    $"`features[{index}].type` must be \"Feature\" per the GeoJSON contract; got {Truncate(feature)}.");
+            }
+
+            if (!feature.TryGetProperty("properties", out var props)
+                || props.ValueKind is not (JsonValueKind.Object or JsonValueKind.Null))
+            {
+                throw new ContractDriftException(
+                    contract,
+                    $"`features[{index}].properties` must be an object (the canonical attributes map); got {Truncate(feature)}.");
+            }
+
+            index++;
+        }
+    }
+
+    /// <summary>
+    /// Asserts a live apply-edits response conforms to the canonical
+    /// <c>geospatial.v1.ApplyEditsResponse</c> contract: at least one of
+    /// <c>addResults</c> / <c>updateResults</c> / <c>deleteResults</c>, each a
+    /// result array whose members carry a boolean <c>success</c>. Throws
+    /// <see cref="ContractDriftException"/> naming the field on any mismatch.
+    /// </summary>
+    public static void AssertApplyEditsResponse(JsonElement live)
+    {
+        const string contract = FeatureApplyEditsContract;
+
+        if (live.ValueKind != JsonValueKind.Object)
+        {
+            throw new ContractDriftException(
+                contract,
+                $"expected the response root to be a JSON object (per ApplyEditsResponse), got {live.ValueKind}.");
+        }
+
+        var sawResultArray = false;
+        foreach (var resultsKey in new[] { "addResults", "updateResults", "deleteResults" })
+        {
+            if (!live.TryGetProperty(resultsKey, out var results))
+            {
+                continue;
+            }
+
+            sawResultArray = true;
+            if (results.ValueKind != JsonValueKind.Array)
+            {
+                throw new ContractDriftException(
+                    contract,
+                    $"`{resultsKey}` must be an array of edit results per the canonical contract, got {results.ValueKind}.");
+            }
+
+            var index = 0;
+            foreach (var result in results.EnumerateArray())
+            {
+                if (result.ValueKind != JsonValueKind.Object
+                    || !result.TryGetProperty("success", out var success)
+                    || success.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+                {
+                    throw new ContractDriftException(
+                        contract,
+                        $"`{resultsKey}[{index}]` must be an object with a boolean `success` "
+                        + $"per the canonical contract; got {Truncate(result)}.");
+                }
+
+                index++;
+            }
+        }
+
+        if (!sawResultArray)
+        {
+            throw new ContractDriftException(
+                contract,
+                "response carried none of `addResults`/`updateResults`/`deleteResults` "
+                + $"required by the canonical ApplyEditsResponse contract. Keys present: {DescribeKeys(live)}.");
+        }
+    }
+
+    private static void AssertFeatureShape(string contract, JsonElement feature, int index)
+    {
+        if (feature.ValueKind != JsonValueKind.Object)
+        {
+            throw new ContractDriftException(
+                contract,
+                $"`features[{index}]` must be an object per the canonical Feature contract, got {feature.ValueKind}.");
+        }
+
+        if (!feature.TryGetProperty("attributes", out var attributes)
+            || attributes.ValueKind != JsonValueKind.Object)
+        {
+            throw new ContractDriftException(
+                contract,
+                $"`features[{index}].attributes` must be an object (canonical "
+                + $"geospatial.v1.Feature.attributes map); got {Truncate(feature)}.");
+        }
+    }
+
+    private static bool TryGetArray(JsonElement parent, string name, out JsonElement array)
+    {
+        if (parent.TryGetProperty(name, out array) && array.ValueKind == JsonValueKind.Array)
+        {
+            return true;
+        }
+
+        array = default;
+        return false;
+    }
+
+    private static string DescribeKeys(JsonElement obj)
+    {
+        if (obj.ValueKind != JsonValueKind.Object)
+        {
+            return $"<{obj.ValueKind}>";
+        }
+
+        var keys = obj.EnumerateObject().Select(p => p.Name).Take(16).ToArray();
+        return keys.Length == 0 ? "(none)" : string.Join(", ", keys);
+    }
+
+    private static string Truncate(JsonElement element, int max = 240)
+    {
+        var raw = element.GetRawText();
+        return raw.Length <= max ? raw : raw[..max] + "…";
+    }
+}

--- a/tests/Honua.Mobile.ServerIntegration.Tests/KnownServerGaps.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/KnownServerGaps.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+
+namespace Honua.Mobile.ServerIntegration.Tests;
+
+/// <summary>
+/// Registry of <b>already-tracked</b> <c>honua-server:nightly</c> contract gaps
+/// that the Compatibility-Train conformance checks are expected to hit until the
+/// matching server fix lands. Each gap is recorded with an explicit issue
+/// reference so the <c>Live Server Integration</c> job stays green (the harness
+/// is wired) while a tracked server regression is <b>visibly</b> marked
+/// known-expected-failing (xfail) — never silenced, never blanket
+/// <c>continue-on-error</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A drift that matches a registered gap is reported via
+/// <c>Skip.If(...)</c> (an xfail) carrying the issue URL and the attributed
+/// contract drift. Any <b>new / untracked</b> drift is <b>not</b> matched here and
+/// therefore fails the suite — that is the regression-detection guarantee.
+/// </para>
+/// <para>
+/// When a server fix lands, delete the corresponding entry: the xfail then flips
+/// to a required assertion and a re-introduced regression fails the build.
+/// </para>
+/// </remarks>
+public static class KnownServerGaps
+{
+    /// <summary>A single tracked server gap.</summary>
+    /// <param name="Issue">The tracking issue, e.g. <c>honua-server#1238</c>.</param>
+    /// <param name="Summary">Short description of the gapped contract surface.</param>
+    /// <param name="Matches">Predicate identifying a drift caused by this gap.</param>
+    public sealed record Gap(string Issue, string Summary, Func<ContractDriftException, bool> Matches)
+    {
+        /// <summary>Full URL of the tracking issue.</summary>
+        public string IssueUrl
+        {
+            get
+            {
+                var parts = Issue.Split('#', 2);
+                return parts.Length == 2
+                    ? $"https://github.com/honua-io/{parts[0]}/issues/{parts[1]}"
+                    : Issue;
+            }
+        }
+    }
+
+    /// <summary>
+    /// honua-server#1238 — FeatureServer/OGC JSONB-attribute projection drift on
+    /// the seeded <c>mobile_offline_demo</c> layer <c>68910</c>. The query/
+    /// projection pipeline emits bare SQL columns for JSONB-backed declared fields
+    /// (<c>42703 column "globalid" does not exist</c>), so the FeatureServer
+    /// <c>/query</c> path returns HTTP 400 and the OGC <c>/items</c> path returns
+    /// HTTP 500 — the read paths never produce a conforming feature collection.
+    /// </summary>
+    public static readonly Gap FeatureServerOgcJsonbProjection = new(
+        Issue: "honua-server#1238",
+        Summary: "FeatureServer/OGC JSONB-attribute projection (mobile_offline_demo layer 68910) emits bare SQL columns",
+        Matches: drift =>
+            (drift.Contract == FeatureContractConformance.FeatureQueryContract
+                && drift.IsTransportStatus(HttpStatusCode.BadRequest))
+            || (drift.Contract == FeatureContractConformance.OgcItemsContract
+                && drift.IsTransportStatus(HttpStatusCode.InternalServerError)));
+
+    /// <summary>honua-server#1166 — temporal query/filter contract gap.</summary>
+    public static readonly Gap TemporalQuery = new(
+        Issue: "honua-server#1166",
+        Summary: "Temporal query/filter contract",
+        Matches: drift => drift.MentionsAny("temporal", "time filter", "timeextent"));
+
+    /// <summary>honua-server#1167 — replica sync contract gap.</summary>
+    public static readonly Gap ReplicaSync = new(
+        Issue: "honua-server#1167",
+        Summary: "Replica sync contract",
+        Matches: drift => drift.MentionsAny("replica"));
+
+    /// <summary>honua-server#1237 — analysis list/estimate contract gap.</summary>
+    public static readonly Gap AnalysisListEstimate = new(
+        Issue: "honua-server#1237",
+        Summary: "Analysis list/estimate contract",
+        Matches: drift => drift.MentionsAny("analysis", "estimate"));
+
+    /// <summary>All registered gaps.</summary>
+    public static readonly IReadOnlyList<Gap> All =
+    [
+        FeatureServerOgcJsonbProjection,
+        TemporalQuery,
+        ReplicaSync,
+        AnalysisListEstimate,
+    ];
+
+    /// <summary>
+    /// Returns the tracked gap that explains <paramref name="drift"/>, or
+    /// <c>null</c> when the drift is new/untracked (and must fail the suite).
+    /// </summary>
+    public static Gap? Match(ContractDriftException drift)
+    {
+        ArgumentNullException.ThrowIfNull(drift);
+        return All.FirstOrDefault(gap => gap.Matches(drift));
+    }
+}

--- a/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/LiveHonuaServerInteractionTests.cs
@@ -57,55 +57,78 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
         Skip.IfNot(_server.Enabled, "HONUA_MOBILE_LIVE_SERVER_TESTS not set or fixture sql missing");
 
         using var client = CreateMobileClient(preferGrpc: false);
-        using var query = await client.QueryFeaturesAsync(new QueryFeaturesRequest
-        {
-            ServiceId = _server.Options.ServiceId,
-            LayerId = _server.Options.LayerId,
-            Where = "1=1",
-            OutFields = ["*"],
-            ReturnGeometry = true,
-            ResultRecordCount = 1,
-        });
-        Assert.Equal(JsonValueKind.Object, query.RootElement.ValueKind);
 
-        JsonDocument? streamPage = null;
-        await foreach (var page in client.QueryFeaturesStreamAsync(new QueryFeaturesRequest
-        {
-            ServiceId = _server.Options.ServiceId,
-            LayerId = _server.Options.LayerId,
-            ResultRecordCount = 1,
-        }))
-        {
-            streamPage = page;
-            break;
-        }
+        // Conformance: the FeatureServer REST query response must conform to the
+        // canonical geospatial.v1.QueryFeaturesResponse contract (shared fixture
+        // feature_query_response.json). A #1238-class JSONB-projection regression
+        // returns HTTP 400 here; the runner attributes that to the named contract
+        // and marks it known-tracked-xfail rather than surfacing a bare 400.
+        await ConformanceContractRunner.RunAsync(
+            FeatureContractConformance.FeatureQueryContract,
+            async () =>
+            {
+                using var query = await client.QueryFeaturesAsync(new QueryFeaturesRequest
+                {
+                    ServiceId = _server.Options.ServiceId,
+                    LayerId = _server.Options.LayerId,
+                    Where = "1=1",
+                    OutFields = ["*"],
+                    ReturnGeometry = true,
+                    ResultRecordCount = 1,
+                });
+                AssertFeatureQueryContract(query.RootElement, requireFeature: true);
 
-        using (streamPage)
-        {
-            Assert.NotNull(streamPage);
-            Assert.Equal(JsonValueKind.Object, streamPage.RootElement.ValueKind);
-        }
+                JsonDocument? streamPage = null;
+                await foreach (var page in client.QueryFeaturesStreamAsync(new QueryFeaturesRequest
+                {
+                    ServiceId = _server.Options.ServiceId,
+                    LayerId = _server.Options.LayerId,
+                    ResultRecordCount = 1,
+                }))
+                {
+                    streamPage = page;
+                    break;
+                }
 
-        var sdkQuery = await client.QueryAsync(new FeatureQueryRequest
-        {
-            Source = FeatureSource(),
-            Limit = 1,
-        });
-        Assert.NotEmpty(sdkQuery.Features);
+                using (streamPage)
+                {
+                    if (streamPage is null)
+                    {
+                        throw new ContractDriftException(
+                            FeatureContractConformance.FeatureQueryContract,
+                            "server-streaming query yielded no page for the seeded layer.");
+                    }
 
-        FeatureQueryResult? sdkPage = null;
-        await foreach (var page in client.QueryPagesAsync(new FeatureQueryRequest
-        {
-            Source = FeatureSource(),
-            Limit = 1,
-        }))
-        {
-            sdkPage = page;
-            break;
-        }
+                    AssertFeatureQueryContract(streamPage.RootElement, requireFeature: false);
+                }
 
-        Assert.NotNull(sdkPage);
-        Assert.NotEmpty(sdkPage.Features);
+                var sdkQuery = await client.QueryAsync(new FeatureQueryRequest
+                {
+                    Source = FeatureSource(),
+                    Limit = 1,
+                });
+                AssertFeatureQueryContract(ToFeatureServerJson(sdkQuery), requireFeature: true);
+
+                FeatureQueryResult? sdkPage = null;
+                await foreach (var page in client.QueryPagesAsync(new FeatureQueryRequest
+                {
+                    Source = FeatureSource(),
+                    Limit = 1,
+                }))
+                {
+                    sdkPage = page;
+                    break;
+                }
+
+                if (sdkPage is null)
+                {
+                    throw new ContractDriftException(
+                        FeatureContractConformance.FeatureQueryContract,
+                        "SDK QueryPagesAsync yielded no page for the seeded layer.");
+                }
+
+                AssertFeatureQueryContract(ToFeatureServerJson(sdkPage), requireFeature: true);
+            });
 
         long? restObjectId = null;
         long? sdkObjectId = null;
@@ -166,15 +189,24 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
         using var client = CreateMobileClient(preferGrpc: false);
         IHonuaFeatureQueryClient featureClient = new SdkFeatureClient(client);
 
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        var result = await featureClient.QueryAsync(new FeatureQueryRequest
-        {
-            Source = FeatureSource(),
-            Limit = 1,
-        }, timeout.Token);
-
         Assert.Equal("honua-mobile", featureClient.ProviderName);
-        Assert.NotNull(result.Features);
+
+        // Conformance: the SDK feature-client adapter response must conform to the
+        // canonical FeatureService.QueryFeatures contract. A #1238-class regression
+        // returns HTTP 400 here; attributed + known-tracked-xfail by the runner.
+        await ConformanceContractRunner.RunAsync(
+            FeatureContractConformance.FeatureQueryContract,
+            async () =>
+            {
+                using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                var result = await featureClient.QueryAsync(new FeatureQueryRequest
+                {
+                    Source = FeatureSource(),
+                    Limit = 1,
+                }, timeout.Token);
+
+                AssertFeatureQueryContract(ToFeatureServerJson(result), requireFeature: true);
+            });
     }
 
     [SkippableFact]
@@ -183,13 +215,21 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
         Skip.IfNot(_server.Enabled, "HONUA_MOBILE_LIVE_SERVER_TESTS not set or fixture sql missing");
 
         using var client = CreateMobileClient(preferGrpc: true, allowRestFallbackOnGrpcFailure: false);
-        using var query = await client.QueryFeaturesAsync(new QueryFeaturesRequest
-        {
-            ServiceId = _server.Options.ServiceId,
-            LayerId = _server.Options.LayerId,
-            ResultRecordCount = 1,
-        });
-        Assert.Equal(JsonValueKind.Object, query.RootElement.ValueKind);
+
+        // Conformance: the gRPC query response (mapped to FeatureServer JSON) must
+        // conform to the canonical geospatial.v1.QueryFeaturesResponse contract.
+        await ConformanceContractRunner.RunAsync(
+            FeatureContractConformance.FeatureQueryContract,
+            async () =>
+            {
+                using var query = await client.QueryFeaturesAsync(new QueryFeaturesRequest
+                {
+                    ServiceId = _server.Options.ServiceId,
+                    LayerId = _server.Options.LayerId,
+                    ResultRecordCount = 1,
+                });
+                AssertFeatureQueryContract(query.RootElement, requireFeature: false);
+            });
 
         long? objectId = null;
         try
@@ -225,30 +265,39 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
         // than being silently masked by the unary REST path.
         using var client = CreateMobileClient(preferGrpc: true, allowRestFallbackOnGrpcFailure: false);
 
-        JsonDocument? page = null;
-        await foreach (var streamed in client.QueryFeaturesStreamAsync(new QueryFeaturesRequest
-        {
-            ServiceId = _server.Options.ServiceId,
-            LayerId = _server.Options.LayerId,
-            Where = "1=1",
-            OutFields = ["*"],
-            ReturnGeometry = true,
-            ResultRecordCount = 1,
-        }))
-        {
-            page = streamed;
-            break;
-        }
+        await ConformanceContractRunner.RunAsync(
+            FeatureContractConformance.FeatureQueryContract,
+            async () =>
+            {
+                JsonDocument? page = null;
+                await foreach (var streamed in client.QueryFeaturesStreamAsync(new QueryFeaturesRequest
+                {
+                    ServiceId = _server.Options.ServiceId,
+                    LayerId = _server.Options.LayerId,
+                    Where = "1=1",
+                    OutFields = ["*"],
+                    ReturnGeometry = true,
+                    ResultRecordCount = 1,
+                }))
+                {
+                    page = streamed;
+                    break;
+                }
 
-        using (page)
-        {
-            Assert.NotNull(page);
-            Assert.Equal(JsonValueKind.Object, page.RootElement.ValueKind);
-            Assert.True(
-                page.RootElement.TryGetProperty("features", out var features)
-                    && features.ValueKind == JsonValueKind.Array,
-                page.RootElement.GetRawText());
-        }
+                using (page)
+                {
+                    if (page is null)
+                    {
+                        throw new ContractDriftException(
+                            FeatureContractConformance.FeatureQueryContract,
+                            "gRPC server-streaming query yielded no page for the seeded layer.");
+                    }
+
+                    // Conformance: gRPC streaming page conforms to the canonical
+                    // QueryFeaturesResponse envelope (features array + per-feature shape).
+                    AssertFeatureQueryContract(page.RootElement, requireFeature: false);
+                }
+            });
     }
 
     [SkippableFact]
@@ -259,36 +308,56 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
         using var client = CreateMobileClient(preferGrpc: false);
         var ogcSource = new FeatureSource { CollectionId = _server.Options.OgcCollectionId };
 
-        using var collections = await client.GetOgcCollectionsAsync();
-        Assert.Equal(JsonValueKind.Object, collections.RootElement.ValueKind);
+        // Conformance: the OGC Features read paths must conform to the canonical
+        // FeatureService query contract mapped onto GeoJSON (FeatureCollection of
+        // GeoJSON Features). A #1238-class regression returns HTTP 500 here; the
+        // runner attributes it to the OGC contract and marks it known-tracked-xfail.
+        await ConformanceContractRunner.RunAsync(
+            FeatureContractConformance.OgcItemsContract,
+            async () =>
+            {
+                using var collections = await client.GetOgcCollectionsAsync();
+                if (collections.RootElement.ValueKind != JsonValueKind.Object)
+                {
+                    throw new ContractDriftException(
+                        FeatureContractConformance.OgcItemsContract,
+                        $"GET collections root must be a JSON object, got {collections.RootElement.ValueKind}.");
+                }
 
-        using var items = await client.GetOgcItemsAsync(new OgcItemsRequest
-        {
-            CollectionId = _server.Options.OgcCollectionId,
-            Limit = 1,
-        });
-        Assert.Equal("FeatureCollection", items.RootElement.GetProperty("type").GetString());
+                using var items = await client.GetOgcItemsAsync(new OgcItemsRequest
+                {
+                    CollectionId = _server.Options.OgcCollectionId,
+                    Limit = 1,
+                });
+                AssertOgcItemsContract(items.RootElement, requireFeature: true);
 
-        var sdkQuery = await client.QueryAsync(new FeatureQueryRequest
-        {
-            Source = ogcSource,
-            Limit = 1,
-        });
-        Assert.NotEmpty(sdkQuery.Features);
+                var sdkQuery = await client.QueryAsync(new FeatureQueryRequest
+                {
+                    Source = ogcSource,
+                    Limit = 1,
+                });
+                AssertOgcItemsContract(ToOgcFeatureCollectionJson(sdkQuery), requireFeature: true);
 
-        FeatureQueryResult? sdkPage = null;
-        await foreach (var page in client.QueryPagesAsync(new FeatureQueryRequest
-        {
-            Source = ogcSource,
-            Limit = 1,
-        }))
-        {
-            sdkPage = page;
-            break;
-        }
+                FeatureQueryResult? sdkPage = null;
+                await foreach (var page in client.QueryPagesAsync(new FeatureQueryRequest
+                {
+                    Source = ogcSource,
+                    Limit = 1,
+                }))
+                {
+                    sdkPage = page;
+                    break;
+                }
 
-        Assert.NotNull(sdkPage);
-        Assert.NotEmpty(sdkPage.Features);
+                if (sdkPage is null)
+                {
+                    throw new ContractDriftException(
+                        FeatureContractConformance.OgcItemsContract,
+                        "SDK QueryPagesAsync (OGC source) yielded no page for the seeded collection.");
+                }
+
+                AssertOgcItemsContract(ToOgcFeatureCollectionJson(sdkPage), requireFeature: true);
+            });
 
         var featureId = $"mobile-live-ogc-{Guid.NewGuid():N}";
         var sdkFeatureId = $"mobile-live-ogc-sdk-{Guid.NewGuid():N}";
@@ -619,6 +688,89 @@ public sealed class LiveHonuaServerInteractionTests : IClassFixture<LiveHonuaSer
         {
             Directory.Delete(_rootDirectory, recursive: true);
         }
+    }
+
+    // --- Compatibility-Train conformance helpers ------------------------------
+    //
+    // Assert a live FeatureServer/OGC response against the shared, pinned
+    // geospatial-grpc conformance fixtures (see ConformanceFixtures /
+    // FeatureContractConformance). When the fixtures bundle has not been fetched
+    // (HONUA_MOBILE_CONFORMANCE_FIXTURES_DIR unset) the structural contract checks
+    // still run; the canonical fixture is consulted only to confirm it loads and
+    // names the contract, so a developer without the bundle is not blocked.
+
+    private static void AssertFeatureQueryContract(JsonElement live, bool requireFeature)
+    {
+        var canonical = ConformanceFixtures.Instance.Available
+            ? ConformanceFixtures.Instance.FeatureQueryResponse
+            : default;
+        FeatureContractConformance.AssertFeatureQueryResponse(live, canonical, requireFeature);
+    }
+
+    private static void AssertOgcItemsContract(JsonElement live, bool requireFeature)
+        => FeatureContractConformance.AssertOgcItemsResponse(live, requireFeature);
+
+    // Project the provider-neutral SDK FeatureQueryResult into the canonical
+    // FeatureServer JSON envelope (objectIdFieldName + features[].attributes/geometry)
+    // so it can be validated against the same QueryFeaturesResponse contract as the
+    // raw REST/gRPC responses.
+    private static JsonElement ToFeatureServerJson(FeatureQueryResult result)
+    {
+        var features = result.Features.Select(feature =>
+        {
+            var obj = new Dictionary<string, object?>
+            {
+                ["attributes"] = feature.Attributes.ToDictionary(kvp => kvp.Key, kvp => (object?)kvp.Value),
+            };
+            if (feature.Geometry is { } geometry)
+            {
+                obj["geometry"] = geometry;
+            }
+
+            return obj;
+        }).ToArray();
+
+        var envelope = new Dictionary<string, object?>
+        {
+            ["objectIdFieldName"] = result.ObjectIdFieldName ?? "OBJECTID",
+            ["features"] = features,
+        };
+
+        return JsonSerializer.SerializeToElement(envelope, JsonOptions);
+    }
+
+    // Project the provider-neutral SDK FeatureQueryResult into a GeoJSON
+    // FeatureCollection so the OGC read path can be validated against the OGC items
+    // contract.
+    private static JsonElement ToOgcFeatureCollectionJson(FeatureQueryResult result)
+    {
+        var features = result.Features.Select(feature =>
+        {
+            var obj = new Dictionary<string, object?>
+            {
+                ["type"] = "Feature",
+                ["properties"] = feature.Attributes.ToDictionary(kvp => kvp.Key, kvp => (object?)kvp.Value),
+            };
+            if (feature.Id is not null)
+            {
+                obj["id"] = feature.Id;
+            }
+
+            if (feature.Geometry is { } geometry)
+            {
+                obj["geometry"] = geometry;
+            }
+
+            return obj;
+        }).ToArray();
+
+        var envelope = new Dictionary<string, object?>
+        {
+            ["type"] = "FeatureCollection",
+            ["features"] = features,
+        };
+
+        return JsonSerializer.SerializeToElement(envelope, JsonOptions);
     }
 
     private HttpClient CreateHttpClient()

--- a/tests/conformance/UPSTREAM.md
+++ b/tests/conformance/UPSTREAM.md
@@ -1,0 +1,111 @@
+# Shared conformance fixtures: `geospatial-grpc` Compatibility Train
+
+This directory wires the `Live Server Integration` suite into the **Compatibility
+Train** (epic [`geospatial-grpc#18`](https://github.com/honua-io/geospatial-grpc/issues/18)).
+Rather than asserting ad-hoc payload shapes, `LiveHonuaServerInteractionTests`
+validates live `honua-server` FeatureServer/OGC responses against the **shared,
+versioned, published conformance fixtures** owned by
+[`honua-io/geospatial-grpc`](https://github.com/honua-io/geospatial-grpc)
+(delivered by `geospatial-grpc#19`), so a contract regression like
+[`honua-server#1238`](https://github.com/honua-io/honua-server/issues/1238) is
+attributed to a specific named `geospatial.v1` contract instead of surfacing as
+an opaque HTTP 400/500.
+
+The fixtures are **not vendored** into this repo. CI pulls the pinned version at
+run time with `tests/conformance/fetch-fixtures.sh` (a verbatim copy of the
+downstream helper published by `geospatial-grpc#19`). This is the same
+"pin + pull a released artifact" model the SDK train uses, mirroring how
+`tests/seed/UPSTREAM.md` records the vendored seed's provenance.
+
+## Pinned fixture version
+
+| Field | Value |
+| --- | --- |
+| Fixture version | `0.1.0-alpha.1` |
+| Pinned in | `Directory.Build.props` → `<HonuaConformanceFixturesVersion>` |
+| Upstream repo | `honua-io/geospatial-grpc` |
+| GitHub Release / tag | `v0.1.0-alpha.1` |
+| Release commit | `216a00193c36822aa980d2b371f7d9eef06a176b` |
+| Release published | `2026-05-30T22:00:50Z` |
+| Tarball asset | `conformance-fixtures-0.1.0-alpha.1.tar.gz` |
+| Tarball SHA-256 | `e43deb8831dc8e4dc570b5b339ecb7619240b8bdaa439704cdf7f44bb0826a17` |
+| Schema mapping | fixture version maps **1:1** to the `geospatial.v1` schema at tag `v0.1.0-alpha.1` (enforced upstream by `conformance/check-version.sh` == `Geospatial.Grpc.csproj <Version>`) |
+
+The fixture version is a **pin, not "latest"**, so the live suite is
+deterministic and a fixture set unambiguously corresponds to one
+`geospatial.v1` schema release.
+
+## How the suite consumes the fixtures
+
+1. **Fetch (CI / local).** `tests/conformance/fetch-fixtures.sh --version
+   <X.Y.Z> [--dest DIR]` downloads the release asset
+   `conformance-fixtures-<version>.tar.gz` (+ `.sha256`) from the `v<version>`
+   GitHub Release of `honua-io/geospatial-grpc` (via `gh release download` when
+   available, else `curl`/`wget`), verifies the tarball SHA-256, extracts it,
+   re-verifies every file against the in-tarball `SHA256SUMS`, and asserts the
+   embedded `VERSION` equals the requested pin. It leaves `fixtures/`
+   (+ `manifest.txt`), `golden/`, `run.sh`, and `VERSION` in `--dest`
+   (default `./conformance-fixtures-<version>/`).
+
+   Equivalent raw pull (no helper):
+
+   ```bash
+   v=0.1.0-alpha.1
+   base="https://github.com/honua-io/geospatial-grpc/releases/download/v${v}"
+   curl -fsSLO "${base}/conformance-fixtures-${v}.tar.gz"
+   curl -fsSLO "${base}/conformance-fixtures-${v}.tar.gz.sha256"
+   sha256sum -c "conformance-fixtures-${v}.tar.gz.sha256"
+   tar -xzf "conformance-fixtures-${v}.tar.gz"
+   ```
+
+2. **Locate (tests).** `LiveHonuaServerInteractionTests` discovers the fetched
+   fixture directory via the `HONUA_MOBILE_CONFORMANCE_FIXTURES_DIR` environment
+   variable (set by the workflow to the `--dest` directory). When unset, the
+   contract-conformance assertions are skipped (the rest of the live suite still
+   runs), so a developer who has not fetched the fixtures is not blocked.
+
+3. **Assert (tests).** The mobile-relevant subset — `FeatureService` query /
+   apply-edits and the OGC Features read/CRUD paths the suite exercises against
+   the `mobile_offline_demo` seed (layer `68910`) — is validated against the
+   canonical `feature_query_response` / `feature_apply_edits_response` fixtures
+   using the protobuf JSON mapping conventions documented in
+   `geospatial-grpc/conformance/README.md` (camelCase fields, enum names as
+   strings, `int64` as strings). See
+   `tests/Honua.Mobile.ServerIntegration.Tests/ConformanceFixtures.cs`.
+
+## When a contract drifts
+
+A live response that no longer conforms fails the suite with a message that
+**names the drifted contract and the specific field** — e.g.
+`FeatureService.QueryFeatures response contract drift: …`. The
+[`honua-server#1238`](https://github.com/honua-io/honua-server/issues/1238)
+class of regression (JSONB-attribute projection emitting bare SQL columns →
+FeatureServer 400 / OGC 500) reads as a named contract failure rather than a
+bare HTTP error.
+
+Some `honua-server:nightly` gaps are **already tracked** and are marked
+known-expected-failing (xfail) in the suite, with an explicit issue reference,
+so the job stays green while the harness is wired — but any **new / untracked**
+contract drift still fails. When a tracked server fix lands, flip the xfail to
+required (see `KnownServerGaps` in the test source). Currently tracked:
+
+| Issue | Contract surface |
+| --- | --- |
+| [`honua-server#1238`](https://github.com/honua-io/honua-server/issues/1238) | FeatureServer/OGC JSONB-attribute projection (layer `68910`) |
+| [`honua-server#1166`](https://github.com/honua-io/honua-server/issues/1166) | Temporal query/filter |
+| [`honua-server#1167`](https://github.com/honua-io/honua-server/issues/1167) | Replica sync |
+| [`honua-server#1237`](https://github.com/honua-io/honua-server/issues/1237) | Analysis list/estimate |
+
+## Updating the pin
+
+To adopt a newer fixture release:
+
+1. Bump `<HonuaConformanceFixturesVersion>` in `Directory.Build.props`.
+2. Refresh the **Pinned fixture version** table above (release commit, publish
+   timestamp, tarball SHA-256 — grab them with
+   `gh release view v<version> --repo honua-io/geospatial-grpc --json …`).
+3. Re-run the `Live Server Integration` workflow and reconcile any new contract
+   diffs (a real server fix may let you flip a tracked xfail to required).
+
+Commit the version bump and this doc together so the pin and its provenance
+always move in lockstep.

--- a/tests/conformance/fetch-fixtures.sh
+++ b/tests/conformance/fetch-fixtures.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Fetch a *pinned* conformance fixture version from the geospatial-grpc GitHub
+# Release and verify its integrity. This is the helper downstream SDK CI jobs
+# (honua-sdk-dotnet / honua-sdk-js / honua-sdk-python / honua-mobile) use to
+# pull the same canonical fixtures rather than copying files from the repo tree.
+#
+# It downloads the release asset
+#   conformance-fixtures-<version>.tar.gz
+# (and its .sha256), verifies the checksum, extracts it, and re-verifies every
+# packaged file against the in-tarball SHA256SUMS. The result is a directory
+# containing fixtures/, golden/, run.sh, manifest, and VERSION for that exact
+# schema release.
+#
+# Usage:
+#   conformance/fetch-fixtures.sh --version 0.1.0-alpha.1 [--dest DIR] [--repo OWNER/REPO]
+#
+# Pin a specific version (never "latest") so CI is deterministic. The version
+# string maps 1:1 to a geospatial-grpc release tag (see conformance/README.md
+# and VERSIONING.md).
+#
+# Download method (auto-detected, in order):
+#   1. `gh release download` if the GitHub CLI is available and authenticated;
+#   2. plain `curl`/`wget` against the public release-download URL otherwise.
+#
+# Requirements: bash, tar, sha256sum, and one of (gh | curl | wget).
+
+set -euo pipefail
+
+VERSION=""
+DEST=""
+REPO="honua-io/geospatial-grpc"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) VERSION="${2:-}"; shift 2 ;;
+    --dest)    DEST="${2:-}"; shift 2 ;;
+    --repo)    REPO="${2:-}"; shift 2 ;;
+    -h|--help)
+      sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      echo "usage: $0 --version X.Y.Z [--dest DIR] [--repo OWNER/REPO]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${VERSION}" ]]; then
+  echo "error: --version is required (pin an exact version, not 'latest')" >&2
+  exit 2
+fi
+
+for tool in tar sha256sum; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "error: ${tool} not found on PATH" >&2
+    exit 1
+  fi
+done
+
+PKG_NAME="conformance-fixtures-${VERSION}"
+TARBALL="${PKG_NAME}.tar.gz"
+TAG="v${VERSION}"
+DEST="${DEST:-${PKG_NAME}}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+download_with_gh() {
+  command -v gh >/dev/null 2>&1 || return 1
+  gh release download "${TAG}" \
+    --repo "${REPO}" \
+    --pattern "${TARBALL}" \
+    --pattern "${TARBALL}.sha256" \
+    --dir "${WORK}" 2>/dev/null
+}
+
+download_with_http() {
+  local base="https://github.com/${REPO}/releases/download/${TAG}"
+  local f
+  for f in "${TARBALL}" "${TARBALL}.sha256"; do
+    if command -v curl >/dev/null 2>&1; then
+      curl -fsSL -o "${WORK}/${f}" "${base}/${f}" || return 1
+    elif command -v wget >/dev/null 2>&1; then
+      wget -q -O "${WORK}/${f}" "${base}/${f}" || return 1
+    else
+      echo "error: need gh, curl, or wget to download" >&2
+      return 1
+    fi
+  done
+}
+
+echo "Fetching ${TARBALL} from ${REPO}@${TAG} ..."
+if ! download_with_gh; then
+  download_with_http
+fi
+
+if [[ ! -f "${WORK}/${TARBALL}" ]]; then
+  echo "error: failed to download ${TARBALL} for ${TAG} from ${REPO}" >&2
+  exit 1
+fi
+
+# Verify the tarball checksum if the .sha256 sidecar was retrieved.
+if [[ -f "${WORK}/${TARBALL}.sha256" ]]; then
+  echo "Verifying tarball checksum ..."
+  (cd "${WORK}" && sha256sum -c "${TARBALL}.sha256")
+else
+  echo "warning: ${TARBALL}.sha256 not found; skipping tarball checksum verification" >&2
+fi
+
+# Extract.
+mkdir -p "${WORK}/extract"
+tar -C "${WORK}/extract" -xzf "${WORK}/${TARBALL}"
+
+EXTRACTED="${WORK}/extract/${PKG_NAME}"
+if [[ ! -d "${EXTRACTED}" ]]; then
+  echo "error: extracted tarball missing expected dir ${PKG_NAME}/" >&2
+  exit 1
+fi
+
+# Re-verify every packaged file against the in-tarball manifest.
+if [[ -f "${EXTRACTED}/SHA256SUMS" ]]; then
+  echo "Verifying per-file checksums ..."
+  (cd "${EXTRACTED}" && sha256sum -c SHA256SUMS)
+fi
+
+# Confirm the embedded VERSION matches the requested pin.
+if [[ -f "${EXTRACTED}/VERSION" ]]; then
+  got="$(tr -d '[:space:]' < "${EXTRACTED}/VERSION")"
+  if [[ "${got}" != "${VERSION}" ]]; then
+    echo "error: tarball VERSION (${got}) does not match requested (${VERSION})" >&2
+    exit 1
+  fi
+fi
+
+# Publish to the destination directory.
+rm -rf "${DEST}"
+mkdir -p "$(dirname "${DEST}")" 2>/dev/null || true
+mv "${EXTRACTED}" "${DEST}"
+
+echo
+echo "Fixtures ${VERSION} ready at: ${DEST}"
+echo "  fixtures/       canonical payloads + manifest.txt"
+echo "  golden/         canonical round-trip goldens"
+echo "  run.sh          verification harness (buf required on PATH)"
+echo "  VERSION         ${VERSION}"


### PR DESCRIPTION
Closes #273. Child of the Compatibility Train epic (geospatial-grpc#18).

## What

Wires the existing **Live Server Integration** suite into the Compatibility Train: it now consumes the **shared, pinned, published `geospatial-grpc` conformance fixtures** and detects contract drift **systematically and attributably**, so a regression like honua-server#1238 surfaces as a named-contract failure instead of an opaque HTTP 400/500.

## Consume the shared fixtures (no copies)

- Pull the pinned fixtures via `tests/conformance/fetch-fixtures.sh` — a verbatim copy of the downstream helper published by geospatial-grpc#19. It downloads the `conformance-fixtures-<version>.tar.gz` release asset, verifies the tarball SHA-256, extracts it, re-verifies every file against the in-tarball `SHA256SUMS`, and asserts the embedded `VERSION` equals the pin.
- Version pinned in `Directory.Build.props` (`<HonuaConformanceFixturesVersion>0.1.0-alpha.1</…>`); provenance recorded in `tests/conformance/UPSTREAM.md` (release commit, publish time, tarball SHA-256), mirroring the vendored-seed provenance model. The fixture version maps 1:1 to a `geospatial.v1` schema release.

## Assert live responses against canonical contracts

- `FeatureContractConformance` replaces the ad-hoc `JsonValueKind`/property-presence assertions in `LiveHonuaServerInteractionTests` (FeatureServer REST + gRPC + SDK query, OGC read/query) with structural checks against the canonical `FeatureService.QueryFeatures` / `ApplyEdits` / OGC items contracts (protobuf JSON mapping conventions per `conformance/README.md`).
- A failing check throws `ContractDriftException` that **names the drifted contract and the specific field**, extending the existing `FormatFeatureEditDiagnostic` attribution pattern.

## Make drift gated + known gaps xfail (not fake-green)

- `ConformanceContractRunner` attributes an opaque transport failure (the #1238 400/500 class) to the named contract, then applies the **known-tracked-xfail** policy via `KnownServerGaps`:
  - honua-server#1238 (FeatureServer/OGC JSONB projection), #1166 (temporal), #1167 (replica), #1237 (analysis list/estimate) are registered with explicit issue references.
  - A matching drift becomes a **visible `Skip` (xfail)** carrying the issue URL — never silent, never blanket `continue-on-error`.
  - **Any new/untracked drift FAILS** the suite. When a server fix lands, remove the gap entry and the xfail flips to required.
- `ConformanceContractTests` covers the harness itself (conforming passes, tracked drift xfails with attribution, untracked drift fails) so the gate is effective on every PR.

## Gate it as part of the train

- `live-server-integration.yml` fetches + verifies the pinned fixtures, points the suite at them, and records the pinned **honua-server image** (`honuaio/honua-server:nightly`, tracks trunk to match the vendored seed) and **fixtures version** in the run + job summary. The existing `workflow_dispatch` `honua_server_image` input lets the honua-devops cross-repo train gate invoke this suite against a proposed server version.

## Validation

- Built clean (0 warnings). `dotnet format` clean.
- Harness unit tests: 11/11 pass (no Docker).
- Live run against `honuaio/honua-server:nightly` + `postgis/postgis:17-3.5-alpine` with the seeded `mobile_offline_demo` layer: the three #1238 cases **SKIP** with `KNOWN-EXPECTED-FAILING (honua-server#1238)` attributed to `FeatureService.QueryFeatures response` (HTTP 400) / `OGC Features items collection` (HTTP 500); gRPC query + health **PASS**. Run is green.

No `honua-server` changes; no new mobile-owned contract surface — consumes the shared fixtures + the existing vendored seed only.