### PR TITLE
docs: add OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Honua Mobile SDK for .NET
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/honua-io/honua-mobile/badge)](https://scorecard.dev/viewer/?uri=github.com/honua-io/honua-mobile)
+
 .NET MAUI mobile SDK for [Honua Server](https://github.com/honua-io/honua-server) --
 offline-first field data collection with GeoPackage storage, gRPC transport,
 dynamic forms, and background sync.


### PR DESCRIPTION
Adds the public OpenSSF Scorecard badge to the README (score now published via the org security workflow). Part of the Phase 1 security program (honua-compliance #6).