### PR TITLE
ci: least-privilege workflow token permissions

### DIFF
--- a/.github/workflows/android-internal-distribution.yml
+++ b/.github/workflows/android-internal-distribution.yml
@@ -49,6 +49,9 @@ name: Android Internal Distribution
         default: "Internal validation build."
         type: string
 
+permissions:
+  contents: read
+
 env:
   DOTNET_VERSION: "10.0.x"
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   validate-pr:
     name: Validate Mobile SDK PR

--- a/.github/workflows/publish-dotnet-mobile.yml
+++ b/.github/workflows/publish-dotnet-mobile.yml
@@ -17,6 +17,9 @@ on:
     tags:
       - "mobile-dotnet-v*"
 
+permissions:
+  contents: read
+
 env:
   DOTNET_VERSION: "10.0.x"
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/.github/workflows/publish-npm-embed.yml
+++ b/.github/workflows/publish-npm-embed.yml
@@ -12,6 +12,9 @@ on:
     tags:
       - "mobile-embed-v*"
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: "24.x"
 


### PR DESCRIPTION
## Summary

Hardens supply-chain posture (OpenSSF Scorecard Token-Permissions).

**Token-Permissions:** Added a top-level `permissions: { contents: read }` block to the four workflows that previously had none:

| Workflow | Notes |
|---|---|
| `android-internal-distribution.yml` | Single `distribute` job already had job-level `contents: read`/`packages: read`; top-level read added. |
| `pr-validation.yml` | `validate-pr` job keeps its job-level `pull-requests: write`/`issues: write`/`statuses: write` (comments on PRs + commit status). `mobile-specific-checks` is read-only and now inherits top-level read. |
| `publish-dotnet-mobile.yml` | `publish` job keeps job-level `packages: write` (NuGet push to GitHub Packages). |
| `publish-npm-embed.yml` | `publish` job keeps job-level `packages: write` (npm publish to GitHub Packages). |

The remaining seven workflows already declared top-level `permissions:` and were not modified. No existing permission was removed or reduced; all write-needing jobs retain their explicit job-level scopes.

**Dependabot:** No change. `.github/dependabot.yml` already covers `nuget`, `npm` (`/src/Honua.Embed`), and `github-actions`.

## Dependabot alerts (report only)
- No open **high/critical** alerts. The only open alert is `protobufjs` (`GHSA-jggg-4jg4-v7c6`) at **medium** severity, with an existing Dependabot auto-PR: #283 ("chore(deps): bump protobufjs from 8.0.3 to 8.6.1 in /src/Honua.Embed").

## Scope
Touches only the four workflow YAML files (top-level `permissions:` insertion). Do not merge until reviewed.