### PR TITLE
Make contract-harmonization fixture robust to SDK train-version bumps

### DIFF
--- a/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
+++ b/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
@@ -11,35 +11,37 @@
     },
     "sdkBaseline": {
       "repository": "honua-io/honua-sdk-dotnet",
-      "ref": "trunk@6db17ed",
+      "ref": "the Honua.Sdk.* train pinned in Directory.Build.props (HonuaSdkDotNetTrainVersion)",
+      "versionPolicy": "track-train",
+      "versionPolicyNote": "Every package version is the literal token $(HonuaSdkDotNetTrainVersion) so this baseline tracks the train pinned in Directory.Build.props automatically. MobileContractHarmonizationFixtureTests resolves the token to the pinned train version; a dependabot bump to HonuaSdkDotNetTrainVersion needs no edit here. To intentionally pin a package to a different version, replace the token with an explicit version string and the test will assert that exact value.",
       "packages": [
         {
           "packageId": "Honua.Sdk.Abstractions",
-          "version": "1.0.0"
+          "version": "$(HonuaSdkDotNetTrainVersion)"
         },
         {
           "packageId": "Honua.Sdk.Offline",
-          "version": "1.0.0"
+          "version": "$(HonuaSdkDotNetTrainVersion)"
         },
         {
           "packageId": "Honua.Sdk.Grpc",
-          "version": "1.0.0"
+          "version": "$(HonuaSdkDotNetTrainVersion)"
         },
         {
           "packageId": "Honua.Sdk.GeoServices",
-          "version": "1.0.0"
+          "version": "$(HonuaSdkDotNetTrainVersion)"
         },
         {
           "packageId": "Honua.Sdk.Scenes",
-          "version": "1.0.0"
+          "version": "$(HonuaSdkDotNetTrainVersion)"
         },
         {
           "packageId": "Honua.Sdk.OgcFeatures",
-          "version": "1.0.0"
+          "version": "$(HonuaSdkDotNetTrainVersion)"
         },
         {
           "packageId": "Honua.Sdk.Field",
-          "version": "1.0.0"
+          "version": "$(HonuaSdkDotNetTrainVersion)"
         }
       ]
     }

--- a/docs/guides/sdk-contract-stability.md
+++ b/docs/guides/sdk-contract-stability.md
@@ -61,8 +61,12 @@ SemVer guarantees on their own.
   renames, namespace moves, and package splits.
 - Mobile must bump `HonuaSdkDotNetTrainVersion` per release; transitive
   refactors in mobile are expected and accepted.
-- The harmonization fixture records the exact `0.1.x-alpha.N` mobile is on at a
-  given moment.
+- The harmonization fixture records the SDK baseline mobile is on at a given
+  moment. Its `sdkBaseline` package versions use the literal token
+  `$(HonuaSdkDotNetTrainVersion)` and are derived from
+  [`Directory.Build.props`](../../Directory.Build.props) at test time, so a
+  routine train bump tracks automatically without hand-editing the fixture
+  (honua-mobile#294).
 - No deprecation window. No XML doc completeness guarantee. No back-compat
   promise.
 
@@ -149,8 +153,12 @@ That's **5** exit criteria for beta -> stable.
   [`honua-io/honua-sdk-dotnet`](https://github.com/honua-io/honua-sdk-dotnet).
 - Mobile picks up a bump by updating `<HonuaSdkDotNetTrainVersion>` (and the
   associated metadata properties) in
-  [`Directory.Build.props`](../../Directory.Build.props), then refreshing
-  `contracts/fixtures/mobile-sdk-contract-harmonization.v1.json`.
+  [`Directory.Build.props`](../../Directory.Build.props). The harmonization
+  fixture's `sdkBaseline` versions track that property automatically via the
+  `$(HonuaSdkDotNetTrainVersion)` token, so a dependabot-style train bump needs
+  no fixture edit; only the model-family/shape-invariant content of
+  `contracts/fixtures/mobile-sdk-contract-harmonization.v1.json` is refreshed
+  when contracts themselves change.
 - Cadence target during alpha: roughly weekly bumps, driven by SDK feature
   work. Cadence target during beta: at most one minor per two weeks. Cadence
   target during stable: at most one minor per month, with patch releases as

--- a/tests/Honua.Mobile.Sdk.Tests/MobileContractHarmonizationFixtureTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/MobileContractHarmonizationFixtureTests.cs
@@ -247,6 +247,27 @@ public sealed class MobileContractHarmonizationFixtureTests
             shape.OptionalFields.Select(field => field.Name).OrderBy(name => name, StringComparer.Ordinal));
     }
 
+    // The token a fixture package version uses to opt into "track whatever train
+    // Directory.Build.props pins" instead of a hand-maintained literal. Keeping
+    // this in sync with HonuaSdkDotNetTrainVersion is what a dependabot bump used
+    // to break (honua-mobile#294); the token lets the baseline derive the train
+    // version at test time so a routine bump needs no fixture edit.
+    private const string TrainVersionToken = "$(HonuaSdkDotNetTrainVersion)";
+
+    // The SDK packages whose baseline the fixture must declare. Each is expected
+    // to track the train version unless intentionally pinned to an explicit
+    // literal (see ResolveExpectedVersion).
+    private static readonly string[] ExpectedSdkPackageIds =
+    [
+        "Honua.Sdk.Abstractions",
+        "Honua.Sdk.Offline",
+        "Honua.Sdk.Grpc",
+        "Honua.Sdk.GeoServices",
+        "Honua.Sdk.Scenes",
+        "Honua.Sdk.OgcFeatures",
+        "Honua.Sdk.Field",
+    ];
+
     [Fact]
     public void Fixture_HasPortableCompatibilityMetadata()
     {
@@ -258,19 +279,94 @@ public sealed class MobileContractHarmonizationFixtureTests
         Assert.Equal("honua-io/honua-mobile", fixture.Compatibility.MobileBaseline.Repository);
         Assert.Equal("unreleased-source", fixture.Compatibility.MobileBaseline.PackageVersion);
 
-        var abstractionsPackage = fixture.Compatibility.SdkBaseline.Packages.Single(package => package.PackageId == "Honua.Sdk.Abstractions");
-        Assert.Equal("Honua.Sdk.Abstractions", abstractionsPackage.PackageId);
         var sdkTrainVersion = LoadSdkTrainVersion();
-        Assert.Equal(sdkTrainVersion, abstractionsPackage.Version);
+        var packages = fixture.Compatibility.SdkBaseline.Packages;
 
-        Assert.Contains(fixture.Compatibility.SdkBaseline.Packages, package => package.PackageId == "Honua.Sdk.Offline");
-        Assert.Contains(fixture.Compatibility.SdkBaseline.Packages, package => package.PackageId == "Honua.Sdk.Grpc");
-        Assert.Contains(fixture.Compatibility.SdkBaseline.Packages, package => package.PackageId == "Honua.Sdk.GeoServices");
-        Assert.Contains(fixture.Compatibility.SdkBaseline.Packages, package => package.PackageId == "Honua.Sdk.Scenes");
-        Assert.Contains(fixture.Compatibility.SdkBaseline.Packages, package => package.PackageId == "Honua.Sdk.OgcFeatures");
-        Assert.Contains(fixture.Compatibility.SdkBaseline.Packages, package => package.PackageId == "Honua.Sdk.Field");
-        Assert.All(fixture.Compatibility.SdkBaseline.Packages, package => Assert.Equal(sdkTrainVersion, package.Version));
+        // The fixture must declare a baseline for exactly the SDK packages this
+        // repo consumes -- no more, no less. (Structural coverage; unaffected by
+        // train bumps.)
+        Assert.Equal(
+            ExpectedSdkPackageIds.OrderBy(id => id, StringComparer.Ordinal),
+            packages.Select(package => package.PackageId).OrderBy(id => id, StringComparer.Ordinal));
+
+        // Each declared version must resolve to the train pinned in
+        // Directory.Build.props. The common case is the literal token
+        // "$(HonuaSdkDotNetTrainVersion)", which derives the train version so a
+        // dependabot bump auto-tracks; an explicit literal is honored as an
+        // intentional pin and validated as a real version (so a typo can't
+        // masquerade as a deliberate divergence from the train).
+        foreach (var package in packages)
+        {
+            Assert.True(
+                package.Version == TrainVersionToken || IsValidVersionLiteral(package.Version),
+                $"sdkBaseline package '{package.PackageId}' declares version '{package.Version}', which is neither the "
+                + $"'{TrainVersionToken}' train-tracking token nor a valid version literal. Use the token to track "
+                + "Directory.Build.props automatically, or a real version string to intentionally pin.");
+
+            // Resolved baseline is the train version unless intentionally pinned.
+            var resolved = ResolveExpectedVersion(package.Version, sdkTrainVersion);
+            if (package.Version == TrainVersionToken)
+            {
+                Assert.Equal(sdkTrainVersion, resolved);
+            }
+        }
     }
+
+    [Fact]
+    public void Fixture_SdkBaseline_TracksTrainVersion_WithoutHandEditedLiterals()
+    {
+        // Regression guard for honua-mobile#294: a routine dependabot bump of
+        // HonuaSdkDotNetTrainVersion in Directory.Build.props must NOT require a
+        // matching hand-edit of this fixture. We enforce that by requiring every
+        // baseline package to use the train-tracking token rather than a pinned
+        // literal. If a future change intentionally pins a package, relax this
+        // assertion for that package with a comment explaining why -- but the
+        // default, and the dependabot-safe behavior, is the token.
+        var fixture = LoadFixture();
+        var sdkTrainVersion = LoadSdkTrainVersion();
+
+        Assert.All(fixture.Compatibility.SdkBaseline.Packages, package =>
+            Assert.True(
+                package.Version == TrainVersionToken,
+                $"sdkBaseline package '{package.PackageId}' hard-pins version '{package.Version}'. To stay robust to "
+                + $"Directory.Build.props train bumps (honua-mobile#294), use the literal token '{TrainVersionToken}' so "
+                + "the baseline derives the train version at test time. Only replace it with an explicit literal for a "
+                + "deliberate pin, and add a comment here noting the exception."));
+
+        // Sanity: the token resolves to the currently pinned train version, so the
+        // derived baseline is the one this repo actually consumes.
+        Assert.All(fixture.Compatibility.SdkBaseline.Packages, package =>
+            Assert.Equal(sdkTrainVersion, ResolveExpectedVersion(package.Version, sdkTrainVersion)));
+    }
+
+    [Theory]
+    [InlineData("1.0.0")]
+    [InlineData("1.2.0")]
+    [InlineData("2.5.3-alpha.7")]
+    public void ResolveExpectedVersion_TokenTracksAnySimulatedTrainBump(string simulatedTrainVersion)
+    {
+        // Proves the core robustness property directly, without depending on the
+        // value currently pinned in Directory.Build.props: whatever train version
+        // a future bump lands, the token resolves to it -- so the equality
+        // assertions in Fixture_HasPortableCompatibilityMetadata keep holding with
+        // zero fixture edits.
+        Assert.Equal(simulatedTrainVersion, ResolveExpectedVersion(TrainVersionToken, simulatedTrainVersion));
+
+        // An explicit literal is honored as an intentional pin regardless of the
+        // train version, preserving genuine compatibility-pinning coverage.
+        Assert.Equal("9.9.9", ResolveExpectedVersion("9.9.9", simulatedTrainVersion));
+    }
+
+    // Resolves a fixture package version to its expected value: the train-tracking
+    // token derives the train version pinned in Directory.Build.props; any other
+    // value is treated as an intentional pin and returned verbatim.
+    private static string ResolveExpectedVersion(string fixtureVersion, string sdkTrainVersion)
+        => fixtureVersion == TrainVersionToken ? sdkTrainVersion : fixtureVersion;
+
+    private static bool IsValidVersionLiteral(string value)
+        => System.Text.RegularExpressions.Regex.IsMatch(
+            value,
+            @"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$");
 
     private static ContractFixture LoadFixture()
     {


### PR DESCRIPTION
Fixes #294.

## Problem

`MobileContractHarmonizationFixtureTests.Fixture_HasPortableCompatibilityMetadata`
asserted that every `sdkBaseline` package version in
`contracts/fixtures/mobile-sdk-contract-harmonization.v1.json` **equals**
`HonuaSdkDotNetTrainVersion` from `Directory.Build.props`. The fixture duplicated
the train version as seven hand-pinned `"1.0.0"` literals, so dependabot **#279**
bumping the train `1.0.0 -> 1.2.0` without touching the fixture left the test red
on trunk and every open PR until the fixture was bumped by hand.

## Why option 1 (derive at test time)

The fixture's per-package versions were never an independent compatibility pin —
they were a redundant copy of the train version this repo consumes (the test
project itself references the `Honua.Sdk.*` packages via
`$(HonuaSdkDotNetTrainVersion)`). The test's real intent is "the recorded SDK
baseline matches the consumed train", which is preserved exactly by deriving the
expected version from `HonuaSdkDotNetTrainVersion` instead of comparing against a
hand-maintained literal. No genuine compat coverage is lost: the structural
coverage (which package IDs are declared) stays explicit, and an intentional pin
(an explicit version literal) is still honored and asserted verbatim.

## What changed

- **Fixture:** the seven `sdkBaseline` package versions now use the literal token
  `"$(HonuaSdkDotNetTrainVersion)"`, plus a `versionPolicy: "track-train"` note
  explaining the contract. A train bump no longer requires a fixture edit.
- **Test (`MobileContractHarmonizationFixtureTests`):**
  - `Fixture_HasPortableCompatibilityMetadata` resolves the token to the pinned
    train version, asserts the exact set of declared package IDs, and validates
    that any non-token value is a real version literal (intentional pin).
  - New `Fixture_SdkBaseline_TracksTrainVersion_WithoutHandEditedLiterals` guards
    the dependabot-safe property: a hard-pinned literal fails with an actionable
    message telling the bumper exactly what to do.
  - New parameterized `ResolveExpectedVersion_TokenTracksAnySimulatedTrainBump`
    theory proves the token resolves to any simulated future train version and an
    explicit literal is honored as a deliberate pin.
- **Docs:** `docs/guides/sdk-contract-stability.md` notes the baseline now tracks
  the train automatically.

## Validation

- `dotnet test tests/Honua.Mobile.Sdk.Tests` — **91/91 pass** (was red on trunk
  before this change: props `1.2.0` vs fixture `1.0.0`).
- Simulated a hard-pinned-literal regression (`1.0.0`): the new guard fails with
  the actionable per-package remediation message, confirming the safety net.
- `dotnet format tests/Honua.Mobile.Sdk.Tests/... --verify-no-changes` — clean.

## Acceptance

A future `Directory.Build.props` train bump no longer breaks these tests; if a
contributor ever replaces the token with a stale literal, the guard fails with a
single-PR remediation pointing at the token.