### PR TITLE
Re-vendor mobile-offline-demo-v1.sql seed from upstream

### DIFF
--- a/tests/seed/UPSTREAM.md
+++ b/tests/seed/UPSTREAM.md
@@ -27,10 +27,10 @@ section below.
 | --- | --- |
 | Upstream path | `tests/seed/mobile-offline-demo-v1.sql` |
 | Upstream repo | `honua-io/honua-server` |
-| Upstream blob SHA | `03a6a8e05d30bfbbfa913634397d74e7a13e447d` |
-| Upstream `trunk` commit at fetch time | `0cd9f0ef4c4bf8db65353004c931ef091821f54d` |
-| Vendored on | 2026-05-21 |
-| Bytes | 14082 |
+| Upstream blob SHA | `3420275023fa3cee45b1a4517ee1ac5cc74e9a55` |
+| Upstream `trunk` commit at fetch time | `5c179776929e4b62fdce11a5bc2e1e0369897466` |
+| Vendored on | 2026-06-20 |
+| Bytes | 14684 |
 
 When updating, refresh every row above (the blob SHA in particular --
 that's what the sync script checks against to detect drift).

--- a/tests/seed/mobile-offline-demo-v1.sql
+++ b/tests/seed/mobile-offline-demo-v1.sql
@@ -7,28 +7,6 @@
 
 BEGIN;
 
-CREATE TABLE IF NOT EXISTS honua.metadata_v2_snapshots (
-    environment TEXT NOT NULL,
-    revision BIGINT NOT NULL,
-    schema_version TEXT NOT NULL,
-    api_version TEXT NOT NULL,
-    document JSONB NOT NULL,
-    etag TEXT NOT NULL,
-    generated_at TIMESTAMPTZ NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    PRIMARY KEY (environment, revision)
-);
-
-CREATE TABLE IF NOT EXISTS honua.metadata_v2_current (
-    environment TEXT NOT NULL PRIMARY KEY,
-    revision BIGINT NOT NULL,
-    etag TEXT NOT NULL,
-    activated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    FOREIGN KEY (environment, revision)
-        REFERENCES honua.metadata_v2_snapshots(environment, revision)
-        ON DELETE RESTRICT
-);
-
 ALTER TABLE IF EXISTS honua.services
     ADD COLUMN IF NOT EXISTS metadata JSONB;
 
@@ -95,7 +73,7 @@ VALUES (
         'accessPolicy', jsonb_build_object('allowAnonymous', true, 'allowAnonymousWrite', true),
         'demoFixture', jsonb_build_object(
             'id', 'mobile-offline-field-ops-v1',
-            'issue', 'honua-server#895',
+            'issue', 'honua-server#965',
             'enabledIssues', jsonb_build_array('honua-mobile#92', 'honua-mobile#95', 'honua-mobile#97'),
             'setupSeed', 'tests/seed/mobile-offline-demo-v1.sql',
             'conflictSeed', 'tests/seed/mobile-offline-demo-conflict-delta.sql',
@@ -110,7 +88,7 @@ VALUES (
                 'packageId', 'mobile-offline-field-ops-v1',
                 'serviceId', 'mobile_offline_demo',
                 'format', 'json',
-                'syncModel', 'perLayer',
+                'syncModel', 'perReplica',
                 'bbox', jsonb_build_array(-158.1250, 21.2600, -157.7000, 21.5200),
                 'pageSize', 100,
                 'sourceIds', jsonb_build_array('mobile_offline_demo/FeatureServer/68910', 'mobile_offline_demo/FeatureServer/68920'),
@@ -149,6 +127,7 @@ INSERT INTO honua.layers (
     table_name,
     primary_key_column,
     geometry_column,
+    storage_options,
     storage_srid,
     temporal_column,
     geometry_type,
@@ -163,10 +142,15 @@ VALUES
         68910,
         'Offline Field Sites',
         'Mobile-editable point layer for SDK offline create, update, delete, and conflict scenarios.',
-        'public',
+        current_schema(),
         'features',
         'objectid',
         'geometry',
+        -- Non-key fields (globalid, site_name, status, ...) live as keys in the shared
+        -- honua.features.attributes JSONB column, not as physical columns. Declare the
+        -- accessor so the storage-mapped reader projects attributes->>'field' instead of
+        -- bare columns (which produce Postgres 42703 "column ... does not exist").
+        jsonb_build_object('attributesColumn', 'attributes'),
         4326,
         'inspection_date',
         'Point',
@@ -204,10 +188,12 @@ VALUES
         68920,
         'Offline Work Zones',
         'Polygon context layer included in the offline package as readonly operational context.',
-        'public',
+        current_schema(),
         'features',
         'objectid',
         'geometry',
+        -- See 68910: shared features.attributes JSONB column holds the declared fields.
+        jsonb_build_object('attributesColumn', 'attributes'),
         4326,
         NULL,
         'Polygon',
@@ -320,325 +306,6 @@ VALUES
     (68920, 'sync_version', 'Integer', 4, NULL, false, '1', 'Readonly context generation token'),
     (68920, 'notes', 'String', 5, 1024, true, NULL, 'Zone notes'),
     (68920, 'shape', 'Geometry', 6, NULL, true, NULL, 'Geometry');
-
-DO $$
-DECLARE
-    target_environment TEXT;
-    snapshot_revision BIGINT := 1;
-    generated_at TIMESTAMPTZ := NOW();
-    snapshot_document JSONB;
-    snapshot_etag TEXT;
-BEGIN
-    FOREACH target_environment IN ARRAY ARRAY['default', 'Development', 'Test']
-    LOOP
-        WITH fixture_layers AS (
-            SELECT l.*
-            FROM honua.layers l
-            JOIN honua.service_layers sl ON sl.layer_id = l.layer_id
-            WHERE sl.service_name = 'mobile_offline_demo'
-            ORDER BY sl.layer_order, l.layer_id
-        ),
-        status_doc AS (
-            SELECT jsonb_build_object('lifecycle', 'active', 'state', 'ready') AS value
-        ),
-        resources AS (
-            SELECT COALESCE(jsonb_agg(
-                jsonb_build_object(
-                    'metadata', jsonb_build_object(
-                        'id', 'mobile-offline-layer-' || l.layer_id::TEXT,
-                        'name', l.layer_id::TEXT,
-                        'title', l.layer_name,
-                        'description', l.description,
-                        'labels', jsonb_build_object('fixture', 'mobile-offline-field-ops-v1')
-                    ),
-                    'type', 'feature-dataset',
-                    'storageBindingIds', jsonb_build_array('mobile-offline-storage-' || l.layer_id::TEXT),
-                    'primaryStorageBindingId', 'mobile-offline-storage-' || l.layer_id::TEXT,
-                    'schemaFields', COALESCE((
-                        SELECT jsonb_agg(
-                            jsonb_build_object(
-                                'name', f.field_name,
-                                'type', CASE lower(f.field_type)
-                                    WHEN 'integer' THEN 'integer'
-                                    WHEN 'string' THEN 'string'
-                                    WHEN 'datetime' THEN 'datetime'
-                                    WHEN 'date' THEN 'date'
-                                    WHEN 'time' THEN 'time'
-                                    WHEN 'double' THEN 'double'
-                                    WHEN 'float' THEN 'float'
-                                    WHEN 'boolean' THEN 'boolean'
-                                    WHEN 'geometry' THEN 'geometry'
-                                    ELSE 'unknown'
-                                END,
-                                'title', f.description,
-                                'description', f.description,
-                                'nullable', f.nullable,
-                                'semanticRoles', CASE
-                                    WHEN f.field_name = l.primary_key_column OR lower(f.field_name) = 'objectid'
-                                        THEN jsonb_build_array('id.primary')
-                                    WHEN f.field_name = COALESCE(l.geometry_column, 'geometry') OR lower(f.field_type) = 'geometry'
-                                        THEN jsonb_build_array('geometry.primary')
-                                    ELSE '[]'::jsonb
-                                END,
-                                'extensions', jsonb_build_object(
-                                    'fieldOrder', f.field_order,
-                                    'maxLength', f.max_length,
-                                    'defaultValue', f.default_value
-                                )
-                            )
-                            ORDER BY f.field_order, f.field_name
-                        )
-                        FROM honua.layer_fields f
-                        WHERE f.layer_id = l.layer_id
-                    ), '[]'::jsonb),
-                    'styleResourceIds', '[]'::jsonb,
-                    'policyIds', '[]'::jsonb,
-                    'relationships', '[]'::jsonb,
-                    'accessPolicy', jsonb_build_object('allowAnonymous', true, 'allowAnonymousWrite', true),
-                    'spatial', jsonb_build_object(
-                        'spatialReference', jsonb_build_object(
-                            'srid', COALESCE(l.storage_srid, l.srid, 4326),
-                            'crs', 'EPSG:' || COALESCE(l.storage_srid, l.srid, 4326)::TEXT,
-                            'isGeographic', COALESCE(l.storage_srid, l.srid, 4326) = 4326
-                        ),
-                        'geometryType', CASE lower(l.geometry_type)
-                            WHEN 'point' THEN 'point'
-                            WHEN 'multipoint' THEN 'multipoint'
-                            WHEN 'line' THEN 'linestring'
-                            WHEN 'polyline' THEN 'linestring'
-                            WHEN 'linestring' THEN 'linestring'
-                            WHEN 'multilinestring' THEN 'multilinestring'
-                            WHEN 'polygon' THEN 'polygon'
-                            WHEN 'multipolygon' THEN 'multipolygon'
-                            ELSE 'mixed'
-                        END,
-                        'bbox', jsonb_build_object(
-                            'west', ST_XMin(l.extent),
-                            'south', ST_YMin(l.extent),
-                            'east', ST_XMax(l.extent),
-                            'north', ST_YMax(l.extent)
-                        ),
-                        'primaryGeometryField', COALESCE(l.geometry_column, 'geometry')
-                    ),
-                    'temporal', CASE
-                        WHEN l.temporal_column IS NULL THEN NULL
-                        ELSE jsonb_build_object('startTimeField', l.temporal_column)
-                    END,
-                    'status', (SELECT value FROM status_doc),
-                    'extensions', jsonb_build_object(
-                        'legacyLayerId', l.layer_id,
-                        'legacyMetadata', COALESCE(l.metadata, '{}'::jsonb)
-                    )
-                )
-                ORDER BY l.layer_id
-            ), '[]'::jsonb) AS value
-            FROM fixture_layers l
-        ),
-        storage_bindings AS (
-            SELECT COALESCE(jsonb_agg(
-                jsonb_build_object(
-                    'metadata', jsonb_build_object(
-                        'id', 'mobile-offline-storage-' || l.layer_id::TEXT,
-                        'name', COALESCE(l.table_schema, 'public') || '.' || l.table_name || ':' || l.layer_id::TEXT,
-                        'title', l.layer_name || ' storage'
-                    ),
-                    'resourceId', 'mobile-offline-layer-' || l.layer_id::TEXT,
-                    'connectionId', 'mobile-offline-postgres',
-                    'storageType', 'relational-table',
-                    'locator', COALESCE(l.table_schema, 'public') || '.' || l.table_name,
-                    'storageLayerId', l.layer_id,
-                    'capabilities', CASE
-                        WHEN l.layer_id = 68910 THEN jsonb_build_array('query', 'filter', 'sort', 'aggregate', 'edit', 'transactions', 'render', 'tile', 'search')
-                        ELSE jsonb_build_array('query', 'filter', 'sort', 'aggregate', 'render', 'tile', 'search')
-                    END,
-                    'options', jsonb_build_object(
-                        'primaryKeyColumn', l.primary_key_column,
-                        'geometryColumn', l.geometry_column
-                    ),
-                    'status', (SELECT value FROM status_doc),
-                    'extensions', '{}'::jsonb
-                )
-                ORDER BY l.layer_id
-            ), '[]'::jsonb) AS value
-            FROM fixture_layers l
-        ),
-        ogc_publications AS (
-            SELECT COALESCE(jsonb_agg(
-                jsonb_build_object(
-                    'metadata', jsonb_build_object(
-                        'id', 'mobile-offline-ogc-' || l.layer_id::TEXT,
-                        'name', l.layer_id::TEXT,
-                        'title', l.layer_name
-                    ),
-                    'resourceId', 'mobile-offline-layer-' || l.layer_id::TEXT,
-                    'serviceId', 'mobile-offline-ogc-service',
-                    'storageBindingId', 'mobile-offline-storage-' || l.layer_id::TEXT,
-                    'publicationType', 'ogc-collection',
-                    'identifier', jsonb_build_object('value', l.layer_id::TEXT, 'isNumeric', true),
-                    'path', l.layer_id::TEXT,
-                    'layerIndex', l.layer_id,
-                    'supportedFormats', jsonb_build_array('json', 'geojson'),
-                    'fieldAliases', '{}'::jsonb,
-                    'capabilities', jsonb_build_array('query', 'create', 'update', 'delete'),
-                    'serviceLocalId', l.layer_id::TEXT,
-                    'isPrimary', true,
-                    'options', '{}'::jsonb,
-                    'status', (SELECT value FROM status_doc),
-                    'extensions', '{}'::jsonb
-                )
-                ORDER BY l.layer_id
-            ), '[]'::jsonb) AS value
-            FROM fixture_layers l
-        ),
-        feature_publications AS (
-            SELECT COALESCE(jsonb_agg(
-                jsonb_build_object(
-                    'metadata', jsonb_build_object(
-                        'id', 'mobile-offline-feature-' || l.layer_id::TEXT,
-                        'name', l.layer_id::TEXT,
-                        'title', l.layer_name
-                    ),
-                    'resourceId', 'mobile-offline-layer-' || l.layer_id::TEXT,
-                    'serviceId', 'mobile-offline-feature-service',
-                    'storageBindingId', 'mobile-offline-storage-' || l.layer_id::TEXT,
-                    'publicationType', 'esri-feature-layer',
-                    'identifier', jsonb_build_object('value', l.layer_id::TEXT, 'isNumeric', true),
-                    'path', l.layer_id::TEXT,
-                    'layerIndex', l.layer_id,
-                    'supportedFormats', jsonb_build_array('json', 'geojson'),
-                    'fieldAliases', '{}'::jsonb,
-                    'capabilities', jsonb_build_array('query', 'create', 'update', 'delete', 'sync'),
-                    'serviceLocalId', l.layer_id::TEXT,
-                    'isPrimary', true,
-                    'options', '{}'::jsonb,
-                    'status', (SELECT value FROM status_doc),
-                    'extensions', '{}'::jsonb
-                )
-                ORDER BY l.layer_id
-            ), '[]'::jsonb) AS value
-            FROM fixture_layers l
-        )
-        SELECT jsonb_build_object(
-            'schemaVersion', '2.0.0-alpha.1',
-            'apiVersion', 'metadata.honua.io/v2alpha1',
-            'revision', snapshot_revision,
-            'environment', target_environment,
-            'generatedAt', generated_at,
-            'namespaces', jsonb_build_array('mobile-offline-demo'),
-            'metadata', jsonb_build_object(
-                'id', 'mobile-offline-field-ops-v1',
-                'name', 'mobile_offline_demo',
-                'title', 'Mobile offline field operations fixture',
-                'description', 'Metadata v2 compatibility graph for the mobile live-image fixture.'
-            ),
-            'catalogs', '[]'::jsonb,
-            'resources', resources.value,
-            'connections', jsonb_build_array(jsonb_build_object(
-                'metadata', jsonb_build_object(
-                    'id', 'mobile-offline-postgres',
-                    'name', 'mobile-offline-postgres',
-                    'title', 'Mobile fixture PostgreSQL'
-                ),
-                'type', 'managed',
-                'provider', 'postgres',
-                'options', '{}'::jsonb,
-                'status', (SELECT value FROM status_doc),
-                'extensions', '{}'::jsonb
-            )),
-            'storageBindings', storage_bindings.value,
-            'services', jsonb_build_array(
-                jsonb_build_object(
-                    'metadata', jsonb_build_object(
-                        'id', 'mobile-offline-feature-service',
-                        'name', 'mobile_offline_demo',
-                        'title', 'Mobile Offline Demo FeatureServer'
-                    ),
-                    'serviceType', 'esri-feature-service',
-                    'route', '/rest/services/mobile_offline_demo/FeatureServer',
-                    'publicationIds', jsonb_build_array('mobile-offline-feature-68910', 'mobile-offline-feature-68920'),
-                    'accessPolicy', jsonb_build_object('allowAnonymous', true, 'allowAnonymousWrite', true),
-                    'spatialReference', jsonb_build_object('srid', 4326, 'crs', 'EPSG:4326', 'isGeographic', true),
-                    'enabledProtocols', jsonb_build_array('FeatureServer', 'Grpc'),
-                    'protocols', jsonb_build_array('FeatureServer', 'Grpc'),
-                    'options', '{}'::jsonb,
-                    'status', (SELECT value FROM status_doc),
-                    'extensions', '{}'::jsonb
-                ),
-                jsonb_build_object(
-                    'metadata', jsonb_build_object(
-                        'id', 'mobile-offline-ogc-service',
-                        'name', 'mobile_offline_demo',
-                        'title', 'Mobile Offline Demo OGC API Features'
-                    ),
-                    'serviceType', 'ogc-api-features',
-                    'route', '/ogc/features',
-                    'publicationIds', jsonb_build_array('mobile-offline-ogc-68910', 'mobile-offline-ogc-68920'),
-                    'accessPolicy', jsonb_build_object('allowAnonymous', true, 'allowAnonymousWrite', true),
-                    'spatialReference', jsonb_build_object('srid', 4326, 'crs', 'EPSG:4326', 'isGeographic', true),
-                    'enabledProtocols', jsonb_build_array('OgcFeatures'),
-                    'protocols', jsonb_build_array('OgcFeatures'),
-                    'options', '{}'::jsonb,
-                    'status', (SELECT value FROM status_doc),
-                    'extensions', '{}'::jsonb
-                )
-            ),
-            'publications', ogc_publications.value || feature_publications.value,
-            'projectionProfiles', '[]'::jsonb,
-            'policies', '[]'::jsonb,
-            'roles', '[]'::jsonb,
-            'runtime', '{}'::jsonb,
-            'extensionPoints', '[]'::jsonb,
-            'extensions', jsonb_build_object(
-                'fixtureSeed', 'tests/seed/mobile-offline-demo-v1.sql',
-                'compatibilityPurpose', 'Live-image OGC edit outbox service resolution'
-            )
-        )
-        INTO snapshot_document
-        FROM resources, storage_bindings, ogc_publications, feature_publications;
-
-        snapshot_etag := '"' || md5(snapshot_document::TEXT) || '"';
-
-        INSERT INTO honua.metadata_v2_snapshots (
-            environment,
-            revision,
-            schema_version,
-            api_version,
-            document,
-            etag,
-            generated_at
-        )
-        VALUES (
-            target_environment,
-            snapshot_revision,
-            '2.0.0-alpha.1',
-            'metadata.honua.io/v2alpha1',
-            snapshot_document,
-            snapshot_etag,
-            generated_at
-        )
-        ON CONFLICT (environment, revision) DO UPDATE SET
-            schema_version = EXCLUDED.schema_version,
-            api_version = EXCLUDED.api_version,
-            document = EXCLUDED.document,
-            etag = EXCLUDED.etag,
-            generated_at = EXCLUDED.generated_at;
-
-        INSERT INTO honua.metadata_v2_current (
-            environment,
-            revision,
-            etag
-        )
-        VALUES (
-            target_environment,
-            snapshot_revision,
-            snapshot_etag
-        )
-        ON CONFLICT (environment) DO UPDATE SET
-            revision = EXCLUDED.revision,
-            etag = EXCLUDED.etag,
-            activated_at = NOW();
-    END LOOP;
-END $$;
 
 INSERT INTO features (objectid, layer_id, geometry, attributes)
 VALUES


### PR DESCRIPTION
Resolves the recurring `seed-drift: mobile-offline-demo-v1.sql` drift detected by the scheduled drift-check workflow.

## What drifted
The vendored fixture seed `tests/seed/mobile-offline-demo-v1.sql` fell behind the upstream copy in `honua-io/honua-server`:

| Field | Was | Now |
| --- | --- | --- |
| Upstream blob SHA | `03a6a8e05d30bfbbfa913634397d74e7a13e447d` | `3420275023fa3cee45b1a4517ee1ac5cc74e9a55` |
| Bytes | 14082 | 14684 |

## How it was synced
Regenerated via the only supported path, `tools/sync-mobile-offline-seed.sh --write`, then refreshed the `tests/seed/UPSTREAM.md` current-snapshot table (blob SHA, upstream `trunk` commit `5c179776929e4b62fdce11a5bc2e1e0369897466`, vendored date, byte count) so the recorded SHA and the file move in lockstep.

(The script's UPSTREAM.md auto-refresh step needs `python3`, which was unavailable in this environment, so the snapshot table was updated by hand to the exact values the script would have written.)

## Validation
- `tools/sync-mobile-offline-seed.sh` (diff-only) now reports **up to date** with upstream (sha `3420275023fa3cee45b1a4517ee1ac5cc74e9a55`).
- Staged blob SHA equals the upstream blob SHA exactly (`git ls-files -s`), so the scheduled drift check will pass.
- Test-relevant identifiers preserved in the new seed: `mobile_offline_demo` service, scene `downtown-honolulu`, layers `68910`/`68920`.

Closes #268