### PR TITLE
fix(field-sync): close three offline-sync data-loss bugs (#303, #304, #305)

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Models/CoreModels.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Models/CoreModels.cs
@@ -19,6 +19,15 @@ public class Feature
     public DateTime? ModifiedAt { get; set; }
     public DateTime? UpdatedAt { get; set; }
     public long Version { get; set; } = 1;
+
+    /// <summary>
+    /// The server <see cref="Version"/> this local row was last reconciled against
+    /// (the "base" the local edit, if any, was made on top of). When the local row
+    /// has uncommitted edits, <see cref="Version"/> is advanced past
+    /// <see cref="BaseVersion"/>; the difference is what marks the row dirty and is
+    /// used to detect genuine concurrent edits during pull.
+    /// </summary>
+    public long BaseVersion { get; set; }
     public string? CreatedBy { get; set; }
     public string? UpdatedBy { get; set; }
     public bool IsPendingSync { get; set; }

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
@@ -387,6 +387,10 @@ public class GeoPackageStorageService : IDisposable
         await _dbLock.WaitAsync();
         try
         {
+            // Stamp a durable client-generated GlobalID at capture time so a retried
+            // Insert (after a lost upload ack) can be deduped against the server feature
+            // instead of creating a duplicate (#305).
+            EnsureGlobalId(feature);
             return await SaveFeatureAsync(feature, StorageSyncStatus.PendingUpload, trackChange: true, ChangeOperation.Insert);
         }
         finally
@@ -547,6 +551,30 @@ public class GeoPackageStorageService : IDisposable
         {
             _dbLock.Release();
         }
+    }
+
+    /// <summary>
+    /// Attribute carrying the durable client-generated idempotency token used to dedupe
+    /// retried Inserts against server features (#305).
+    /// </summary>
+    internal const string GlobalIdAttribute = "globalid";
+
+    private static readonly string[] GlobalIdFieldCandidates =
+        ["globalid", "GlobalID", "GLOBALID", "global_id"];
+
+    private static void EnsureGlobalId(Feature feature)
+    {
+        foreach (var candidate in GlobalIdFieldCandidates)
+        {
+            if (feature.Attributes.TryGetValue(candidate, out var existing) &&
+                existing is not null &&
+                !string.IsNullOrWhiteSpace(existing.ToString()))
+            {
+                return;
+            }
+        }
+
+        feature.Attributes[GlobalIdAttribute] = Guid.NewGuid().ToString("N");
     }
 
     private async Task<string> SaveFeatureAsync(

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
@@ -574,6 +574,42 @@ public class GeoPackageStorageService : IDisposable
             feature.Version = 1;
         }
 
+        // Determine the version/base-version pair that gets persisted.
+        //
+        // Remote applies (trackChange == false) write the server's authoritative
+        // version as both the row Version and its ServerVersion "base" — the row is
+        // clean and reconciled to that base.
+        //
+        // Local edits (trackChange == true) must advance Version PAST the row's base
+        // so the dirty row is distinguishable from the last-synced server version.
+        // Without this, a pulled-then-edited row keeps the exact version it last
+        // synced at and the pull-side conflict guard is structurally dead (#303).
+        long baseVersion;
+        if (trackChange)
+        {
+            var existing = await _connection.Table<LocalFeature>()
+                .FirstOrDefaultAsync(f => f.Id == feature.Id && f.LayerId == feature.LayerId);
+
+            // The base is the server version we last reconciled this row against.
+            // Fall back to the existing row Version (legacy rows without a recorded
+            // base) and finally the incoming Version for brand-new inserts.
+            baseVersion = existing?.ServerVersion ?? existing?.Version ?? feature.Version;
+            if (baseVersion <= 0)
+            {
+                baseVersion = 1;
+            }
+
+            var previousVersion = existing?.Version ?? feature.Version;
+            feature.Version = Math.Max(previousVersion, baseVersion) + 1;
+        }
+        else
+        {
+            // Server-authoritative write: row reconciled to the incoming version.
+            baseVersion = feature.Version;
+        }
+
+        feature.BaseVersion = baseVersion;
+
         var geometry = ConvertToNtsGeometry(feature.Geometry);
         var localFeature = new LocalFeature
         {
@@ -585,6 +621,7 @@ public class GeoPackageStorageService : IDisposable
             CreatedAt = feature.CreatedAt,
             ModifiedAt = feature.ModifiedAt.Value,
             Version = feature.Version,
+            ServerVersion = baseVersion,
             SyncStatus = syncStatus
         };
 
@@ -1887,6 +1924,7 @@ public class GeoPackageStorageService : IDisposable
             ModifiedAt = localFeature.ModifiedAt,
             UpdatedAt = localFeature.ModifiedAt,
             Version = localFeature.Version,
+            BaseVersion = localFeature.ServerVersion ?? localFeature.Version,
             IsPendingSync = localFeature.SyncStatus == StorageSyncStatus.PendingUpload
         };
     }

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs
@@ -160,6 +160,16 @@ public sealed class HonuaFieldCollectionChangeUploader :
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
+    /// <summary>
+    /// Attribute that carries the client-generated idempotency token for an Insert.
+    /// Sent with the Add so the server persists it, and used to dedupe a retried Insert
+    /// after a lost ack so the same captured feature can never be double-created (#305).
+    /// </summary>
+    internal const string GlobalIdAttribute = "globalid";
+
+    private static readonly string[] GlobalIdFieldCandidates =
+        ["globalid", "GlobalID", "GLOBALID", "global_id"];
+
     private readonly GeoPackageStorageService _storage;
     private readonly IFieldCollectionMetadataService _metadataService;
     private readonly IFieldCollectionFeatureSyncClient _featureClient;
@@ -209,6 +219,16 @@ public sealed class HonuaFieldCollectionChangeUploader :
                 if (localFeature == null)
                 {
                     return false;
+                }
+
+                // Idempotency guard (#305): an Insert resent after a lost ack must not
+                // create a server duplicate. Stamp a stable client-generated GlobalID and
+                // reconcile against any feature the server already created under it before
+                // re-adding.
+                await EnsureGlobalIdAsync(localFeature).ConfigureAwait(false);
+                if (await TryReconcileExistingInsertAsync(change, localFeature, serviceId, cancellationToken).ConfigureAwait(false))
+                {
+                    return true;
                 }
 
                 adds = [ToEditFeature(localFeature)];
@@ -297,6 +317,159 @@ public sealed class HonuaFieldCollectionChangeUploader :
         localFeature.Attributes["objectid"] = objectId;
         localFeature.Attributes["OBJECTID"] = objectId;
         await _storage.ApplyRemoteFeatureAsync(localFeature).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Ensures the feature carries a stable client-generated GlobalID. New captures are
+    /// stamped at storage time (<see cref="GeoPackageStorageService.StoreFeatureAsync"/>);
+    /// this is a defensive fallback for legacy rows that predate the durable token. When a
+    /// fallback token is minted it is persisted so it survives subsequent upload retries (#305).
+    /// </summary>
+    private async Task EnsureGlobalIdAsync(Feature feature)
+    {
+        if (!string.IsNullOrWhiteSpace(ReadGlobalId(feature)))
+        {
+            return;
+        }
+
+        feature.Attributes[GlobalIdAttribute] = Guid.NewGuid().ToString("N");
+
+        // Persist the token without re-queuing a change so retries reuse the same id.
+        await _storage.ApplyRemoteFeatureAsync(feature).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reconciles a pending Insert against a feature the server already created under the
+    /// same GlobalID (a prior attempt whose ack was lost). When found, stamps the server
+    /// OBJECTID locally and reports success so the Insert is NOT re-sent — preventing a
+    /// duplicate (#305). Returns false when no such server feature exists.
+    /// </summary>
+    private async Task<bool> TryReconcileExistingInsertAsync(
+        StorageChangeRecord change,
+        Feature localFeature,
+        string serviceId,
+        CancellationToken cancellationToken)
+    {
+        var globalId = ReadGlobalId(localFeature);
+        if (string.IsNullOrWhiteSpace(globalId))
+        {
+            return false;
+        }
+
+        // If the local row already has an OBJECTID the Insert clearly landed; nothing to do.
+        if (TryReadObjectId(localFeature, out _))
+        {
+            return false;
+        }
+
+        FeatureQueryResult result;
+        try
+        {
+            result = await _featureClient.QueryAsync(
+                new FeatureQueryRequest
+                {
+                    Source = new FeatureSource { ServiceId = serviceId, LayerId = change.LayerId },
+                    Filter = BuildGlobalIdFilter(globalId),
+                    OutFields = ["*"],
+                    ReturnGeometry = false
+                },
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // A failed reconcile query must not double-create: fall back to the normal
+            // add path only if it is safe. Here we cannot confirm the server state, so we
+            // surface the failure and leave the change pending for a later retry.
+            _logger?.LogWarning(
+                ex,
+                "Idempotency reconcile query failed for insert change {ChangeId}; leaving change pending",
+                change.Id);
+            throw;
+        }
+
+        var existing = result.Features.FirstOrDefault(record =>
+            string.Equals(ReadGlobalId(record), globalId, StringComparison.OrdinalIgnoreCase));
+        if (existing is null)
+        {
+            return false;
+        }
+
+        if (!TryResolveServerObjectId(existing, result.ObjectIdFieldName, out var objectId))
+        {
+            // Server has the feature but we cannot resolve its OBJECTID; do not re-add.
+            _logger?.LogWarning(
+                "Insert change {ChangeId} already exists on the server under GlobalID {GlobalId} but no object id could be resolved; leaving change pending",
+                change.Id,
+                globalId);
+            return false;
+        }
+
+        localFeature.Attributes["objectid"] = objectId;
+        localFeature.Attributes["OBJECTID"] = objectId;
+        await _storage.ApplyRemoteFeatureAsync(localFeature).ConfigureAwait(false);
+
+        _logger?.LogInformation(
+            "Reconciled retried insert change {ChangeId} to existing server feature {ObjectId} via GlobalID {GlobalId}",
+            change.Id,
+            objectId,
+            globalId);
+        return true;
+    }
+
+    private static string? ReadGlobalId(Feature feature)
+    {
+        foreach (var candidate in GlobalIdFieldCandidates)
+        {
+            if (feature.Attributes.TryGetValue(candidate, out var value) &&
+                value is not null &&
+                !string.IsNullOrWhiteSpace(value.ToString()))
+            {
+                return value.ToString();
+            }
+        }
+
+        return null;
+    }
+
+    private static string? ReadGlobalId(FeatureRecord record)
+    {
+        foreach (var candidate in GlobalIdFieldCandidates)
+        {
+            if (record.Attributes.TryGetValue(candidate, out var value))
+            {
+                var text = value.ValueKind == JsonValueKind.String ? value.GetString() : value.GetRawText();
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    return text.Trim('"');
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string BuildGlobalIdFilter(string globalId)
+    {
+        var escaped = globalId.Replace("'", "''", StringComparison.Ordinal);
+        return $"{GlobalIdAttribute} = '{escaped}'";
+    }
+
+    private static bool TryResolveServerObjectId(FeatureRecord record, string? objectIdFieldName, out long objectId)
+    {
+        objectId = 0;
+        IEnumerable<string> candidates = string.IsNullOrWhiteSpace(objectIdFieldName)
+            ? ["objectid", "OBJECTID", "FID"]
+            : [objectIdFieldName, "objectid", "OBJECTID", "FID"];
+
+        foreach (var fieldName in candidates)
+        {
+            if (record.Attributes.TryGetValue(fieldName, out var value) && TryConvertInt64(value, out objectId))
+            {
+                return true;
+            }
+        }
+
+        return long.TryParse(record.Id, NumberStyles.Integer, CultureInfo.InvariantCulture, out objectId);
     }
 
     private async Task StoreConflictAsync(

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs
@@ -573,7 +573,6 @@ public sealed class HonuaFieldCollectionChangePuller :
     private readonly IFieldCollectionFeatureSyncClient _featureClient;
     private readonly ISettingsService _settingsService;
     private readonly ILogger<HonuaFieldCollectionChangePuller>? _logger;
-    private long? _pendingObservedGeneration;
 
     public HonuaFieldCollectionChangePuller(
         IFieldCollectionMetadataService metadataService,
@@ -602,7 +601,6 @@ public sealed class HonuaFieldCollectionChangePuller :
 
         var layers = await _metadataService.GetLayersAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         var changes = new List<ServerChange>();
-        var maxGeneration = sinceGeneration;
 
         foreach (var layer in layers.Where(layer => layer.IsEditable))
         {
@@ -630,7 +628,6 @@ public sealed class HonuaFieldCollectionChangePuller :
                 feature.UpdatedAt = ResolveFeatureTimestamp(feature, record) ?? DateTime.UtcNow;
                 feature.ModifiedAt = feature.UpdatedAt;
 
-                maxGeneration = Math.Max(maxGeneration, feature.Version);
                 if (feature.Version <= sinceGeneration)
                 {
                     continue;
@@ -648,7 +645,6 @@ public sealed class HonuaFieldCollectionChangePuller :
             }
         }
 
-        _pendingObservedGeneration = Math.Max(_pendingObservedGeneration ?? sinceGeneration, maxGeneration);
         return changes;
     }
 
@@ -656,16 +652,22 @@ public sealed class HonuaFieldCollectionChangePuller :
     {
         cancellationToken.ThrowIfCancellationRequested();
         var cursorKey = await GetCursorKeyAsync(cancellationToken).ConfigureAwait(false);
-
-        if (_pendingObservedGeneration.HasValue)
-        {
-            var observed = _pendingObservedGeneration.Value;
-            await _settingsService.SetSettingAsync(cursorKey, observed).ConfigureAwait(false);
-            _pendingObservedGeneration = null;
-            return observed;
-        }
-
         return await _settingsService.GetSettingAsync<long>(cursorKey, 0L).ConfigureAwait(false);
+    }
+
+    public async Task CommitSyncedGenerationAsync(long generation, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var cursorKey = await GetCursorKeyAsync(cancellationToken).ConfigureAwait(false);
+
+        // The cursor must only ever move forward. Advancing to a generation that was
+        // actually applied (computed by the sync service) keeps un-applied/conflicted
+        // changes within the next pull window so they are re-downloaded (#304).
+        var current = await _settingsService.GetSettingAsync<long>(cursorKey, 0L).ConfigureAwait(false);
+        if (generation > current)
+        {
+            await _settingsService.SetSettingAsync(cursorKey, generation).ConfigureAwait(false);
+        }
     }
 
     public async Task<long> GetLastSyncedGenerationAsync(CancellationToken cancellationToken = default)
@@ -1408,5 +1410,12 @@ public sealed class LocalOnlyFieldCollectionChangePuller :
     {
         cancellationToken.ThrowIfCancellationRequested();
         return Task.FromResult(0L);
+    }
+
+    public Task CommitSyncedGenerationAsync(long generation, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        // Local-only pulls have no durable server cursor to advance.
+        return Task.CompletedTask;
     }
 }

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/GeoPackageSyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/GeoPackageSyncService.cs
@@ -34,6 +34,15 @@ public interface IFieldCollectionChangePuller
     Task<IReadOnlyList<ServerChange>> GetChangesAsync(long sinceGeneration, CancellationToken cancellationToken = default);
     Task<long> GetLatestServerGenerationAsync(CancellationToken cancellationToken = default);
     Task<long> GetLastSyncedGenerationAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Durably advances the pull watermark to <paramref name="generation"/>. The caller
+    /// passes only the highest generation whose change was actually applied so the cursor
+    /// never moves past an un-applied/conflicted change (otherwise that change would be
+    /// filtered out of the next pull and permanently skipped, #304). The cursor never
+    /// moves backwards.
+    /// </summary>
+    Task CommitSyncedGenerationAsync(long generation, CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -359,17 +368,38 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
                 session.LocalGeneration,
                 cancellationToken);
 
-            foreach (var serverChange in changesSinceLastSync)
+            // Advance the durable cursor only to the highest generation whose change was
+            // actually applied, and never past a gap left by an un-applied/conflicted
+            // change. Processing in ascending generation order lets us stop advancing the
+            // watermark at the first generation that does NOT fully apply, so that change
+            // (and anything after it) is re-downloaded on the next pull (#304).
+            var startGeneration = session.LocalGeneration;
+            var safeGeneration = startGeneration;
+            var watermarkSealed = false;
+
+            foreach (var serverChange in changesSinceLastSync.OrderBy(change => change.Version))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (await ApplyServerChangeAsync(serverChange, session))
+                var applied = await ApplyServerChangeAsync(serverChange, session);
+                if (applied)
                 {
                     session.ChangesPulled++;
+                    if (!watermarkSealed)
+                    {
+                        safeGeneration = Math.Max(safeGeneration, serverChange.Version);
+                    }
+                }
+                else
+                {
+                    // An un-applied (conflicted/skipped) change seals the watermark: we
+                    // must not advance past it or it will be filtered out next pull.
+                    watermarkSealed = true;
                 }
             }
 
-            session.ServerGeneration = await _changePuller.GetLatestServerGenerationAsync(cancellationToken);
+            await _changePuller.CommitSyncedGenerationAsync(safeGeneration, cancellationToken);
+            session.ServerGeneration = safeGeneration;
             return true;
         }
         catch (OperationCanceledException)
@@ -1110,6 +1140,12 @@ internal sealed class UnconfiguredFieldCollectionChangePuller :
     {
         throw new InvalidOperationException(
             "Field collection local sync generation lookup is not configured.");
+    }
+
+    public Task CommitSyncedGenerationAsync(long generation, CancellationToken cancellationToken = default)
+    {
+        // Unconfigured pulls never apply changes, so there is nothing to commit.
+        return Task.CompletedTask;
     }
 }
 

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/GeoPackageSyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/GeoPackageSyncService.cs
@@ -673,9 +673,10 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
             // Check for conflicts
             var localFeature = await _storage.GetFeatureAsync(serverChange.FeatureId, serverChange.LayerId);
 
-            if (localFeature != null && localFeature.Version > serverChange.Version)
+            if (localFeature != null && HasConflict(localFeature, serverChange))
             {
-                // Conflict detected - local is newer
+                // Conflict detected - the local row carries an uncommitted edit that
+                // would be silently overwritten by this server change.
                 await CreateConflictRecordAsync(serverChange, localFeature, session);
                 session.ConflictsDetected++;
                 return false;
@@ -694,6 +695,29 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
                 serverChange.LayerId);
             throw;
         }
+    }
+
+    /// <summary>
+    /// Determines whether a pulled server change conflicts with an uncommitted local
+    /// edit. A conflict exists when the local row has a pending (un-pushed) edit and
+    /// the server has advanced beyond the base version that edit was made on top of —
+    /// applying the change would silently clobber the captured local edit (#303).
+    /// Also retains the legacy "local row is strictly newer" guard for callers/tests
+    /// that stage a higher local Version directly.
+    /// </summary>
+    private static bool HasConflict(Feature localFeature, ServerChange serverChange)
+    {
+        var hasPendingLocalEdit = localFeature.IsPendingSync &&
+            localFeature.Version > localFeature.BaseVersion;
+
+        if (hasPendingLocalEdit && serverChange.Version > localFeature.BaseVersion)
+        {
+            return true;
+        }
+
+        // Legacy guard: the local row's own version is strictly newer than the
+        // incoming server version (e.g. a manually staged conflict).
+        return localFeature.Version > serverChange.Version;
     }
 
     private async Task ApplyResolvedServerChangeAsync(ServerChange serverChange)

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/LocalFieldConflictReplayHarness.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/LocalFieldConflictReplayHarness.cs
@@ -71,6 +71,7 @@ public sealed class LocalReplayFieldSyncPeer :
     public bool RejectUploads { get; set; }
     public AttachmentSyncResult PushAttachmentResult { get; set; } = new();
     public AttachmentSyncResult PullAttachmentResult { get; set; } = new();
+    public long? CommittedGeneration { get; private set; }
 
     public Task<bool> UploadChangeAsync(
         StorageChangeRecord change,
@@ -99,6 +100,13 @@ public sealed class LocalReplayFieldSyncPeer :
     {
         cancellationToken.ThrowIfCancellationRequested();
         return Task.FromResult(0L);
+    }
+
+    public Task CommitSyncedGenerationAsync(long generation, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        CommittedGeneration = generation;
+        return Task.CompletedTask;
     }
 
     public Task<AttachmentSyncResult> PushPendingAttachmentsAsync(CancellationToken cancellationToken = default)

--- a/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionAttachmentServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/FieldCollectionAttachmentServiceTests.cs
@@ -571,6 +571,11 @@ public sealed class FieldCollectionAttachmentServiceTests
         {
             return Task.FromResult(0L);
         }
+
+        public Task CommitSyncedGenerationAsync(long generation, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class FixedMetadataService : IFieldCollectionMetadataService

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -384,6 +384,53 @@ public sealed class GeoPackageSyncServiceTests
     }
 
     [Fact]
+    public async Task PullChangesAsync_WhenCommittedLocalEditExistsAtSameBaseVersion_StoresConflictAndKeepsLocalEdit()
+    {
+        // Regression for #303: a pulled-then-edited feature keeps the version it last
+        // synced at, so the legacy local.Version > server.Version guard was structurally
+        // dead. The committed local edit must surface as a conflict, not be overwritten.
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+
+        // Reconcile a feature to server base version 5, then make a committed local edit.
+        var serverBaseline = CreateFeature("asset-1", version: 5);
+        serverBaseline.Attributes["name"] = "server-v5";
+        await storage.ApplyRemoteFeatureAsync(serverBaseline);
+
+        var localEdit = await storage.GetFeatureAsync("asset-1", 1);
+        Assert.NotNull(localEdit);
+        localEdit.Attributes["name"] = "field-edit";
+        Assert.True(await storage.UpdateFeatureAsync(localEdit));
+
+        // Server advances to version 6 (another editor) for the same feature.
+        var serverChangeFeature = CreateFeature("asset-1", version: 6);
+        serverChangeFeature.Attributes["name"] = "server-v6";
+        var serverChange = new ServerChange
+        {
+            FeatureId = "asset-1",
+            LayerId = 1,
+            Operation = StorageChangeOperation.Update,
+            Version = 6,
+            Feature = serverChangeFeature
+        };
+        using var sync = CreateSyncService(storage, puller: new FixedPuller([serverChange]));
+
+        var result = await sync.PullChangesAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, result.ChangesPulled);
+        var conflict = Assert.Single(await sync.GetConflictsAsync());
+        Assert.Equal("asset-1", conflict.FeatureId);
+
+        // The committed local edit must NOT have been clobbered by the server values.
+        var stored = await storage.GetFeatureAsync("asset-1", 1);
+        Assert.NotNull(stored);
+        Assert.Equal("field-edit", stored.Attributes["name"]?.ToString());
+        Assert.True(stored.IsPendingSync);
+    }
+
+    [Fact]
     public void IsRemoteSyncConfigured_ReflectsDynamicTransportConfiguration()
     {
         var databasePath = CreateDatabasePath();
@@ -884,6 +931,8 @@ public sealed class GeoPackageSyncServiceTests
             _changes = changes;
         }
 
+        public long? CommittedGeneration { get; private set; }
+
         public Task<IReadOnlyList<ServerChange>> GetChangesAsync(
             long sinceGeneration,
             CancellationToken cancellationToken = default)
@@ -899,6 +948,12 @@ public sealed class GeoPackageSyncServiceTests
         public Task<long> GetLastSyncedGenerationAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult(0L);
+        }
+
+        public Task CommitSyncedGenerationAsync(long generation, CancellationToken cancellationToken = default)
+        {
+            CommittedGeneration = generation;
+            return Task.CompletedTask;
         }
     }
 
@@ -919,6 +974,11 @@ public sealed class GeoPackageSyncServiceTests
         public Task<long> GetLastSyncedGenerationAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult(0L);
+        }
+
+        public Task CommitSyncedGenerationAsync(long generation, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
         }
     }
 

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -480,6 +480,77 @@ public sealed class GeoPackageSyncServiceTests
     }
 
     [Fact]
+    public async Task PushChangesAsync_WhenInsertRetriedAfterLostAck_ReconcilesByGlobalIdWithoutDuplicate()
+    {
+        // Regression for #305: an Insert resent after a lost ack must not create a server
+        // duplicate. The retry queries by the durable GlobalID and reconciles to the
+        // already-created server feature instead of re-adding.
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var layer = CreateLayer();
+        await storage.CreateLayerAsync(layer);
+        await storage.StoreFeatureAsync(CreateFeature("asset-1", version: 1));
+
+        // The GlobalID stamped at capture time is what the server echoes back.
+        var stored = await storage.GetFeatureAsync("asset-1", 1);
+        Assert.NotNull(stored);
+        var globalId = stored.Attributes["globalid"]?.ToString();
+        Assert.False(string.IsNullOrWhiteSpace(globalId));
+
+        var metadata = new FixedMetadataService([layer]);
+        var client = new RecordingFeatureSyncClient
+        {
+            // The prior attempt already created OBJECTID 77 on the server under this GlobalID.
+            QueryResponse = new FeatureQueryResult
+            {
+                ProviderName = "test",
+                ObjectIdFieldName = "objectid",
+                Features =
+                [
+                    new FeatureRecord
+                    {
+                        Id = "77",
+                        Attributes = new Dictionary<string, JsonElement>
+                        {
+                            ["objectid"] = JsonSerializer.SerializeToElement(77),
+                            ["globalid"] = JsonSerializer.SerializeToElement(globalId)
+                        }
+                    }
+                ]
+            }
+        };
+        using var sync = CreateSyncService(
+            storage,
+            uploader: new HonuaFieldCollectionChangeUploader(storage, metadata, client));
+
+        var result = await sync.PushChangesAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(await storage.GetPendingChangesAsync());
+        // No Add was sent: the retry reconciled instead of re-creating.
+        Assert.Empty(client.EditRequests);
+        var reconciled = await storage.GetFeatureAsync("asset-1", 1);
+        Assert.NotNull(reconciled);
+        Assert.Equal("77", reconciled.Attributes["objectid"]?.ToString());
+    }
+
+    [Fact]
+    public async Task StoreFeatureAsync_StampsDurableGlobalIdOnInsert()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+
+        await storage.StoreFeatureAsync(CreateFeature("asset-1", version: 1));
+
+        var stored = await storage.GetFeatureAsync("asset-1", 1);
+        Assert.NotNull(stored);
+        Assert.True(stored.Attributes.TryGetValue("globalid", out var globalId));
+        Assert.False(string.IsNullOrWhiteSpace(globalId?.ToString()));
+    }
+
+    [Fact]
     public void IsRemoteSyncConfigured_ReflectsDynamicTransportConfiguration()
     {
         var databasePath = CreateDatabasePath();

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -431,6 +431,55 @@ public sealed class GeoPackageSyncServiceTests
     }
 
     [Fact]
+    public async Task PullChangesAsync_WhenEarlierChangeConflicts_DoesNotAdvanceCursorPastUnappliedChange()
+    {
+        // Regression for #304: the watermark must not advance to the max observed version
+        // when an earlier-version change was not applied, or that change is filtered out of
+        // the next pull and permanently skipped.
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+
+        // Local committed edit on asset-1 reconciled to base version 9.
+        var baseline = CreateFeature("asset-1", version: 9);
+        await storage.ApplyRemoteFeatureAsync(baseline);
+        var localEdit = await storage.GetFeatureAsync("asset-1", 1);
+        localEdit!.Attributes["name"] = "field-edit";
+        await storage.UpdateFeatureAsync(localEdit);
+
+        // Batch: asset-1 (v10) conflicts/skips; asset-2 (v12) applies cleanly.
+        var conflicting = CreateFeature("asset-1", version: 10);
+        var applied = CreateFeature("asset-2", version: 12);
+        var puller = new FixedPuller(
+        [
+            new ServerChange
+            {
+                FeatureId = "asset-1", LayerId = 1, Operation = StorageChangeOperation.Update,
+                Version = 10, Feature = conflicting
+            },
+            new ServerChange
+            {
+                FeatureId = "asset-2", LayerId = 1, Operation = StorageChangeOperation.Update,
+                Version = 12, Feature = applied
+            }
+        ]);
+        using var sync = CreateSyncService(storage, puller: puller);
+
+        var result = await sync.PullChangesAsync();
+
+        Assert.True(result.IsSuccess);
+        // asset-2 applied, asset-1 conflicted.
+        Assert.Equal(1, result.ChangesPulled);
+        Assert.Single(await sync.GetConflictsAsync());
+        // Cursor must stop BELOW the unapplied v10 change so it is re-downloaded next pull,
+        // never jumping to the max observed v12.
+        Assert.NotNull(puller.CommittedGeneration);
+        Assert.True(
+            puller.CommittedGeneration < 10,
+            $"Cursor advanced to {puller.CommittedGeneration}, past the unapplied v10 change.");
+    }
+
+    [Fact]
     public void IsRemoteSyncConfigured_ReflectsDynamicTransportConfiguration()
     {
         var databasePath = CreateDatabasePath();


### PR DESCRIPTION
Fixes three verified P1 offline-sync data-loss bugs in `apps/Honua.Mobile.FieldCollection.Core`, each with focused regression tests.

## #303 — pull silently clobbers a committed local edit
The only pull-side conflict guard, `local.Version > server.Version`, was structurally dead: a local edit never bumped `Version` (`SaveFeatureAsync` only set it when `<= 0`), so a pulled-then-edited row kept the version it last synced at and a pull-before-push overwrote the captured edit with server values, silently losing it.

- Track a per-row base (server) version using the existing unused `ServerVersion` column.
- Remote applies write the server version as both `Version` and the base; local edits advance `Version` past the base so a dirty row is distinguishable, surfaced as `Feature.BaseVersion`.
- The pull guard (`HasConflict`) now flags a conflict when a pending local edit exists and the server has advanced beyond the edit's base, creating a conflict record instead of clobbering the row. The legacy strictly-newer guard is retained.

## #304 — pull watermark advances to max observed version, skipping unapplied changes
`GetChangesAsync` took `maxGeneration` across all features and persisted it as the durable cursor regardless of per-change apply success. A conflicted/skipped change at a lower generation than a successfully applied one in the same batch was filtered out of the next pull and permanently skipped.

- The cursor is now driven by apply results, not observed versions: new `IFieldCollectionChangePuller.CommitSyncedGenerationAsync` (monotonic) and a pull loop that processes changes in ascending generation order, advancing a safe watermark only while each change applies and sealing it at the first un-applied/conflicted change.

## #305 — non-idempotent Insert → server duplicates
An Insert had no idempotency/dedupe key, so a retry after a lost ack re-created the feature on the server.

- A durable client-generated GlobalID is stamped on every captured feature at storage time and sent in the Add attributes.
- On retry the uploader queries the server by GlobalID and, when the feature already exists, reconciles the returned OBJECTID locally and marks the change synced instead of re-adding.

### Deferred / server dependency (#305)
The provider-neutral `FeatureEditFeature` contract in `honua-sdk-dotnet` has no first-class idempotency-token field, so dedupe is enforced **client-side** via query-by-GlobalID before re-add. A server-side upsert-by-GlobalID (or an idempotency-key field on the edit contract) would let the server reject duplicates directly and close the small window between the reconcile query and the add. No server-side change is made in this PR.

## Tests
Added focused regression tests for all three (committed-local-edit conflict, cursor-not-past-unapplied-change, insert-retry-reconciles-by-GlobalID, durable-GlobalID stamp). Full `Honua.Mobile.FieldCollection.Tests` suite: 133 passed, 0 failed.

Closes #303
Closes #304
Closes #305