### PR TITLE
docs: correct release claims (AR concept, IoT refs, stale test counts)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,6 @@ src/
   Honua.Mobile.Sdk/      Core mobile client: transport, auth, gRPC/REST, routing, scene adapter
   Honua.Mobile.Offline/  GeoPackage storage, sync queue, map-area download, conflict resolution
   Honua.Mobile.Maui/     MAUI DI registration, native display, location, scene anchoring
-  Honua.Mobile.IoT/      IoT sensor interfaces only — no implementation yet
   Honua.Embed/           @honua-io/embed web component package (TS/Vite); tests in tests/
 apps/
   Honua.Mobile.App/                 Reference MAUI application
@@ -139,10 +138,9 @@ NuGet.config             Package sources + source mapping (Honua.* -> github-hon
 - **Consume `Honua.Sdk.*` as versioned NuGet packages.** Do not copy SDK source
   or add long-lived `ProjectReference` links to `honua-sdk-dotnet`; temporary
   local references need an explicit removal issue.
-- `src/Honua.Mobile.IoT` is interface-only (no implementation yet).
 - CI builds core libraries with **warnings-as-errors** and enforces
   `dotnet format`; run format checks before pushing.
-- `Honua.Mobile.IoT`-style migration: files under `Honua.Mobile.Sdk` that are
+- SDK-migration candidates: files under `Honua.Mobile.Sdk` that are
   server API clients or plain models are migration input for the SDK, not new
   mobile-owned surface.
 - The `Live Server Integration` workflow is a hard gate on PRs and pushes to

--- a/README.md
+++ b/README.md
@@ -164,20 +164,19 @@ var terrainUrl = scene.TerrainUrl;
 ```
 src/
   Honua.Embed/                Embeddable map web component package
-    tests/                    Web component DOM behavior tests (17 tests)
+    tests/                    Web component DOM behavior tests
   Honua.Mobile.Sdk/           Core mobile client
   Honua.Mobile.Offline/       GeoPackage sync engine
   Honua.Mobile.Maui/          MAUI platform integration, native display, location, and scene anchoring
-  Honua.Mobile.IoT/           IoT sensor abstractions (interface-only, future)
 apps/
   Honua.Mobile.App/           Reference MAUI application
 tests/
-  Honua.Mobile.Sdk.Tests/     HTTP client, transport security, gRPC translation, routing, scenes (80 tests)
-  Honua.Mobile.FieldCollection.Tests/ FieldCollection auth, sync, storage, diagnostics (10 tests)
+  Honua.Mobile.Sdk.Tests/     HTTP client, transport security, gRPC translation, routing, scenes
+  Honua.Mobile.FieldCollection.Tests/ FieldCollection auth, sync, storage, diagnostics
   Honua.Mobile.ServerIntegration.Tests/ Loopback and opt-in live Honua image integration surface
-  Honua.Mobile.Offline.Tests/ Sync engine, conflicts, map download, GeoPackage (65 tests)
-  Honua.Mobile.Maui.Tests/    MAUI integration helpers, map annotations, native display, location, scene anchoring (40 tests)
-  Honua.Mobile.Smoke.Tests/   End-to-end smoke paths and optional live Honua query (7 tests)
+  Honua.Mobile.Offline.Tests/ Sync engine, conflicts, map download, GeoPackage
+  Honua.Mobile.Maui.Tests/    MAUI integration helpers, map annotations, native display, location, scene anchoring
+  Honua.Mobile.Smoke.Tests/   End-to-end smoke paths and optional live Honua query
 proto/
   honua/v1/                   gRPC protocol definitions
 ```
@@ -249,9 +248,6 @@ for scope, triggers, and the seed-SQL gap.
 Production-ready foundation for offline sync, forms, and gRPC transport.
 .NET test coverage across SDK, Field, FieldCollection, server integration,
 Offline, MAUI, and Smoke projects, plus DOM tests for the embeddable map package.
-
-The IoT module (`Honua.Mobile.IoT`) contains interface definitions only --
-no implementation yet.
 
 ## Documentation
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -10,7 +10,7 @@ This repository owns mobile SDK packages, MAUI integration, offline field workfl
 - `Honua.Mobile.Offline`: GeoPackage storage, sync queue, pull/push sync, conflicts, map area download, delta cursors, TTL/cache governance, and R-tree bbox lookup.
 - `Honua.Mobile.Maui`: DI registration, native display boundaries, map annotations, secure auth token storage, device location, background location, and geofencing contracts.
 - `@honua/embed`: framework-agnostic `<honua-map>` and `<honua-scene>` components with display adapters, scene package caching, snippets, and DOM behavior tests.
-- Reference MAUI applications, field collection example, embed example, scene example, AR utility visualization example, and field collector template.
+- Reference MAUI applications, field collection example, embed example, scene example, and field collector template.
 - Integration and smoke tests for loopback server paths, offline sync, no-cloud field-day acceptance, local package import/download, MAUI helpers, embed components, and optional live Honua query.
 
 ## Source Evidence

--- a/examples/ar-utility-visualization/README.md
+++ b/examples/ar-utility-visualization/README.md
@@ -1,448 +1,48 @@
-# AR Utility Visualization - Revolutionary Infrastructure Experience
+# AR Utility Visualization (Concept)
 
-**World's first AR-powered underground utility visualization for field workers**
+> **Status: forward-looking concept — not implemented.**
+> This document describes a *proposed* augmented-reality experience for visualizing
+> underground utilities on top of Honua feature data. There is **no application
+> code, no SDK, and no installable package** behind it yet. Everything below is a
+> design sketch for discussion, not shipped functionality. Do not cite it as an
+> available capability.
 
-Transform how utility workers, inspectors, and field technicians interact with underground infrastructure by overlaying digital utility data onto real-world camera feeds using cutting-edge AR technology.
+## Idea
 
-## 🚀 Revolutionary Features
+Overlay digital utility data (water, gas, electric, telecom, sewer) onto a live
+camera feed so field workers can see the approximate position and depth of
+underground infrastructure before excavating. The concept would build on Honua's
+existing feature-query and offline capabilities.
 
-### **🥽 Augmented Reality Visualization**
-- **See-through vision** for underground utilities
-- **Real-time 3D rendering** of pipes, cables, and infrastructure
-- **Depth-based visualization** with accurate underground positioning
-- **Cross-platform AR** using ARKit (iOS) and ARCore (Android)
+## Why it is a concept and not an example
 
-### **🔍 Intelligent Utility Detection**
-- **Automatic utility loading** based on GPS location
-- **Spatial filtering** for performance optimization
-- **Multi-utility support** (water, gas, electric, telecom, sewer)
-- **Status-based visualization** (active, needs repair, inspection required)
+The earlier version of this file advertised a complete, shippable application —
+with install steps, a `@honua/react-native-sdk` import, and external links — none
+of which exist. To avoid misleading readers, the marketing content and fabricated
+code samples were removed. This file is intentionally short until a real prototype
+lands.
 
-### **📱 Professional Field Tools**
-- **AR photography** with utility overlays for documentation
-- **Precise measurements** using AR depth sensing
-- **Interactive utility information** with tap-to-select
-- **Offline AR capability** with cached utility data
+## What would be required to build it
 
-### **⚡ High-Performance Architecture**
-- **gRPC streaming** for efficient utility data loading
-- **Spatial indexing** for sub-second utility queries
-- **Adaptive rendering** based on device capabilities
-- **Battery-optimized** AR session management
+- A React Native (or MAUI) host app with ARKit (iOS) / ARCore (Android) integration.
+- A published mobile SDK surface for AR rendering (does not exist today).
+- Spatial queries against a Honua FeatureServer to load utilities near the device,
+  using the gRPC-first transport already provided by `Honua.Mobile.Sdk`.
+- A coordinate-alignment step mapping WGS84 GPS positions into local AR space.
 
-## 🎯 Use Cases
+## Open questions
 
-### **Utility Inspection & Maintenance**
-- **Locate utilities** without digging or ground-penetrating radar
-- **Verify utility depths** and positions before excavation
-- **Document utility conditions** with AR-enhanced photos
-- **Plan maintenance routes** with 3D utility visualization
+- Positional accuracy: AR anchoring on consumer GPS is typically only metre-level;
+  utility-strike prevention needs survey-grade corrections (RTK) to be safe.
+- Occlusion and depth rendering fidelity across device tiers.
+- Offline caching and data-freshness guarantees for safety-critical use.
 
-### **Construction & Excavation Safety**
-- **Prevent utility strikes** with real-time underground visualization
-- **Verify clearances** before digging operations
-- **Coordinate with multiple utilities** in congested areas
-- **Emergency response** for utility damage assessment
+## Contributing
 
-### **Asset Management & Documentation**
-- **Inventory underground assets** with precise positioning
-- **Update utility records** with AR-verified locations
-- **Training new workers** with immersive AR experience
-- **Quality assurance** for new utility installations
+If you want to prototype this, start a discussion in the repository's issues
+before writing code, so the SDK surface and accuracy requirements can be agreed
+up front.
 
-## 📦 Installation & Setup
+## License
 
-### **Prerequisites**
-- iOS 12.0+ with ARKit support OR Android 7.0+ with ARCore support
-- Device with rear camera and motion sensors
-- GPS capability for location-based utility loading
-- Network connectivity for utility data synchronization
-
-### **Quick Start**
-
-```bash
-# Clone and setup
-git clone https://github.com/honua-org/honua-server.git
-cd examples/mobile/ar-utility-visualization
-npm install
-
-# iOS setup
-cd ios && pod install && cd ..
-
-# Run the app
-npm run ios     # iOS
-npm run android # Android
-```
-
-### **Configuration**
-
-Edit `src/config/ar-config.ts`:
-
-```typescript
-export const arConfig = {
-  honua: {
-    serverUrl: 'https://your-honua-server.com',
-    apiKey: 'your-api-key',
-    utilityServiceId: 'utilities',
-    utilityLayerId: 0
-  },
-  ar: {
-    maxRenderDistance: 100,      // meters
-    enableDepthVisualization: true,
-    renderingQuality: 'high',
-    autoLoadRadius: 50,          // meters
-    enableOcclusion: true,
-    showUtilityLabels: true
-  }
-};
-```
-
-## 🎮 How to Use
-
-### **1. Initialize AR Session**
-
-```typescript
-import { UtilityARView } from '@honua/react-native-sdk';
-
-function ARUtilityScreen() {
-  const [selectedUtility, setSelectedUtility] = useState(null);
-
-  return (
-    <UtilityARView
-      serviceId="utilities"
-      layerId={0}
-      onUtilitySelected={setSelectedUtility}
-      maxRenderDistance={100}
-      enableDepthVisualization
-      style={{ flex: 1 }}
-    >
-      {selectedUtility && (
-        <UtilityDetailsOverlay utility={selectedUtility} />
-      )}
-    </UtilityARView>
-  );
-}
-```
-
-### **2. Basic AR Controls**
-
-- **👀 Look Around**: Move device to see utilities in different directions
-- **📍 Tap Utilities**: Tap on virtual utilities to see detailed information
-- **🔄 Refresh Data**: Pull down or tap refresh to reload utility data
-- **📸 Capture AR**: Take photos with utility overlays for documentation
-- **⚙️ Filter Types**: Toggle visibility of different utility types
-
-### **3. Advanced Features**
-
-```typescript
-// Custom AR configuration
-const customConfig = {
-  utilityTypes: [UtilityType.Water, UtilityType.Gas], // Show only specific types
-  depthRange: { min: 0.5, max: 5.0 },                // Limit depth visualization
-  statusFilters: [UtilityStatus.NeedsRepair],        // Highlight problem utilities
-  enableCollision: true,                             // Prevent utility overlap
-  renderingQuality: 'high'                           // Maximum visual quality
-};
-
-// Load utilities in custom area
-const loadCustomArea = async () => {
-  const extent = {
-    minLatitude: 37.7749,
-    maxLatitude: 37.7849,
-    minLongitude: -122.4294,
-    maxLongitude: -122.4094,
-    bufferMeters: 25
-  };
-
-  await arService.loadUtilityDataAsync('utilities', 0, extent);
-};
-```
-
-## 🏗️ Application Architecture
-
-### **Core Components**
-
-```
-AR Utility Visualization
-├── UtilityARView.tsx          # Main AR component
-├── ARUtilityService.ts        # AR session management
-├── UtilityDataManager.ts      # Spatial data loading
-├── ARRenderingEngine.ts       # 3D visualization
-└── UtilityInteractionHandler.ts # Gesture and tap handling
-```
-
-### **AR Rendering Pipeline**
-
-```
-GPS Location → Spatial Query → Utility Loading → 3D Conversion → AR Rendering
-     ↓              ↓             ↓              ↓             ↓
-  [Location]   [GeoJSON]    [Utility Models]  [3D Meshes]  [AR Scene]
-     ↓              ↓             ↓              ↓             ↓
-Geolocation → HonuaClient → UtilityConverter → ARRenderer → Camera View
-```
-
-### **Data Flow**
-
-1. **Location Detection**: GPS provides current field position
-2. **Spatial Query**: Query utilities within AR view radius via gRPC
-3. **Data Processing**: Convert GeoJSON features to 3D utility models
-4. **AR Rendering**: Display utilities as 3D objects in camera view
-5. **User Interaction**: Handle taps, gestures, and utility selection
-6. **Information Display**: Show utility details and status overlays
-
-## 🎨 Utility Visualization Styles
-
-### **Color Coding by Utility Type**
-```typescript
-const utilityColors = {
-  [UtilityType.Water]: '#2196F3',        // Blue
-  [UtilityType.Gas]: '#FFEB3B',          // Yellow
-  [UtilityType.Electric]: '#F44336',     // Red
-  [UtilityType.Telecommunications]: '#4CAF50', // Green
-  [UtilityType.Sewer]: '#795548',        // Brown
-  [UtilityType.FiberOptic]: '#9C27B0',   // Purple
-  [UtilityType.Steam]: '#FF9800',        // Orange
-};
-```
-
-### **Status-Based Effects**
-- **🟢 Active**: Standard visualization with utility type color
-- **🟡 Needs Inspection**: Pulsing yellow glow effect
-- **🔴 Needs Repair**: Bright red emission with alert icon
-- **⚪ Inactive**: Faded/transparent with reduced opacity
-- **🏗️ Under Construction**: Animated construction pattern
-
-### **Depth Visualization**
-- **Shallow (0-1m)**: Full opacity, bright colors
-- **Medium (1-3m)**: 70% opacity, slightly muted colors
-- **Deep (3m+)**: 50% opacity, darker tones
-- **X-Ray Mode**: See-through visualization for occluded utilities
-
-## 📊 Performance Optimization
-
-### **Spatial Culling**
-```typescript
-// Only render utilities within view frustum
-const cullUtilities = (utilities: UtilityLine[], cameraFrustum: Frustum) => {
-  return utilities.filter(utility =>
-    utility.path.some(point => cameraFrustum.containsPoint(point))
-  );
-};
-```
-
-### **Level of Detail (LOD)**
-```typescript
-// Reduce detail for distant utilities
-const calculateLOD = (distance: number) => {
-  if (distance < 10) return 'high';    // Detailed pipes with textures
-  if (distance < 50) return 'medium';  // Simple cylinders
-  return 'low';                        // Basic lines
-};
-```
-
-### **Adaptive Rendering**
-- **High-end devices**: Realistic pipe models with textures and lighting
-- **Mid-range devices**: Simplified geometry with solid colors
-- **Lower-end devices**: Basic line rendering with utility markers
-
-## 🔧 Advanced Configuration
-
-### **AR Session Settings**
-```typescript
-const arConfiguration = {
-  // Tracking configuration
-  worldAlignment: 'gravityAndHeading',  // Use GPS heading for alignment
-  planeDetection: 'horizontal',         // Detect ground planes
-  lightEstimation: true,                // Realistic lighting
-
-  // Rendering settings
-  preferredFramesPerSecond: 60,         // Smooth AR experience
-  renderingQuality: 'high',             // Maximum visual quality
-  enableOcclusion: true,                // Hide utilities behind objects
-
-  // Performance tuning
-  maxSimultaneousUtilities: 100,        // Limit for performance
-  cullingDistance: 100,                 // Meters beyond which utilities are hidden
-  updateFrequency: 30                   // Hz for utility position updates
-};
-```
-
-### **Coordinate System Alignment**
-```typescript
-// Convert between coordinate systems
-const alignUtilityCoordinates = async (gpsLocation: Location) => {
-  // Convert WGS84 GPS to local AR coordinates
-  const localOrigin = await arSession.getCurrentCameraPose();
-
-  return utilities.map(utility => ({
-    ...utility,
-    path: utility.path.map(point =>
-      convertGPSToARCoordinates(point, gpsLocation, localOrigin)
-    )
-  }));
-};
-```
-
-### **Precision Modes**
-- **Survey Grade**: Sub-meter accuracy using RTK GPS corrections
-- **Standard**: Standard GPS accuracy (2-5 meters)
-- **Approximate**: Network-based location for general visualization
-
-## 📸 AR Documentation Features
-
-### **AR Photography**
-```typescript
-// Capture AR scene with utility overlays
-const captureARDocumentation = async () => {
-  const arImage = await utilityARView.captureARImage();
-
-  // Add metadata overlay
-  const documentedImage = await addMetadataOverlay(arImage, {
-    timestamp: new Date(),
-    gpsLocation: await getCurrentLocation(),
-    visibleUtilities: getVisibleUtilities(),
-    cameraSettings: getCameraConfiguration()
-  });
-
-  // Save for inspection reports
-  await saveToPhotoLibrary(documentedImage);
-};
-```
-
-### **Measurement Tools**
-```typescript
-// Measure distances in AR
-const measureUtilityDistance = async (startPoint: Vector3, endPoint: Vector3) => {
-  const distance = Vector3.distance(startPoint, endPoint);
-
-  // Display measurement overlay
-  return {
-    distance,
-    accuracy: estimateAccuracy(startPoint, endPoint),
-    units: 'meters'
-  };
-};
-```
-
-## 🧪 Testing & Validation
-
-### **AR Tracking Quality**
-```typescript
-// Monitor AR tracking performance
-const trackingQuality = {
-  'NotAvailable': 'AR not supported',
-  'Limited': 'Poor lighting or motion',
-  'Normal': 'Good tracking quality'
-};
-
-const handleTrackingChange = (state: ARTrackingState) => {
-  if (state === 'Limited') {
-    showTrackingGuidance();  // Guide user to improve conditions
-  }
-};
-```
-
-### **Utility Accuracy Validation**
-- **GPS Verification**: Compare AR positions with known survey points
-- **Ground Truth**: Physical utility location verification
-- **Cross-Reference**: Validate against multiple utility databases
-- **Precision Metrics**: Track accuracy statistics over time
-
-## 🔒 Security & Privacy
-
-### **Data Protection**
-- **Encrypted transmission** of utility data via gRPC TLS
-- **Local AR processing** - no camera data sent to servers
-- **Utility data caching** with automatic expiration
-- **Access controls** for sensitive infrastructure data
-
-### **Permission Management**
-```typescript
-// Required device permissions
-const requiredPermissions = {
-  camera: 'AR visualization',
-  location: 'Utility data loading',
-  storage: 'AR image capture',
-  motion: 'Device tracking'
-};
-
-// Check permissions before AR session
-const validatePermissions = async () => {
-  const cameraPermission = await checkPermission('camera');
-  const locationPermission = await checkPermission('location');
-
-  if (!cameraPermission || !locationPermission) {
-    throw new Error('Required permissions not granted');
-  }
-};
-```
-
-## 🌟 Benefits & Impact
-
-### **Field Worker Productivity**
-- **50% reduction** in time to locate utilities
-- **90% reduction** in accidental utility strikes
-- **Instant access** to utility information without paperwork
-- **Enhanced safety** through better situational awareness
-
-### **Cost Savings**
-- **Eliminate expensive** ground-penetrating radar surveys
-- **Reduce excavation** damage repair costs
-- **Minimize service** disruptions from utility strikes
-- **Accelerate project** completion timelines
-
-### **Accuracy Improvements**
-- **Meter-level precision** for utility positioning
-- **Real-time validation** of utility database records
-- **Continuous updates** from field verification
-- **3D spatial understanding** vs traditional 2D maps
-
-## 📈 Future Roadmap
-
-### **Enhanced Visualization**
-- **Volumetric rendering** for complex utility networks
-- **Thermal overlay** integration for pipe condition assessment
-- **Flow visualization** for active utilities
-- **Multi-layer infrastructure** (utilities at different depths)
-
-### **AI-Powered Features**
-- **Automatic utility detection** from camera imagery
-- **Predictive maintenance** alerts based on utility condition
-- **Intelligent routing** for excavation planning
-- **Anomaly detection** for unauthorized utility changes
-
-### **Extended Platform Support**
-- **HoloLens integration** for hands-free operation
-- **Magic Leap support** for enterprise AR workflows
-- **Web AR** for browser-based utility visualization
-- **Drone AR** for aerial utility inspection
-
-## 🤝 Contributing
-
-We welcome contributions to advance AR utility visualization:
-
-- **AR Rendering** improvements and optimizations
-- **Utility data** format converters and integrators
-- **Device support** for new AR platforms
-- **Accuracy testing** and validation tools
-
-## 📄 License
-
-This example is licensed under [Apache License 2.0](LICENSE) - **Fully Open Source**
-
----
-
-## 🎯 Transform Your Field Operations Today
-
-**Ready to revolutionize how your team works with underground infrastructure?**
-
-This AR utility visualization system represents the future of field work - where digital infrastructure data seamlessly integrates with the physical world through cutting-edge augmented reality.
-
-**Key Advantages:**
-- ✅ **No vendor lock-in** - fully open source implementation
-- ✅ **Enterprise ready** - proven gRPC architecture
-- ✅ **Cross-platform** - iOS and Android support
-- ✅ **Standards compliant** - OGC/OpenGeospatial compatibility
-- ✅ **Performance optimized** - 60fps AR with large datasets
-
-[📚 Read Documentation](https://docs.honua.com/ar-visualization) • [💬 Join Community](https://github.com/honua-org/community) • [🎯 Schedule Demo](https://honua.com/demo)
+This repository is licensed under the [Apache License 2.0](../../LICENSE).


### PR DESCRIPTION
## Summary

Reconciles public-facing docs with what actually ships, per the release audit (#316).

- **AR utility-visualization example → concept.** The README advertised a complete,
  shippable application with install steps, a non-existent `@honua/react-native-sdk`
  import, wrong repo URLs (`honua-org/*`), and dead external links — none backed by
  any code. It is relabelled as a clearly-marked forward-looking **concept**, the
  fabricated install/usage/marketing content is removed, and the LICENSE link now
  points at the repo-root `LICENSE`.
- **Removed from "Current Capabilities".** `docs/features/README.md` no longer lists
  the AR example as a shipped capability.
- **`Honua.Mobile.IoT` references removed.** No such project exists in the tree, so
  the module is dropped from `README.md` and `AGENTS.md` (the migration note is
  reworded to not reference it).
- **Stale exact test counts removed** from the README repository-structure listing
  so they can no longer drift from reality.

## Scope / not included

This PR addresses the AR-example, IoT-reference, and stale-test-count items of #316.
It does **not** address the other items in that issue:

- Commit/PR **no-AI-attribution enforcement** and the decision on scrubbing existing
  history — that is a governance/history-rewrite decision for the repo owner.
- Applying a uniform **Apache-2.0 license header** policy across all `src/` library
  sources — a separate, mechanical policy change.

`Refs #316` (intentionally not `Closes`, since the items above remain).

## Testing

Docs-only change; no code paths affected.
