### PR TITLE
fix: harden auth token handling and tighten the live-server CI gate

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Services/IAuthenticationService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/IAuthenticationService.cs
@@ -179,11 +179,14 @@ public class AuthenticationService : IAuthenticationService
         "/api/health"
     };
 
+    // API-key validation probes only authenticated endpoints that reject a bad key
+    // with 401/403. The unauthenticated health endpoints are intentionally excluded:
+    // they return 200 regardless of the key, so treating that as success would let a
+    // bogus key falsely validate.
     private static readonly string[] AuthenticatedValidationPaths =
     {
         "/api/scenes?f=json",
-        "/rest/services?f=json",
-        "/health"
+        "/rest/services?f=json"
     };
 
     private static readonly string[] TokenEndpointPaths =

--- a/src/Honua.Mobile.Offline/Sync/OfflineSyncEngine.cs
+++ b/src/Honua.Mobile.Offline/Sync/OfflineSyncEngine.cs
@@ -168,6 +168,12 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
         switch (strategy)
         {
             case SyncConflictStrategy.ServerWins:
+                // ServerWins is intentionally discard-only: the local pending edit is
+                // dropped (marked succeeded so it is no longer retried) and the server's
+                // existing value is left authoritative. This engine does not re-pull and
+                // overwrite the local feature here; callers that need the local store to
+                // reflect the server value must run a delta/replica download afterwards.
+                // See OfflineSyncEngineTests.SyncAsync_ServerWins_DiscardsLocalEditWithoutReUpload.
                 await _store.MarkSucceededAsync(operation.OperationId, ct).ConfigureAwait(false);
                 return ConflictResolutionState.ResolvedState;
 

--- a/src/Honua.Mobile.Sdk/Auth/RefreshingAuthTokenProvider.cs
+++ b/src/Honua.Mobile.Sdk/Auth/RefreshingAuthTokenProvider.cs
@@ -35,6 +35,16 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
     private readonly HttpClient _http;
     private readonly RefreshingAuthTokenProviderOptions _options;
 
+    // Serializes refreshes and cache updates so concurrent callers coalesce onto a
+    // single refresh instead of racing the token store (critical with rotating /
+    // single-use refresh tokens). Also guards the in-memory cache below.
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    // In-memory copy of the persisted token so the secure keystore is read once at
+    // startup and only on a cache miss or rotation, rather than on every request.
+    private HonuaAuthToken? _cached;
+    private bool _cacheLoaded;
+
     /// <summary>
     /// Initializes a new <see cref="RefreshingAuthTokenProvider"/>.
     /// </summary>
@@ -56,19 +66,38 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
     {
         try
         {
-            var token = await _store.ReadAsync(ct).ConfigureAwait(false);
-            if (token is null)
+            // Fast path: serve a still-valid cached token without touching the
+            // keystore or taking the lock.
+            var cached = Volatile.Read(ref _cached);
+            if (_cacheLoaded &&
+                cached is not null &&
+                !cached.ShouldRefresh(_options.TimeProvider.GetUtcNow(), _options.RefreshSkew))
             {
-                return null;
+                return cached;
             }
 
-            var now = _options.TimeProvider.GetUtcNow();
-            if (!token.ShouldRefresh(now, _options.RefreshSkew))
+            await _gate.WaitAsync(ct).ConfigureAwait(false);
+            try
             {
-                return token;
-            }
+                var token = await LoadCachedTokenLockedAsync(ct).ConfigureAwait(false);
+                if (token is null)
+                {
+                    return null;
+                }
 
-            return await RefreshTokenAsync(ct).ConfigureAwait(false);
+                // Re-check under the lock: a concurrent caller may have refreshed
+                // while we waited, so we avoid a redundant network round-trip.
+                if (!token.ShouldRefresh(_options.TimeProvider.GetUtcNow(), _options.RefreshSkew))
+                {
+                    return token;
+                }
+
+                return await RefreshLockedAsync(ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                _gate.Release();
+            }
         }
         catch (HonuaMobileAuthException)
         {
@@ -87,11 +116,27 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
     /// <inheritdoc />
     public async ValueTask<HonuaAuthToken?> RefreshTokenAsync(CancellationToken ct = default)
     {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            return await RefreshLockedAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    // Performs the refresh while holding <see cref="_gate"/>. Re-reads the current
+    // token from the cache/store inside the lock so a coalesced caller always
+    // refreshes with the latest (possibly already-rotated) refresh token.
+    private async ValueTask<HonuaAuthToken?> RefreshLockedAsync(CancellationToken ct)
+    {
         using var activity = MobileAuthTelemetry.ActivitySource.StartActivity("honua.mobile.auth.refresh", ActivityKind.Client);
 
         try
         {
-            var current = await _store.ReadAsync(ct).ConfigureAwait(false);
+            var current = await LoadCachedTokenLockedAsync(ct).ConfigureAwait(false);
             activity?.SetTag("auth.scheme", current?.Scheme.ToString().ToLowerInvariant() ?? "none");
 
             if (current is null ||
@@ -125,6 +170,8 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
                 ct).ConfigureAwait(false);
             var refreshed = ParseRefreshResponse(payload, current, _options.TimeProvider.GetUtcNow());
             await _store.WriteAsync(refreshed, ct).ConfigureAwait(false);
+            _cached = refreshed;
+            _cacheLoaded = true;
 
             MobileAuthTelemetry.RecordTokenRefresh("success");
             activity?.SetTag("auth.refresh.result", "success");
@@ -156,7 +203,17 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
 
         try
         {
-            await _store.WriteAsync(token, ct).ConfigureAwait(false);
+            await _gate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                await _store.WriteAsync(token, ct).ConfigureAwait(false);
+                _cached = token;
+                _cacheLoaded = true;
+            }
+            finally
+            {
+                _gate.Release();
+            }
         }
         catch (OperationCanceledException)
         {
@@ -173,7 +230,17 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
     {
         try
         {
-            await _store.ClearAsync(ct).ConfigureAwait(false);
+            await _gate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                await _store.ClearAsync(ct).ConfigureAwait(false);
+                _cached = null;
+                _cacheLoaded = true;
+            }
+            finally
+            {
+                _gate.Release();
+            }
         }
         catch (OperationCanceledException)
         {
@@ -183,6 +250,20 @@ public sealed class RefreshingAuthTokenProvider : IAuthTokenProvider
         {
             throw new HonuaMobileAuthException("Honua auth token clearing failed.", ex);
         }
+    }
+
+    // Returns the in-memory token, loading it from the secure store exactly once on
+    // first use. Must be called while holding <see cref="_gate"/>.
+    private async ValueTask<HonuaAuthToken?> LoadCachedTokenLockedAsync(CancellationToken ct)
+    {
+        if (_cacheLoaded)
+        {
+            return _cached;
+        }
+
+        _cached = await _store.ReadAsync(ct).ConfigureAwait(false);
+        _cacheLoaded = true;
+        return _cached;
     }
 
     private static HonuaAuthToken ParseRefreshResponse(

--- a/tests/Honua.Mobile.FieldCollection.Tests/AuthenticationServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/AuthenticationServiceTests.cs
@@ -45,6 +45,28 @@ public sealed class AuthenticationServiceTests
     }
 
     [Fact]
+    public async Task ValidateConnection_WithApiKey_DoesNotFalselySucceedViaHealthEndpoint()
+    {
+        var requestedPaths = new List<string>();
+        using var http = new HttpClient(new StubHttpMessageHandler(request =>
+        {
+            requestedPaths.Add(request.RequestUri!.AbsolutePath);
+
+            // Authenticated endpoints are absent; only the unauthenticated health
+            // endpoint answers 200. A bogus key must not validate against it.
+            return request.RequestUri!.AbsolutePath == "/health"
+                ? new HttpResponseMessage(HttpStatusCode.OK)
+                : new HttpResponseMessage(HttpStatusCode.NotFound);
+        }));
+        var service = new AuthenticationService(http);
+
+        var isValid = await service.ValidateConnectionAsync("https://api.honua.test", "bogus-key");
+
+        Assert.False(isValid);
+        Assert.DoesNotContain("/health", requestedPaths);
+    }
+
+    [Fact]
     public async Task ValidateConnection_WithoutApiKey_AllowsPublicHealthEndpoint()
     {
         using var http = new HttpClient(new StubHttpMessageHandler(request =>

--- a/tests/Honua.Mobile.Offline.Tests/OfflineSyncEngineTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/OfflineSyncEngineTests.cs
@@ -151,6 +151,34 @@ public sealed class OfflineSyncEngineTests : IDisposable
     }
 
     [Fact]
+    public async Task SyncAsync_ServerWins_DiscardsLocalEditWithoutReUpload()
+    {
+        // ServerWins is intentionally discard-only: the conflicting local edit is
+        // dropped (marked succeeded) and the server value stays authoritative. The
+        // engine must NOT issue a force-write re-upload, and there is no local
+        // re-pull/overwrite step here. This test pins that documented divergence so a
+        // future change to ServerWins semantics is a deliberate, reviewed decision.
+        var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions { DatabasePath = _databasePath });
+        await store.InitializeAsync();
+        await store.EnqueueAsync(CreateOperation("server-wins-discard", "assets", OfflineOperationType.Update));
+
+        var uploader = new AlwaysConflictRecordingUploader();
+        var engine = new OfflineSyncEngine(
+            store,
+            uploader,
+            new OfflineSyncEngineOptions { ConflictStrategy = SyncConflictStrategy.ServerWins });
+
+        var result = await engine.SyncAsync();
+
+        Assert.Equal(1, result.Succeeded);
+        Assert.Equal(0, result.Failed);
+        // The local edit was discarded, not retried/forced.
+        Assert.Null(await ReadOperationStateAsync("server-wins-discard"));
+        Assert.Single(uploader.Calls);
+        Assert.DoesNotContain(uploader.Calls, call => call.ForceWrite);
+    }
+
+    [Fact]
     public async Task SyncAsync_WhenCanceled_RequeuesClaimedOperationsWithoutIncrementingAttempts()
     {
         var store = new GeoPackageSyncStore(new GeoPackageSyncStoreOptions { DatabasePath = _databasePath });

--- a/tests/Honua.Mobile.Sdk.Tests/AuthTokenProviderTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/AuthTokenProviderTests.cs
@@ -451,6 +451,85 @@ public sealed class AuthTokenProviderTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await provider.GetTokenAsync(cts.Token));
     }
 
+    [Fact]
+    public async Task GetTokenAsync_ConcurrentExpiredCallers_CoalesceToSingleRefresh()
+    {
+        var now = new DateTimeOffset(2026, 5, 6, 12, 0, 0, TimeSpan.Zero);
+        var refreshCalls = 0;
+        var store = new CountingAuthTokenStore();
+        await store.WriteAsync(new HonuaAuthToken(
+            HonuaAuthScheme.Bearer,
+            "expired-token",
+            "refresh-token",
+            now.AddMinutes(-5)));
+
+        var provider = new RefreshingAuthTokenProvider(
+            store,
+            new HttpClient(new StubHttpMessageHandler(_ =>
+            {
+                Interlocked.Increment(ref refreshCalls);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """
+                        {
+                            "accessToken": "fresh-token",
+                            "refreshToken": "next-refresh-token",
+                            "expiresIn": 3600
+                        }
+                        """,
+                        Encoding.UTF8,
+                        "application/json"),
+                };
+            })),
+            new RefreshingAuthTokenProviderOptions
+            {
+                RefreshEndpoint = new Uri("https://auth.honua.test/token/refresh"),
+                TimeProvider = new FixedTimeProvider(now),
+            });
+
+        var tokens = await Task.WhenAll(
+            Enumerable.Range(0, 8).Select(_ => provider.GetTokenAsync().AsTask()));
+
+        Assert.Equal(1, refreshCalls);
+        Assert.All(tokens, token => Assert.Equal("fresh-token", token?.AccessToken));
+        // The rotating refresh token was persisted exactly once.
+        var stored = await store.ReadAsync();
+        Assert.Equal("next-refresh-token", stored?.RefreshToken);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_WithValidCachedToken_ReadsSecureStoreOnce()
+    {
+        var now = new DateTimeOffset(2026, 5, 6, 12, 0, 0, TimeSpan.Zero);
+        var store = new CountingAuthTokenStore();
+        await store.WriteAsync(new HonuaAuthToken(
+            HonuaAuthScheme.Bearer,
+            "valid-token",
+            "refresh-token",
+            now.AddHours(1)));
+
+        var provider = new RefreshingAuthTokenProvider(
+            store,
+            new HttpClient(new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK))),
+            new RefreshingAuthTokenProviderOptions
+            {
+                RefreshEndpoint = new Uri("https://auth.honua.test/token/refresh"),
+                TimeProvider = new FixedTimeProvider(now),
+            });
+
+        var readsBefore = store.ReadCount;
+        for (var i = 0; i < 5; i++)
+        {
+            var token = await provider.GetTokenAsync();
+            Assert.Equal("valid-token", token?.AccessToken);
+        }
+
+        // The keystore is read once on first use; subsequent requests are served
+        // from the in-memory cache.
+        Assert.Equal(readsBefore + 1, store.ReadCount);
+    }
+
     private static HonuaMobileClient CreateClient(
         Func<HttpRequestMessage, HttpResponseMessage> handler,
         IAuthTokenProvider provider,
@@ -495,5 +574,25 @@ public sealed class AuthTokenProviderTests
         }
 
         public override DateTimeOffset GetUtcNow() => _now;
+    }
+
+    private sealed class CountingAuthTokenStore : IAuthTokenStore
+    {
+        private readonly InMemoryAuthTokenStore _inner = new();
+        private int _readCount;
+
+        public int ReadCount => Volatile.Read(ref _readCount);
+
+        public ValueTask<HonuaAuthToken?> ReadAsync(CancellationToken ct = default)
+        {
+            Interlocked.Increment(ref _readCount);
+            return _inner.ReadAsync(ct);
+        }
+
+        public ValueTask WriteAsync(HonuaAuthToken token, CancellationToken ct = default)
+            => _inner.WriteAsync(token, ct);
+
+        public ValueTask ClearAsync(CancellationToken ct = default)
+            => _inner.ClearAsync(ct);
     }
 }

--- a/tests/Honua.Mobile.ServerIntegration.Tests/ConformanceContractTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/ConformanceContractTests.cs
@@ -87,11 +87,13 @@ public sealed class ConformanceContractTests
     {
         var featureServer = new ContractDriftException(
             FeatureContractConformance.FeatureQueryContract,
-            "live request failed with HTTP 400",
+            "live request failed with HTTP 400 (BadRequest). Server detail: "
+            + "{\"error\":{\"code\":400,\"message\":\"42703: column \\\"globalid\\\" does not exist\"}}",
             transportStatus: HttpStatusCode.BadRequest);
         var ogc = new ContractDriftException(
             FeatureContractConformance.OgcItemsContract,
-            "live request failed with HTTP 500",
+            "live request failed with HTTP 500 (InternalServerError). Server detail: "
+            + "column \"globalid\" does not exist",
             transportStatus: HttpStatusCode.InternalServerError);
 
         Assert.Equal("honua-server#1238", KnownServerGaps.Match(featureServer)?.Issue);
@@ -121,7 +123,7 @@ public sealed class ConformanceContractTests
                 () => throw new HonuaMobileApiException(
                     HttpStatusCode.BadRequest,
                     "Bad Request",
-                    """{"error":{"code":400,"message":"Invalid query parameters"}}""")));
+                    """{"error":{"code":400,"message":"42703: column "globalid" does not exist"}}""")));
 
         Assert.Contains("KNOWN-EXPECTED-FAILING", skip.Message, StringComparison.Ordinal);
         Assert.Contains("honua-server#1238", skip.Message, StringComparison.Ordinal);

--- a/tests/Honua.Mobile.ServerIntegration.Tests/KnownServerGaps.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/KnownServerGaps.cs
@@ -59,10 +59,25 @@ public static class KnownServerGaps
         Issue: "honua-server#1238",
         Summary: "FeatureServer/OGC JSONB-attribute projection (mobile_offline_demo layer 68910) emits bare SQL columns",
         Matches: drift =>
-            (drift.Contract == FeatureContractConformance.FeatureQueryContract
+            ((drift.Contract == FeatureContractConformance.FeatureQueryContract
                 && drift.IsTransportStatus(HttpStatusCode.BadRequest))
             || (drift.Contract == FeatureContractConformance.OgcItemsContract
-                && drift.IsTransportStatus(HttpStatusCode.InternalServerError)));
+                && drift.IsTransportStatus(HttpStatusCode.InternalServerError)))
+            // Only xfail when the server error body carries the #1238 JSONB-projection
+            // signature. Without this, the matcher swallowed *any* 400/500 on the core
+            // read paths, leaving the hard gate green while an unrelated regression broke
+            // the primary feature-read surface.
+            && drift.MentionsAny("42703", "column \"globalid\" does not exist"));
+
+    /// <summary>
+    /// Core live feature-read gaps whose xfail masks the primary read path (the
+    /// FeatureServer <c>/query</c> and OGC <c>/items</c> surfaces). Surfaced
+    /// separately so CI can report how many core-read gaps are actively xfailed.
+    /// </summary>
+    public static readonly IReadOnlyList<Gap> CoreReadGaps =
+    [
+        FeatureServerOgcJsonbProjection,
+    ];
 
     /// <summary>honua-server#1166 — temporal query/filter contract gap.</summary>
     public static readonly Gap TemporalQuery = new(

--- a/tests/Honua.Mobile.ServerIntegration.Tests/KnownServerGapsTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/KnownServerGapsTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using Xunit;
+
+namespace Honua.Mobile.ServerIntegration.Tests;
+
+/// <summary>
+/// Unit coverage for the <see cref="KnownServerGaps"/> matcher policy. These assert
+/// the regression-detection guarantee: the honua-server#1238 core-read xfail only
+/// swallows drifts that carry the JSONB-projection error signature, so an unrelated
+/// 400/500 on the same read paths still fails the hard gate.
+/// </summary>
+public sealed class KnownServerGapsTests
+{
+    private const string Jsonb1238Detail =
+        "live request failed with HTTP 400 (BadRequest) before a conforming response body "
+        + "could be validated. Server detail: {\"error\":{\"code\":400,\"message\":\"42703: "
+        + "column \\\"globalid\\\" does not exist\"}}";
+
+    [Fact]
+    public void Match_FeatureQuery400_WithJsonbSignature_ReturnsTrackedGap()
+    {
+        var drift = new ContractDriftException(
+            FeatureContractConformance.FeatureQueryContract,
+            Jsonb1238Detail,
+            transportStatus: HttpStatusCode.BadRequest);
+
+        var gap = KnownServerGaps.Match(drift);
+
+        Assert.NotNull(gap);
+        Assert.Equal("honua-server#1238", gap!.Issue);
+    }
+
+    [Fact]
+    public void Match_OgcItems500_WithJsonbSignature_ReturnsTrackedGap()
+    {
+        var drift = new ContractDriftException(
+            FeatureContractConformance.OgcItemsContract,
+            "Server detail: column \"globalid\" does not exist",
+            transportStatus: HttpStatusCode.InternalServerError);
+
+        var gap = KnownServerGaps.Match(drift);
+
+        Assert.NotNull(gap);
+        Assert.Equal("honua-server#1238", gap!.Issue);
+    }
+
+    [Fact]
+    public void Match_FeatureQuery400_WithoutJsonbSignature_DoesNotMatch()
+    {
+        // An unrelated 400 on the core read path (e.g. a malformed where-clause
+        // regression) must NOT be swallowed by the #1238 gap.
+        var drift = new ContractDriftException(
+            FeatureContractConformance.FeatureQueryContract,
+            "live request failed with HTTP 400 (BadRequest). Server detail: "
+            + "{\"error\":{\"code\":400,\"message\":\"Invalid where clause\"}}",
+            transportStatus: HttpStatusCode.BadRequest);
+
+        Assert.Null(KnownServerGaps.Match(drift));
+    }
+
+    [Fact]
+    public void Match_OgcItems500_WithoutJsonbSignature_DoesNotMatch()
+    {
+        var drift = new ContractDriftException(
+            FeatureContractConformance.OgcItemsContract,
+            "live request failed with HTTP 500 (InternalServerError). Server detail: "
+            + "{\"error\":\"NullReferenceException in projection\"}",
+            transportStatus: HttpStatusCode.InternalServerError);
+
+        Assert.Null(KnownServerGaps.Match(drift));
+    }
+
+    [Fact]
+    public void FeatureServerOgcJsonbProjection_IsTrackedAsCoreReadGap()
+    {
+        Assert.Contains(KnownServerGaps.FeatureServerOgcJsonbProjection, KnownServerGaps.CoreReadGaps);
+    }
+}


### PR DESCRIPTION
## Summary

Pre-release reliability and gate-integrity fixes from the audit (auth handling
#313, CI gate integrity #317).

### Auth token handling (#313)
- **Single-flight refresh.** `RefreshingAuthTokenProvider` now serializes refreshes
  and cache access through a `SemaphoreSlim(1,1)`. Concurrent callers coalesce onto
  one refresh and re-read the latest token under the lock, instead of racing the
  token store — important for rotating / single-use refresh tokens, where parallel
  refreshes could consume an already-rotated token and log the user out.
- **In-memory token cache.** The parsed token is cached in memory and the secure
  keystore is read once on first use, then only on a cache miss or rotation. The
  cache is invalidated/updated on write, clear, and refresh. This removes the
  per-HTTP-request Keychain/Keystore read + JSON parse.
- **API-key validation no longer falsely succeeds via the health endpoint.** The
  unauthenticated `/health` path was in the API-key validation set; it returns 200
  regardless of the key, so a bogus key could validate. It is removed from
  `AuthenticatedValidationPaths`, so key validation only trusts endpoints that
  reject a bad key with 401/403.

### CI gate integrity (#317)
- **Tightened the honua-server#1238 known-gap matcher.** It previously xfailed
  *any* 400 on the FeatureServer `/query` contract or *any* 500 on the OGC `/items`
  contract, so the hard gate stayed green even if an unrelated regression broke the
  primary feature-read path. It now also requires the #1238 JSONB-projection
  signature (`42703` / `column "globalid" does not exist`) in the server error body,
  so unrelated read-path failures fail the suite. Added `KnownServerGaps.CoreReadGaps`
  to make the core-read gap set explicit.
- **Documented ServerWins as discard-only** in `OfflineSyncEngine` and added a test
  pinning that the conflicting local edit is dropped (marked succeeded) with no
  force-write re-upload and no local re-pull — making the divergence explicit so any
  future change is deliberate.

## Tests
- New unit tests:
  - SDK: concurrent-refresh coalescing and read-store-once caching.
  - FieldCollection: API-key validation does not succeed via `/health`.
  - Offline: ServerWins discards the local edit without re-upload.
  - ServerIntegration: `KnownServerGaps` matcher matches the #1238 signature and
    rejects unrelated 400/500s on the core read paths.
- Verified locally (per-project `dotnet test`, under the shared build lock).

Fixes #313
Fixes #317
