### PR TITLE
fix: offline sync integrity, GeoServices query envelope, and mobile hot-path perf

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Services/ISyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/ISyncService.cs
@@ -84,6 +84,7 @@ public class ConflictInfo
         ConflictType.UpdateUpdate => "Local and server versions were both updated.",
         ConflictType.UpdateDelete => "Local changes conflict with a server delete.",
         ConflictType.DeleteUpdate => "A local delete conflicts with server changes.",
+        ConflictType.DeleteDelete => "Local and server versions were both deleted.",
         ConflictType.GeometryOverlap => "Geometry overlaps with an existing feature.",
         _ => "Sync conflict requires review."
     };
@@ -94,6 +95,7 @@ public enum ConflictType
     UpdateUpdate,
     UpdateDelete,
     DeleteUpdate,
+    DeleteDelete,
     GeometryOverlap
 }
 

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
@@ -25,7 +25,7 @@ namespace Honua.Mobile.FieldCollection.Services.Storage;
 /// OGC GeoPackage-compliant storage service for offline field data collection
 /// Implements SQLite-based spatial database with change tracking for delta sync
 /// </summary>
-public class GeoPackageStorageService : IDisposable
+public class GeoPackageStorageService : IDisposable, IAsyncDisposable
 {
     private static readonly JsonSerializerOptions SchemaJsonOptions = new()
     {
@@ -806,16 +806,61 @@ public class GeoPackageStorageService : IDisposable
 
     public async Task MarkChangesAsSynced(List<string> changeIds)
     {
+        ArgumentNullException.ThrowIfNull(changeIds);
+        if (changeIds.Count == 0)
+        {
+            return;
+        }
+
         await EnsureInitializedAsync();
         await _dbLock.WaitAsync();
         try
         {
-            foreach (var changeId in changeIds)
+            // Mark every change in a single transaction so a mid-operation crash cannot leave
+            // part of the batch marked Synced while the rest stays PendingUpload. That split state
+            // would cause the un-marked changes to be re-uploaded on the next sync, double-applying
+            // them server-side. RunInTransactionAsync rolls back on failure, so the batch is
+            // all-or-nothing. Each chunk is one set-based UPDATE to stay within the SQLite
+            // bound-parameter limit.
+            await _connection.RunInTransactionAsync(connection =>
             {
-                await _connection.ExecuteAsync(
-                    "UPDATE change_records SET sync_status = ? WHERE id = ?",
-                    StorageSyncStatus.Synced, changeId);
-            }
+                const int chunkSize = 500;
+                for (var offset = 0; offset < changeIds.Count; offset += chunkSize)
+                {
+                    var chunk = changeIds.GetRange(offset, Math.Min(chunkSize, changeIds.Count - offset));
+                    var placeholders = string.Join(",", Enumerable.Repeat("?", chunk.Count));
+                    var args = new object[chunk.Count + 1];
+                    args[0] = StorageSyncStatus.Synced;
+                    for (var i = 0; i < chunk.Count; i++)
+                    {
+                        args[i + 1] = chunk[i];
+                    }
+
+                    connection.Execute(
+                        $"UPDATE change_records SET sync_status = ? WHERE id IN ({placeholders})",
+                        args);
+                }
+            });
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Returns the number of change records still queued for upload without materializing the
+    /// rows. Used by the pending-changes poll, which only needs the count.
+    /// </summary>
+    public async Task<int> GetPendingChangesCountAsync()
+    {
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            return await _connection.ExecuteScalarAsync<int>(
+                "SELECT COUNT(*) FROM change_records WHERE sync_status = ?",
+                StorageSyncStatus.PendingUpload);
         }
         finally
         {
@@ -2434,9 +2479,24 @@ public class GeoPackageStorageService : IDisposable
 
     #region IDisposable
 
+    public async ValueTask DisposeAsync()
+    {
+        if (_connection is not null)
+        {
+            // Close the SQLite connection without blocking and without forcing continuations
+            // back onto the captured (UI) context.
+            await _connection.CloseAsync().ConfigureAwait(false);
+        }
+
+        _dbLock?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
     public void Dispose()
     {
-        _connection?.CloseAsync().Wait();
+        // Prefer DisposeAsync. When a synchronous Dispose is unavoidable, close off the captured
+        // context so the connection close cannot deadlock against a UI-thread continuation.
+        _connection?.CloseAsync().ConfigureAwait(false).GetAwaiter().GetResult();
         _dbLock?.Dispose();
         GC.SuppressFinalize(this);
     }

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/GeoPackageSyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/GeoPackageSyncService.cs
@@ -143,9 +143,9 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         {
             try
             {
-                var changes = await _storage.GetPendingChangesAsync();
+                var pendingChanges = await _storage.GetPendingChangesCountAsync();
                 var pendingAttachments = await _storage.GetPendingAttachmentChangesCountAsync();
-                PendingChangesCount = changes.Count + pendingAttachments;
+                PendingChangesCount = pendingChanges + pendingAttachments;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -788,13 +788,19 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         return _storage.StoreConflictAsync(conflict);
     }
 
-    private static ConflictType MapConflictType(StorageConflictType conflictType)
+    // Maps the persisted storage conflict category to the UI/domain category. Every storage value
+    // is mapped explicitly: a previous default arm collapsed DeleteDelete onto UpdateUpdate, so a
+    // both-sides-deleted conflict was shown to the user mislabeled as an update/update conflict.
+    internal static ConflictType MapConflictType(StorageConflictType conflictType)
     {
         return conflictType switch
         {
+            StorageConflictType.UpdateUpdate => ConflictType.UpdateUpdate,
             StorageConflictType.UpdateDelete => ConflictType.UpdateDelete,
             StorageConflictType.DeleteUpdate => ConflictType.DeleteUpdate,
-            _ => ConflictType.UpdateUpdate
+            StorageConflictType.DeleteDelete => ConflictType.DeleteDelete,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(conflictType), conflictType, "Unmapped storage conflict type.")
         };
     }
 

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs
@@ -186,7 +186,9 @@ public sealed partial class HonuaMobileClient
 
     /// <summary>
     /// Applies feature edits (adds, updates, deletes) to a feature service layer.
-    /// Prefers gRPC transport when available and falls back to REST on failure.
+    /// Prefers gRPC transport when available. Unlike queries, a failed gRPC edit does
+    /// <em>not</em> fall back to REST unless <see cref="HonuaMobileClientOptions.AllowRestFallbackOnGrpcEditFailure"/>
+    /// is enabled, because re-issuing a non-idempotent edit could double-apply it.
     /// </summary>
     /// <param name="request">The edit payload including adds, updates, and deletes.</param>
     /// <param name="ct">Cancellation token.</param>
@@ -203,9 +205,10 @@ public sealed partial class HonuaMobileClient
             {
                 return await ApplyEditsGrpcAsync(request, ct).ConfigureAwait(false);
             }
-            catch (HonuaGrpcException) when (_options.AllowRestFallbackOnGrpcFailure)
+            catch (HonuaGrpcException) when (_options.AllowRestFallbackOnGrpcEditFailure)
             {
-                // Fall through to REST transport.
+                // Fall through to REST transport. Disabled by default for edits:
+                // re-issuing a non-idempotent edit over REST could double-apply it.
             }
         }
 
@@ -217,7 +220,7 @@ public sealed partial class HonuaMobileClient
         var response = await GetGrpcClient()
             .QueryAsync(ToSdkFeatureQueryRequest(request), ct)
             .ConfigureAwait(false);
-        return ToLegacyFeatureQueryJsonDocument(response);
+        return ToLegacyFeatureQueryJsonDocument(response, request.ReturnCountOnly);
     }
 
     private async IAsyncEnumerable<JsonDocument> QueryFeaturesGrpcPagesAsync(
@@ -228,7 +231,7 @@ public sealed partial class HonuaMobileClient
             .QueryPagesAsync(ToSdkFeatureQueryRequest(request), ct)
             .ConfigureAwait(false))
         {
-            yield return ToLegacyFeatureQueryJsonDocument(page);
+            yield return ToLegacyFeatureQueryJsonDocument(page, request.ReturnCountOnly);
         }
     }
 
@@ -404,9 +407,10 @@ public sealed partial class HonuaMobileClient
             {
                 return await GetGrpcClient().ApplyEditsAsync(request, ct).ConfigureAwait(false);
             }
-            catch (HonuaGrpcException) when (_options.AllowRestFallbackOnGrpcFailure)
+            catch (HonuaGrpcException) when (_options.AllowRestFallbackOnGrpcEditFailure)
             {
-                // Fall through to REST transport.
+                // Fall through to REST transport. Disabled by default for edits:
+                // re-issuing a non-idempotent edit over REST could double-apply it.
             }
         }
 
@@ -729,7 +733,19 @@ public sealed partial class HonuaMobileClient
         writer.WriteEndObject();
     }
 
-    private static JsonDocument ToLegacyFeatureQueryJsonDocument(FeatureQueryResult response)
+    /// <summary>
+    /// Projects a gRPC/SDK <see cref="FeatureQueryResult"/> into the legacy Esri-style query JSON.
+    /// </summary>
+    /// <remarks>
+    /// Transport-parity note: the gRPC <see cref="FeatureQueryResult"/> contract does not currently
+    /// carry <c>spatialReference</c>, <c>geometryType</c>, or the layer <c>fields</c> that the raw
+    /// REST FeatureServer response passes through. Callers that need the spatial reference or field
+    /// schema must read them from layer metadata when the gRPC transport is used. Closing this gap
+    /// fully requires the SDK/server feature-query contract to surface those values.
+    /// <paramref name="returnCountOnly"/> gates the top-level <c>count</c>: Esri reserves it for
+    /// <c>returnCountOnly</c> responses, so it is omitted for normal feature queries.
+    /// </remarks>
+    internal static JsonDocument ToLegacyFeatureQueryJsonDocument(FeatureQueryResult response, bool returnCountOnly)
         => CreateJsonDocument(writer =>
         {
             writer.WriteStartObject();
@@ -739,7 +755,7 @@ public sealed partial class HonuaMobileClient
                 writer.WriteString("objectIdFieldName", response.ObjectIdFieldName);
             }
 
-            if (response.NumberMatched is { } numberMatched)
+            if (returnCountOnly && response.NumberMatched is { } numberMatched)
             {
                 writer.WriteNumber("count", numberMatched);
             }

--- a/src/Honua.Mobile.Sdk/HonuaMobileClientOptions.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClientOptions.cs
@@ -29,9 +29,24 @@ public sealed class HonuaMobileClientOptions
     public bool PreferGrpcForFeatureEdits { get; init; } = true;
 
     /// <summary>
-    /// When <see langword="true"/>, the client automatically falls back to REST when a gRPC call fails. Defaults to <see langword="true"/>.
+    /// When <see langword="true"/>, the client automatically falls back to REST when a gRPC
+    /// query call fails. Defaults to <see langword="true"/>. This governs read-only queries only;
+    /// mutating edits are governed separately by <see cref="AllowRestFallbackOnGrpcEditFailure"/>.
     /// </summary>
     public bool AllowRestFallbackOnGrpcFailure { get; init; } = true;
+
+    /// <summary>
+    /// When <see langword="true"/>, the client falls back to REST when a gRPC feature <em>edit</em>
+    /// (applyEdits) call fails. Defaults to <see langword="false"/>.
+    /// <para>
+    /// Edits are not idempotent, so a blanket REST retry after a gRPC failure can double-apply an
+    /// edit whose gRPC request actually reached the server (e.g. the failure occurred while reading
+    /// the response). Leaving this off means a failed gRPC edit surfaces as an error instead of
+    /// silently re-applying. Only enable it when the remote guarantees edit idempotency (e.g. via an
+    /// idempotency/edit token).
+    /// </para>
+    /// </summary>
+    public bool AllowRestFallbackOnGrpcEditFailure { get; init; }
 
     /// <summary>
     /// Optional API key sent via the <c>X-API-Key</c> header.

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -23,6 +23,69 @@ public sealed class GeoPackageSyncServiceTests
     }
 
     [Fact]
+    public async Task MarkChangesAsSynced_MarksOnlyTheRequestedChanges()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.StoreFeatureAsync(CreateFeature("asset-1", version: 1));
+        await storage.StoreFeatureAsync(CreateFeature("asset-2", version: 1));
+
+        var pending = await storage.GetPendingChangesAsync();
+        Assert.Equal(2, pending.Count);
+
+        await storage.MarkChangesAsSynced(new List<string> { pending[0].Id });
+
+        var remaining = await storage.GetPendingChangesAsync();
+        Assert.Single(remaining);
+        Assert.Equal(pending[1].Id, remaining[0].Id);
+    }
+
+    [Fact]
+    public async Task MarkChangesAsSynced_WithEmptyList_IsNoOp()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.StoreFeatureAsync(CreateFeature("asset-1", version: 1));
+
+        await storage.MarkChangesAsSynced(new List<string>());
+
+        Assert.Single(await storage.GetPendingChangesAsync());
+    }
+
+    [Fact]
+    public async Task GetPendingChangesCountAsync_CountsPendingUploads()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.StoreFeatureAsync(CreateFeature("asset-1", version: 1));
+        await storage.StoreFeatureAsync(CreateFeature("asset-2", version: 1));
+
+        Assert.Equal(2, await storage.GetPendingChangesCountAsync());
+
+        var pending = await storage.GetPendingChangesAsync();
+        await storage.MarkChangesAsSynced(pending.Select(change => change.Id).ToList());
+
+        Assert.Equal(0, await storage.GetPendingChangesCountAsync());
+    }
+
+    [Theory]
+    [InlineData(StorageConflictType.UpdateUpdate, ConflictType.UpdateUpdate)]
+    [InlineData(StorageConflictType.UpdateDelete, ConflictType.UpdateDelete)]
+    [InlineData(StorageConflictType.DeleteUpdate, ConflictType.DeleteUpdate)]
+    [InlineData(StorageConflictType.DeleteDelete, ConflictType.DeleteDelete)]
+    public void MapConflictType_MapsEveryStorageCategoryExplicitly(
+        StorageConflictType storage,
+        ConflictType expected)
+    {
+        // DeleteDelete previously collapsed onto UpdateUpdate via a default arm; it must now
+        // map to its own category so a both-sides-deleted conflict is not mislabeled in the UI.
+        Assert.Equal(expected, GeoPackageSyncService.MapConflictType(storage));
+    }
+
+    [Fact]
     public async Task PushChangesAsync_WhenUploaderReturnsFalse_ReturnsFailureAndLeavesChangePending()
     {
         var databasePath = CreateDatabasePath();

--- a/tests/Honua.Mobile.Sdk.Tests/LegacyFeatureQueryEnvelopeTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/LegacyFeatureQueryEnvelopeTests.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+
+namespace Honua.Mobile.Sdk.Tests;
+
+public sealed class LegacyFeatureQueryEnvelopeTests
+{
+    [Fact]
+    public void ToLegacyFeatureQueryJsonDocument_NormalQuery_OmitsTopLevelCount()
+    {
+        var result = new FeatureQueryResult
+        {
+            NumberMatched = 42,
+            Features =
+            [
+                new FeatureRecord { Id = "1" },
+            ],
+        };
+
+        using var document = HonuaMobileClient.ToLegacyFeatureQueryJsonDocument(result, returnCountOnly: false);
+
+        // Esri reserves the top-level "count" for returnCountOnly responses; a normal feature
+        // query must not emit it alongside features.
+        Assert.False(document.RootElement.TryGetProperty("count", out _));
+        Assert.True(document.RootElement.TryGetProperty("features", out var features));
+        Assert.Equal(1, features.GetArrayLength());
+    }
+
+    [Fact]
+    public void ToLegacyFeatureQueryJsonDocument_ReturnCountOnly_EmitsTopLevelCount()
+    {
+        var result = new FeatureQueryResult
+        {
+            NumberMatched = 42,
+            Features = [],
+        };
+
+        using var document = HonuaMobileClient.ToLegacyFeatureQueryJsonDocument(result, returnCountOnly: true);
+
+        Assert.True(document.RootElement.TryGetProperty("count", out var count));
+        Assert.Equal(42, count.GetInt64());
+    }
+}
+
+public sealed class GrpcEditFallbackOptionTests
+{
+    [Fact]
+    public void AllowRestFallbackOnGrpcEditFailure_DefaultsToOff()
+    {
+        // Queries are safe to retry over REST, but edits are not idempotent, so the edit-specific
+        // fallback must default off to avoid double-applying an edit that already reached the server.
+        var options = new HonuaMobileClientOptions();
+
+        Assert.True(options.AllowRestFallbackOnGrpcFailure);
+        Assert.False(options.AllowRestFallbackOnGrpcEditFailure);
+    }
+}


### PR DESCRIPTION
## Summary

Pre-release reliability fixes from the release audit, covering offline sync data
integrity (#311), the GeoServices query envelope (#314), and mobile hot-path
performance (#312). Library/SDK changes only; all covered by unit tests.

### Offline sync data integrity (#311)
- **Atomic `MarkChangesAsSynced`.** Marking N changes ran N separate `UPDATE`s outside
  a transaction. A mid-loop crash left part of the batch `Synced` and the rest
  `PendingUpload`, so the un-marked edits were re-uploaded on the next sync and
  double-applied server-side. It now marks the whole batch in one transaction using
  set-based `UPDATE ... WHERE id IN (...)` chunks (rolled back on failure).
- **gRPC→REST edit fallback is no longer unconditional.** A failed gRPC `applyEdits`
  used to blanket-fall-back to REST under the same flag as queries. Because edits are
  not idempotent, that could re-apply an edit whose gRPC request had already reached
  the server. Edit fallback is now gated behind a new, default-off
  `AllowRestFallbackOnGrpcEditFailure` option, separate from the query fallback.
- **Exhaustive conflict-type mapping.** A persisted `DeleteDelete` conflict was
  collapsed onto `UpdateUpdate` by a `default` switch arm and shown to the user
  mislabeled. `DeleteDelete` is added to the domain `ConflictType` enum and every
  storage category is now mapped explicitly.

### GeoServices query envelope (#314)
- **Top-level `count` only for `returnCountOnly`.** The legacy gRPC-derived query JSON
  emitted a top-level `count` for normal queries; Esri reserves that field for
  `returnCountOnly` responses. It is now gated on the request flag.

### Performance (#312)
- **Pending-changes poll uses `COUNT(*)`.** The 5s poll materialized every
  `ChangeRecord` just to count them; it now calls a new `GetPendingChangesCountAsync`
  (`SELECT COUNT(*) WHERE sync_status = PendingUpload`).
- **`IAsyncDisposable`.** `GeoPackageStorageService` now implements `IAsyncDisposable`
  and awaits the connection close off the captured context; the synchronous `Dispose`
  no longer blocks the UI thread via `.Wait()`.

## Tests
- SDK: legacy query envelope omits/includes `count` correctly; edit-fallback option
  defaults off while query fallback stays on.
- FieldCollection: `MarkChangesAsSynced` marks only the requested changes (and is a
  no-op on empty), `GetPendingChangesCountAsync` counts pending uploads, and
  `MapConflictType` maps every storage category (incl. `DeleteDelete`) explicitly.
- Full suites green: `Honua.Mobile.Sdk.Tests` (94) and
  `Honua.Mobile.FieldCollection.Tests` (140). `dotnet format` verified on changed files.
  The `net10.0-android` MAUI app target is not buildable in the Linux CI env; these
  changes are in the net10.0 Core/SDK libraries and exercised by their test suites.

## Scope / deferred (intentionally not `Fixes`)

These remaining audit sub-items are genuinely out of scope for this PR and need work
this change cannot safely do on its own:

- **#311 — server-side `applyEdits` conflict classification.** Mapping the exact
  HTTP-200 per-feature conflict code into the Conflict branch requires confirming the
  code honua-server actually emits for an optimistic-concurrency conflict plus a live
  conflict integration test. Cross-repo; left for a follow-up with server confirmation.
- **#314 — full REST/gRPC envelope parity.** The gRPC `FeatureQueryResult` contract
  (SDK 1.3.0) does not carry `spatialReference`/`geometryType`/`fields`. True parity
  needs an SDK/server contract change; this PR documents the omission so callers read
  SR from layer metadata on the gRPC transport.
- **#312 — spatial-query R-tree and N+1 push batching.** Both are larger refactors (an
  on-disk index migration with triggers; a batched `applyEdits` uploader with
  per-feature result handling, entangled with the conflict-code item above) that need
  device/live-server verification not available in this environment.

Refs #311
Refs #312
Refs #314
