### PR TITLE
fix: delta-sync cursor correctness, batched GeoPackage writes, dedupe service-id resolution

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs
@@ -201,7 +201,7 @@ public sealed class HonuaFieldCollectionChangeUploader :
         }
 
         var layer = await ResolveLayerAsync(change.LayerId, cancellationToken).ConfigureAwait(false);
-        var serviceId = ResolveServiceId(layer);
+        var serviceId = FieldCollectionSyncLayer.ResolveServiceId(layer);
         if (string.IsNullOrWhiteSpace(serviceId))
         {
             _logger?.LogWarning("Cannot upload change {ChangeId}; layer {LayerId} has no service id", change.Id, change.LayerId);
@@ -717,23 +717,6 @@ public sealed class HonuaFieldCollectionChangeUploader :
             return true;
         }
     }
-
-    private static string? ResolveServiceId(LayerInfo layer)
-    {
-        if (!string.IsNullOrWhiteSpace(layer.ServiceId))
-        {
-            return layer.ServiceId;
-        }
-
-        const string separator = "/FeatureServer/";
-        if (!string.IsNullOrWhiteSpace(layer.SourceId) &&
-            layer.SourceId.IndexOf(separator, StringComparison.OrdinalIgnoreCase) is var index and >= 0)
-        {
-            return layer.SourceId[..index];
-        }
-
-        return null;
-    }
 }
 
 public sealed class HonuaFieldCollectionChangePuller :
@@ -777,7 +760,7 @@ public sealed class HonuaFieldCollectionChangePuller :
 
         foreach (var layer in layers.Where(layer => layer.IsEditable))
         {
-            var serviceId = ResolveServiceId(layer);
+            var serviceId = FieldCollectionSyncLayer.ResolveServiceId(layer);
             if (string.IsNullOrWhiteSpace(serviceId))
             {
                 continue;
@@ -1038,23 +1021,6 @@ public sealed class HonuaFieldCollectionChangePuller :
             return true;
         }
     }
-
-    private static string? ResolveServiceId(LayerInfo layer)
-    {
-        if (!string.IsNullOrWhiteSpace(layer.ServiceId))
-        {
-            return layer.ServiceId;
-        }
-
-        const string separator = "/FeatureServer/";
-        if (!string.IsNullOrWhiteSpace(layer.SourceId) &&
-            layer.SourceId.IndexOf(separator, StringComparison.OrdinalIgnoreCase) is var index and >= 0)
-        {
-            return layer.SourceId[..index];
-        }
-
-        return null;
-    }
 }
 
 public sealed class HonuaFieldCollectionAttachmentSynchronizer :
@@ -1106,7 +1072,7 @@ public sealed class HonuaFieldCollectionAttachmentSynchronizer :
             }
 
             var layer = layers.FirstOrDefault(layer => layer.Id == attachment.LayerId);
-            var serviceId = layer == null ? null : ResolveServiceId(layer);
+            var serviceId = layer == null ? null : FieldCollectionSyncLayer.ResolveServiceId(layer);
             if (string.IsNullOrWhiteSpace(serviceId))
             {
                 await MarkAttachmentFailureAsync(
@@ -1183,7 +1149,7 @@ public sealed class HonuaFieldCollectionAttachmentSynchronizer :
         var layers = await _metadataService.GetLayersAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         foreach (var layer in layers.Where(layer => layer.IsEditable))
         {
-            var serviceId = ResolveServiceId(layer);
+            var serviceId = FieldCollectionSyncLayer.ResolveServiceId(layer);
             if (string.IsNullOrWhiteSpace(serviceId))
             {
                 continue;
@@ -1473,23 +1439,6 @@ public sealed class HonuaFieldCollectionAttachmentSynchronizer :
             ? fallback
             : response.Error.Message;
     }
-
-    private static string? ResolveServiceId(LayerInfo layer)
-    {
-        if (!string.IsNullOrWhiteSpace(layer.ServiceId))
-        {
-            return layer.ServiceId;
-        }
-
-        const string separator = "/FeatureServer/";
-        if (!string.IsNullOrWhiteSpace(layer.SourceId) &&
-            layer.SourceId.IndexOf(separator, StringComparison.OrdinalIgnoreCase) is var index and >= 0)
-        {
-            return layer.SourceId[..index];
-        }
-
-        return null;
-    }
 }
 
 public sealed class QueuedFieldCollectionChangeUploader :
@@ -1590,5 +1539,36 @@ public sealed class LocalOnlyFieldCollectionChangePuller :
         cancellationToken.ThrowIfCancellationRequested();
         // Local-only pulls have no durable server cursor to advance.
         return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Shared helpers for resolving sync routing information from a <see cref="LayerInfo"/>.
+/// </summary>
+internal static class FieldCollectionSyncLayer
+{
+    private const string FeatureServerSeparator = "/FeatureServer/";
+
+    /// <summary>
+    /// Resolves the feature service id a layer belongs to, preferring the explicit
+    /// <see cref="LayerInfo.ServiceId"/> and otherwise parsing it from the
+    /// <see cref="LayerInfo.SourceId"/> (the segment before <c>/FeatureServer/</c>).
+    /// This is the single source of truth used by upload, pull, and attachment sync so the
+    /// three transports cannot diverge on how routing is derived.
+    /// </summary>
+    public static string? ResolveServiceId(LayerInfo layer)
+    {
+        if (!string.IsNullOrWhiteSpace(layer.ServiceId))
+        {
+            return layer.ServiceId;
+        }
+
+        if (!string.IsNullOrWhiteSpace(layer.SourceId) &&
+            layer.SourceId.IndexOf(FeatureServerSeparator, StringComparison.OrdinalIgnoreCase) is var index and >= 0)
+        {
+            return layer.SourceId[..index];
+        }
+
+        return null;
     }
 }

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
@@ -713,25 +713,7 @@ LIMIT 1;
         using var activity = MobileStorageTelemetry.ActivitySource.StartActivity("honua.mobile.storage.feature.upsert", ActivityKind.Internal);
         activity?.SetTag("layer_key", layerKey);
 
-        FeatureCacheRecord feature;
-        try
-        {
-            feature = ExtractFeatureCacheRecord(featureJson);
-        }
-        catch (JsonException ex)
-        {
-            activity?.SetStatus(ActivityStatusCode.Error);
-            throw GeoPackageStorageProblems.InvalidFeatureJson(ex);
-        }
-        catch (InvalidOperationException ex)
-        {
-            activity?.SetStatus(ActivityStatusCode.Error);
-            throw GeoPackageStorageProblems.InvalidFeatureJson(ex);
-        }
-
-        var objectId = feature.ObjectId;
-        var extent = feature.Extent;
-        var spatialReference = feature.SpatialReference ?? FeatureSpatialReference.Default;
+        var feature = ParseFeatureCacheRecord(featureJson, activity);
         var expiresAtUtc = ResolveFeatureExpiresAtUtc(layerKey);
 
         await using var connection = OpenConnection();
@@ -740,42 +722,62 @@ LIMIT 1;
         await ExecuteTransactionCommandAsync(connection, "BEGIN IMMEDIATE;", ct).ConfigureAwait(false);
         try
         {
-            await UpsertFeatureLayerMetadataAsync(
-                connection,
-                layerKey,
-                spatialReference,
-                feature.SpatialReference is not null,
-                ct).ConfigureAwait(false);
+            await WriteFeatureCoreAsync(connection, layerKey, feature, featureJson, expiresAtUtc, ct).ConfigureAwait(false);
+            await ExecuteTransactionCommandAsync(connection, "COMMIT;", ct).ConfigureAwait(false);
+        }
+        catch (SqliteException ex)
+        {
+            await RollbackQuietlyAsync(connection).ConfigureAwait(false);
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw GeoPackageStorageProblems.WriteFailed(ex);
+        }
+        catch
+        {
+            await RollbackQuietlyAsync(connection).ConfigureAwait(false);
+            throw;
+        }
+    }
 
-            await using (var command = connection.CreateCommand())
+    /// <inheritdoc />
+    public async Task UpsertFeaturesAsync(string layerKey, IReadOnlyList<string> featureJsons, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(layerKey);
+        ArgumentNullException.ThrowIfNull(featureJsons);
+
+        if (featureJsons.Count == 0)
+        {
+            return;
+        }
+
+        using var activity = MobileStorageTelemetry.ActivitySource.StartActivity("honua.mobile.storage.feature.upsert.batch", ActivityKind.Internal);
+        activity?.SetTag("layer_key", layerKey);
+        activity?.SetTag("feature_count", featureJsons.Count);
+
+        // Parse and validate every payload before opening the connection so a malformed
+        // feature fails fast without leaving a half-applied write lock open.
+        var parsed = new FeatureCacheRecord[featureJsons.Count];
+        for (var i = 0; i < featureJsons.Count; i++)
+        {
+            var featureJson = featureJsons[i];
+            ArgumentException.ThrowIfNullOrWhiteSpace(featureJson, $"{nameof(featureJsons)}[{i}]");
+            parsed[i] = ParseFeatureCacheRecord(featureJson, activity);
+        }
+
+        var expiresAtUtc = ResolveFeatureExpiresAtUtc(layerKey);
+
+        await using var connection = OpenConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+
+        // A single BEGIN IMMEDIATE / COMMIT around the whole batch means one fsync for the
+        // entire change set instead of one per feature.
+        await ExecuteTransactionCommandAsync(connection, "BEGIN IMMEDIATE;", ct).ConfigureAwait(false);
+        try
+        {
+            for (var i = 0; i < parsed.Length; i++)
             {
-                command.CommandText = @"
-INSERT INTO honua_features (layer_key, object_id, feature_json, updated_at_utc, expires_at_utc, min_x, min_y, max_x, max_y)
-VALUES ($layer_key, $object_id, $feature_json, $updated_at_utc, $expires_at_utc, $min_x, $min_y, $max_x, $max_y)
-ON CONFLICT(layer_key, object_id) DO UPDATE SET
-  feature_json = excluded.feature_json,
-  updated_at_utc = excluded.updated_at_utc,
-  expires_at_utc = excluded.expires_at_utc,
-  min_x = excluded.min_x,
-  min_y = excluded.min_y,
-  max_x = excluded.max_x,
-  max_y = excluded.max_y;
-";
-
-                command.Parameters.AddWithValue("$layer_key", layerKey);
-                command.Parameters.AddWithValue("$object_id", objectId);
-                command.Parameters.AddWithValue("$feature_json", featureJson);
-                command.Parameters.AddWithValue("$updated_at_utc", _options.TimeProvider.GetUtcNow().ToString("O", CultureInfo.InvariantCulture));
-                command.Parameters.AddWithValue("$expires_at_utc", ToDbValue(expiresAtUtc));
-                command.Parameters.AddWithValue("$min_x", ToDbValue(extent?.MinX));
-                command.Parameters.AddWithValue("$min_y", ToDbValue(extent?.MinY));
-                command.Parameters.AddWithValue("$max_x", ToDbValue(extent?.MaxX));
-                command.Parameters.AddWithValue("$max_y", ToDbValue(extent?.MaxY));
-
-                await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+                await WriteFeatureCoreAsync(connection, layerKey, parsed[i], featureJsons[i], expiresAtUtc, ct).ConfigureAwait(false);
             }
 
-            await UpsertFeatureIndexAsync(connection, layerKey, objectId, extent, ct).ConfigureAwait(false);
             await ExecuteTransactionCommandAsync(connection, "COMMIT;", ct).ConfigureAwait(false);
         }
         catch (SqliteException ex)
@@ -802,18 +804,7 @@ ON CONFLICT(layer_key, object_id) DO UPDATE SET
         await ExecuteTransactionCommandAsync(connection, "BEGIN IMMEDIATE;", ct).ConfigureAwait(false);
         try
         {
-            var indexId = await GetFeatureIndexIdAsync(connection, layerKey, objectId, ct).ConfigureAwait(false);
-            if (indexId.HasValue)
-            {
-                await DeleteFeatureIndexAsync(connection, indexId.Value, ct).ConfigureAwait(false);
-            }
-
-            await using var command = connection.CreateCommand();
-            command.CommandText = "DELETE FROM honua_features WHERE layer_key = $layer_key AND object_id = $object_id;";
-            command.Parameters.AddWithValue("$layer_key", layerKey);
-            command.Parameters.AddWithValue("$object_id", objectId);
-
-            await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            await RemoveFeatureCoreAsync(connection, layerKey, objectId, ct).ConfigureAwait(false);
             await ExecuteTransactionCommandAsync(connection, "COMMIT;", ct).ConfigureAwait(false);
         }
         catch (SqliteException ex)
@@ -826,6 +817,130 @@ ON CONFLICT(layer_key, object_id) DO UPDATE SET
             await RollbackQuietlyAsync(connection).ConfigureAwait(false);
             throw;
         }
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteFeaturesAsync(string layerKey, IReadOnlyList<long> objectIds, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(layerKey);
+        ArgumentNullException.ThrowIfNull(objectIds);
+
+        if (objectIds.Count == 0)
+        {
+            return;
+        }
+
+        await using var connection = OpenConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+
+        await ExecuteTransactionCommandAsync(connection, "BEGIN IMMEDIATE;", ct).ConfigureAwait(false);
+        try
+        {
+            foreach (var objectId in objectIds)
+            {
+                await RemoveFeatureCoreAsync(connection, layerKey, objectId, ct).ConfigureAwait(false);
+            }
+
+            await ExecuteTransactionCommandAsync(connection, "COMMIT;", ct).ConfigureAwait(false);
+        }
+        catch (SqliteException ex)
+        {
+            await RollbackQuietlyAsync(connection).ConfigureAwait(false);
+            throw GeoPackageStorageProblems.DeleteFailed(ex);
+        }
+        catch
+        {
+            await RollbackQuietlyAsync(connection).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private static FeatureCacheRecord ParseFeatureCacheRecord(string featureJson, Activity? activity)
+    {
+        try
+        {
+            return ExtractFeatureCacheRecord(featureJson);
+        }
+        catch (JsonException ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw GeoPackageStorageProblems.InvalidFeatureJson(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw GeoPackageStorageProblems.InvalidFeatureJson(ex);
+        }
+    }
+
+    private async Task WriteFeatureCoreAsync(
+        SqliteConnection connection,
+        string layerKey,
+        FeatureCacheRecord feature,
+        string featureJson,
+        DateTimeOffset? expiresAtUtc,
+        CancellationToken ct)
+    {
+        var objectId = feature.ObjectId;
+        var extent = feature.Extent;
+        var spatialReference = feature.SpatialReference ?? FeatureSpatialReference.Default;
+
+        await UpsertFeatureLayerMetadataAsync(
+            connection,
+            layerKey,
+            spatialReference,
+            feature.SpatialReference is not null,
+            ct).ConfigureAwait(false);
+
+        await using (var command = connection.CreateCommand())
+        {
+            command.CommandText = @"
+INSERT INTO honua_features (layer_key, object_id, feature_json, updated_at_utc, expires_at_utc, min_x, min_y, max_x, max_y)
+VALUES ($layer_key, $object_id, $feature_json, $updated_at_utc, $expires_at_utc, $min_x, $min_y, $max_x, $max_y)
+ON CONFLICT(layer_key, object_id) DO UPDATE SET
+  feature_json = excluded.feature_json,
+  updated_at_utc = excluded.updated_at_utc,
+  expires_at_utc = excluded.expires_at_utc,
+  min_x = excluded.min_x,
+  min_y = excluded.min_y,
+  max_x = excluded.max_x,
+  max_y = excluded.max_y;
+";
+
+            command.Parameters.AddWithValue("$layer_key", layerKey);
+            command.Parameters.AddWithValue("$object_id", objectId);
+            command.Parameters.AddWithValue("$feature_json", featureJson);
+            command.Parameters.AddWithValue("$updated_at_utc", _options.TimeProvider.GetUtcNow().ToString("O", CultureInfo.InvariantCulture));
+            command.Parameters.AddWithValue("$expires_at_utc", ToDbValue(expiresAtUtc));
+            command.Parameters.AddWithValue("$min_x", ToDbValue(extent?.MinX));
+            command.Parameters.AddWithValue("$min_y", ToDbValue(extent?.MinY));
+            command.Parameters.AddWithValue("$max_x", ToDbValue(extent?.MaxX));
+            command.Parameters.AddWithValue("$max_y", ToDbValue(extent?.MaxY));
+
+            await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+
+        await UpsertFeatureIndexAsync(connection, layerKey, objectId, extent, ct).ConfigureAwait(false);
+    }
+
+    private static async Task RemoveFeatureCoreAsync(
+        SqliteConnection connection,
+        string layerKey,
+        long objectId,
+        CancellationToken ct)
+    {
+        var indexId = await GetFeatureIndexIdAsync(connection, layerKey, objectId, ct).ConfigureAwait(false);
+        if (indexId.HasValue)
+        {
+            await DeleteFeatureIndexAsync(connection, indexId.Value, ct).ConfigureAwait(false);
+        }
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "DELETE FROM honua_features WHERE layer_key = $layer_key AND object_id = $object_id;";
+        command.Parameters.AddWithValue("$layer_key", layerKey);
+        command.Parameters.AddWithValue("$object_id", objectId);
+
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />

--- a/src/Honua.Mobile.Offline/GeoPackage/IGeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/IGeoPackageSyncStore.cs
@@ -143,12 +143,44 @@ public interface IGeoPackageSyncStore
     Task UpsertFeatureAsync(string layerKey, string featureJson, CancellationToken ct = default);
 
     /// <summary>
+    /// Inserts or updates a batch of replicated features in the local cache within a single
+    /// transaction. Implementations should commit the whole batch atomically so that a delta
+    /// download pays one durable write instead of one per feature.
+    /// </summary>
+    /// <param name="layerKey">The layer identifier for the features.</param>
+    /// <param name="featureJsons">The full feature JSON payloads including attributes and geometry.</param>
+    /// <param name="ct">Cancellation token.</param>
+    async Task UpsertFeaturesAsync(string layerKey, IReadOnlyList<string> featureJsons, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(featureJsons);
+        foreach (var featureJson in featureJsons)
+        {
+            await UpsertFeatureAsync(layerKey, featureJson, ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
     /// Deletes a replicated feature from the local cache.
     /// </summary>
     /// <param name="layerKey">The layer identifier for the feature.</param>
     /// <param name="objectId">The object ID of the feature to delete.</param>
     /// <param name="ct">Cancellation token.</param>
     Task DeleteFeatureAsync(string layerKey, long objectId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes a batch of replicated features from the local cache within a single transaction.
+    /// </summary>
+    /// <param name="layerKey">The layer identifier for the features.</param>
+    /// <param name="objectIds">The object IDs of the features to delete.</param>
+    /// <param name="ct">Cancellation token.</param>
+    async Task DeleteFeaturesAsync(string layerKey, IReadOnlyList<long> objectIds, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(objectIds);
+        foreach (var objectId in objectIds)
+        {
+            await DeleteFeatureAsync(layerKey, objectId, ct).ConfigureAwait(false);
+        }
+    }
 
     /// <summary>
     /// Retrieves all cached feature JSON payloads for a given layer, ordered by object ID.

--- a/src/Honua.Mobile.Offline/Sync/DeltaDownloadEngine.cs
+++ b/src/Honua.Mobile.Offline/Sync/DeltaDownloadEngine.cs
@@ -73,44 +73,51 @@ public sealed class DeltaDownloadEngine
         {
             var layerKey = layerChange.LayerId.ToString(CultureInfo.InvariantCulture);
 
-            if (layerChange.AddFeaturesJson is { Count: > 0 })
+            // Adds and updates are both upserts; apply them as a single batched transaction
+            // per layer so the store pays one durable write instead of one fsync per feature.
+            var upserts = new List<string>();
+            if (layerChange.AddFeaturesJson is { Count: > 0 } adds)
             {
-                foreach (var featureJson in layerChange.AddFeaturesJson)
-                {
-                    await _store.UpsertFeatureAsync(layerKey, featureJson, ct).ConfigureAwait(false);
-                    totalAdds++;
-                }
+                upserts.AddRange(adds);
+                totalAdds += adds.Count;
             }
 
-            if (layerChange.UpdateFeaturesJson is { Count: > 0 })
+            if (layerChange.UpdateFeaturesJson is { Count: > 0 } updates)
             {
-                foreach (var featureJson in layerChange.UpdateFeaturesJson)
-                {
-                    await _store.UpsertFeatureAsync(layerKey, featureJson, ct).ConfigureAwait(false);
-                    totalUpdates++;
-                }
+                upserts.AddRange(updates);
+                totalUpdates += updates.Count;
             }
 
-            if (layerChange.DeleteIds is { Count: > 0 })
+            if (upserts.Count > 0)
             {
-                foreach (var objectId in layerChange.DeleteIds)
-                {
-                    await _store.DeleteFeatureAsync(layerKey, objectId, ct).ConfigureAwait(false);
-                    totalDeletes++;
-                }
+                await _store.UpsertFeaturesAsync(layerKey, upserts, ct).ConfigureAwait(false);
+            }
+
+            if (layerChange.DeleteIds is { Count: > 0 } deletes)
+            {
+                await _store.DeleteFeaturesAsync(layerKey, deletes, ct).ConfigureAwait(false);
+                totalDeletes += deletes.Count;
             }
         }
 
-        var syncResult = await _replicaClient.SynchronizeReplicaAsync(serviceId, replicaId, "download", ct).ConfigureAwait(false);
+        // Acknowledge the replica server-side so it can reclaim change-tracking state. The
+        // synchronize response generation is intentionally not used as the cursor (see below).
+        await _replicaClient.SynchronizeReplicaAsync(serviceId, replicaId, "download", ct).ConfigureAwait(false);
 
-        await _store.SetSyncCursorAsync(serverGenCursorKey, syncResult.ServerGen.ToString(CultureInfo.InvariantCulture), ct).ConfigureAwait(false);
+        // Advance the "since" cursor to the generation the applied changes were extracted at,
+        // NOT the synchronize response generation. Synchronize runs after extract over a
+        // separate round-trip, so the synchronize generation can be strictly greater than
+        // extractResult.ServerGen when the server commits edits between the two calls. Persisting
+        // the higher value would make the next extractChanges skip the changes in
+        // (extractResult.ServerGen, synchronizeGen] permanently.
+        await _store.SetSyncCursorAsync(serverGenCursorKey, extractResult.ServerGen.ToString(CultureInfo.InvariantCulture), ct).ConfigureAwait(false);
 
         return new DeltaDownloadResult
         {
             Adds = totalAdds,
             Updates = totalUpdates,
             Deletes = totalDeletes,
-            ServerGen = syncResult.ServerGen,
+            ServerGen = extractResult.ServerGen,
         };
     }
 }

--- a/tests/Honua.Mobile.Offline.Tests/DeltaDownloadEngineTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/DeltaDownloadEngineTests.cs
@@ -191,17 +191,61 @@ public sealed class DeltaDownloadEngineTests : IDisposable
         var engine = new DeltaDownloadEngine(store, replicaClient);
 
         await engine.DownloadAsync("svc");
-        // First sync advanced the persisted cursor to the synchronize generation (20).
+        // First sync advanced the persisted cursor to the extracted generation (20).
         Assert.Equal("20", await store.GetSyncCursorAsync("servergen:svc"));
 
+        replicaClient.ExtractChangesResponse = new ExtractChangesResult
+        {
+            ServerGen = 30,
+            LayerChanges = [],
+        };
         replicaClient.SynchronizeResponse = new SynchronizeResult("replica-delta", 30);
 
         await engine.DownloadAsync("svc");
 
         // Second sync must scope extractChanges to the persisted generation rather than
-        // re-downloading the full change set.
+        // re-downloading the full change set, then advance the cursor to the extracted generation.
         Assert.Equal("20", replicaClient.LastExtractSinceServerGen);
         Assert.Equal("30", await store.GetSyncCursorAsync("servergen:svc"));
+    }
+
+    [Fact]
+    public async Task DownloadAsync_SynchronizeGenAheadOfExtractGen_PersistsExtractGen()
+    {
+        // Regression: synchronize runs after extract over a separate round-trip, so the server
+        // can commit edits in between and return a higher generation. The cursor must advance to
+        // the generation the applied changes were extracted at, otherwise the next extractChanges
+        // would skip the changes in (extractGen, synchronizeGen] permanently.
+        var store = CreateStore();
+        var replicaClient = new FakeReplicaSyncClient
+        {
+            CreateReplicaResponse = new CreateReplicaResult("replica-divergent", 10),
+            ExtractChangesResponse = new ExtractChangesResult
+            {
+                ServerGen = 20,
+                LayerChanges =
+                [
+                    new LayerChangeSet
+                    {
+                        LayerId = 0,
+                        AddFeaturesJson = ["""{"attributes":{"objectid":1,"name":"Feature A"}}"""],
+                    },
+                ],
+            },
+            // Server advanced to 35 between extract and synchronize.
+            SynchronizeResponse = new SynchronizeResult("replica-divergent", 35),
+        };
+
+        var engine = new DeltaDownloadEngine(store, replicaClient);
+        var result = await engine.DownloadAsync("assets");
+
+        Assert.Equal(20, result.ServerGen);
+        Assert.Equal("20", await store.GetSyncCursorAsync("servergen:assets"));
+
+        // The next run must re-request changes starting from the extracted generation (20),
+        // not the synchronize generation (35), so nothing in (20, 35] is missed.
+        await engine.DownloadAsync("assets");
+        Assert.Equal("20", replicaClient.LastExtractSinceServerGen);
     }
 
     [Fact]

--- a/tests/Honua.Mobile.ServerIntegration.Tests/DisconnectedFieldWorkflowAcceptanceTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/DisconnectedFieldWorkflowAcceptanceTests.cs
@@ -96,7 +96,11 @@ public sealed class DisconnectedFieldWorkflowAcceptanceTests : IDisposable
         Assert.Equal(0, result.Evidence.FinalState.PendingOperationCount);
         Assert.True(result.Evidence.FinalState.LocalFeatureCount >= 1);
         Assert.Equal("replica-abc-123", result.Evidence.CursorState["replica:assets"]);
-        Assert.Equal("100", result.Evidence.CursorState["servergen:assets"]);
+        // The delta-sync "since" cursor advances to the generation changes were extracted at
+        // (extractChanges => 55), not the later synchronizeReplica response generation (100).
+        // Persisting the higher synchronize generation would permanently skip any changes the
+        // server commits between the extract and synchronize round-trips.
+        Assert.Equal("55", result.Evidence.CursorState["servergen:assets"]);
         Assert.Equal(
             [
                 "op-acceptance-add-001",


### PR DESCRIPTION
Round-1 audit fixes for `honua-mobile` (S2 findings). Grouped by theme into one PR.

## Correctness / reliability: delta-sync cursor (S2)
`DeltaDownloadEngine.DownloadAsync` applied changes from `extractChanges` but advanced the persisted `since` cursor using the **synchronize** response generation. Synchronize runs after extract over a separate round-trip, so its generation can be strictly greater than the extract generation when the server commits edits between the two calls. Changes in `(extractGen, synchronizeGen]` were never applied yet were permanently skipped on the next run — silent missed updates.

- The cursor and the returned `DeltaDownloadResult.ServerGen` now use `extractResult.ServerGen`.
- Added regression test `DownloadAsync_SynchronizeGenAheadOfExtractGen_PersistsExtractGen` exercising the divergent case (extract gen 20, synchronize gen 35).
- Corrected `DownloadAsync_SecondCall_PassesPersistedServerGenToExtractChanges`, which had encoded the buggy behavior (it expected the synchronize gen to win).

Addresses:
- `src/Honua.Mobile.Offline/Sync/DeltaDownloadEngine.cs:106` — cursor advanced with synchronize gen, ignoring extract gen.

## Performance: bulk feature apply (S2)
`GeoPackageSyncStore.UpsertFeatureAsync` / `DeleteFeatureAsync` opened a fresh connection and `BEGIN IMMEDIATE`/`COMMIT` (one fsync) per feature; `DeltaDownloadEngine` looped one `await` per feature, so N features meant N fsyncs.

- Added batch `UpsertFeaturesAsync(layerKey, IReadOnlyList<string>)` and `DeleteFeaturesAsync(layerKey, IReadOnlyList<long>)` to `IGeoPackageSyncStore` (default fallbacks loop the single-item methods) and implemented them in `GeoPackageSyncStore` as a single `BEGIN IMMEDIATE`/`COMMIT` per layer change set (one fsync per batch).
- Routed `DeltaDownloadEngine` through the batch methods (adds + updates coalesced into one upsert batch per layer, deletes in one batch).
- Single-item paths refactored onto shared `WriteFeatureCoreAsync` / `RemoveFeatureCoreAsync` / `ParseFeatureCacheRecord` helpers (no behavior change).

Addresses:
- `src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs:708` / `:795` — one connection + transaction per feature on bulk apply.

Note: the finding also suggested `journal_mode=WAL`. WAL was prototyped but globally changes the GeoPackage file lifecycle (the file/`-wal`/`-shm` handles are held open under connection pooling, which broke file delete/move semantics relied on across the suite). It needs a dedicated connection-lifecycle change (checkpoint-on-dispose + sidecar cleanup) and is intentionally **not** included here; the batched transaction is the substantive fsync win.

## DRY/reuse: duplicated ResolveServiceId (S2)
`ResolveServiceId(LayerInfo)` was copy-pasted verbatim into the uploader, puller, and attachment synchronizer. Collapsed into one shared `FieldCollectionSyncLayer.ResolveServiceId` so the three transports cannot diverge on routing.

Addresses:
- `apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs:721` / `:1042` / `:1477`.

## Not addressed here
- `FieldCollectionSyncTransports.cs:786` (S2, DRY) — field-collection pull does a full `1=1` table scan per layer and discards rows client-side instead of using the SDK delta engine / a server-side modified-since filter. The robust fix (consolidate the two offline-sync stacks onto `DeltaDownloadEngine`/`IReplicaSyncClient`, or push a server-side since-bound) requires server query-semantics knowledge and a product decision on unifying conflict/version handling across the two stacks; out of scope for a minimal round-1 fix.

## Verification
Built `Honua.Mobile.Offline` and `Honua.Mobile.FieldCollection.Core` (Release, 0 errors). On Linux: `Honua.Mobile.Offline.Tests` 85/85 pass, `Honua.Mobile.FieldCollection.Tests` 141/141 pass. `dotnet format` on the Offline core library passes. (On Windows hosts these SQLite suites pre-exist as flaky due to file-lock-on-delete in test `Dispose`, unrelated to this change.)