### PR TITLE
fix(field-collection): push sync delta filter to server instead of full-table scan

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs
@@ -783,13 +783,25 @@ public sealed class HonuaFieldCollectionChangePuller :
                 continue;
             }
 
+            // Push the delta down to the server so the pull is O(changes) instead of
+            // scanning the whole layer every sync (#S2). When the layer schema exposes a
+            // version column we filter on it server-side; otherwise we fall back to the
+            // full scan and rely on the client-side guard below to discard already-seen
+            // rows. The client-side guard is also kept as defense-in-depth for layers whose
+            // version is derived from a timestamp (no comparable column to push down).
+            var deltaFilter = BuildDeltaFilter(layer, sinceGeneration, out var versionField);
+
             var result = await _featureClient.QueryAsync(
                 new FeatureQueryRequest
                 {
                     Source = new FeatureSource { ServiceId = serviceId, LayerId = layer.Id },
-                    Filter = "1=1",
+                    Filter = deltaFilter,
                     OutFields = ["*"],
-                    ReturnGeometry = true
+                    ReturnGeometry = true,
+                    // Oldest deltas first so the cursor advances monotonically if the
+                    // server caps the result set; only ordered when a real version
+                    // column was resolved.
+                    OrderBy = versionField is null ? null : $"{versionField} ASC"
                 },
                 cancellationToken).ConfigureAwait(false);
 
@@ -882,9 +894,15 @@ public sealed class HonuaFieldCollectionChangePuller :
         return Guid.NewGuid().ToString("N");
     }
 
+    // Integer version columns, in the precedence used to derive a feature's version.
+    // The delta filter pushed to the server must resolve to the same column so the
+    // server-side predicate matches the value compared client-side.
+    private static readonly string[] VersionFieldCandidates =
+        { "sync_version", "version", "server_version", "edit_version" };
+
     private static long ResolveFeatureVersion(Feature feature, FeatureRecord record)
     {
-        foreach (var fieldName in new[] { "sync_version", "version", "server_version", "edit_version" })
+        foreach (var fieldName in VersionFieldCandidates)
         {
             if (TryReadInt64(feature.Attributes, fieldName, out var version) ||
                 (record.Attributes.TryGetValue(fieldName, out var value) && TryReadInt64(value, out version)))
@@ -899,6 +917,58 @@ public sealed class HonuaFieldCollectionChangePuller :
         }
 
         return 1;
+    }
+
+    /// <summary>
+    /// Builds the server-side filter for an incremental pull. When the layer schema
+    /// exposes one of the <see cref="VersionFieldCandidates"/> columns, the delta is
+    /// pushed down as a <c>&gt; sinceGeneration</c> predicate so only changed rows are
+    /// returned. When no version column is known the filter falls back to <c>1=1</c>
+    /// (and <paramref name="versionField"/> is <see langword="null"/>), in which case the
+    /// caller's client-side guard still discards already-seen rows.
+    /// </summary>
+    /// <remarks>
+    /// Honua Server currently has no generic incremental-change query parameter on this
+    /// feature read path, so the delta is expressed as a WHERE predicate on the version
+    /// column. A dedicated server-side change-generation parameter (cross-repo:
+    /// honua-server) would let timestamp-versioned layers also pull O(delta).
+    /// </remarks>
+    private static string BuildDeltaFilter(LayerInfo layer, long sinceGeneration, out string? versionField)
+    {
+        versionField = ResolveVersionFieldName(layer);
+        if (versionField is null)
+        {
+            return "1=1";
+        }
+
+        return string.Create(CultureInfo.InvariantCulture, $"{versionField} > {sinceGeneration}");
+    }
+
+    private static string? ResolveVersionFieldName(LayerInfo layer)
+    {
+        if (layer.Schema.Count == 0)
+        {
+            return null;
+        }
+
+        // Honour the same precedence as ResolveFeatureVersion and only emit a column
+        // name drawn from the known candidate list (acts as a whitelist for the filter).
+        foreach (var candidate in VersionFieldCandidates)
+        {
+            foreach (var field in layer.Schema)
+            {
+                var column = string.IsNullOrWhiteSpace(field.SourceFieldName)
+                    ? field.FieldId
+                    : field.SourceFieldName;
+
+                if (string.Equals(column, candidate, StringComparison.OrdinalIgnoreCase))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
     }
 
     private static DateTime? ResolveFeatureTimestamp(Feature feature, FeatureRecord record)

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -5,6 +5,7 @@ using Honua.Mobile.FieldCollection.Services.Sync;
 using Honua.Mobile.FieldCollection.Services.Storage;
 using Honua.Mobile.Maui.Diagnostics;
 using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Field.Forms;
 using Microsoft.Extensions.Logging.Abstractions;
 using SQLite;
 using System.Text.Json;
@@ -444,6 +445,102 @@ public sealed class GeoPackageSyncServiceTests
         var feature = await storage.GetFeatureAsync("42", 1);
         Assert.NotNull(feature);
         Assert.Equal("server", feature.Attributes["name"]?.ToString());
+    }
+
+    [Fact]
+    public async Task GetChangesAsync_WhenLayerExposesVersionColumn_PushesDeltaFilterToServer()
+    {
+        // Regression for the S2 full-table-scan finding: the pull must filter by the
+        // change/version column server-side (> sinceGeneration) instead of querying
+        // "1=1" and discarding rows client-side.
+        var layer = CreateLayer();
+        layer.Schema.Add(new FieldDefinition
+        {
+            FieldId = "sync_version",
+            SourceFieldName = "sync_version",
+            Label = "Sync Version",
+            Type = FormFieldType.Numeric
+        });
+        var metadata = new FixedMetadataService([layer]);
+        var settings = new InMemorySettingsService();
+        var client = new RecordingFeatureSyncClient
+        {
+            QueryResponse = new FeatureQueryResult
+            {
+                ProviderName = "test",
+                ObjectIdFieldName = "objectid",
+                Features =
+                [
+                    new FeatureRecord
+                    {
+                        Id = "42",
+                        Attributes = new Dictionary<string, JsonElement>
+                        {
+                            ["objectid"] = JsonSerializer.SerializeToElement(42),
+                            ["sync_version"] = JsonSerializer.SerializeToElement(7L)
+                        }
+                    }
+                ]
+            }
+        };
+        var puller = new HonuaFieldCollectionChangePuller(metadata, client, settings);
+
+        var changes = await puller.GetChangesAsync(sinceGeneration: 5);
+
+        var request = Assert.Single(client.QueryRequests);
+        Assert.Equal("sync_version > 5", request.Filter);
+        Assert.Equal("sync_version ASC", request.OrderBy);
+        var change = Assert.Single(changes);
+        Assert.Equal(7, change.Version);
+    }
+
+    [Fact]
+    public async Task GetChangesAsync_WhenLayerHasNoVersionColumn_FallsBackToFullScanAndClientSideGuard()
+    {
+        // Without a known version column there is no predicate to push down, so the pull
+        // falls back to a full scan and the client-side guard discards already-seen rows.
+        var layer = CreateLayer();
+        var metadata = new FixedMetadataService([layer]);
+        var settings = new InMemorySettingsService();
+        var client = new RecordingFeatureSyncClient
+        {
+            QueryResponse = new FeatureQueryResult
+            {
+                ProviderName = "test",
+                ObjectIdFieldName = "objectid",
+                Features =
+                [
+                    new FeatureRecord
+                    {
+                        Id = "1",
+                        Attributes = new Dictionary<string, JsonElement>
+                        {
+                            ["objectid"] = JsonSerializer.SerializeToElement(1),
+                            ["sync_version"] = JsonSerializer.SerializeToElement(3L)
+                        }
+                    },
+                    new FeatureRecord
+                    {
+                        Id = "2",
+                        Attributes = new Dictionary<string, JsonElement>
+                        {
+                            ["objectid"] = JsonSerializer.SerializeToElement(2),
+                            ["sync_version"] = JsonSerializer.SerializeToElement(9L)
+                        }
+                    }
+                ]
+            }
+        };
+        var puller = new HonuaFieldCollectionChangePuller(metadata, client, settings);
+
+        var changes = await puller.GetChangesAsync(sinceGeneration: 5);
+
+        var request = Assert.Single(client.QueryRequests);
+        Assert.Equal("1=1", request.Filter);
+        Assert.Null(request.OrderBy);
+        // Client-side guard keeps only the row newer than the cursor (version 9 > 5).
+        var change = Assert.Single(changes);
+        Assert.Equal(9, change.Version);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes Round-1 audit finding **S2** (perf/scale + correctness): the field-collection change pull issued a full `Filter="1=1"` table scan per editable layer and then discarded rows client-side via `feature.Version <= sinceGeneration`. This pulled the entire layer on every sync — O(table) instead of O(delta).

## What changed

`HonuaFieldCollectionChangePuller.GetChangesAsync` (`apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs`):

- When the layer schema exposes a known version column (`sync_version`, `version`, `server_version`, `edit_version`), the delta is now pushed to the server as a `<column> > sinceGeneration` predicate.
- Results are ordered oldest-first (`<column> ASC`) so the cursor advances monotonically even if the server caps the result set.
- The version column is resolved with the **same precedence** used to compute `feature.Version`, so the server-side predicate matches the value compared client-side. The candidate list now lives in a shared `VersionFieldCandidates` array.
- The client-side guard is retained as defense-in-depth.

### Fallback / unchanged behaviour
When no version column is known (e.g. layers whose version is derived from a timestamp, or layers with no schema), the query falls back to the previous `1=1` full scan + client-side discard. Behaviour for those layers is unchanged.

## Cross-repo dependency (honua-server)

Honua Server currently exposes **no generic incremental-change query parameter** on this feature read path, so the delta is expressed as a WHERE predicate on the version column. A dedicated server-side change-generation parameter would let *timestamp-versioned* layers also pull O(delta). Tracked as a follow-up in honua-server.

## Tests

- Added `GetChangesAsync_WhenLayerExposesVersionColumn_PushesDeltaFilterToServer` — asserts `Filter == "sync_version > 5"` and `OrderBy == "sync_version ASC"`.
- Added `GetChangesAsync_WhenLayerHasNoVersionColumn_FallsBackToFullScanAndClientSideGuard` — asserts `1=1` fallback and client-side discard.
- Full `Honua.Mobile.FieldCollection.Tests` suite: **143 passed, 0 failed**.
- `dotnet format` verify-no-changes: clean.

> Note: the MAUI app target (`net10.0-android`) is not buildable in this Linux env (XA5300); the affected code lives in the `net10.0` `Honua.Mobile.FieldCollection.Core` library, which builds and tests cleanly.
> The deliberately-deferred `journal_mode=WAL` change is **not** included.