### PR TITLE
fix(offline): at-most-once edits, conflict-code classification, and spatial pre-filter

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
@@ -154,10 +154,71 @@ public class GeoPackageStorageService : IDisposable, IAsyncDisposable
             await MigrateLocalFeaturesTableAsync();
         }
 
+        await EnsureLocalFeaturesBboxColumnsAsync();
+
         await _connection.ExecuteAsync("CREATE INDEX IF NOT EXISTS idx_local_features_id_layer_id ON local_features(id, layer_id)");
         await _connection.ExecuteAsync("CREATE INDEX IF NOT EXISTS idx_local_features_layer_id ON local_features(layer_id)");
         await _connection.ExecuteAsync("CREATE INDEX IF NOT EXISTS idx_local_features_modified_at ON local_features(modified_at)");
         await _connection.ExecuteAsync("CREATE INDEX IF NOT EXISTS idx_local_features_sync_status ON local_features(sync_status)");
+        // Supports the bounded-query bbox pre-filter (layer-scoped envelope range scan).
+        await _connection.ExecuteAsync(
+            "CREATE INDEX IF NOT EXISTS idx_local_features_layer_bbox ON local_features(layer_id, min_x, max_x, min_y, max_y)");
+    }
+
+    /// <summary>
+    /// Adds the cached geometry-envelope columns (<c>min_x</c>/<c>min_y</c>/<c>max_x</c>/<c>max_y</c>)
+    /// to a pre-existing <c>local_features</c> table and backfills them from stored geometry. New
+    /// databases get the columns from <see cref="CreateLocalFeaturesTableAsync"/>; this only runs the
+    /// one-time migration for tables created before the spatial pre-filter existed.
+    /// </summary>
+    private async Task EnsureLocalFeaturesBboxColumnsAsync()
+    {
+        var columns = await _connection.QueryAsync<TableColumnInfo>("PRAGMA table_info(local_features)");
+        var columnNames = columns
+            .Select(column => column.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var bboxColumn in new[] { "min_x", "min_y", "max_x", "max_y" })
+        {
+            if (!columnNames.Contains(bboxColumn))
+            {
+                await _connection.ExecuteAsync($"ALTER TABLE local_features ADD COLUMN {bboxColumn} REAL");
+            }
+        }
+
+        // Backfill any geometry rows missing a cached envelope. This covers both freshly added
+        // columns and rows copied in by a schema migration (which recreates the table with the
+        // bbox columns already present, so the ALTER above is a no-op for them). The guard keeps
+        // normal startups from rescanning once every row is populated.
+        var pendingBackfill = await _connection.ExecuteScalarAsync<int>(
+            "SELECT EXISTS(SELECT 1 FROM local_features WHERE geometry IS NOT NULL AND min_x IS NULL)");
+        if (pendingBackfill != 0)
+        {
+            await BackfillLocalFeaturesBboxAsync();
+        }
+    }
+
+    /// <summary>
+    /// Computes and persists the envelope columns for rows that have geometry but no cached bbox
+    /// (legacy rows after the column migration). Decodes each WKB once.
+    /// </summary>
+    private async Task BackfillLocalFeaturesBboxAsync()
+    {
+        var rows = await _connection.QueryAsync<LocalFeature>(
+            "SELECT * FROM local_features WHERE geometry IS NOT NULL AND min_x IS NULL");
+
+        foreach (var row in rows)
+        {
+            if (row.Geometry is null)
+            {
+                continue;
+            }
+
+            var envelope = _wkbReader.Read(row.Geometry).EnvelopeInternal;
+            await _connection.ExecuteAsync(
+                "UPDATE local_features SET min_x = ?, min_y = ?, max_x = ?, max_y = ? WHERE storage_key = ?",
+                envelope.MinX, envelope.MinY, envelope.MaxX, envelope.MaxY, row.StorageKey);
+        }
     }
 
     private async Task<bool> LocalFeaturesTableUsesStorageKeyAsync()
@@ -362,6 +423,10 @@ public class GeoPackageStorageService : IDisposable, IAsyncDisposable
                 id TEXT NOT NULL,
                 layer_id INTEGER NOT NULL,
                 geometry BLOB,
+                min_x REAL,
+                min_y REAL,
+                max_x REAL,
+                max_y REAL,
                 attributes TEXT,
                 created_at DATETIME NOT NULL,
                 modified_at DATETIME NOT NULL,
@@ -422,23 +487,52 @@ public class GeoPackageStorageService : IDisposable, IAsyncDisposable
         await _dbLock.WaitAsync();
         try
         {
-            var localFeatures = await _connection.Table<LocalFeature>()
-                .Where(f => f.LayerId == layerId)
-                .ToListAsync();
-
-            if (spatialQuery != null)
+            if (spatialQuery is null)
             {
-                localFeatures = localFeatures
-                    .Where(feature => MatchesSpatialQuery(feature, spatialQuery))
-                    .ToList();
+                var all = await _connection.Table<LocalFeature>()
+                    .Where(f => f.LayerId == layerId)
+                    .ToListAsync();
+                return all.Select(ConvertToFeature).ToList();
+            }
 
-                if (spatialQuery.MaxResults.HasValue)
+            if (!spatialQuery.Bounds.IsValid)
+            {
+                // Preserves prior behaviour: an invalid query window matches nothing.
+                return [];
+            }
+
+            // Pre-filter to rows whose cached envelope overlaps the query window using an indexed
+            // range scan, so we only decode WKB and run the exact NTS predicate on real candidates
+            // instead of materialising and testing the whole layer. Inclusive comparisons keep this
+            // a correct superset for every supported relationship (including Touches on a shared edge).
+            var bounds = spatialQuery.Bounds;
+            var candidates = await _connection.QueryAsync<LocalFeature>(
+                @"SELECT * FROM local_features
+                  WHERE layer_id = ?
+                    AND min_x IS NOT NULL
+                    AND max_x >= ? AND min_x <= ?
+                    AND max_y >= ? AND min_y <= ?",
+                layerId, bounds.MinX, bounds.MaxX, bounds.MinY, bounds.MaxY);
+
+            var matches = new List<Feature>();
+            foreach (var candidate in candidates)
+            {
+                if (!MatchesSpatialQuery(candidate, spatialQuery))
                 {
-                    localFeatures = localFeatures.Take(spatialQuery.MaxResults.Value).ToList();
+                    continue;
+                }
+
+                matches.Add(ConvertToFeature(candidate));
+
+                // MaxResults is applied after the exact predicate (the bbox candidate set is a
+                // superset, so it cannot be capped earlier without dropping valid matches).
+                if (spatialQuery.MaxResults is { } max && matches.Count >= max)
+                {
+                    break;
                 }
             }
 
-            return localFeatures.Select(ConvertToFeature).ToList();
+            return matches;
         }
         finally
         {
@@ -639,12 +733,17 @@ public class GeoPackageStorageService : IDisposable, IAsyncDisposable
         feature.BaseVersion = baseVersion;
 
         var geometry = ConvertToNtsGeometry(feature.Geometry);
+        var envelope = geometry?.EnvelopeInternal;
         var localFeature = new LocalFeature
         {
             StorageKey = BuildStorageKey(feature.LayerId, feature.Id),
             Id = feature.Id,
             LayerId = feature.LayerId,
             Geometry = geometry != null ? _wkbWriter.Write(geometry) : null,
+            MinX = envelope?.MinX,
+            MinY = envelope?.MinY,
+            MaxX = envelope?.MaxX,
+            MaxY = envelope?.MaxY,
             Attributes = JsonSerializer.Serialize(feature.Attributes),
             CreatedAt = feature.CreatedAt,
             ModifiedAt = feature.ModifiedAt.Value,

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/Models/StorageModels.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/Models/StorageModels.cs
@@ -26,6 +26,21 @@ public class LocalFeature
     [Column("geometry")]
     public byte[]? Geometry { get; set; }
 
+    // Cached geometry envelope (WGS84) used as a cheap spatial pre-filter so a bounded query can
+    // skip rows whose bounding box cannot overlap the query window without decoding every WKB blob.
+    // Null when the row has no geometry.
+    [Column("min_x")]
+    public double? MinX { get; set; }
+
+    [Column("min_y")]
+    public double? MinY { get; set; }
+
+    [Column("max_x")]
+    public double? MaxX { get; set; }
+
+    [Column("max_y")]
+    public double? MaxY { get; set; }
+
     [Column("attributes")]
     public string? Attributes { get; set; }
 

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/FieldCollectionSyncTransports.cs
@@ -17,7 +17,16 @@ namespace Honua.Mobile.FieldCollection.Services.Sync;
 public interface IFieldCollectionFeatureSyncClient
 {
     bool IsConfigured { get; }
-    Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Applies feature edits, optionally attaching a stable <paramref name="idempotencyKey"/> so the
+    /// server dedupes a retried upload (at-most-once, honua-server #2250).
+    /// </summary>
+    Task<FeatureEditResponse> ApplyEditsAsync(
+        FeatureEditRequest request,
+        string? idempotencyKey = null,
+        CancellationToken cancellationToken = default);
+
     Task<FeatureQueryResult> QueryAsync(FeatureQueryRequest request, CancellationToken cancellationToken = default);
 }
 
@@ -60,10 +69,11 @@ public sealed class HonuaSdkFieldCollectionFeatureSyncClient :
 
     public async Task<FeatureEditResponse> ApplyEditsAsync(
         FeatureEditRequest request,
+        string? idempotencyKey = null,
         CancellationToken cancellationToken = default)
     {
         using var client = CreateClient();
-        return await client.ApplyEditsAsync(request, cancellationToken).ConfigureAwait(false);
+        return await client.ApplyEditsAsync(request, idempotencyKey, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<FeatureQueryResult> QueryAsync(
@@ -272,7 +282,12 @@ public sealed class HonuaFieldCollectionChangeUploader :
             ForceWrite = false
         };
 
-        var response = await _featureClient.ApplyEditsAsync(request, cancellationToken).ConfigureAwait(false);
+        // The change id is durable until the change is marked synced, so a re-upload after a lost
+        // ack carries the same key and the server replays the original result instead of applying
+        // the edit twice (at-most-once, #2250). This complements the insert GlobalID reconcile above
+        // and extends at-most-once to updates and deletes.
+        var idempotencyKey = $"fieldchange:{change.Id}";
+        var response = await _featureClient.ApplyEditsAsync(request, idempotencyKey, cancellationToken).ConfigureAwait(false);
         if (response.Succeeded)
         {
             await UpdateLocalFeatureAfterSuccessfulAddAsync(change, localFeature, response).ConfigureAwait(false);

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/GeoPackageSyncService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Sync/GeoPackageSyncService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Honua.Mobile.FieldCollection.Models;
@@ -211,7 +212,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
                 // Phase 2: Push local changes
                 Status = SyncStatus.PushingChanges;
                 SyncMessage = "Uploading changes to server...";
-                await PushChangesInternalAsync(session, _syncCancellation.Token);
+                await PushChangesInternalAsync(session, pendingChanges: null, _syncCancellation.Token);
                 pushedAttachments = await PushAttachmentsInternalAsync(_syncCancellation.Token);
 
                 SyncProgress = 0.8;
@@ -458,7 +459,7 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
             IsSyncing = true;
             Status = SyncStatus.PushingChanges;
 
-            await PushChangesInternalAsync(session, _syncCancellation.Token);
+            await PushChangesInternalAsync(session, pendingChanges, _syncCancellation.Token);
             var pushedAttachments = await PushAttachmentsInternalAsync(_syncCancellation.Token);
             await CompleteSyncSessionAsync(session, StorageSyncSessionStatus.Completed);
 
@@ -501,53 +502,76 @@ public partial class GeoPackageSyncService : ObservableObject, ISyncService, IDi
         }
     }
 
-    private async Task<bool> PushChangesInternalAsync(StorageSyncSession session, CancellationToken cancellationToken)
+    // Upload fan-out cap. Bounds concurrent applyEdits round-trips so a large queue is not pushed
+    // one blocking request at a time (the N+1 latency cliff) without overwhelming the device/server.
+    private const int MaxConcurrentChangeUploads = 4;
+
+    private async Task<bool> PushChangesInternalAsync(
+        StorageSyncSession session,
+        IReadOnlyList<StorageChangeRecord>? pendingChanges,
+        CancellationToken cancellationToken)
     {
-        try
+        // Reuse the list the caller already fetched instead of re-querying the change log.
+        pendingChanges ??= await _storage.GetPendingChangesAsync();
+        if (pendingChanges.Count == 0)
         {
-            var pendingChanges = await _storage.GetPendingChangesAsync();
-            var successfulChanges = new List<string>();
-            var failedChanges = new List<string>();
-
-            foreach (var change in pendingChanges)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var success = await _changeUploader.UploadChangeAsync(change, cancellationToken);
-
-                if (success)
-                {
-                    successfulChanges.Add(change.Id);
-                    session.ChangesPushed++;
-                }
-                else
-                {
-                    failedChanges.Add(change.Id);
-                }
-            }
-
-            // Mark successful changes as synced
-            if (successfulChanges.Any())
-            {
-                await _storage.MarkChangesAsSynced(successfulChanges);
-            }
-
-            if (failedChanges.Count > 0)
-            {
-                throw new InvalidOperationException(
-                    $"{failedChanges.Count} pending change(s) failed to upload and remain unsynced.");
-            }
-
             return true;
         }
-        catch (OperationCanceledException)
+
+        var successfulChanges = new ConcurrentQueue<string>();
+        var failedChanges = new ConcurrentQueue<string>();
+
+        // Group by feature so edits to the same feature stay strictly ordered (an insert must land
+        // before its later update/delete). GroupBy preserves source order within each group, and the
+        // pending list is already ordered by timestamp. Distinct features upload concurrently, capped
+        // by the semaphore, which removes the per-change sequential round-trip pattern.
+        using var concurrency = new SemaphoreSlim(MaxConcurrentChangeUploads, MaxConcurrentChangeUploads);
+        var featureGroups = pendingChanges.GroupBy(change => (change.LayerId, change.FeatureId));
+
+        var uploads = featureGroups.Select(async group =>
         {
-            throw;
-        }
-        catch (Exception)
+            await concurrency.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                foreach (var change in group)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if (await _changeUploader.UploadChangeAsync(change, cancellationToken).ConfigureAwait(false))
+                    {
+                        successfulChanges.Enqueue(change.Id);
+                    }
+                    else
+                    {
+                        // Stop this feature's chain on first failure so a dependent edit is not
+                        // applied on top of an edit that never landed; it stays pending for retry.
+                        failedChanges.Enqueue(change.Id);
+                        break;
+                    }
+                }
+            }
+            finally
+            {
+                concurrency.Release();
+            }
+        });
+
+        await Task.WhenAll(uploads).ConfigureAwait(false);
+
+        session.ChangesPushed += successfulChanges.Count;
+
+        if (!successfulChanges.IsEmpty)
         {
-            throw;
+            await _storage.MarkChangesAsSynced(successfulChanges.ToList());
         }
+
+        if (!failedChanges.IsEmpty)
+        {
+            throw new InvalidOperationException(
+                $"{failedChanges.Count} pending change(s) failed to upload and remain unsynced.");
+        }
+
+        return true;
     }
 
     private async Task<AttachmentSyncResult> PushAttachmentsInternalAsync(CancellationToken cancellationToken)

--- a/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
+++ b/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
@@ -124,9 +124,18 @@ public sealed class HonuaApiOfflineOperationUploader : IOfflineOperationUploader
             ForceWrite = forceWrite,
         };
 
-        var response = await _client.ApplyEditsAsync(request, ct).ConfigureAwait(false);
+        // Stable across retries of this queued operation: a re-upload after a lost ack carries the
+        // same key so the server replays the original result instead of re-applying the edit (#2250).
+        var response = await _client.ApplyEditsAsync(request, BuildIdempotencyKey(operation), ct).ConfigureAwait(false);
         return ToUploadResult(response);
     }
+
+    /// <summary>
+    /// Derives the at-most-once idempotency key for a queued operation from its durable
+    /// <see cref="OfflineEditOperation.OperationId"/>, which is stable across upload retries.
+    /// </summary>
+    private static string BuildIdempotencyKey(OfflineEditOperation operation)
+        => $"offline-op:{operation.OperationId}";
 
     private async Task<UploadResult> UploadOgcAsync(
         OfflineEditOperation operation,

--- a/src/Honua.Mobile.Offline/Sync/MobileSyncProblem.cs
+++ b/src/Honua.Mobile.Offline/Sync/MobileSyncProblem.cs
@@ -5,6 +5,42 @@ using Honua.Mobile.Sdk;
 namespace Honua.Mobile.Offline.Sync;
 
 /// <summary>
+/// Stable per-feature <c>applyEdits</c> error-classification codes published by Honua Server in
+/// the HTTP-200 edit result envelope (honua-server <c>GeoServicesEditErrorCodes</c>, #2251). These
+/// are a documented contract: a code never changes meaning once published, so clients branch on the
+/// code rather than parsing the (sanitized, free-form) error description.
+/// </summary>
+internal static class GeoServicesEditErrorCodes
+{
+    /// <summary>Unclassified / fallback failure (unexpected provider error).</summary>
+    public const int Generic = 1000;
+
+    /// <summary>Update/delete object id missing, non-numeric, or unresolvable (request-shape error).</summary>
+    public const int InvalidObjectId = 1001;
+
+    /// <summary>The update target feature does not exist (or is hidden by row-level security).</summary>
+    public const int NotFound = 1002;
+
+    /// <summary>Delete conflict: the delete target was already removed, typically by another writer.</summary>
+    public const int DeleteConflict = 1003;
+
+    /// <summary>Update conflict: optimistic-concurrency/version mismatch — the row changed since read.</summary>
+    public const int UpdateConflict = 1004;
+
+    /// <summary>The feature is locked by another editor/session (HTTP 423 semantics).</summary>
+    public const int Locked = 1005;
+
+    /// <summary>Invalid attributes/geometry, attribute-rule, or contingent-value violation (request-shape error).</summary>
+    public const int ValidationFailed = 1006;
+
+    /// <summary>Denied by an owner-based edit policy.</summary>
+    public const int NotPermitted = 1007;
+
+    /// <summary>Rolled back because a sibling operation failed under <c>rollbackOnFailure=true</c>.</summary>
+    public const int RolledBack = 1008;
+}
+
+/// <summary>
 /// Sanitized sync failure category safe to surface in mobile sync results.
 /// </summary>
 public enum MobileSyncProblemCategory
@@ -137,17 +173,43 @@ public static class MobileSyncProblemHelper
     /// <summary>
     /// Maps a server edit error code to a sync problem.
     /// </summary>
+    /// <remarks>
+    /// Handles both transport-level HTTP status codes (409/412/429/5xx) and the stable
+    /// per-feature <c>applyEdits</c> classification codes Honua Server emits inside an HTTP-200
+    /// result envelope (<see cref="GeoServicesEditErrorCodes"/>, honua-server #2251). The
+    /// conflict classes (delete-delete, update-update, not-found) are routed to
+    /// <see cref="MobileSyncProblemCategory.Conflict"/> so they flow through conflict
+    /// resolution instead of being dropped as fatal; transient classes (locked, rolled-back)
+    /// are marked retryable.
+    /// </remarks>
     /// <param name="code">Provider edit error code.</param>
     /// <param name="message">Optional provider message.</param>
     /// <returns>Sanitized problem details.</returns>
     public static MobileSyncProblem FromErrorCode(int? code, string? message)
     {
-        if (code is 409 or 412)
+        // Per-feature applyEdits conflict classes: surface as Conflict so the offline engine
+        // reconciles them rather than discarding the edit as a fatal failure.
+        if (code is GeoServicesEditErrorCodes.NotFound
+                 or GeoServicesEditErrorCodes.DeleteConflict
+                 or GeoServicesEditErrorCodes.UpdateConflict
+                 or 409 or 412)
         {
             return new MobileSyncProblem(MobileSyncProblemCategory.Conflict, message ?? "Conflict", Retryable: false);
         }
 
-        if (code is 408 or 429 || (code.HasValue && code.Value >= 500))
+        // Per-feature classes that can succeed on a later attempt: a held lock clears, and a
+        // sibling-triggered rollback under rollbackOnFailure can re-run once the sibling is fixed.
+        if (code is GeoServicesEditErrorCodes.Locked or GeoServicesEditErrorCodes.RolledBack)
+        {
+            return new MobileSyncProblem(
+                MobileSyncProblemCategory.Transport,
+                message ?? UnknownRetryMessage,
+                Retryable: true);
+        }
+
+        // HTTP-style transport codes only (5xx). Bounded to < 600 so it does not swallow the
+        // four-digit per-feature classification codes, which are a separate code space.
+        if (code is 408 or 429 or (>= 500 and < 600))
         {
             return new MobileSyncProblem(
                 MobileSyncProblemCategory.Transport,
@@ -155,6 +217,9 @@ public static class MobileSyncProblemHelper
                 Retryable: true);
         }
 
+        // Remaining per-feature classes (generic, invalid-object-id, validation, not-permitted)
+        // and any other non-success code are request-shape/authorization failures that will not
+        // succeed on a blind retry.
         return new MobileSyncProblem(
             MobileSyncProblemCategory.InvalidOperation,
             message ?? "Fatal error",

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs
@@ -82,7 +82,27 @@ public sealed partial class HonuaMobileClient
     /// <param name="request">SDK feature edit request.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A provider-neutral feature edit response.</returns>
-    public async Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken ct = default)
+    public Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken ct = default)
+        => ApplyEditsAsync(request, idempotencyKey: null, ct);
+
+    /// <summary>
+    /// Applies feature edits through the SDK provider-neutral feature contract, attaching a stable
+    /// <c>Idempotency-Key</c> so the server can dedupe a retried edit (at-most-once, honua-server #2250).
+    /// </summary>
+    /// <remarks>
+    /// When <paramref name="idempotencyKey"/> is supplied the FeatureServer edit is sent over REST even
+    /// if gRPC is preferred, because the gRPC edit contract does not yet carry the idempotency header;
+    /// routing over REST is what makes a post-crash re-upload safe. Callers that do not need at-most-once
+    /// semantics can pass <see langword="null"/> to keep the default (gRPC-preferred) transport selection.
+    /// </remarks>
+    /// <param name="request">SDK feature edit request.</param>
+    /// <param name="idempotencyKey">Stable client-generated key (≤200 chars, no control characters), or <see langword="null"/>.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A provider-neutral feature edit response.</returns>
+    public async Task<FeatureEditResponse> ApplyEditsAsync(
+        FeatureEditRequest request,
+        string? idempotencyKey,
+        CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -93,7 +113,7 @@ public sealed partial class HonuaMobileClient
 
         if (HasFeatureServerSource(request.Source))
         {
-            return await ApplyFeatureServerSdkEditsAsync(request, ct).ConfigureAwait(false);
+            return await ApplyFeatureServerSdkEditsAsync(request, idempotencyKey, ct).ConfigureAwait(false);
         }
 
         return new FeatureEditResponse
@@ -195,11 +215,27 @@ public sealed partial class HonuaMobileClient
     /// <returns>A <see cref="JsonDocument"/> containing per-feature edit results.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="request"/> is <see langword="null"/>.</exception>
     /// <exception cref="HonuaMobileApiException">Thrown when the server returns a non-success HTTP status code.</exception>
-    public async Task<JsonDocument> ApplyEditsAsync(ApplyEditsRequest request, CancellationToken ct = default)
+    public Task<JsonDocument> ApplyEditsAsync(ApplyEditsRequest request, CancellationToken ct = default)
+        => ApplyEditsAsync(request, idempotencyKey: null, ct);
+
+    /// <summary>
+    /// Applies feature edits, attaching a stable <c>Idempotency-Key</c> so the server can dedupe a
+    /// retried edit (at-most-once, honua-server #2250). When <paramref name="idempotencyKey"/> is
+    /// supplied the edit is sent over REST even if gRPC is preferred, because the gRPC edit contract
+    /// does not yet carry the idempotency header.
+    /// </summary>
+    /// <param name="request">The edit payload including adds, updates, and deletes.</param>
+    /// <param name="idempotencyKey">Stable client-generated key (≤200 chars, no control characters), or <see langword="null"/>.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A <see cref="JsonDocument"/> containing per-feature edit results.</returns>
+    public async Task<JsonDocument> ApplyEditsAsync(
+        ApplyEditsRequest request,
+        string? idempotencyKey,
+        CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        if (CanUseGrpcForEdits)
+        if (string.IsNullOrWhiteSpace(idempotencyKey) && CanUseGrpcForEdits)
         {
             try
             {
@@ -212,7 +248,7 @@ public sealed partial class HonuaMobileClient
             }
         }
 
-        return await ApplyEditsRestAsync(request, ct).ConfigureAwait(false);
+        return await ApplyEditsRestAsync(request, idempotencyKey, ct).ConfigureAwait(false);
     }
 
     private async Task<JsonDocument> QueryFeaturesGrpcAsync(QueryFeaturesRequest request, CancellationToken ct)
@@ -254,7 +290,7 @@ public sealed partial class HonuaMobileClient
             ct).ConfigureAwait(false);
     }
 
-    private async Task<JsonDocument> ApplyEditsRestAsync(ApplyEditsRequest request, CancellationToken ct)
+    private async Task<JsonDocument> ApplyEditsRestAsync(ApplyEditsRequest request, string? idempotencyKey, CancellationToken ct)
     {
         var path = $"/rest/services/{EscapePathSegments(request.ServiceId)}/FeatureServer/{request.LayerId}/applyEdits";
         return await SendJsonAsync(
@@ -262,7 +298,8 @@ public sealed partial class HonuaMobileClient
             path,
             query: null,
             new FormUrlEncodedContent(BuildFeatureServerEditFormParameters(request)),
-            ct).ConfigureAwait(false);
+            ct,
+            idempotencyKey).ConfigureAwait(false);
     }
 
     private async Task<FeatureQueryResult> QueryOgcFeaturesSdkAsync(FeatureQueryRequest request, CancellationToken ct)
@@ -399,9 +436,16 @@ public sealed partial class HonuaMobileClient
         }
     }
 
-    private async Task<FeatureEditResponse> ApplyFeatureServerSdkEditsAsync(FeatureEditRequest request, CancellationToken ct)
+    private async Task<FeatureEditResponse> ApplyFeatureServerSdkEditsAsync(
+        FeatureEditRequest request,
+        string? idempotencyKey,
+        CancellationToken ct)
     {
-        if (CanUseGrpcForEdits)
+        // gRPC cannot carry the Idempotency-Key header, so when an idempotency key is supplied we go
+        // straight to REST: that is the only transport that delivers the at-most-once guarantee the
+        // caller is asking for. Without a key, keep the default gRPC-preferred path (fallback to REST
+        // is still gated off by default for non-idempotent edits).
+        if (string.IsNullOrWhiteSpace(idempotencyKey) && CanUseGrpcForEdits)
         {
             try
             {
@@ -414,11 +458,14 @@ public sealed partial class HonuaMobileClient
             }
         }
 
-        using var raw = await ApplyFeatureServerSdkEditsRestAsync(request, ct).ConfigureAwait(false);
+        using var raw = await ApplyFeatureServerSdkEditsRestAsync(request, idempotencyKey, ct).ConfigureAwait(false);
         return ToFeatureServerFeatureEditResponse(raw.RootElement);
     }
 
-    private async Task<JsonDocument> ApplyFeatureServerSdkEditsRestAsync(FeatureEditRequest request, CancellationToken ct)
+    private async Task<JsonDocument> ApplyFeatureServerSdkEditsRestAsync(
+        FeatureEditRequest request,
+        string? idempotencyKey,
+        CancellationToken ct)
     {
         var source = request.Source;
         var serviceId = source.ServiceId
@@ -443,7 +490,8 @@ public sealed partial class HonuaMobileClient
             path,
             query: null,
             new FormUrlEncodedContent(FeatureServerRequestConverters.ToFeatureServerEditFormParameters(editRequest)),
-            ct).ConfigureAwait(false);
+            ct,
+            idempotencyKey).ConfigureAwait(false);
     }
 
     private static FeatureEditResponse ToFeatureServerFeatureEditResponse(JsonElement root)

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.Internals.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.Internals.cs
@@ -13,12 +13,24 @@ public sealed partial class HonuaMobileClient
         string relativePath,
         IReadOnlyDictionary<string, string?>? query,
         HttpContent? content,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? idempotencyKey = null)
     {
         using var request = new HttpRequestMessage(method, BuildAbsoluteUri(relativePath, query));
         request.Content = content;
         request.Headers.UserAgent.Clear();
         request.Headers.UserAgent.Add(_userAgent);
+
+        // At-most-once edits: the server dedupes a retried mutating request keyed by
+        // (principal, service, layer, key) so a re-upload after a lost ack replays the
+        // original response instead of re-applying the edit (honua-server #2250). The key
+        // must be a stable, non-control string of at most 200 chars or the server rejects
+        // the request with 400.
+        if (!string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            request.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey);
+        }
+
         await ApplyHttpAuthenticationAsync(request, ct).ConfigureAwait(false);
 
         // Apply per-request timeout via a linked cancellation token so the caller's

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageSyncServiceTests.cs
@@ -296,6 +296,12 @@ public sealed class GeoPackageSyncServiceTests
         Assert.Empty(request.Adds);
         Assert.Empty(request.Updates);
         Assert.Equal([42], request.DeleteObjectIds);
+
+        // The upload must carry a stable per-change idempotency key so a retry after a lost ack
+        // is deduped server-side (at-most-once, #2250).
+        var idempotencyKey = Assert.Single(client.EditIdempotencyKeys);
+        Assert.False(string.IsNullOrWhiteSpace(idempotencyKey));
+        Assert.StartsWith("fieldchange:", idempotencyKey);
     }
 
     [Fact]
@@ -1137,6 +1143,56 @@ public sealed class GeoPackageSyncServiceTests
         };
     }
 
+    [Fact]
+    public async Task QueryFeaturesAsync_WithBounds_ReturnsOnlyOverlappingFeaturesAndRespectsMaxResults()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var layer = CreateLayer();
+        await storage.CreateLayerAsync(layer);
+
+        // Point(latitude, longitude) -> NTS envelope X = longitude, Y = latitude.
+        await storage.StoreFeatureAsync(CreateFeature("near-a", version: 1, new Point(21.30, -157.80)));
+        await storage.StoreFeatureAsync(CreateFeature("near-b", version: 1, new Point(21.40, -157.70)));
+        await storage.StoreFeatureAsync(CreateFeature("far", version: 1, new Point(40.00, -100.00)));
+
+        var window = new Honua.Mobile.FieldCollection.Services.Storage.Models.SpatialQuery
+        {
+            Bounds = Honua.Mobile.FieldCollection.Services.Storage.Models.BoundingBox.FromCoordinates(-158.0, 21.0, -157.5, 21.5),
+        };
+
+        var matches = await storage.QueryFeaturesAsync(layer.Id, window);
+
+        Assert.Equal(2, matches.Count);
+        Assert.DoesNotContain(matches, feature => feature.Id == "far");
+        Assert.Contains(matches, feature => feature.Id == "near-a");
+        Assert.Contains(matches, feature => feature.Id == "near-b");
+
+        window.MaxResults = 1;
+        var capped = await storage.QueryFeaturesAsync(layer.Id, window);
+        Assert.Single(capped);
+        Assert.NotEqual("far", capped[0].Id);
+    }
+
+    [Fact]
+    public async Task QueryFeaturesAsync_WithDisjointBounds_ReturnsEmpty()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new DatabaseCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var layer = CreateLayer();
+        await storage.CreateLayerAsync(layer);
+        await storage.StoreFeatureAsync(CreateFeature("hawaii", version: 1, new Point(21.30, -157.80)));
+
+        var window = new Honua.Mobile.FieldCollection.Services.Storage.Models.SpatialQuery
+        {
+            Bounds = Honua.Mobile.FieldCollection.Services.Storage.Models.BoundingBox.FromCoordinates(0.0, 0.0, 1.0, 1.0),
+        };
+
+        Assert.Empty(await storage.QueryFeaturesAsync(layer.Id, window));
+    }
+
     private static Feature CreateFeature(
         string id,
         long version,
@@ -1268,13 +1324,16 @@ public sealed class GeoPackageSyncServiceTests
         public FeatureEditResponse? EditResponse { get; set; }
         public FeatureQueryResult? QueryResponse { get; set; }
         public List<FeatureEditRequest> EditRequests { get; } = [];
+        public List<string?> EditIdempotencyKeys { get; } = [];
         public List<FeatureQueryRequest> QueryRequests { get; } = [];
 
         public Task<FeatureEditResponse> ApplyEditsAsync(
             FeatureEditRequest request,
+            string? idempotencyKey = null,
             CancellationToken cancellationToken = default)
         {
             EditRequests.Add(request);
+            EditIdempotencyKeys.Add(idempotencyKey);
             return Task.FromResult(EditResponse ?? new FeatureEditResponse
             {
                 ProviderName = "test",

--- a/tests/Honua.Mobile.Offline.Tests/HonuaApiOfflineOperationUploaderTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/HonuaApiOfflineOperationUploaderTests.cs
@@ -327,6 +327,89 @@ public sealed class HonuaApiOfflineOperationUploaderTests
         }, forceWrite: false, cts.Token));
     }
 
+    [Fact]
+    public async Task UploadAsync_FeatureServerPerFeatureUpdateConflictCode_ReturnsConflict()
+    {
+        // Honua Server returns HTTP 200 with a per-feature error carrying the stable update-update
+        // conflict code (1004); it must be routed through conflict resolution, not dropped as fatal.
+        var uploader = CreateUploader((request, _) =>
+        {
+            if (request.Method == HttpMethod.Get)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("""{"objectIdField":"objectid"}""", Encoding.UTF8, "application/json"),
+                };
+            }
+
+            var body = "{\"addResults\":[],\"updateResults\":[{\"success\":false,\"error\":{\"code\":1004,\"description\":\"version mismatch\"}}],\"deleteResults\":[]}";
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+        });
+
+        var result = await uploader.UploadAsync(new OfflineEditOperation
+        {
+            LayerKey = "assets",
+            TargetCollection = "assets",
+            OperationType = OfflineOperationType.Update,
+            PayloadJson = """
+            {
+              "protocol": "FeatureServer",
+              "serviceId": "default",
+              "layerId": 0,
+              "feature": { "attributes": { "objectid": 1, "asset_id": "A-1" } }
+            }
+            """,
+        }, forceWrite: false);
+
+        Assert.Equal(UploadOutcome.Conflict, result.Outcome);
+    }
+
+    [Fact]
+    public async Task UploadAsync_FeatureServer_SendsStableIdempotencyKeyAcrossRetries()
+    {
+        var capturedKeys = new List<string?>();
+        var uploader = CreateUploader((request, _) =>
+        {
+            capturedKeys.Add(request.Headers.TryGetValues("Idempotency-Key", out var values)
+                ? values.FirstOrDefault()
+                : null);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "{\"addResults\":[{\"success\":true,\"objectId\":1}],\"updateResults\":[],\"deleteResults\":[]}",
+                    Encoding.UTF8,
+                    "application/json"),
+            };
+        });
+
+        var operation = new OfflineEditOperation
+        {
+            LayerKey = "assets",
+            TargetCollection = "assets",
+            OperationType = OfflineOperationType.Add,
+            PayloadJson = """
+            {
+              "protocol": "FeatureServer",
+              "serviceId": "default",
+              "layerId": 0,
+              "feature": { "attributes": { "asset_id": "A-1" } }
+            }
+            """,
+        };
+
+        // Simulate the same queued operation being uploaded twice (e.g. a lost ack on the first try).
+        await uploader.UploadAsync(operation, forceWrite: false);
+        await uploader.UploadAsync(operation, forceWrite: false);
+
+        Assert.Equal(2, capturedKeys.Count);
+        Assert.All(capturedKeys, key => Assert.False(string.IsNullOrWhiteSpace(key)));
+        Assert.Equal(capturedKeys[0], capturedKeys[1]);
+        Assert.Contains(operation.OperationId, capturedKeys[0]!, StringComparison.Ordinal);
+    }
+
     private static HonuaApiOfflineOperationUploader CreateUploader(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> responder)
     {
         var client = new HonuaMobileClient(

--- a/tests/Honua.Mobile.Offline.Tests/MobileSyncProblemHelperTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/MobileSyncProblemHelperTests.cs
@@ -1,0 +1,50 @@
+using Honua.Mobile.Offline.Sync;
+
+namespace Honua.Mobile.Offline.Tests;
+
+public sealed class MobileSyncProblemHelperTests
+{
+    // The stable per-feature applyEdits classification codes published by Honua Server (#2251).
+    [Theory]
+    [InlineData(1002)] // not found (update target gone)
+    [InlineData(1003)] // delete-delete conflict
+    [InlineData(1004)] // update-update (optimistic concurrency) conflict
+    [InlineData(409)]  // transport-level conflict
+    [InlineData(412)]  // precondition failed
+    public void FromErrorCode_ConflictClasses_AreClassifiedAsConflict(int code)
+    {
+        var problem = MobileSyncProblemHelper.FromErrorCode(code, message: null);
+
+        Assert.Equal(MobileSyncProblemCategory.Conflict, problem.Category);
+        Assert.False(problem.Retryable);
+
+        // A conflict must drive the conflict-resolution path, not a fatal/retry outcome.
+        var upload = MobileSyncProblemHelper.ToUploadResult(problem);
+        Assert.Equal(UploadOutcome.Conflict, upload.Outcome);
+    }
+
+    [Theory]
+    [InlineData(1005)] // locked
+    [InlineData(1008)] // rolled back because a sibling failed under rollbackOnFailure
+    public void FromErrorCode_TransientClasses_AreRetryable(int code)
+    {
+        var problem = MobileSyncProblemHelper.FromErrorCode(code, message: null);
+
+        Assert.True(problem.Retryable);
+        Assert.Equal(UploadOutcome.RetryableFailure, MobileSyncProblemHelper.ToUploadResult(problem).Outcome);
+    }
+
+    [Theory]
+    [InlineData(1000)] // generic / unexpected
+    [InlineData(1001)] // invalid object id
+    [InlineData(1006)] // validation failed
+    [InlineData(1007)] // not permitted
+    public void FromErrorCode_RequestShapeClasses_AreFatal(int code)
+    {
+        var problem = MobileSyncProblemHelper.FromErrorCode(code, message: null);
+
+        Assert.False(problem.Retryable);
+        Assert.Equal(MobileSyncProblemCategory.InvalidOperation, problem.Category);
+        Assert.Equal(UploadOutcome.FatalFailure, MobileSyncProblemHelper.ToUploadResult(problem).Outcome);
+    }
+}

--- a/tests/Honua.Mobile.Sdk.Tests/HonuaMobileClientHttpTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/HonuaMobileClientHttpTests.cs
@@ -92,6 +92,111 @@ public sealed class HonuaMobileClientHttpTests
     }
 
     [Fact]
+    public async Task ApplyEditsAsync_WithIdempotencyKey_SendsHeader()
+    {
+        string? capturedKey = null;
+        var handler = new StubHttpMessageHandler((request, _) =>
+        {
+            capturedKey = request.Headers.TryGetValues("Idempotency-Key", out var values)
+                ? values.FirstOrDefault()
+                : null;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"addResults":[{"objectId":42,"success":true}],"updateResults":[],"deleteResults":[]}""",
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+        });
+
+        var client = CreateClient(handler);
+        using var result = await client.ApplyEditsAsync(
+            new ApplyEditsRequest
+            {
+                ServiceId = "default",
+                LayerId = 0,
+                AddsJson = """[{"attributes":{"name":"Test"}}]""",
+            },
+            idempotencyKey: "field-change-42");
+
+        Assert.Equal("field-change-42", capturedKey);
+    }
+
+    [Fact]
+    public async Task ApplyEditsAsync_WithoutIdempotencyKey_OmitsHeader()
+    {
+        var hadHeader = true;
+        var handler = new StubHttpMessageHandler((request, _) =>
+        {
+            hadHeader = request.Headers.Contains("Idempotency-Key");
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"addResults":[{"objectId":42,"success":true}],"updateResults":[],"deleteResults":[]}""",
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+        });
+
+        var client = CreateClient(handler);
+        using var result = await client.ApplyEditsAsync(new ApplyEditsRequest
+        {
+            ServiceId = "default",
+            LayerId = 0,
+            AddsJson = """[{"attributes":{"name":"Test"}}]""",
+        });
+
+        Assert.False(hadHeader);
+    }
+
+    [Fact]
+    public async Task ApplyEditsAsync_SdkRequestWithIdempotencyKey_SendsHeaderOverRest()
+    {
+        string? capturedKey = null;
+        var handler = new StubHttpMessageHandler((request, _) =>
+        {
+            capturedKey = request.Headers.TryGetValues("Idempotency-Key", out var values)
+                ? values.FirstOrDefault()
+                : null;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"addResults":[{"objectId":42,"success":true}],"updateResults":[],"deleteResults":[]}""",
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+        });
+
+        // gRPC is preferred here, but supplying an idempotency key must force the REST transport
+        // (the only one that carries the header).
+        var client = CreateClient(handler, new HonuaMobileClientOptions
+        {
+            BaseUri = new Uri("https://api.honua.test"),
+            PreferGrpcForFeatureEdits = true,
+        });
+
+        var result = await client.ApplyEditsAsync(
+            new FeatureEditRequest
+            {
+                Source = new FeatureSource { ServiceId = "default", LayerId = 0 },
+                Adds =
+                [
+                    new FeatureEditFeature
+                    {
+                        Attributes = new Dictionary<string, JsonElement>
+                        {
+                            ["name"] = JsonSerializer.SerializeToElement("Test"),
+                        },
+                    },
+                ],
+            },
+            idempotencyKey: "offline-op:abc123");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("offline-op:abc123", capturedKey);
+    }
+
+    [Fact]
     public async Task FeatureServerRestAsync_WithFolderedServiceId_PreservesFolderPath()
     {
         var capturedPaths = new List<string>();


### PR DESCRIPTION
Closes the remaining sub-items on two pre-release audits. The transactional `MarkChangesAsSynced`, the gRPC-edit fallback gating, the exhaustive `MapConflictType`, the pending-count poll, and `IAsyncDisposable` were already merged on trunk; this finishes what was left.

## Offline sync data integrity — Closes #311
- **Idempotency-Key on retried applyEdits (server #2250 now merged).** New `ApplyEditsAsync(..., string? idempotencyKey, ...)` overloads thread an `Idempotency-Key` header through the REST applyEdits path. Because the gRPC edit contract cannot carry the header, supplying a key routes the edit over REST — the only transport that delivers the at-most-once guarantee. The SDK offline uploader derives the key from the durable `OperationId`; the field-collection uploader derives it from the change id. A re-upload after a lost ack now replays the original server result instead of double-applying.
- **Server conflict-code classification (server #2251 now merged).** `MobileSyncProblemHelper.FromErrorCode` maps the documented per-feature `applyEdits` classes: `not-found`/`delete-delete`/`update-update` → Conflict (routed through conflict resolution, not dropped as fatal), `locked`/`rolled-back` → retryable. Fixed a latent bug where the `>= 500` transport branch swallowed the four-digit per-feature codes; it is now bounded to the HTTP 5xx range.

## Performance / runtime reliability — Closes #312
- **Spatial query no longer loads the whole layer.** `local_features` now caches the geometry envelope (`min_x/min_y/max_x/max_y`, indexed, migrated + backfilled). Bounded queries pre-filter candidates by an indexed bbox range scan, then decode WKB and run the exact NTS predicate only on survivors; `MaxResults` is applied after the exact predicate (the bbox set is a superset, so it cannot be capped earlier).
- **Push N+1.** The push reuses the already-fetched pending-change list instead of re-querying, and uploads distinct features concurrently (bounded) while keeping edits to the same feature strictly ordered.

## Tests
- SDK: `Idempotency-Key` sent when a key is supplied (and over REST even when gRPC is preferred); omitted otherwise.
- Offline: per-feature code mapping (1002/1003/1004 → Conflict, 1005/1008 → retryable, 1000/1001/1006/1007 → fatal); a real per-feature `1004` conflict driven end-to-end through `HonuaApiOfflineOperationUploader`; a stable key resent across two uploads of the same operation.
- Field collection: bbox pre-filter returns only overlapping features and respects `MaxResults`; disjoint window returns empty; the upload carries a stable `fieldchange:` key.

## Validation
`dotnet build` + targeted `dotnet test` green for `Honua.Mobile.Sdk` (99), `Honua.Mobile.Offline` (new tests), and `Honua.Mobile.FieldCollection` (41); `dotnet format --verify-no-changes` clean on the changed core libraries. The MAUI app project and live-server/gRPC integration suites are not buildable/runnable in this environment (no Android workload / live cluster).