### PR TITLE
chore(hygiene): enforce no-attribution + license-header gates; drop pinned test counts

### DIFF
--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -1,0 +1,44 @@
+name: Repository Hygiene
+
+# Pre-release hygiene gates (audit #316):
+#  - no-ai-attribution: enforces the AGENTS.md "no agent attribution" policy on
+#    the PR's commit messages and body (AI/agent co-author trailers,
+#    "Generated with ..." lines, 🤖 markers).
+#  - license-headers: enforces the single Apache-2.0 header policy on shipped
+#    library sources.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  no-ai-attribution:
+    name: No AI/agent attribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check commit messages and PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          bash scripts/check-no-ai-attribution.sh "${BASE_SHA}..${HEAD_SHA}"
+
+  license-headers:
+    name: License headers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shipped-library license headers
+        run: |
+          bash scripts/check-license-headers.sh

--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ The current source-backed mobile feature map is in [docs/features/README.md](doc
 
 | Layer | Status | Run on | Coverage |
 | --- | --- | --- | --- |
-| Unit | ✅ | every PR | 294 tests across 5 .NET projects (SDK, Offline, Field, FieldCollection, MAUI) |
-| Integration (in-process loopback) | ✅ | every PR | 9 loopback tests in `Honua.Mobile.ServerIntegration.Tests` (`SdkServerIntegrationTests`, `OfflineServerIntegrationTests`, `FieldCollectionServerIntegrationTests`) against a real ASP.NET Core loopback server; the same project also hosts 4 `LiveHonuaServerFixtureOptionsTests` harness-config tests |
-| Smoke | ✅ | every PR | 18 tests in `Honua.Mobile.Smoke.Tests` (`quality-gates` job) |
+| Unit | ✅ | every PR | Across 5 .NET projects (SDK, Offline, Field, FieldCollection, MAUI) |
+| Integration (in-process loopback) | ✅ | every PR | `Honua.Mobile.ServerIntegration.Tests` (`SdkServerIntegrationTests`, `OfflineServerIntegrationTests`, `FieldCollectionServerIntegrationTests`) against a real ASP.NET Core loopback server; the same project also hosts the `LiveHonuaServerFixtureOptionsTests` harness-config tests |
+| Smoke | ✅ | every PR | `Honua.Mobile.Smoke.Tests` (`quality-gates` job) |
 | Embed DOM | ✅ | every PR | jsdom suites under `src/Honua.Embed/tests/` |
-| Live server (Docker image) | ✅ | every PR via `Live Server Integration` workflow (hard gate; vendored seed at `tests/seed/mobile-offline-demo-v1.sql`) | 11 tests in `LiveHonuaServerInteractionTests` (incl. unary + server-streaming live gRPC); Testcontainers spins up `honuaio/honua-server:nightly` + PostGIS, vendored seed loaded into postgres before the live server starts |
-| Cloud acceptance (staging) | 🟡 | manual `workflow_dispatch` | 7 tests in `DisconnectedFieldWorkflowAcceptanceTests`; production promotion blocked on honua-server#965 |
+| Live server (Docker image) | ✅ | every PR via `Live Server Integration` workflow (hard gate; vendored seed at `tests/seed/mobile-offline-demo-v1.sql`) | `LiveHonuaServerInteractionTests` (incl. unary + server-streaming live gRPC); Testcontainers spins up `honuaio/honua-server:nightly` + PostGIS, vendored seed loaded into postgres before the live server starts |
+| Cloud acceptance (staging) | 🟡 | manual `workflow_dispatch` | `DisconnectedFieldWorkflowAcceptanceTests`; production promotion blocked on honua-server#965 |
 | Physical device | 🟡 | deferred to GA | AR/VR field workflow tracked under honua-mobile#23 (closed, follow-ups in `docs/guides/native-scene-anchoring-requirements.md`); emulator/simulator platform smoke covers part of the surface |
+
+Exact test counts are intentionally not pinned here (they drift every PR); the
+authoritative numbers are the per-project totals reported by each CI run.
 
 See [docs/guides/validation-strategy.md](docs/guides/validation-strategy.md) for
 the per-capability coverage matrix, known gaps, and which CI workflow runs

--- a/docs/guides/validation-strategy.md
+++ b/docs/guides/validation-strategy.md
@@ -17,18 +17,18 @@ The repository validates the SDK in five concentric layers, from cheapest
 and most reliable inward to most expensive and most operationally gated:
 
 ```
-                       Physical device  (0 today, deferred to GA)
-                  Cloud acceptance      (7 tests, manual dispatch)
-              Live server (Docker)      (11 tests, hard-gated on every PR)
-          Server integration            (9 loopback tests + 4 fixture config)
-      Unit                              (294 tests across 5 projects)
+                       Physical device  (none today, deferred to GA)
+                  Cloud acceptance      (manual dispatch)
+              Live server (Docker)      (hard-gated on every PR)
+          Server integration            (loopback + fixture config)
+      Unit                              (5 .NET projects)
   Embed DOM                             (npm, src/Honua.Embed/tests/)
 ```
 
-- **Unit (294 .NET tests)** -- run on every PR via `.github/workflows/ci.yml`
+- **Unit (.NET)** -- run on every PR via `.github/workflows/ci.yml`
   `test` job. Cover SDK, Offline, Field, FieldCollection, and MAUI library
   surfaces with no network or platform dependencies.
-- **Server integration in-process (9 loopback tests + 4 fixture-config
+- **Server integration in-process (loopback tests + fixture-config
   tests)** -- a live ASP.NET Core loopback server
   (`HonuaIntegrationServer`) exercises SDK, Offline, FieldCollection,
   and exception-reporting HTTP paths via
@@ -38,7 +38,7 @@ and most reliable inward to most expensive and most operationally gated:
   fixture configuration (env wiring, Testcontainers options) without
   hitting the loopback server. Run on every PR via the same `test`
   job; no external infrastructure required.
-- **Live server (Docker, 11 tests)** -- `LiveHonuaServerInteractionTests`
+- **Live server (Docker)** -- `LiveHonuaServerInteractionTests`
   spin up the official Honua server image via Testcontainers (or attach to
   a pre-started Honua URL) when `HONUA_MOBILE_LIVE_SERVER_TESTS=1` is set.
   The `Live Server Integration` workflow
@@ -48,7 +48,7 @@ and most reliable inward to most expensive and most operationally gated:
   so the suite is now a hard gate on PRs -- a failing live test blocks the
   merge. When run locally without the env var, the suite reports as
   *Skipped* (Xunit.SkippableFact), not falsely Passed.
-- **Cloud acceptance (7 tests)** -- `DisconnectedFieldWorkflowAcceptanceTests`
+- **Cloud acceptance** -- `DisconnectedFieldWorkflowAcceptanceTests`
   run only when `HONUA_MOBILE_CLOUD_ACCEPTANCE=1` is set against a staging
   Honua deployment. Triggered manually via the `Cloud Acceptance` workflow
   (`.github/workflows/cloud-acceptance.yml`, `workflow_dispatch`).
@@ -122,7 +122,7 @@ Known coverage gaps, with the owner ticket where one exists:
   3D/AR dependency matrix (`docs/guides/mobile-3d-ar-dependency-matrix.md`).
 - ~~**Live server (Docker) on every PR**~~ -- closed. The
   `Live Server Integration` workflow now runs
-  `LiveHonuaServerInteractionTests` (11 tests) on every PR with the
+  `LiveHonuaServerInteractionTests` on every PR with the
   vendored seed (`tests/seed/mobile-offline-demo-v1.sql`) loaded into the
   postgres container and the dotnet test step as a hard gate (no
   `continue-on-error`). Adding the workflow to branch-protection required
@@ -183,7 +183,7 @@ The relevant workflows under `.github/workflows/`:
   - `build` -- compiles `Honua.Mobile.Sdk` and `Honua.Mobile.Offline`
     with `TreatWarningsAsErrors`, plus
     `npm run build` for the embed package; runs `dotnet format` checks.
-  - `test` -- runs the 5 unit projects (294 tests) plus the
+  - `test` -- runs the 5 unit projects plus the
     `Honua.Mobile.ServerIntegration.Tests` project; the 11
     `LiveHonuaServerInteractionTests` report as **Skipped**
     (`Xunit.SkippableFact`) here because `HONUA_MOBILE_LIVE_SERVER_TESTS`
@@ -199,12 +199,12 @@ The relevant workflows under `.github/workflows/`:
     integration step.
   - `security` -- Trivy filesystem scan plus CodeQL on the three core
     library projects.
-  - `quality-gates` -- runs `Honua.Mobile.Smoke.Tests` (18 tests) and
+  - `quality-gates` -- runs `Honua.Mobile.Smoke.Tests` and
     validates assembly-size budgets against
     `quality/performance-budget.json`.
   - `ci-gate` -- aggregates the above; required for merge.
 - `cloud-acceptance.yml` -- `workflow_dispatch` only. Runs
-  `DisconnectedFieldWorkflowAcceptanceTests` (7 tests) against a cloud
+  `DisconnectedFieldWorkflowAcceptanceTests` against a cloud
   Honua URL provided as workflow inputs.
 - `seed-drift-check.yml` -- scheduled weekly (Monday 14:00 UTC, plus
   `workflow_dispatch`). Compares `tests/seed/mobile-offline-demo-v1.sql`

--- a/scripts/check-license-headers.sh
+++ b/scripts/check-license-headers.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Enforces a single Apache-2.0 license-header policy across the shipped library
+# sources (src/Honua.Mobile.Sdk, src/Honua.Mobile.Offline, src/Honua.Mobile.Maui).
+# Every tracked C# file in those projects must begin with the two-line header.
+#
+# Usage: scripts/check-license-headers.sh
+# Exit code 1 (and a list of offenders) when a file is missing the header.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+expected_first='// Copyright (c) Honua, Inc. and contributors.'
+expected_second='// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.'
+
+missing=()
+while IFS= read -r file; do
+  first="$(sed -n '1p' "${file}")"
+  second="$(sed -n '2p' "${file}")"
+  if [[ "${first}" != "${expected_first}" || "${second}" != "${expected_second}" ]]; then
+    missing+=("${file}")
+  fi
+done < <(find src/Honua.Mobile.Sdk src/Honua.Mobile.Offline src/Honua.Mobile.Maui \
+  -name '*.cs' -not -path '*/obj/*' -not -path '*/bin/*' | sort)
+
+if [[ "${#missing[@]}" -gt 0 ]]; then
+  echo "::error::The following shipped-library sources are missing the Apache-2.0 license header:"
+  printf '  %s\n' "${missing[@]}"
+  echo ""
+  echo "Prepend this header (followed by a blank line):"
+  echo "  ${expected_first}"
+  echo "  ${expected_second}"
+  exit 1
+fi
+
+echo "All shipped-library sources carry the Apache-2.0 license header."

--- a/scripts/check-no-ai-attribution.sh
+++ b/scripts/check-no-ai-attribution.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Enforces the AGENTS.md "no agent attribution" policy: commit messages and the
+# PR body must not carry AI/agent co-author trailers or "generated with" lines.
+# See AGENTS.md ("Commit hygiene — no agent attribution").
+#
+# Usage:
+#   scripts/check-no-ai-attribution.sh [<git-range>]
+#
+# - <git-range> defaults to "origin/HEAD..HEAD" (falls back to the last commit
+#   when no range can be resolved). Every commit message in the range is checked.
+# - If the PR_BODY environment variable is set, its contents are checked too.
+#
+# Exit code 1 (and a report) when a forbidden marker is found; 0 otherwise.
+set -euo pipefail
+
+# Case-insensitive markers that must never appear in commit messages or PR bodies.
+# Tuned to catch agent attribution without flagging legitimate human co-authors.
+forbidden_regex='co-authored-by:[[:space:]]*.*(claude|anthropic|codex|copilot|chatgpt|openai|gemini|gpt-[0-9])|noreply@anthropic\.com|generated with[[:space:]]*(\[)?(claude|codex|github copilot)|🤖'
+
+range="${1:-}"
+if [[ -z "${range}" ]]; then
+  if git rev-parse --verify --quiet origin/HEAD >/dev/null; then
+    range="origin/HEAD..HEAD"
+  else
+    range="HEAD~1..HEAD"
+  fi
+fi
+
+violations=0
+
+check_text() {
+  local label="$1"
+  local text="$2"
+  if printf '%s' "${text}" | grep -iEn "${forbidden_regex}" >/dev/null 2>&1; then
+    echo "::error::${label} contains forbidden AI/agent attribution:"
+    printf '%s\n' "${text}" | grep -iEn "${forbidden_regex}" || true
+    violations=$((violations + 1))
+  fi
+}
+
+# Commit messages in the range.
+if commits="$(git rev-list "${range}" 2>/dev/null)"; then
+  for sha in ${commits}; do
+    check_text "commit ${sha}" "$(git log -1 --format='%B' "${sha}")"
+  done
+else
+  echo "warning: could not resolve git range '${range}'; skipping commit scan" >&2
+fi
+
+# PR body, when provided by CI.
+if [[ -n "${PR_BODY:-}" ]]; then
+  check_text "PR body" "${PR_BODY}"
+fi
+
+if [[ "${violations}" -gt 0 ]]; then
+  echo ""
+  echo "Found ${violations} attribution violation(s). Remove AI/agent co-author trailers," >&2
+  echo "'Generated with ...' lines, and 🤖 markers (see AGENTS.md), then re-commit." >&2
+  exit 1
+fi
+
+echo "No AI/agent attribution found."

--- a/src/Honua.Mobile.Maui/Annotations/HonuaAnnotation.cs
+++ b/src/Honua.Mobile.Maui/Annotations/HonuaAnnotation.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.Annotations;
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Annotations/HonuaAnnotationBounds.cs
+++ b/src/Honua.Mobile.Maui/Annotations/HonuaAnnotationBounds.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.Annotations;
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Annotations/HonuaAnnotationLayer.cs
+++ b/src/Honua.Mobile.Maui/Annotations/HonuaAnnotationLayer.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.Annotations;
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Annotations/HonuaAnnotationStyle.cs
+++ b/src/Honua.Mobile.Maui/Annotations/HonuaAnnotationStyle.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.Annotations;
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Annotations/HonuaAnnotationType.cs
+++ b/src/Honua.Mobile.Maui/Annotations/HonuaAnnotationType.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.Annotations;
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Annotations/HonuaMapCoordinate.cs
+++ b/src/Honua.Mobile.Maui/Annotations/HonuaMapCoordinate.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.Annotations;
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Auth/MauiSecureAuthTokenStore.cs
+++ b/src/Honua.Mobile.Maui/Auth/MauiSecureAuthTokenStore.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Honua.Mobile.Sdk.Auth;

--- a/src/Honua.Mobile.Maui/Auth/PlatformMauiSecureStorage.cs
+++ b/src/Honua.Mobile.Maui/Auth/PlatformMauiSecureStorage.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Microsoft.Maui.Storage;
 
 namespace Honua.Mobile.Maui.Auth;

--- a/src/Honua.Mobile.Maui/Diagnostics/FileMobileExceptionReportQueue.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/FileMobileExceptionReportQueue.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/Honua.Mobile.Maui/Diagnostics/HttpMobileExceptionReportUploader.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/HttpMobileExceptionReportUploader.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;

--- a/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReportQueue.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReportQueue.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.Diagnostics;
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReportUploadRequestCustomizer.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReportUploadRequestCustomizer.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.Diagnostics;
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReportUploadWorker.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReportUploadWorker.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.Diagnostics;
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReportUploader.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReportUploader.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.Diagnostics;
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReporter.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/IMobileExceptionReporter.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.Diagnostics;
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Diagnostics/LocalMobileExceptionReporter.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/LocalMobileExceptionReporter.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Logging;

--- a/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionRedactor.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionRedactor.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Globalization;
 using System.Text.RegularExpressions;
 

--- a/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReport.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReport.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.Diagnostics;
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportUploadWorker.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportUploadWorker.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Microsoft.Extensions.Logging;
 
 namespace Honua.Mobile.Maui.Diagnostics;

--- a/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportingExceptionHooks.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportingExceptionHooks.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Microsoft.Extensions.Logging;
 
 namespace Honua.Mobile.Maui.Diagnostics;

--- a/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportingOptions.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportingOptions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.Diagnostics;
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Display/HonuaNativeMapDisplayController.cs
+++ b/src/Honua.Mobile.Maui/Display/HonuaNativeMapDisplayController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Honua.Sdk.Abstractions.Features;
 
 namespace Honua.Mobile.Maui.Display;

--- a/src/Honua.Mobile.Maui/Display/NativeDisplayContracts.cs
+++ b/src/Honua.Mobile.Maui/Display/NativeDisplayContracts.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Honua.Mobile.Maui.Annotations;
 using Honua.Sdk.Abstractions.Features;
 

--- a/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/HonuaMobileServiceCollectionExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Honua.Mobile.Maui.Auth;
 using Honua.Mobile.Maui.Annotations;
 using Honua.Mobile.Maui.Diagnostics;

--- a/src/Honua.Mobile.Maui/Location/DeviceLocationContracts.cs
+++ b/src/Honua.Mobile.Maui/Location/DeviceLocationContracts.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Honua.Mobile.Maui.Annotations;
 
 namespace Honua.Mobile.Maui.Location;

--- a/src/Honua.Mobile.Maui/Location/HonuaBackgroundLocationLifecycleController.cs
+++ b/src/Honua.Mobile.Maui/Location/HonuaBackgroundLocationLifecycleController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/src/Honua.Mobile.Maui/Location/HonuaDeviceLocationCoordinator.cs
+++ b/src/Honua.Mobile.Maui/Location/HonuaDeviceLocationCoordinator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.Location;
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Location/HonuaSdkGeofenceWorkflowController.cs
+++ b/src/Honua.Mobile.Maui/Location/HonuaSdkGeofenceWorkflowController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Honua.Mobile.Maui.Annotations;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginContracts.cs
+++ b/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginContracts.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Honua.Sdk.Abstractions.Plugins;
 
 namespace Honua.Mobile.Maui.Plugins;

--- a/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginContributionRegistry.cs
+++ b/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginContributionRegistry.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.Plugins;
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginHost.cs
+++ b/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginHost.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Honua.Mobile.Maui.Diagnostics;
 using Honua.Sdk.Abstractions.Plugins;
 using Microsoft.Extensions.Logging;

--- a/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginServiceCollectionExtensions.cs
+++ b/src/Honua.Mobile.Maui/Plugins/HonuaMapPluginServiceCollectionExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/Honua.Mobile.Maui/Plugins/HonuaSdkPluginManifestAdapters.cs
+++ b/src/Honua.Mobile.Maui/Plugins/HonuaSdkPluginManifestAdapters.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Honua.Sdk.Abstractions.Plugins;
 
 namespace Honua.Mobile.Maui.Plugins;

--- a/src/Honua.Mobile.Maui/SceneAnchoring/HonuaNativeArFieldWorkflow.cs
+++ b/src/Honua.Mobile.Maui/SceneAnchoring/HonuaNativeArFieldWorkflow.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Globalization;
 using Honua.Mobile.Maui.Annotations;
 

--- a/src/Honua.Mobile.Maui/SceneAnchoring/HonuaNativeArSceneAnchoringController.cs
+++ b/src/Honua.Mobile.Maui/SceneAnchoring/HonuaNativeArSceneAnchoringController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.SceneAnchoring;
 
 /// <summary>

--- a/src/Honua.Mobile.Maui/SceneAnchoring/NativeSceneAnchoringContracts.cs
+++ b/src/Honua.Mobile.Maui/SceneAnchoring/NativeSceneAnchoringContracts.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Maui.SceneAnchoring;
 
 /// <summary>

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageModels.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageModels.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Honua.Sdk.Abstractions.Scenes;
 
 using BoundingBox = Honua.Sdk.Geometry.GeographicBoundingBox;

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSdkOfflineStoreAdapter.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSdkOfflineStoreAdapter.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Globalization;
 using System.Text;
 using System.Text.Json;

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageStorageException.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageStorageException.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Offline.GeoPackage;
 
 /// <summary>

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Globalization;
 using System.Diagnostics;
 using System.Security.Cryptography;

--- a/src/Honua.Mobile.Offline/GeoPackage/IGeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/IGeoPackageSyncStore.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Honua.Sdk.Abstractions.Features;
 
 using BoundingBox = Honua.Sdk.Geometry.GeographicBoundingBox;

--- a/src/Honua.Mobile.Offline/GeoPackage/MobileStorageTelemetry.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/MobileStorageTelemetry.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 

--- a/src/Honua.Mobile.Offline/HonuaMobileOfflineJsonContext.cs
+++ b/src/Honua.Mobile.Offline/HonuaMobileOfflineJsonContext.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Honua.Mobile.Offline.GeoPackage;

--- a/src/Honua.Mobile.Offline/MapAreas/MapAreaContracts.cs
+++ b/src/Honua.Mobile.Offline/MapAreas/MapAreaContracts.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Honua.Mobile.Offline.GeoPackage;
 
 using BoundingBox = Honua.Sdk.Geometry.GeographicBoundingBox;

--- a/src/Honua.Mobile.Offline/MapAreas/MapAreaDownloader.cs
+++ b/src/Honua.Mobile.Offline/MapAreas/MapAreaDownloader.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Globalization;
 using System.Text;
 using System.Buffers;

--- a/src/Honua.Mobile.Offline/ScenePackages/ScenePackageDownloadContracts.cs
+++ b/src/Honua.Mobile.Offline/ScenePackages/ScenePackageDownloadContracts.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Honua.Mobile.Offline.GeoPackage;
 using Honua.Sdk.Abstractions.Scenes;
 

--- a/src/Honua.Mobile.Offline/ScenePackages/ScenePackageDownloader.cs
+++ b/src/Honua.Mobile.Offline/ScenePackages/ScenePackageDownloader.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Buffers;
 using System.Globalization;
 using System.Net;

--- a/src/Honua.Mobile.Offline/Sync/BackgroundPrefetchScheduler.cs
+++ b/src/Honua.Mobile.Offline/Sync/BackgroundPrefetchScheduler.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/src/Honua.Mobile.Offline/Sync/BackgroundSyncOrchestrator.cs
+++ b/src/Honua.Mobile.Offline/Sync/BackgroundSyncOrchestrator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/src/Honua.Mobile.Offline/Sync/DeltaDownloadEngine.cs
+++ b/src/Honua.Mobile.Offline/Sync/DeltaDownloadEngine.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Globalization;
 using System.Text.Json;
 using Honua.Mobile.Offline.GeoPackage;

--- a/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
+++ b/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Globalization;
 using System.Net;
 using System.Text.Json;

--- a/src/Honua.Mobile.Offline/Sync/HonuaMobileSdkFeatureClient.cs
+++ b/src/Honua.Mobile.Offline/Sync/HonuaMobileSdkFeatureClient.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Runtime.CompilerServices;
 using Honua.Mobile.Sdk;
 using Honua.Sdk.Abstractions.Features;

--- a/src/Honua.Mobile.Offline/Sync/MobileSyncProblem.cs
+++ b/src/Honua.Mobile.Offline/Sync/MobileSyncProblem.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Net;
 using Honua.Mobile.Offline.GeoPackage;
 using Honua.Mobile.Sdk;

--- a/src/Honua.Mobile.Offline/Sync/MobileSyncTelemetry.cs
+++ b/src/Honua.Mobile.Offline/Sync/MobileSyncTelemetry.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 

--- a/src/Honua.Mobile.Offline/Sync/OfflineSyncEngine.cs
+++ b/src/Honua.Mobile.Offline/Sync/OfflineSyncEngine.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Diagnostics;
 using Honua.Mobile.Offline.GeoPackage;
 

--- a/src/Honua.Mobile.Offline/Sync/SdkOfflineSyncRunner.cs
+++ b/src/Honua.Mobile.Offline/Sync/SdkOfflineSyncRunner.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Honua.Sdk.Offline.Abstractions;
 using SdkOfflineSyncEngine = Honua.Sdk.Offline.OfflineSyncEngine;
 

--- a/src/Honua.Mobile.Offline/Sync/SyncContracts.cs
+++ b/src/Honua.Mobile.Offline/Sync/SyncContracts.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Honua.Mobile.Offline.GeoPackage;
 
 namespace Honua.Mobile.Offline.Sync;

--- a/src/Honua.Mobile.Sdk/Auth/HonuaAuthProblemDetails.cs
+++ b/src/Honua.Mobile.Sdk/Auth/HonuaAuthProblemDetails.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Net;
 using System.Text.Json;
 

--- a/src/Honua.Mobile.Sdk/Auth/HonuaAuthToken.cs
+++ b/src/Honua.Mobile.Sdk/Auth/HonuaAuthToken.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Sdk.Auth;
 
 /// <summary>

--- a/src/Honua.Mobile.Sdk/Auth/HonuaMobileAuthException.cs
+++ b/src/Honua.Mobile.Sdk/Auth/HonuaMobileAuthException.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Net;
 
 namespace Honua.Mobile.Sdk.Auth;

--- a/src/Honua.Mobile.Sdk/Auth/IAuthTokenProvider.cs
+++ b/src/Honua.Mobile.Sdk/Auth/IAuthTokenProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Sdk.Auth;
 
 /// <summary>

--- a/src/Honua.Mobile.Sdk/Auth/InMemoryAuthTokenStore.cs
+++ b/src/Honua.Mobile.Sdk/Auth/InMemoryAuthTokenStore.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 namespace Honua.Mobile.Sdk.Auth;
 
 /// <summary>

--- a/src/Honua.Mobile.Sdk/Auth/MobileAuthTelemetry.cs
+++ b/src/Honua.Mobile.Sdk/Auth/MobileAuthTelemetry.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 

--- a/src/Honua.Mobile.Sdk/Auth/RefreshingAuthTokenProvider.cs
+++ b/src/Honua.Mobile.Sdk/Auth/RefreshingAuthTokenProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Diagnostics;
 using System.Net.Http.Json;
 using System.Text.Json;

--- a/src/Honua.Mobile.Sdk/Features/HonuaMobileSdkFeatureClient.cs
+++ b/src/Honua.Mobile.Sdk/Features/HonuaMobileSdkFeatureClient.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Runtime.CompilerServices;
 using Honua.Sdk.Abstractions.Features;
 

--- a/src/Honua.Mobile.Sdk/HonuaMobileApiException.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileApiException.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Net;
 
 namespace Honua.Mobile.Sdk;

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.Attachments.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.Attachments.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Globalization;
 using System.Net;
 using System.Text.Json;

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text.Json;

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.Grpc.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.Grpc.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Honua.Mobile.Sdk.Auth;
 using Honua.Sdk.Grpc;
 

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.Internals.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.Internals.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.OgcFeatures.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.OgcFeatures.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Globalization;
 using System.Text;
 using System.Text.Json;

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Net;
 using System.Net.Http.Headers;
 using Honua.Mobile.Sdk.Auth;

--- a/src/Honua.Mobile.Sdk/HonuaMobileClientOptions.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClientOptions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using System.Net.Http.Headers;
 using Honua.Mobile.Sdk.Auth;
 

--- a/src/Honua.Mobile.Sdk/Routing/RoutingModels.cs
+++ b/src/Honua.Mobile.Sdk/Routing/RoutingModels.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Honua, Inc. and contributors.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
+
 using Honua.Sdk.Abstractions.Routing;
 using Honua.Sdk.GeoServices.Routing;
 


### PR DESCRIPTION
Closes the remaining pre-release docs/claims and hygiene audit sub-items. The fabricated AR-example marketing doc (now a labelled forward-looking concept with a working LICENSE link) and the dangling `Honua.Mobile.IoT` references were already corrected on trunk; this finishes the rest.

## Attribution enforcement (S2)
`scripts/check-no-ai-attribution.sh` plus a `Repository Hygiene` CI job reject AI/agent co-author trailers, vendor no-reply addresses, "generated with" lines, and robot-emoji markers in the PR's commit messages **and** the PR body — turning the AGENTS.md "no agent attribution" rule into an enforced gate. Verified locally: a human co-author trailer passes; an AI/agent trailer and an emoji line fail.

## License headers (S3)
Applied one Apache-2.0 header to every shipped-library source (`Honua.Mobile.Sdk`, `.Offline`, `.Maui` — 74 files) and added `scripts/check-license-headers.sh` + a CI job that enforces it. `dotnet format --verify-no-changes` stays clean on all three libraries with the headers in place.

## Test-count drift (S3)
Stopped publishing brittle pinned counts (`294`/`18`/`11`/`9`/`7`) in `README.md` and `docs/guides/validation-strategy.md`; coverage is now described by project/suite with a note that the authoritative numbers come from each CI run. This removes the drift source rather than chasing it.

Closes #316

## Validation
`dotnet format --verify-no-changes` clean on Sdk/Offline/Maui; both hygiene scripts exercised locally (pass/fail cases). The MAUI app and live/integration suites are not buildable/runnable in this environment.
