### PR TITLE
fix(offline): at-most-once OGC create, WAL reads, lossless local geometry, CSV-injection-safe export

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Export/LocalRecordExportService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Export/LocalRecordExportService.cs
@@ -880,13 +880,25 @@ public sealed class LocalRecordExportService : ILocalRecordExportService
 
     private static string EscapeCsv(string value)
     {
-        return value.Contains('"', StringComparison.Ordinal) ||
-            value.Contains(',', StringComparison.Ordinal) ||
-            value.Contains('\n', StringComparison.Ordinal) ||
-            value.Contains('\r', StringComparison.Ordinal)
-            ? $"\"{value.Replace("\"", "\"\"", StringComparison.Ordinal)}\""
-            : value;
+        // Neutralize spreadsheet formula/DDE injection before RFC-4180 quoting. Field-collected
+        // attribute values (operator input and server-synced records) are emitted verbatim, so a
+        // cell beginning with =, +, -, @, tab, or CR is evaluated as a formula when the export is
+        // opened in Excel/Sheets (e.g. =HYPERLINK exfil, DDE). RFC-4180 quoting does not mitigate
+        // this — the spreadsheet strips the surrounding quotes and still evaluates the leading
+        // trigger — so prefix a leading apostrophe per OWASP CSV-injection guidance. Applied to
+        // both attribute headers and data cells (the two EscapeCsv call sites).
+        var guarded = StartsWithFormulaTrigger(value) ? "'" + value : value;
+
+        return guarded.Contains('"', StringComparison.Ordinal) ||
+            guarded.Contains(',', StringComparison.Ordinal) ||
+            guarded.Contains('\n', StringComparison.Ordinal) ||
+            guarded.Contains('\r', StringComparison.Ordinal)
+            ? $"\"{guarded.Replace("\"", "\"\"", StringComparison.Ordinal)}\""
+            : guarded;
     }
+
+    private static bool StartsWithFormulaTrigger(string value)
+        => value.Length > 0 && value[0] is '=' or '+' or '-' or '@' or '\t' or '\r';
 
     private static string FormatDateTime(DateTime? value)
     {

--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
@@ -43,7 +43,9 @@ public class GeoPackageStorageService : IDisposable, IAsyncDisposable
     {
         _databasePath = databasePath;
         _connection = new SQLiteAsyncConnection(databasePath, SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create);
-        _wkbWriter = new WKBWriter();
+        // emitZ so 3D points/vertices survive the local round-trip; the default WKBWriter writes
+        // XY only and would silently drop the Z ordinate even when the geometry carries one.
+        _wkbWriter = new WKBWriter(ByteOrder.LittleEndian, handleSRID: false, emitZ: true);
         _wkbReader = new WKBReader();
         _initializationTask = new Lazy<Task>(InitializeDatabase);
     }
@@ -2299,12 +2301,14 @@ public class GeoPackageStorageService : IDisposable, IAsyncDisposable
     {
         return geometry switch
         {
-            CoreModels.Point point => new NetTopologySuite.Geometries.Point(point.Longitude, point.Latitude),
+            CoreModels.Point point => point.Altitude.HasValue
+                ? new NetTopologySuite.Geometries.Point(ToNtsCoordinate(point))
+                : new NetTopologySuite.Geometries.Point(point.Longitude, point.Latitude),
             CoreModels.LineString line => new NetTopologySuite.Geometries.GeometryFactory(
                     new NetTopologySuite.Geometries.PrecisionModel(),
                     line.SRID)
                 .CreateLineString(line.Coordinates
-                    .Select(point => new NetTopologySuite.Geometries.Coordinate(point.Longitude, point.Latitude))
+                    .Select(ToNtsCoordinate)
                     .ToArray()),
             CoreModels.Polygon polygon => CreateNtsPolygon(polygon),
             null => null,
@@ -2312,33 +2316,67 @@ public class GeoPackageStorageService : IDisposable, IAsyncDisposable
         };
     }
 
+    // Carry the Z ordinate when an altitude is present so 3D captures are not silently flattened
+    // to 2D on the local-storage write path (the WKBWriter is configured with emitZ).
+    private static NetTopologySuite.Geometries.Coordinate ToNtsCoordinate(CoreModels.Point point)
+        => point.Altitude.HasValue
+            ? new NetTopologySuite.Geometries.CoordinateZ(point.Longitude, point.Latitude, point.Altitude.Value)
+            : new NetTopologySuite.Geometries.Coordinate(point.Longitude, point.Latitude);
+
+    private static CoreModels.Point ToCorePoint(NetTopologySuite.Geometries.Coordinate coordinate)
+        => new(coordinate.Y, coordinate.X, double.IsNaN(coordinate.Z) ? null : coordinate.Z);
+
     private static NetTopologySuite.Geometries.Polygon CreateNtsPolygon(CoreModels.Polygon polygon)
     {
         var factory = new NetTopologySuite.Geometries.GeometryFactory(
             new NetTopologySuite.Geometries.PrecisionModel(),
             polygon.SRID);
-        var shellCoordinates = polygon.Coordinates.FirstOrDefault() ?? [];
-        var coordinates = shellCoordinates
-            .Select(point => new NetTopologySuite.Geometries.Coordinate(point.Longitude, point.Latitude))
-            .ToList();
 
-        if (coordinates.Count > 0 && !coordinates[0].Equals2D(coordinates[^1]))
+        var shell = CreateNtsLinearRing(factory, polygon.Coordinates.FirstOrDefault() ?? []);
+        if (shell is null)
         {
-            coordinates.Add(coordinates[0]);
+            return factory.CreatePolygon();
         }
 
-        return factory.CreatePolygon(coordinates.ToArray());
+        // Preserve interior rings (holes) instead of keeping only the shell, matching the other two
+        // geometry serializers in this project (CoreModels.ToGeoJson and FieldCollectionSyncTransports).
+        var holes = polygon.Coordinates
+            .Skip(1)
+            .Select(ring => CreateNtsLinearRing(factory, ring))
+            .Where(ring => ring is not null)
+            .Cast<NetTopologySuite.Geometries.LinearRing>()
+            .ToArray();
+
+        return holes.Length > 0
+            ? factory.CreatePolygon(shell, holes)
+            : factory.CreatePolygon(shell);
+    }
+
+    private static NetTopologySuite.Geometries.LinearRing? CreateNtsLinearRing(
+        NetTopologySuite.Geometries.GeometryFactory factory,
+        IReadOnlyList<CoreModels.Point> ring)
+    {
+        var coordinates = ring.Select(ToNtsCoordinate).ToList();
+        if (coordinates.Count == 0)
+        {
+            return null;
+        }
+
+        if (!coordinates[0].Equals2D(coordinates[^1]))
+        {
+            coordinates.Add(coordinates[0].Copy());
+        }
+
+        return factory.CreateLinearRing(coordinates.ToArray());
     }
 
     private static CoreModels.Geometry? ConvertFromNtsGeometry(NtsGeometry ntsGeometry)
     {
         if (ntsGeometry is NetTopologySuite.Geometries.Point point)
         {
-            return new CoreModels.Point
-            {
-                Latitude = point.Y,
-                Longitude = point.X
-            };
+            return point.Coordinate is { } coordinate
+                ? ToCorePoint(coordinate)
+                : new CoreModels.Point { Latitude = point.Y, Longitude = point.X };
         }
 
         if (ntsGeometry is NetTopologySuite.Geometries.LineString line)
@@ -2346,22 +2384,24 @@ public class GeoPackageStorageService : IDisposable, IAsyncDisposable
             return new CoreModels.LineString
             {
                 Coordinates = line.Coordinates
-                    .Select(point => new CoreModels.Point(point.Y, point.X))
+                    .Select(ToCorePoint)
                     .ToList()
             };
         }
 
         if (ntsGeometry is NetTopologySuite.Geometries.Polygon polygon)
         {
-            return new CoreModels.Polygon
+            var rings = new List<List<CoreModels.Point>>
             {
-                Coordinates =
-                [
-                    polygon.ExteriorRing.Coordinates
-                        .Select(point => new CoreModels.Point(point.Y, point.X))
-                        .ToList()
-                ]
+                polygon.ExteriorRing.Coordinates.Select(ToCorePoint).ToList()
             };
+
+            foreach (var interiorRing in polygon.InteriorRings)
+            {
+                rings.Add(interiorRing.Coordinates.Select(ToCorePoint).ToList());
+            }
+
+            return new CoreModels.Polygon { Coordinates = rings };
         }
 
         throw new NotSupportedException($"Geometry type {ntsGeometry.GeometryType} not supported");

--- a/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
+++ b/src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua, Inc. and contributors.
 // Licensed under the Apache License, Version 2.0. See the LICENSE file in the repository root.
 
+using System.Data;
 using System.Globalization;
 using System.Diagnostics;
 using System.Security.Cryptography;
@@ -2255,6 +2256,31 @@ LIMIT $limit;
             DataSource = _options.DatabasePath,
         };
 
-        return new SqliteConnection(builder.ToString());
+        var connection = new SqliteConnection(builder.ToString());
+
+        // Configure each connection as it opens. Without this the store runs in the default
+        // rollback-journal mode where a write transaction takes an exclusive lock that blocks
+        // concurrent readers, so a UI map query (GetFeaturesAsync) issued while background sync
+        // commits a large delta batch stalls until the command timeout instead of running
+        // concurrently. WAL lets readers proceed against the last committed snapshot during a
+        // write, busy_timeout makes lock contention deterministic, and synchronous=NORMAL is the
+        // recommended durability/throughput tradeoff under WAL. journal_mode=WAL persists in the
+        // database header, but applying it (and the per-connection PRAGMAs) on every open is cheap
+        // and idempotent and also covers databases created before this change.
+        connection.StateChange += ApplyConnectionPragmasOnOpen;
+        return connection;
+    }
+
+    private static void ApplyConnectionPragmasOnOpen(object? sender, StateChangeEventArgs e)
+    {
+        if (e.CurrentState != ConnectionState.Open || sender is not SqliteConnection connection)
+        {
+            return;
+        }
+
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=30000; PRAGMA synchronous=NORMAL;";
+        command.ExecuteNonQuery();
     }
 }

--- a/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
+++ b/src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs
@@ -158,13 +158,21 @@ public sealed class HonuaApiOfflineOperationUploader : IOfflineOperationUploader
         {
             case OfflineOperationType.Add:
                 {
-                    var response = await _client.ApplyEditsAsync(new FeatureEditRequest
+                    // An OGC create is a server-assigned-id POST and is not naturally idempotent, so a
+                    // re-upload after a lost ack would double-create the feature. Route the create through
+                    // CreateOgcItemAsync with the durable per-operation idempotency key (matching the
+                    // FeatureServer at-most-once path) so the server replays the original result instead.
+                    // The generic FeatureEditRequest/ApplyEditsAsync OGC path cannot carry the key because
+                    // it delegates to the SDK OGC client, which has no idempotency-header surface.
+                    using var response = await _client.CreateOgcItemAsync(new OgcCreateItemRequest
                     {
-                        Source = new FeatureSource { CollectionId = payload.CollectionId },
-                        Adds = [ToOgcFeatureEditFeature(payload.Feature, null, "Add operation requires feature payload.")],
-                        RollbackOnFailure = false,
-                    }, ct).ConfigureAwait(false);
-                    return ToUploadResult(response);
+                        CollectionId = payload.CollectionId,
+                        Feature = payload.Feature ?? throw new InvalidOperationException("Add operation requires feature payload."),
+                    }, BuildIdempotencyKey(operation), ct).ConfigureAwait(false);
+
+                    return TryReadError(response.RootElement, out var code, out var message)
+                        ? FromErrorCode(code, message)
+                        : new UploadResult { Outcome = UploadOutcome.Success };
                 }
 
             case OfflineOperationType.Update:

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs
@@ -111,6 +111,11 @@ public sealed partial class HonuaMobileClient
 
         if (HasOgcSource(request.Source))
         {
+            // OGC sources delegate to the SDK OGC client, which has no idempotency-header surface,
+            // so the key cannot be honored on this path. OGC update (PATCH/PUT by id) and delete
+            // (by id) are naturally idempotent; for an at-most-once OGC create use
+            // CreateOgcItemAsync(request, idempotencyKey, ct), which carries the Idempotency-Key
+            // header on the POST.
             return await ApplyOgcSdkEditsAsync(request, ct).ConfigureAwait(false);
         }
 

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.OgcFeatures.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.OgcFeatures.cs
@@ -55,7 +55,31 @@ public sealed partial class HonuaMobileClient
     /// <returns>A <see cref="JsonDocument"/> containing the server response for the created item.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="request"/> is <see langword="null"/>.</exception>
     /// <exception cref="HonuaMobileApiException">Thrown when the server returns a non-success HTTP status code.</exception>
-    public async Task<JsonDocument> CreateOgcItemAsync(OgcCreateItemRequest request, CancellationToken ct = default)
+    public Task<JsonDocument> CreateOgcItemAsync(OgcCreateItemRequest request, CancellationToken ct = default)
+        => CreateOgcItemAsync(request, idempotencyKey: null, ct);
+
+    /// <summary>
+    /// Creates a new feature item in an OGC Features API collection, attaching a stable
+    /// <c>Idempotency-Key</c> so the server can dedupe a retried create (at-most-once,
+    /// honua-server #2250).
+    /// </summary>
+    /// <remarks>
+    /// An OGC create is a server-assigned-id POST and so is not naturally idempotent: a network
+    /// failure after the server commits but before the client reads the ack would, on retry,
+    /// create a duplicate feature. Supplying a stable key lets the server replay the original
+    /// response instead. OGC update (PATCH/PUT by id) and delete (by id) are naturally idempotent
+    /// and do not need a key.
+    /// </remarks>
+    /// <param name="request">The collection ID and GeoJSON feature to create.</param>
+    /// <param name="idempotencyKey">Stable client-generated key (≤200 chars, no control characters), or <see langword="null"/>.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A <see cref="JsonDocument"/> containing the server response for the created item.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="request"/> is <see langword="null"/>.</exception>
+    /// <exception cref="HonuaMobileApiException">Thrown when the server returns a non-success HTTP status code.</exception>
+    public async Task<JsonDocument> CreateOgcItemAsync(
+        OgcCreateItemRequest request,
+        string? idempotencyKey,
+        CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -65,7 +89,8 @@ public sealed partial class HonuaMobileClient
             path,
             query: null,
             CreateJsonContent(request.Feature, "application/geo+json"),
-            ct).ConfigureAwait(false);
+            ct,
+            idempotencyKey).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageGeometryRoundTripTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageGeometryRoundTripTests.cs
@@ -1,0 +1,125 @@
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services.Storage;
+
+namespace Honua.Mobile.FieldCollection.Tests;
+
+public sealed class GeoPackageGeometryRoundTripTests
+{
+    public GeoPackageGeometryRoundTripTests()
+    {
+        SQLitePCL.Batteries_V2.Init();
+    }
+
+    [Fact]
+    public async Task StoreAndGetFeature_PolygonWithHole_PreservesInteriorRing()
+    {
+        var databasePath = CreateDatabasePath();
+        using var cleanup = new TempFile(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.CreateLayerAsync(CreateLayer(GeometryType.Polygon));
+
+        var polygon = new Polygon
+        {
+            Coordinates =
+            [
+                // Shell.
+                [new Point(0, 0), new Point(0, 10), new Point(10, 10), new Point(10, 0), new Point(0, 0)],
+                // Interior ring (hole) that the old converter silently discarded.
+                [new Point(2, 2), new Point(2, 8), new Point(8, 8), new Point(8, 2), new Point(2, 2)],
+            ],
+        };
+
+        await storage.StoreFeatureAsync(CreateFeature("poly-1", polygon));
+
+        var stored = await storage.GetFeatureAsync("poly-1", 1);
+
+        Assert.NotNull(stored);
+        var storedPolygon = Assert.IsType<Polygon>(stored!.Geometry);
+        Assert.Equal(2, storedPolygon.Coordinates.Count);
+        Assert.Equal(5, storedPolygon.Coordinates[0].Count);
+        Assert.Equal(5, storedPolygon.Coordinates[1].Count);
+        Assert.Equal(2, storedPolygon.Coordinates[1][0].Latitude);
+        Assert.Equal(2, storedPolygon.Coordinates[1][0].Longitude);
+    }
+
+    [Fact]
+    public async Task StoreAndGetFeature_PointWithAltitude_PreservesZ()
+    {
+        var databasePath = CreateDatabasePath();
+        using var cleanup = new TempFile(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.CreateLayerAsync(CreateLayer(GeometryType.Point));
+
+        await storage.StoreFeatureAsync(CreateFeature("pt-1", new Point(21.3, -157.8, 1234.5)));
+
+        var stored = await storage.GetFeatureAsync("pt-1", 1);
+
+        Assert.NotNull(stored);
+        var storedPoint = Assert.IsType<Point>(stored!.Geometry);
+        Assert.Equal(21.3, storedPoint.Latitude, 6);
+        Assert.Equal(-157.8, storedPoint.Longitude, 6);
+        Assert.NotNull(storedPoint.Altitude);
+        Assert.Equal(1234.5, storedPoint.Altitude!.Value, 6);
+    }
+
+    [Fact]
+    public async Task StoreAndGetFeature_PointWithoutAltitude_RemainsTwoDimensional()
+    {
+        var databasePath = CreateDatabasePath();
+        using var cleanup = new TempFile(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+        await storage.CreateLayerAsync(CreateLayer(GeometryType.Point));
+
+        await storage.StoreFeatureAsync(CreateFeature("pt-2", new Point(21.3, -157.8)));
+
+        var stored = await storage.GetFeatureAsync("pt-2", 1);
+
+        Assert.NotNull(stored);
+        var storedPoint = Assert.IsType<Point>(stored!.Geometry);
+        Assert.Null(storedPoint.Altitude);
+    }
+
+    private static LayerInfo CreateLayer(GeometryType geometryType) => new()
+    {
+        Id = 1,
+        ServiceId = "field-support",
+        SourceId = "field-support/FeatureServer/1",
+        Name = "Field Assets",
+        GeometryType = geometryType,
+        IsEditable = true,
+    };
+
+    private static Feature CreateFeature(string id, Geometry geometry) => new()
+    {
+        Id = id,
+        LayerId = 1,
+        Version = 1,
+        Geometry = geometry,
+        CreatedAt = DateTime.UtcNow,
+        ModifiedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow,
+        Attributes = new Dictionary<string, object?> { ["name"] = id },
+    };
+
+    private static string CreateDatabasePath()
+        => Path.Combine(Path.GetTempPath(), $"honua-field-geom-{Guid.NewGuid():N}.gpkg");
+
+    private sealed class TempFile : IDisposable
+    {
+        private readonly string _path;
+
+        public TempFile(string path) => _path = path;
+
+        public void Dispose()
+        {
+            foreach (var suffix in new[] { string.Empty, "-wal", "-shm" })
+            {
+                var candidate = _path + suffix;
+                if (File.Exists(candidate))
+                {
+                    File.Delete(candidate);
+                }
+            }
+        }
+    }
+}

--- a/tests/Honua.Mobile.FieldCollection.Tests/LocalRecordExportServiceTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/LocalRecordExportServiceTests.cs
@@ -224,6 +224,53 @@ public sealed class LocalRecordExportServiceTests
         Assert.True(new FileInfo(result.EvidenceManifestPath).Length > 0);
     }
 
+    [Fact]
+    public async Task ExportLayerAsync_NeutralizesCsvFormulaInjectionInAttributeValues()
+    {
+        var databasePath = CreateDatabasePath();
+        var exportRoot = CreateExportRoot();
+        await using var cleanup = new FileCleanup(databasePath, exportRoot);
+        using var storage = new GeoPackageStorageService(databasePath);
+        var layer = CreateLayer();
+
+        var feature = new Feature
+        {
+            Id = "asset-injection",
+            LayerId = 1,
+            Version = 1,
+            Geometry = new Point(21.3, -157.8),
+            CreatedAt = DateTime.UtcNow.AddMinutes(-10),
+            ModifiedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            Attributes = new Dictionary<string, object?>
+            {
+                ["name"] = "asset-injection",
+                ["status"] = "synced",
+                ["formula"] = "=HYPERLINK(\"http://evil.test\",\"click\")",
+                ["dde"] = "@SUM(1+1)",
+            },
+        };
+        await storage.ApplyRemoteFeatureAsync(feature);
+
+        var service = new LocalRecordExportService(storage, exportRoot);
+        var result = await service.ExportLayerAsync(layer);
+
+        var csv = await File.ReadAllTextAsync(result.CsvPath);
+
+        // Formula triggers are apostrophe-guarded so a spreadsheet treats them as text.
+        Assert.Contains("'=HYPERLINK", csv);
+        Assert.Contains("'@SUM", csv);
+
+        // No data cell starts with a bare formula trigger: it would only do so immediately after a
+        // delimiter/quote/line-start. The guard + RFC-4180 quoting prevents that.
+        foreach (var line in csv.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            Assert.DoesNotContain(",=HYPERLINK", line);
+            Assert.DoesNotContain(",@SUM", line);
+            Assert.False(line.StartsWith('='), "A CSV cell must not start with an unescaped formula trigger.");
+        }
+    }
+
     private static LayerInfo CreateLayer()
     {
         return new LayerInfo

--- a/tests/Honua.Mobile.Offline.Tests/HonuaApiOfflineOperationUploaderTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/HonuaApiOfflineOperationUploaderTests.cs
@@ -161,23 +161,27 @@ public sealed class HonuaApiOfflineOperationUploaderTests
     }
 
     [Fact]
-    public async Task UploadAsync_OgcAdd_UsesSdkFeatureEditRequest()
+    public async Task UploadAsync_OgcAdd_PostsGeoJsonItemWithIdempotencyKey()
     {
         string? capturedPath = null;
         string? capturedMediaType = null;
         string? capturedBody = null;
+        string? capturedIdempotencyKey = null;
         var uploader = CreateUploader((request, _) =>
         {
             capturedPath = request.RequestUri!.PathAndQuery;
             capturedMediaType = request.Content?.Headers.ContentType?.MediaType;
             capturedBody = request.Content is null ? null : request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            capturedIdempotencyKey = request.Headers.TryGetValues("Idempotency-Key", out var values)
+                ? values.FirstOrDefault()
+                : null;
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent("""{"type":"Feature","id":"building-1"}""", Encoding.UTF8, "application/json"),
             };
         });
 
-        var result = await uploader.UploadAsync(new OfflineEditOperation
+        var operation = new OfflineEditOperation
         {
             LayerKey = "buildings",
             TargetCollection = "buildings",
@@ -193,12 +197,21 @@ public sealed class HonuaApiOfflineOperationUploaderTests
               }
             }
             """,
-        }, forceWrite: false);
+        };
+
+        var result = await uploader.UploadAsync(operation, forceWrite: false);
 
         Assert.Equal(UploadOutcome.Success, result.Outcome);
         Assert.Contains("/ogc/features/collections/buildings/items", capturedPath);
         Assert.Equal("application/geo+json", capturedMediaType);
-        Assert.Contains("\"name\":\"HQ\"", capturedBody);
+        // The stored GeoJSON feature is forwarded verbatim (no lossy normalization), so assert the
+        // attribute is present rather than a specific compact serialization.
+        Assert.Contains("\"name\"", capturedBody);
+        Assert.Contains("\"HQ\"", capturedBody);
+        // An OGC create is a non-idempotent POST, so it must carry the stable per-operation
+        // Idempotency-Key for at-most-once retries (parity with the FeatureServer path).
+        Assert.False(string.IsNullOrWhiteSpace(capturedIdempotencyKey));
+        Assert.Contains(operation.OperationId, capturedIdempotencyKey!, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Round-2 client-side data-integrity fixes from the release audit. These are new findings (no GitHub issue numbers); each is referenced below by `file:line` and recommendation. Grouped into one PR per the as-few-PRs-as-reasonable preference because they all concern offline/local data correctness and safety. **Do not merge** without review.

## Fixes

### 1. OGC offline create is now at-most-once (S2, correctness / cross-repo-contract)
`src/Honua.Mobile.Offline/Sync/HonuaApiOfflineOperationUploader.cs:161`, `src/Honua.Mobile.Sdk/HonuaMobileClient.OgcFeatures.cs:55`

The FeatureServer at-most-once fix did not cover OGC. An OGC `Add` is a server-assigned-id POST routed through the SDK OGC client, which has no idempotency-header surface, so a re-upload after a lost ack (retryable failure → requeue) double-created the feature. `CreateOgcItemAsync` now accepts a stable idempotency key (mapped to the `Idempotency-Key` header via `SendJsonAsync`), and the offline uploader routes OGC adds through it with `offline-op:{OperationId}`, matching the FeatureServer path. OGC update (PATCH/PUT by id) and delete (by id) are naturally idempotent; the generic `ApplyEditsAsync` OGC branch now documents why it cannot carry the key.

### 2. SQLite store opens with WAL + busy_timeout (S2, reliability)
`src/Honua.Mobile.Offline/GeoPackage/GeoPackageSyncStore.cs:2251`

Connections used the default rollback-journal mode, so a write transaction took an exclusive lock that blocked UI map reads (`GetFeaturesAsync`) during large background-sync delta commits — reads stalled up to the command timeout instead of running concurrently. Each connection now applies `journal_mode=WAL`, `busy_timeout=30000`, and `synchronous=NORMAL` on open (via a `StateChange` hook so all ~25 call sites are covered) so readers proceed against the last committed snapshot.

### 3. Local GeoPackage geometry converter is lossless and symmetric (S2, coherence/correctness)
`apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs:2315`

The converter built NTS polygons from the shell only and points without Z, silently dropping interior rings (holes) and altitude on local round-trip — diverging from the project's two other serializers (`CoreModels.ToGeoJson`, `FieldCollectionSyncTransports`). It now carries all rings (shell + holes) and the Z ordinate in both directions, and the `WKBWriter` is configured with `emitZ`.

### 4. CSV export neutralizes formula/DDE injection (S2, security)
`apps/Honua.Mobile.FieldCollection.Core/Services/Export/LocalRecordExportService.cs:881`

`EscapeCsv` applied only RFC-4180 quoting, so a field-collected cell beginning with `=` `+` `-` `@` tab or CR was evaluated as a formula (e.g. `=HYPERLINK` exfil, DDE) when `records.csv` is opened in Excel/Sheets. Such cells are now apostrophe-guarded per OWASP CSV-injection guidance before quoting, for both attribute headers and data cells.

## Tests
- Updated `UploadAsync_OgcAdd_*` to assert the GeoJSON item POST carries the stable `Idempotency-Key`.
- New `GeoPackageGeometryRoundTripTests`: polygon-with-hole and 3D-point round-trip, plus 2D point stays 2D.
- New `ExportLayerAsync_NeutralizesCsvFormulaInjectionInAttributeValues`.

Builds clean (SDK, Offline, FieldCollection.Core) and the Offline (98), FieldCollection (156), and SDK (99) suites pass; `dotnet format --verify-no-changes` is clean on the core libraries.

## Notes / not in this PR
- Plumbing the idempotency key through the SDK's `HonuaOgcFeaturesClient.ApplyEditsAsync` generically is cross-repo (`honua-sdk-dotnet` owns that client); the concrete duplicate-create vector is fully closed in-repo here by routing the offline create through `CreateOgcItemAsync`.
