### PR TITLE
fix(sdk): route returnExtentOnly feature queries over REST instead of gRPC

### DIFF
--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs
@@ -142,7 +142,7 @@ public sealed partial class HonuaMobileClient
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        if (CanUseGrpcForQueries)
+        if (CanUseGrpcForLegacyQuery(request))
         {
             try
             {
@@ -158,6 +158,15 @@ public sealed partial class HonuaMobileClient
     }
 
     /// <summary>
+    /// gRPC eligibility for the legacy Esri-JSON query surface. <c>returnExtentOnly</c> is forced
+    /// onto REST because the gRPC-to-legacy converter (<see cref="ToLegacyFeatureQueryJsonDocument"/>)
+    /// has no extent branch and would otherwise silently return <c>{"features":[]}</c> instead of an
+    /// extent envelope; REST honors <c>returnExtentOnly</c>.
+    /// </summary>
+    private bool CanUseGrpcForLegacyQuery(QueryFeaturesRequest request)
+        => CanUseGrpcForQueries && !request.ReturnExtentOnly;
+
+    /// <summary>
     /// Streams feature query results as multiple pages via gRPC server streaming, falling back to a single REST page on failure.
     /// </summary>
     /// <param name="request">The query parameters.</param>
@@ -170,7 +179,7 @@ public sealed partial class HonuaMobileClient
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        if (CanUseGrpcForQueries)
+        if (CanUseGrpcForLegacyQuery(request))
         {
             var yieldedGrpcPage = false;
             var grpcSucceeded = false;

--- a/tests/Honua.Mobile.Sdk.Tests/HonuaMobileClientHttpTests.cs
+++ b/tests/Honua.Mobile.Sdk.Tests/HonuaMobileClientHttpTests.cs
@@ -373,6 +373,46 @@ public sealed class HonuaMobileClientHttpTests
     }
 
     [Fact]
+    public async Task QueryFeaturesAsync_ExtentOnly_UsesRestEvenWhenGrpcPreferred()
+    {
+        Uri? capturedUri = null;
+        var handler = new StubHttpMessageHandler((request, _) =>
+        {
+            capturedUri = request.RequestUri;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"extent":{"xmin":-1,"ymin":-2,"xmax":3,"ymax":4,"spatialReference":{"wkid":4326}}}""",
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+        });
+
+        // gRPC preferred with REST fallback disabled: if the extent-only query were (incorrectly)
+        // routed over gRPC it would attempt a gRPC call over the stub HttpClient and throw rather
+        // than reach the REST handler. The legacy gRPC-to-JSON converter has no extent branch and
+        // would otherwise silently yield {"features":[]}.
+        var client = CreateClient(handler, new HonuaMobileClientOptions
+        {
+            BaseUri = new Uri("https://api.honua.test"),
+            PreferGrpcForFeatureQueries = true,
+            AllowRestFallbackOnGrpcFailure = false,
+        });
+
+        using var result = await client.QueryFeaturesAsync(new QueryFeaturesRequest
+        {
+            ServiceId = "assets",
+            LayerId = 0,
+            ReturnExtentOnly = true,
+        });
+
+        Assert.NotNull(capturedUri);
+        Assert.Contains("/FeatureServer/0/query", capturedUri.PathAndQuery);
+        Assert.Contains("returnExtentOnly=true", capturedUri.PathAndQuery);
+        Assert.True(result.RootElement.TryGetProperty("extent", out _));
+    }
+
+    [Fact]
     public async Task GetOgcCollectionsAsync_Success_ReturnsCollections()
     {
         var responseJson = """


### PR DESCRIPTION
## Summary

Round-2 release-audit finding (S2, protocol-compliance; new finding, no GitHub issue number).

`src/Honua.Mobile.Sdk/HonuaMobileClient.Features.cs` — `QueryFeaturesAsync` / `QueryFeaturesStreamAsync` return the legacy Esri-JSON FeatureSet and gRPC is the default query transport (`PreferGrpcForFeatureQueries = true`). The gRPC-to-legacy converter `ToLegacyFeatureQueryJsonDocument` has **no extent branch**, so a `returnExtentOnly` query sent over gRPC silently produced `{"features":[]}` instead of an extent envelope. Only the REST path honors `returnExtentOnly`.

## Fix

`returnExtentOnly` queries are now forced onto REST via a per-request gRPC-eligibility check (`CanUseGrpcForLegacyQuery`) used by both the unary and streaming legacy-JSON query entry points. All other queries keep the default gRPC-preferred selection.

Adds a regression test asserting an extent-only query hits the REST `/query` endpoint with `returnExtentOnly=true` even when gRPC is preferred and REST fallback is disabled.

`Honua.Mobile.Sdk.Tests` passes (100); `dotnet format --verify-no-changes` clean.

## Not in this PR (cross-repo)

The same finding also notes the legacy gRPC FeatureSet omits `spatialReference`/`geometryType`/`fields`. That is a gRPC contract limitation owned by the SDK/proto (`honua-sdk-dotnet`, `geospatial-grpc`) — populating those would require the gRPC `FeatureQueryResult` to carry them — so it is out of scope for this mobile-side change. The concrete silent-empty-result bug (`returnExtentOnly`) is fully fixed here.
