### PR TITLE
fix(mobile): prune leaked retry state; classify invalid-JSON as retryable transport

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,4 +36,17 @@
     <HonuaConformanceFixturesVersion>0.1.0-alpha.1</HonuaConformanceFixturesVersion>
     <HonuaConformanceFixturesRepository>honua-io/geospatial-grpc</HonuaConformanceFixturesRepository>
   </PropertyGroup>
+
+  <!--
+    NuGet audit suppression for GHSA-2m69-gcr7-jv3q (NU1903) against the native
+    SQLitePCLRaw e_sqlite3 library (2.1.x). The advisory is fixed in the 3.x
+    SQLitePCLRaw line, but SQLitePCLRaw.bundle_green has no 3.x release yet, so
+    there is no compatible upgrade path on the current line. The bundled native
+    library is shipped with the app rather than dynamically loaded. Remove this
+    suppression once a 3.x bundle_green (or patched 2.1.x lib.e_sqlite3) is
+    available and pinned.
+  -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
 </Project>

--- a/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportUploadWorker.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportUploadWorker.cs
@@ -55,14 +55,21 @@ public sealed class MobileExceptionReportUploadWorker : IMobileExceptionReportUp
         }
 
         var attempted = 0;
+        var seenQueueIds = new HashSet<string>(StringComparer.Ordinal);
         await foreach (var queued in _queue.ReadPendingAsync(cancellationToken))
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Track every still-pending queue id so stale retry state can be pruned
+            // below. We keep enumerating past the upload batch cap (only skipping the
+            // upload) so the seen-set reflects the full pending queue, not just the
+            // batch we attempted this pass.
+            seenQueueIds.Add(queued.QueueId);
+
             if (attempted >= _options.MaxUploadBatchSize)
             {
-                break;
+                continue;
             }
-
-            cancellationToken.ThrowIfCancellationRequested();
 
             var now = _timeProvider.GetUtcNow();
             if (!IsDue(queued.QueueId, now))
@@ -95,6 +102,13 @@ public sealed class MobileExceptionReportUploadWorker : IMobileExceptionReportUp
 
             ScheduleRetry(queued.QueueId, now);
         }
+
+        // Drop retry state for reports that are no longer on disk. Queue files can be
+        // removed out-of-band (e.g. FileMobileExceptionReportQueue.TrimQueue deleting
+        // excess reports when MaxQueuedReports is exceeded) without routing through the
+        // worker's success/delete path, which would otherwise leak one stale entry per
+        // trimmed-while-failing report and grow _retryStates without bound.
+        PruneRetryStates(seenQueueIds);
     }
 
     private bool IsDue(string queueId, DateTimeOffset now)
@@ -121,6 +135,36 @@ public sealed class MobileExceptionReportUploadWorker : IMobileExceptionReportUp
         lock (_retryGate)
         {
             _retryStates.Remove(queueId);
+        }
+    }
+
+    private void PruneRetryStates(HashSet<string> pendingQueueIds)
+    {
+        lock (_retryGate)
+        {
+            if (_retryStates.Count == 0)
+            {
+                return;
+            }
+
+            List<string>? stale = null;
+            foreach (var queueId in _retryStates.Keys)
+            {
+                if (!pendingQueueIds.Contains(queueId))
+                {
+                    (stale ??= new List<string>()).Add(queueId);
+                }
+            }
+
+            if (stale is null)
+            {
+                return;
+            }
+
+            foreach (var queueId in stale)
+            {
+                _retryStates.Remove(queueId);
+            }
         }
     }
 

--- a/src/Honua.Mobile.Sdk/HonuaMobileApiException.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileApiException.cs
@@ -43,6 +43,20 @@ public sealed class HonuaMobileApiException : Exception
     }
 
     /// <summary>
+    /// Initializes a new <see cref="HonuaMobileApiException"/> with status code, message, optional response body, and inner exception.
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code (or transport-appropriate status) attributed to the failure.</param>
+    /// <param name="message">A human-readable description of the failure.</param>
+    /// <param name="responseBody">The raw response body, if available.</param>
+    /// <param name="innerException">The exception that caused the API failure.</param>
+    public HonuaMobileApiException(HttpStatusCode statusCode, string message, string? responseBody, Exception? innerException)
+        : base(message, innerException)
+    {
+        StatusCode = statusCode;
+        ResponseBody = responseBody;
+    }
+
+    /// <summary>
     /// The HTTP status code returned by the server.
     /// </summary>
     public HttpStatusCode StatusCode { get; }

--- a/src/Honua.Mobile.Sdk/HonuaMobileClient.Internals.cs
+++ b/src/Honua.Mobile.Sdk/HonuaMobileClient.Internals.cs
@@ -86,7 +86,16 @@ public sealed partial class HonuaMobileClient
                     return JsonDocument.Parse("{}");
                 }
 
-                throw new HonuaMobileApiException("Honua mobile request returned invalid JSON.", ex);
+                // A success response whose body is malformed/truncated JSON is a
+                // transport-level garble (a bad upstream/proxy response), not a client
+                // error. Attribute it a 502 so downstream classification treats it as a
+                // retryable transport failure instead of a meaningless Code 0 /
+                // non-retryable InvalidOperation (StatusCode would otherwise default to 0).
+                throw new HonuaMobileApiException(
+                    HttpStatusCode.BadGateway,
+                    "Honua mobile request returned invalid JSON.",
+                    responseBody: null,
+                    innerException: ex);
             }
         }
         finally

--- a/tests/Honua.Mobile.Maui.Tests/Diagnostics/MobileExceptionReportUploadWorkerTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/Diagnostics/MobileExceptionReportUploadWorkerTests.cs
@@ -181,6 +181,56 @@ public sealed class MobileExceptionReportUploadWorkerTests
     }
 
     [Fact]
+    public async Task FlushPendingAsync_PrunesRetryStateForReportsTrimmedOutOfBand()
+    {
+        // A permanently-failing report accumulates retry state, then is removed from the
+        // queue out-of-band (e.g. TrimQueue dropping excess reports) without routing
+        // through the worker's success/delete path. The worker must prune that stale
+        // retry state so _retryStates does not leak one entry per trimmed-while-failing
+        // report. We observe the prune by re-enqueuing a report under the same QueueId:
+        // if the stale backoff state survived, it would still be suppressed; after the
+        // prune it is treated as fresh and uploaded on the next flush.
+        var timeProvider = new MutableTimeProvider(DateTimeOffset.Parse("2026-05-05T00:00:00Z", CultureInfo.InvariantCulture));
+        var queue = new InMemoryExceptionReportQueue();
+        const string trimmedQueueId = "trimmed-queue-id";
+        queue.Reports.Add(new QueuedMobileExceptionReport(trimmedQueueId, CreateReport()));
+        // Uploads: 1st (trimmed report) fails, all subsequent succeed.
+        var uploader = new SequenceUploader([false, true, true]);
+        var worker = new MobileExceptionReportUploadWorker(
+            queue,
+            uploader,
+            new MobileExceptionReportingOptions
+            {
+                Mode = MobileExceptionReportingMode.ServerUpload,
+                UploadEndpoint = new Uri("https://api.honua.test/mobile/exception-reports"),
+                UploadInitialBackoff = TimeSpan.FromMinutes(10),
+                UploadMaxBackoff = TimeSpan.FromMinutes(30),
+            },
+            timeProvider);
+
+        // First flush fails and schedules a long backoff for the trimmed queue id.
+        await worker.FlushPendingAsync();
+        Assert.Equal(1, uploader.Attempts);
+
+        // The failing report is trimmed off disk out-of-band (not via DeleteAsync) and
+        // a different report takes its place. The trimmed id is no longer pending, so its
+        // stale retry state must be pruned rather than leaked.
+        queue.Reports.Clear();
+        queue.Reports.Add(new QueuedMobileExceptionReport("other-queue-id", CreateReport()));
+        await worker.FlushPendingAsync();
+        Assert.Empty(queue.Reports);
+
+        // A new report later reuses the trimmed id. Because the stale backoff state was
+        // pruned (not retained), it is treated as fresh and uploaded immediately rather
+        // than being suppressed by the long backoff that would otherwise have leaked.
+        queue.Reports.Add(new QueuedMobileExceptionReport(trimmedQueueId, CreateReport()));
+        await worker.FlushPendingAsync();
+
+        Assert.Empty(queue.Reports);
+        Assert.Equal(3, uploader.Attempts);
+    }
+
+    [Fact]
     public async Task FlushPendingAsync_SerializesConcurrentFlushes()
     {
         var queue = new InMemoryExceptionReportQueue();

--- a/tests/Honua.Mobile.Offline.Tests/MobileSyncProblemHelperTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/MobileSyncProblemHelperTests.cs
@@ -1,4 +1,6 @@
+using System.Net;
 using Honua.Mobile.Offline.Sync;
+using Honua.Mobile.Sdk;
 
 namespace Honua.Mobile.Offline.Tests;
 
@@ -46,5 +48,36 @@ public sealed class MobileSyncProblemHelperTests
         Assert.False(problem.Retryable);
         Assert.Equal(MobileSyncProblemCategory.InvalidOperation, problem.Category);
         Assert.Equal(UploadOutcome.FatalFailure, MobileSyncProblemHelper.ToUploadResult(problem).Outcome);
+    }
+
+    [Fact]
+    public void FromException_InvalidJsonApiException_IsTransportAndRetryable()
+    {
+        // A success response with malformed/truncated JSON now carries a 502
+        // (transport garble) rather than the default StatusCode 0. It must classify
+        // as a retryable Transport problem, not a non-retryable InvalidOperation /
+        // meaningless Code 0.
+        var ex = new HonuaMobileApiException(
+            HttpStatusCode.BadGateway,
+            "Honua mobile request returned invalid JSON.",
+            responseBody: null,
+            innerException: new InvalidOperationException("boom"));
+
+        var problem = MobileSyncProblemHelper.FromException(ex);
+
+        Assert.Equal(MobileSyncProblemCategory.Transport, problem.Category);
+        Assert.True(problem.Retryable);
+        Assert.Equal(UploadOutcome.RetryableFailure, MobileSyncProblemHelper.ToUploadResult(ex).Outcome);
+    }
+
+    [Fact]
+    public void FromStatusCode_ClientError_RemainsNonRetryableInvalidOperation()
+    {
+        // Genuine client errors (4xx other than conflict/timeout/429) stay fatal so the
+        // 502 transport treatment above is scoped to the garbled-body case only.
+        var problem = MobileSyncProblemHelper.FromStatusCode(HttpStatusCode.BadRequest, "bad");
+
+        Assert.Equal(MobileSyncProblemCategory.InvalidOperation, problem.Category);
+        Assert.False(problem.Retryable);
     }
 }


### PR DESCRIPTION
## Summary
Two runtime reliability/error-model fixes surfaced by the round-3 release audit (new findings, referenced by file:line below).

### 1. Unbounded `_retryStates` growth when queue files are trimmed out-of-band (S2)
`src/Honua.Mobile.Maui/Diagnostics/MobileExceptionReportUploadWorker.cs:96`

`ScheduleRetry` adds/updates a `_retryStates` entry per failed upload, keyed by `QueueId` (the on-disk file path). Entries are removed only via `ClearRetry` on a successful upload. But `FileMobileExceptionReportQueue.TrimQueue` deletes excess report files directly (raw `DeleteFile`, bypassing the worker's `DeleteAsync`/success path) when `MaxQueuedReports` is exceeded. A permanently-failing report keeps accumulating retry state, then is silently trimmed off disk — its `_retryStates` entry is never removed. Over a long-lived process with recurring failures plus a steady stream of new reports trimming old ones, the dictionary leaks one stale entry per trimmed-while-failing report and grows without bound.

**Fix (per recommendation):** `FlushPendingCoreAsync` now collects the full set of currently-pending `QueueId`s during enumeration (continuing past the upload batch cap so the set reflects the whole queue, not just the attempted batch) and prunes any `_retryStates` key not present in that set.

### 2. Invalid-JSON failure has `StatusCode=0`, misclassified as non-retryable Code 0 (S2)
`src/Honua.Mobile.Sdk/HonuaMobileClient.Internals.cs:89`

On a success response with a malformed/truncated body, `SendJsonAsync` threw `HonuaMobileApiException(message, ex)` via the ctor that leaves `StatusCode` at the default `0`. Downstream, `HonuaMobileSdkFeatureClient` mapped `Code=(int)ex.StatusCode=0` and `MobileSyncProblemHelper.FromException` routed `FromStatusCode(0, ...)` to non-retryable `InvalidOperation`. A transient garbled response was thus permanently failed and surfaced a meaningless error code 0.

**Fix (per recommendation):** the invalid-JSON failure is now attributed HTTP `502 BadGateway` (a transport garble / bad upstream response), so existing classification treats it as a retryable `Transport` failure and emits a meaningful status instead of 0. Added a `(statusCode, message, responseBody, innerException)` ctor overload to `HonuaMobileApiException` so the underlying `JsonException` is preserved for diagnostics.

## Tests
- New `MobileExceptionReportUploadWorkerTests.FlushPendingAsync_PrunesRetryStateForReportsTrimmedOutOfBand` — exercises the trim-then-reuse path and proves stale backoff state is pruned, not retained.
- New `MobileSyncProblemHelperTests` cases — invalid-JSON 502 classifies as retryable `Transport`/`RetryableFailure`; genuine 4xx client errors stay fatal `InvalidOperation`.
- `Honua.Mobile.Sdk.Tests` (100), `Honua.Mobile.Maui.Tests` worker suite (8), `Honua.Mobile.Offline.Tests` helper suite (13) all green; existing `ListScenesAsync_InvalidJson` test unaffected. `dotnet format` clean on Sdk + Maui.
