### PR TITLE
test(server-integration): harden KnownServerGaps temporal/replica/analysis matchers

### DIFF
--- a/tests/Honua.Mobile.ServerIntegration.Tests/ConformanceContractTests.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/ConformanceContractTests.cs
@@ -112,6 +112,62 @@ public sealed class ConformanceContractTests
         Assert.Null(KnownServerGaps.Match(structuralDrift));
     }
 
+    [Theory]
+    [InlineData("FeatureService.QueryFeatures temporal filter response", "honua-server#1166")]
+    [InlineData("ReplicaService.CreateReplica response", "honua-server#1167")]
+    [InlineData("AnalysisService.ListAnalyses response", "honua-server#1237")]
+    public void KnownGaps_match_tracked_transport_gap_by_contract_surface(string contract, string expectedIssue)
+    {
+        // A genuine tracked server gap manifests as a hard transport failure on the
+        // named contract surface — these must still xfail (the harness stays wired
+        // until the server fix lands).
+        var drift = new ContractDriftException(
+            contract,
+            "live request failed with HTTP 500 before a conforming response body could be validated",
+            transportStatus: HttpStatusCode.InternalServerError);
+
+        Assert.Equal(expectedIssue, KnownServerGaps.Match(drift)?.Issue);
+    }
+
+    [Theory]
+    [InlineData("temporal")]
+    [InlineData("time filter")]
+    [InlineData("timeextent")]
+    [InlineData("replica")]
+    [InlineData("analysis")]
+    [InlineData("estimate")]
+    public void KnownGaps_do_not_mask_structural_drift_mentioning_gap_keyword_in_detail(string keyword)
+    {
+        // Regression guard: a structural mismatch in an otherwise-200 FeatureQuery body
+        // whose DETAIL text merely mentions a gap keyword (e.g. an attribute named
+        // "estimate" or a message referencing a "temporal" field) must NOT be silently
+        // xfailed. Before hardening, the broad MentionsAny matchers swallowed any such
+        // drift because they inspected the detail text and ignored the transport status.
+        var structuralDrift = new ContractDriftException(
+            FeatureContractConformance.FeatureQueryContract,
+            $"`features[0].attributes.{keyword}` must be an object per the canonical contract");
+
+        Assert.Null(KnownServerGaps.Match(structuralDrift));
+    }
+
+    [Theory]
+    [InlineData("temporal")]
+    [InlineData("replica")]
+    [InlineData("analysis")]
+    public void KnownGaps_do_not_match_transport_failure_on_unrelated_contract_mentioning_keyword_in_detail(string keyword)
+    {
+        // Even a hard transport failure must not be xfailed unless it is on the gap's
+        // named contract surface. A 500 on the core FeatureQuery contract whose detail
+        // happens to mention a gap keyword is an UNTRACKED core-read regression, not the
+        // temporal/replica/analysis gap.
+        var drift = new ContractDriftException(
+            FeatureContractConformance.FeatureQueryContract,
+            $"live request failed with HTTP 500. Server detail: {keyword} subsystem error",
+            transportStatus: HttpStatusCode.InternalServerError);
+
+        Assert.Null(KnownServerGaps.Match(drift));
+    }
+
     [Fact]
     public void Runner_xfails_tracked_transport_failure_with_attribution()
     {

--- a/tests/Honua.Mobile.ServerIntegration.Tests/FeatureContractConformance.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/FeatureContractConformance.cs
@@ -41,6 +41,9 @@ public sealed class ContractDriftException : Exception
     /// <summary>True when the drift was an underlying transport failure with the given status.</summary>
     public bool IsTransportStatus(HttpStatusCode status) => TransportStatus == status;
 
+    /// <summary>True when the drift carries any underlying transport failure status.</summary>
+    public bool HasTransportFailure => TransportStatus is not null;
+
     /// <summary>True when the contract or detail text mentions any of the given (case-insensitive) tokens.</summary>
     public bool MentionsAny(params string[] tokens)
     {
@@ -48,6 +51,25 @@ public sealed class ContractDriftException : Exception
         {
             if (Contract.Contains(token, StringComparison.OrdinalIgnoreCase)
                 || Detail.Contains(token, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// True when the <b>contract name</b> (the named workflow/surface) mentions any of
+    /// the given (case-insensitive) tokens. Unlike <see cref="MentionsAny"/> this does
+    /// <b>not</b> inspect the free-text <see cref="Detail"/>, so a structural mismatch in
+    /// an unrelated contract whose detail happens to contain a keyword is not matched.
+    /// </summary>
+    public bool ContractMentionsAny(params string[] tokens)
+    {
+        foreach (var token in tokens)
+        {
+            if (Contract.Contains(token, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/tests/Honua.Mobile.ServerIntegration.Tests/KnownServerGaps.cs
+++ b/tests/Honua.Mobile.ServerIntegration.Tests/KnownServerGaps.cs
@@ -79,23 +79,52 @@ public static class KnownServerGaps
         FeatureServerOgcJsonbProjection,
     ];
 
-    /// <summary>honua-server#1166 — temporal query/filter contract gap.</summary>
+    /// <summary>
+    /// honua-server#1166 — temporal query/filter contract gap.
+    /// <para>
+    /// Hardened like <see cref="FeatureServerOgcJsonbProjection"/> (#1238): a tracked
+    /// server gap manifests as a hard <b>transport failure</b> on the named temporal
+    /// contract surface, not as a structural mismatch in an otherwise-200 body, and the
+    /// keyword is matched against the <b>contract name</b> only (not the free-text
+    /// detail). Without this gating the matcher swallowed any drift whose detail merely
+    /// mentioned "temporal"/"time filter"/"timeextent" — e.g. an unrelated feature-query
+    /// or OGC structural regression — leaving the live gate green while a real
+    /// regression broke a different surface.
+    /// </para>
+    /// </summary>
     public static readonly Gap TemporalQuery = new(
         Issue: "honua-server#1166",
         Summary: "Temporal query/filter contract",
-        Matches: drift => drift.MentionsAny("temporal", "time filter", "timeextent"));
+        Matches: drift => drift.HasTransportFailure
+            && drift.ContractMentionsAny("temporal", "time filter", "timeextent"));
 
-    /// <summary>honua-server#1167 — replica sync contract gap.</summary>
+    /// <summary>
+    /// honua-server#1167 — replica sync contract gap.
+    /// <para>
+    /// Hardened like #1238: requires a transport failure on a contract whose name
+    /// references the replica surface, so a non-replica structural drift that merely
+    /// mentions "replica" in its detail text is not silently xfailed.
+    /// </para>
+    /// </summary>
     public static readonly Gap ReplicaSync = new(
         Issue: "honua-server#1167",
         Summary: "Replica sync contract",
-        Matches: drift => drift.MentionsAny("replica"));
+        Matches: drift => drift.HasTransportFailure
+            && drift.ContractMentionsAny("replica"));
 
-    /// <summary>honua-server#1237 — analysis list/estimate contract gap.</summary>
+    /// <summary>
+    /// honua-server#1237 — analysis list/estimate contract gap.
+    /// <para>
+    /// Hardened like #1238: requires a transport failure on a contract whose name
+    /// references the analysis surface, so an unrelated structural drift that merely
+    /// mentions "analysis"/"estimate" in its detail text is not silently xfailed.
+    /// </para>
+    /// </summary>
     public static readonly Gap AnalysisListEstimate = new(
         Issue: "honua-server#1237",
         Summary: "Analysis list/estimate contract",
-        Matches: drift => drift.MentionsAny("analysis", "estimate"));
+        Matches: drift => drift.HasTransportFailure
+            && drift.ContractMentionsAny("analysis", "estimate"));
 
     /// <summary>All registered gaps.</summary>
     public static readonly IReadOnlyList<Gap> All =


### PR DESCRIPTION
## Summary
Hardens the `KnownServerGaps` test-integrity matchers surfaced by the round-3 release audit (S2, new finding).

`tests/Honua.Mobile.ServerIntegration.Tests/KnownServerGaps.cs:83` (and `:89`, `:95`)

The `TemporalQuery` (#1166), `ReplicaSync` (#1167), and `AnalysisListEstimate` (#1237) gaps matched **any** drift whose contract **or** free-text `Detail` mentioned a keyword (`MentionsAny`), with **no transport-status or contract-surface gating** — unlike the already-hardened #1238 `FeatureServerOgcJsonbProjection` gap. These gaps are reached via `KnownServerGaps.Match` during the live conformance run, so a real regression on an unrelated surface — e.g. a structural `FeatureService.QueryFeatures` / OGC mismatch whose detail text merely mentions a keyword like "estimate" or "temporal" — was silently xfailed green, defeating the regression-detection guarantee the harness exists to provide.

## Fix (per recommendation: "harden like 1238 and add negative tests")
- Each broad gap now requires a **hard transport failure** (`HasTransportFailure`) **and** matches the keyword against the **contract name only** (new `ContractMentionsAny`), not the arbitrary `Detail` text. A tracked server gap manifests as a transport failure on its named surface — exactly the #1238 model — so a structural mismatch in an otherwise-200 body can no longer be masked.
- Added `ContractDriftException.HasTransportFailure` and `ContractDriftException.ContractMentionsAny(...)` helpers.

## Negative + positive tests added (`ConformanceContractTests`)
- `KnownGaps_match_tracked_transport_gap_by_contract_surface` — a genuine 5xx on the named temporal/replica/analysis contract still xfails to the correct issue.
- `KnownGaps_do_not_mask_structural_drift_mentioning_gap_keyword_in_detail` — a structural (no-transport-status) FeatureQuery drift whose detail mentions any gap keyword is **not** matched.
- `KnownGaps_do_not_match_transport_failure_on_unrelated_contract_mentioning_keyword_in_detail` — a 5xx on the core FeatureQuery contract whose detail mentions a keyword is treated as an untracked core-read regression, not the gap.

## Verification
`Honua.Mobile.ServerIntegration.Tests` build + non-live suite green: 59 passed, 11 skipped (live-server tests, no Docker). `ConformanceContractTests` 23/23 including the new theory cases. `dotnet format` made no changes to the edited files.
