### PR TITLE
fix(mobile): redact low-precision coordinates; retry transient-auth sync uploads

### DIFF
--- a/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionRedactor.cs
+++ b/src/Honua.Mobile.Maui/Diagnostics/MobileExceptionRedactor.cs
@@ -188,6 +188,6 @@ public static partial class MobileExceptionRedactor
     [GeneratedRegex(@"(?<prefix>[?&;](?:access[_-]?token|refresh[_-]?token|token|x[_-]?api[_-]?key|api[_-]?key|apikey|access[_-]?key|accesskey|password|secret|client[_-]?secret|sig|signature|code|key)=)[^&#\s]+", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 250)]
     private static partial Regex SensitiveQueryStringRegex();
 
-    [GeneratedRegex(@"\b(?<key>lat(?:itude)?|lon(?:gitude)?|lng)\s*[:=]\s*-?\d{1,3}(?:\.\d{4,})?\b", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 250)]
+    [GeneratedRegex(@"\b(?<key>lat(?:itude)?|lon(?:gitude)?|lng)\s*[:=]\s*-?\d{1,3}(?:\.\d+)?\b", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 250)]
     private static partial Regex PreciseLocationTextRegex();
 }

--- a/src/Honua.Mobile.Offline/Sync/MobileSyncProblem.cs
+++ b/src/Honua.Mobile.Offline/Sync/MobileSyncProblem.cs
@@ -252,6 +252,21 @@ public static class MobileSyncProblemHelper
                 Retryable: true);
         }
 
+        // 401 Unauthorized (and 425 Too Early) are recoverable: a token can expire between the
+        // auth provider's proactive refreshes, or a refresh can briefly fail, producing a 401
+        // for a queued offline edit that would otherwise be marked FatalFailure and permanently
+        // dropped. Treat these as retryable Transport so the upload re-runs after the auth
+        // provider refreshes the token. 403 Forbidden is a genuine authorization denial and
+        // stays fatal (it will not succeed on a blind retry).
+        if (statusCode == HttpStatusCode.Unauthorized ||
+            (int)statusCode == 425)
+        {
+            return new MobileSyncProblem(
+                MobileSyncProblemCategory.Transport,
+                string.IsNullOrWhiteSpace(message) ? TransportRetryMessage : message,
+                Retryable: true);
+        }
+
         return new MobileSyncProblem(
             MobileSyncProblemCategory.InvalidOperation,
             string.IsNullOrWhiteSpace(message) ? "Sync request was rejected." : message,

--- a/tests/Honua.Mobile.Maui.Tests/Diagnostics/MobileExceptionRedactorTests.cs
+++ b/tests/Honua.Mobile.Maui.Tests/Diagnostics/MobileExceptionRedactorTests.cs
@@ -25,6 +25,36 @@ public sealed class MobileExceptionRedactorTests
         Assert.Contains(MobileExceptionRedactor.RedactedValue, redacted);
     }
 
+    [Theory]
+    [InlineData("captured at lat=21.3, lon=-157.8")]
+    [InlineData("captured at lat=21.306, lon=-157.858")]
+    [InlineData("captured at lat=21.30691, lon=-157.85830")]
+    public void RedactText_RedactsCoordinatesRegardlessOfDecimalPrecision(string text)
+    {
+        var redacted = MobileExceptionRedactor.RedactText(text, new MobileExceptionReportingOptions());
+
+        Assert.NotNull(redacted);
+        // The fractional, precision-carrying digits must not survive in cleartext.
+        Assert.DoesNotContain(".3", redacted);
+        Assert.DoesNotContain(".8", redacted);
+        Assert.DoesNotContain("306", redacted);
+        Assert.DoesNotContain("858", redacted);
+        Assert.DoesNotContain("30691", redacted);
+        Assert.DoesNotContain("85830", redacted);
+        Assert.Contains(MobileExceptionRedactor.RedactedValue, redacted);
+    }
+
+    [Fact]
+    public void RedactText_KeepsPreciseCoordinatesWhenPreciseLocationEnabled()
+    {
+        var options = new MobileExceptionReportingOptions { IncludePreciseLocation = true };
+
+        var redacted = MobileExceptionRedactor.RedactText("captured at lat=21.306, lon=-157.858", options);
+
+        Assert.Contains("21.306", redacted);
+        Assert.Contains("-157.858", redacted);
+    }
+
     [Fact]
     public void RedactProperties_DropsSensitiveLocationFormAndAttachmentValuesByDefault()
     {

--- a/tests/Honua.Mobile.Offline.Tests/MobileSyncProblemHelperTests.cs
+++ b/tests/Honua.Mobile.Offline.Tests/MobileSyncProblemHelperTests.cs
@@ -80,4 +80,29 @@ public sealed class MobileSyncProblemHelperTests
         Assert.Equal(MobileSyncProblemCategory.InvalidOperation, problem.Category);
         Assert.False(problem.Retryable);
     }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized)] // token expired between proactive refreshes
+    [InlineData((HttpStatusCode)425)]          // Too Early
+    public void FromStatusCode_TransientAuthFailures_AreRetryable(HttpStatusCode statusCode)
+    {
+        // A 401 caused by a token that lapsed between the auth provider's proactive
+        // refreshes is recoverable: the queued offline edit must retry after the token
+        // refreshes, not be dropped as a FatalFailure (which would discard the field edit).
+        var problem = MobileSyncProblemHelper.FromStatusCode(statusCode, message: null);
+
+        Assert.Equal(MobileSyncProblemCategory.Transport, problem.Category);
+        Assert.True(problem.Retryable);
+        Assert.Equal(UploadOutcome.RetryableFailure, MobileSyncProblemHelper.ToUploadResult(problem).Outcome);
+    }
+
+    [Fact]
+    public void FromStatusCode_Forbidden_StaysFatal()
+    {
+        // 403 is a genuine authorization denial that will not succeed on a blind retry.
+        var problem = MobileSyncProblemHelper.FromStatusCode(HttpStatusCode.Forbidden, message: null);
+
+        Assert.False(problem.Retryable);
+        Assert.Equal(UploadOutcome.FatalFailure, MobileSyncProblemHelper.ToUploadResult(problem).Outcome);
+    }
 }


### PR DESCRIPTION
## Summary

Two S2 round-4 audit findings on the offline-sync / diagnostics paths, both privacy / data-integrity.

### 1. Low-precision coordinates leak through free-text redaction (security, S2)
`PreciseLocationTextRegex` (`src/Honua.Mobile.Maui/Diagnostics/MobileExceptionRedactor.cs:191`) used `(?:\.\d{4,})?`, so its optional decimal group only matched when a coordinate had **4 or more** fractional digits. For 1-3 decimals the integer part was replaced but the fractional, precision-carrying digits survived:

- `lat=21.306, lon=-157.858` -> `lat=[redacted].306, lon=[redacted].858`
- `lat=21.3` -> `lat=[redacted].3`

`RedactText` is the only text-level coordinate scrubber (the key-based `RedactProperties` path only fires on dictionary keys), so coordinates embedded in a free-text exception `Message` escaped redaction when `IncludePreciseLocation=false` — a privacy regression for field-worker location data.

**Fix:** relax the floor to `(?:\.\d+)?` so the whole numeric token is consumed regardless of precision.

### 2. Transient 401 during sync upload permanently drops queued edits (protocol-error-model, S2)
`MobileSyncProblemHelper.FromStatusCode` (`src/Honua.Mobile.Offline/Sync/MobileSyncProblem.cs:238`) routed every non-success status other than 409/412/408/429/5xx to a non-retryable `InvalidOperation`, which `ToUploadResult` maps to `UploadOutcome.FatalFailure`. The sync queue treats `FatalFailure` as non-retryable and marks the operation `failed`, so it is never re-claimed.

A 401 from a token that expired between the auth provider's *proactive* refreshes (or a refresh that briefly failed) is recoverable, but this path discarded the user's queued field edit.

**Fix:** classify `401 Unauthorized` (and `425 Too Early`) as retryable `Transport` so the upload re-runs after the auth provider refreshes the token. `403 Forbidden` stays fatal — it is a genuine authorization denial that will not succeed on a blind retry.

## Tests
- `MobileExceptionRedactorTests`: precision-regression theory (`lat=21.3` / `21.306` / `21.30691`) plus a case asserting precise coords are kept when `IncludePreciseLocation=true`. 7/7 pass.
- `MobileSyncProblemHelperTests`: 401/425 -> RetryableFailure, 403 -> FatalFailure. 16/16 pass.

Affected projects build clean; `dotnet format --verify-no-changes` passes on both core projects.
