### PR TITLE
perf(mobile): batch feature-create and attachment lookups to drop per-feature SQLite round-trips

### DIFF
--- a/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
+++ b/apps/Honua.Mobile.FieldCollection.Core/Services/Storage/GeoPackageStorageService.cs
@@ -466,6 +466,50 @@ public class GeoPackageStorageService : IDisposable, IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Inserts many features in a single immediate transaction under one lock acquisition,
+    /// instead of one transaction (and one fsync) per feature. Returns the stored feature ids.
+    /// </summary>
+    public async Task<IReadOnlyList<string>> StoreFeaturesAsync(IReadOnlyCollection<Feature> features)
+    {
+        ArgumentNullException.ThrowIfNull(features);
+
+        if (features.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            var ids = new List<string>(features.Count);
+            await ExecuteInImmediateTransactionAsync(async () =>
+            {
+                ids.Clear();
+                foreach (var feature in features)
+                {
+                    // Stamp a durable client-generated GlobalID at capture time so a retried
+                    // Insert (after a lost upload ack) can be deduped against the server feature
+                    // instead of creating a duplicate (#305).
+                    EnsureGlobalId(feature);
+                    ids.Add(await SaveFeatureAsync(
+                        feature,
+                        StorageSyncStatus.PendingUpload,
+                        trackChange: true,
+                        ChangeOperation.Insert,
+                        useTransaction: false));
+                }
+            });
+
+            return ids;
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
     public async Task<Feature?> GetFeatureAsync(string featureId, int layerId)
     {
         await EnsureInitializedAsync();
@@ -677,7 +721,8 @@ public class GeoPackageStorageService : IDisposable, IAsyncDisposable
         Feature feature,
         StorageSyncStatus syncStatus,
         bool trackChange,
-        ChangeOperation operation)
+        ChangeOperation operation,
+        bool useTransaction = true)
     {
         if (string.IsNullOrWhiteSpace(feature.Id))
         {
@@ -757,11 +802,20 @@ public class GeoPackageStorageService : IDisposable, IAsyncDisposable
         if (trackChange)
         {
             var changeData = CreateChangeData(feature, operation);
-            await ExecuteInImmediateTransactionAsync(async () =>
+            if (useTransaction)
             {
+                await ExecuteInImmediateTransactionAsync(async () =>
+                {
+                    await _connection.InsertOrReplaceAsync(localFeature);
+                    await RecordChange(feature.Id, feature.LayerId, operation, changeData);
+                });
+            }
+            else
+            {
+                // Caller owns the surrounding transaction (batch insert).
                 await _connection.InsertOrReplaceAsync(localFeature);
                 await RecordChange(feature.Id, feature.LayerId, operation, changeData);
-            });
+            }
         }
         else
         {
@@ -1061,6 +1115,52 @@ public class GeoPackageStorageService : IDisposable, IAsyncDisposable
                 .OrderBy(row => row.CreatedAt)
                 .Select(ToAttachmentInfo)
                 .ToList();
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Loads attachments for many features in a single query and groups them by feature id.
+    /// Avoids the O(features) per-feature, lock-serialized round-trips of calling
+    /// <see cref="GetAttachmentsForFeatureAsync"/> in a loop on interactive query paths.
+    /// </summary>
+    public async Task<Dictionary<string, List<AttachmentInfo>>> GetAttachmentsForFeaturesAsync(
+        IReadOnlyCollection<string> featureIds,
+        int? layerId = null,
+        bool includeDeleted = false)
+    {
+        if (featureIds is null || featureIds.Count == 0)
+        {
+            return new Dictionary<string, List<AttachmentInfo>>(StringComparer.Ordinal);
+        }
+
+        var idSet = featureIds as HashSet<string> ?? new HashSet<string>(featureIds, StringComparer.Ordinal);
+
+        await EnsureInitializedAsync();
+        await _dbLock.WaitAsync();
+        try
+        {
+            var query = _connection.Table<LocalAttachment>()
+                .Where(row => idSet.Contains(row.FeatureId));
+
+            if (layerId.HasValue)
+            {
+                query = query.Where(row => row.LayerId == layerId.Value);
+            }
+
+            var rows = await query.ToListAsync();
+
+            return rows
+                .Where(row => includeDeleted || !row.IsDeleted)
+                .OrderBy(row => row.CreatedAt)
+                .GroupBy(row => row.FeatureId, StringComparer.Ordinal)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.Select(ToAttachmentInfo).ToList(),
+                    StringComparer.Ordinal);
         }
         finally
         {

--- a/apps/Honua.Mobile.FieldCollection/Services/Features/GeoPackageFeatureService.cs
+++ b/apps/Honua.Mobile.FieldCollection/Services/Features/GeoPackageFeatureService.cs
@@ -152,9 +152,27 @@ public class GeoPackageFeatureService : IFeatureService
 
     private async Task PopulateAttachmentsAsync(IEnumerable<Feature> features)
     {
-        foreach (var feature in features)
+        var featureList = features as IReadOnlyList<Feature> ?? features.ToList();
+        if (featureList.Count == 0)
         {
-            feature.Attachments = await _storage.GetAttachmentsForFeatureAsync(feature.Id, feature.LayerId);
+            return;
+        }
+
+        // Single IN-query for the whole result set instead of one lock-serialized
+        // round-trip per feature (avoids an O(features) query storm on the interactive
+        // map/query path).
+        var ids = featureList
+            .Select(f => f.Id)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var attachmentsByFeature = await _storage.GetAttachmentsForFeaturesAsync(ids);
+
+        foreach (var feature in featureList)
+        {
+            feature.Attachments = attachmentsByFeature.TryGetValue(feature.Id, out var attachments)
+                ? attachments
+                : new List<AttachmentInfo>();
         }
     }
 
@@ -164,19 +182,7 @@ public class GeoPackageFeatureService : IFeatureService
     {
         try
         {
-            feature.LayerId = layerId;
-
-            // Ensure feature has an ID
-            if (string.IsNullOrEmpty(feature.Id))
-            {
-                feature.Id = Guid.NewGuid().ToString();
-            }
-
-            // Set creation metadata
-            feature.CreatedAt = DateTime.UtcNow;
-            feature.ModifiedAt = DateTime.UtcNow;
-            feature.UpdatedAt = feature.ModifiedAt;
-            feature.Version = 1;
+            StampForCreate(feature, layerId);
 
             await _storage.StoreFeatureAsync(feature);
             return feature;
@@ -185,6 +191,24 @@ public class GeoPackageFeatureService : IFeatureService
         {
             throw new InvalidOperationException($"Failed to create feature: {feature.Id}", ex);
         }
+    }
+
+    private static void StampForCreate(Feature feature, int layerId)
+    {
+        feature.LayerId = layerId;
+
+        // Ensure feature has an ID
+        if (string.IsNullOrEmpty(feature.Id))
+        {
+            feature.Id = Guid.NewGuid().ToString();
+        }
+
+        // Set creation metadata
+        var now = DateTime.UtcNow;
+        feature.CreatedAt = now;
+        feature.ModifiedAt = now;
+        feature.UpdatedAt = feature.ModifiedAt;
+        feature.Version = 1;
     }
 
     public async Task<Feature> UpdateFeatureAsync(int layerId, Feature feature)
@@ -233,30 +257,42 @@ public class GeoPackageFeatureService : IFeatureService
     public async Task<BatchResult> CreateFeaturesAsync(List<Feature> features)
     {
         var result = new BatchResult();
-        var successful = new List<string>();
-        var failed = new List<(string Id, string Error)>();
 
-        foreach (var feature in features)
+        if (features.Count == 0)
         {
-            try
-            {
-                var created = await CreateFeatureAsync(feature.LayerId, feature);
-                successful.Add(created.Id);
-                result.SuccessCount++;
-            }
-            catch (Exception ex)
-            {
-                failed.Add((feature.Id, ex.Message));
-                result.ErrorCount++;
-            }
+            result.SuccessfulIds = new List<string>();
+            result.FailedItems = new List<BatchError>();
+            return result;
         }
 
-        result.SuccessfulIds = successful;
-        result.FailedItems = failed.Select(f => new BatchError
+        // Stamp creation metadata up front, then persist the whole batch in a single
+        // immediate transaction (one lock acquisition / one fsync) instead of one
+        // transaction per feature.
+        foreach (var feature in features)
         {
-            Id = f.Id,
-            ErrorMessage = f.Error
-        }).ToList();
+            StampForCreate(feature, feature.LayerId);
+        }
+
+        try
+        {
+            var storedIds = await _storage.StoreFeaturesAsync(features);
+
+            result.SuccessfulIds = storedIds.ToList();
+            result.SuccessCount = storedIds.Count;
+            result.FailedItems = new List<BatchError>();
+        }
+        catch (Exception ex)
+        {
+            // The batch is atomic: a failure rolls back the whole transaction, so no
+            // feature was stored. Report every item as failed.
+            _logger?.LogWarning(ex, "Failed to create {Count} features in batch", features.Count);
+            result.SuccessfulIds = new List<string>();
+            result.SuccessCount = 0;
+            result.ErrorCount = features.Count;
+            result.FailedItems = features
+                .Select(f => new BatchError { Id = f.Id, ErrorMessage = ex.Message })
+                .ToList();
+        }
 
         return result;
     }

--- a/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageBatchStorageTests.cs
+++ b/tests/Honua.Mobile.FieldCollection.Tests/GeoPackageBatchStorageTests.cs
@@ -1,0 +1,166 @@
+using Honua.Mobile.FieldCollection.Models;
+using Honua.Mobile.FieldCollection.Services.Storage;
+
+namespace Honua.Mobile.FieldCollection.Tests;
+
+public sealed class GeoPackageBatchStorageTests
+{
+    public GeoPackageBatchStorageTests()
+    {
+        SQLitePCL.Batteries_V2.Init();
+    }
+
+    [Fact]
+    public async Task StoreFeaturesAsync_PersistsAllFeaturesAndChangeRecordsInOneBatch()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new FileCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+
+        var features = Enumerable.Range(0, 25)
+            .Select(i => CreateFeature($"asset-{i}", layerId: 1))
+            .ToList();
+
+        var ids = await storage.StoreFeaturesAsync(features);
+
+        Assert.Equal(25, ids.Count);
+        Assert.Equal(features.Select(f => f.Id).OrderBy(x => x), ids.OrderBy(x => x));
+
+        var stored = await storage.QueryFeaturesAsync(layerId: 1);
+        Assert.Equal(25, stored.Count);
+
+        // Every insert must record a pending change so it syncs (matches single-insert path).
+        var pending = await storage.GetPendingChangesAsync(layerId: 1);
+        Assert.Equal(25, pending.Count);
+    }
+
+    [Fact]
+    public async Task StoreFeaturesAsync_EmptyBatch_IsNoOp()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new FileCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+
+        var ids = await storage.StoreFeaturesAsync(new List<Feature>());
+
+        Assert.Empty(ids);
+        Assert.Empty(await storage.QueryFeaturesAsync(layerId: 1));
+    }
+
+    [Fact]
+    public async Task GetAttachmentsForFeaturesAsync_GroupsByFeatureInSingleQuery()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new FileCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+
+        await storage.StoreAttachmentMetadataAsync(CreateAttachment("att-1", "asset-1", layerId: 1));
+        await storage.StoreAttachmentMetadataAsync(CreateAttachment("att-2", "asset-1", layerId: 1));
+        await storage.StoreAttachmentMetadataAsync(CreateAttachment("att-3", "asset-2", layerId: 1));
+        await storage.StoreAttachmentMetadataAsync(CreateAttachment("att-4", "asset-3", layerId: 1, isDeleted: true));
+
+        var result = await storage.GetAttachmentsForFeaturesAsync(
+            new[] { "asset-1", "asset-2", "asset-3", "asset-missing" });
+
+        Assert.Equal(2, result["asset-1"].Count);
+        Assert.Single(result["asset-2"]);
+        // Deleted attachments are excluded by default, so asset-3 has no entry.
+        Assert.False(result.ContainsKey("asset-3"));
+        Assert.False(result.ContainsKey("asset-missing"));
+
+        // Same result as calling the single-feature method per feature.
+        var single1 = await storage.GetAttachmentsForFeatureAsync("asset-1", layerId: 1);
+        Assert.Equal(
+            single1.Select(a => a.Id).OrderBy(x => x),
+            result["asset-1"].Select(a => a.Id).OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task GetAttachmentsForFeaturesAsync_RespectsLayerScope()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new FileCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+
+        await storage.StoreAttachmentMetadataAsync(CreateAttachment("att-1", "asset-1", layerId: 1));
+        await storage.StoreAttachmentMetadataAsync(CreateAttachment("att-2", "asset-1", layerId: 2));
+
+        var layer1 = await storage.GetAttachmentsForFeaturesAsync(new[] { "asset-1" }, layerId: 1);
+
+        Assert.Single(layer1["asset-1"]);
+        Assert.Equal("att-1", layer1["asset-1"][0].Id);
+    }
+
+    [Fact]
+    public async Task GetAttachmentsForFeaturesAsync_EmptyInput_ReturnsEmpty()
+    {
+        var databasePath = CreateDatabasePath();
+        await using var cleanup = new FileCleanup(databasePath);
+        using var storage = new GeoPackageStorageService(databasePath);
+
+        var result = await storage.GetAttachmentsForFeaturesAsync(Array.Empty<string>());
+
+        Assert.Empty(result);
+    }
+
+    private static Feature CreateFeature(string id, int layerId)
+    {
+        return new Feature
+        {
+            Id = id,
+            LayerId = layerId,
+            Version = 1,
+            Geometry = new Point(21.3, -157.8),
+            CreatedAt = DateTime.UtcNow,
+            ModifiedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            Attributes = new Dictionary<string, object?> { ["name"] = id },
+        };
+    }
+
+    private static AttachmentInfo CreateAttachment(string id, string featureId, int layerId, bool isDeleted = false)
+    {
+        return new AttachmentInfo
+        {
+            Id = id,
+            FeatureId = featureId,
+            LayerId = layerId,
+            FileName = $"{id}.jpg",
+            ContentType = "image/jpeg",
+            PayloadKind = AttachmentPayloadKind.Photo,
+            CreatedAt = DateTime.UtcNow,
+            SyncStatus = AttachmentSyncStatus.PendingUpload,
+            IsDeleted = isDeleted,
+        };
+    }
+
+    private static string CreateDatabasePath()
+        => Path.Combine(Path.GetTempPath(), $"honua-batch-{Guid.NewGuid():N}.gpkg");
+
+    private sealed class FileCleanup : IAsyncDisposable
+    {
+        private readonly string[] _paths;
+
+        public FileCleanup(params string[] paths) => _paths = paths;
+
+        public ValueTask DisposeAsync()
+        {
+            foreach (var path in _paths)
+            {
+                try
+                {
+                    if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                    }
+                }
+                catch
+                {
+                    // Best-effort cleanup.
+                }
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two S2 round-4 N+1 findings in the field-collection storage path. Each replaced a per-feature, lock-serialized SQLite operation with a single batched one.

### 1. Attachment lookups: one query per feature on the interactive path (performance/N+1, S2)
`GeoPackageFeatureService.PopulateAttachmentsAsync` runs on every feature query (including the interactive map bbox query) and called `GetAttachmentsForFeatureAsync` once per returned feature. Each call takes `_dbLock` and issues its own `Where(FeatureId == ...)` round-trip, so a map pan returning hundreds of features fired hundreds of serial, lock-serialized SQLite queries — O(features), not O(1).

**Fix:** added `GeoPackageStorageService.GetAttachmentsForFeaturesAsync(featureIds, layerId?, includeDeleted?)`, which issues a single `WHERE FeatureId IN (...)` query and groups the rows by feature id in memory. `PopulateAttachmentsAsync` now calls it once for the whole result set.

### 2. Bulk feature create: one transaction (and fsync) per feature (performance/N+1, S2)
`GeoPackageFeatureService.CreateFeaturesAsync` foreach-called `CreateFeatureAsync` -> `StoreFeatureAsync`, and `StoreFeatureAsync` wraps each save in its own immediate transaction. Importing N features therefore cost N lock acquisitions, N transactions, and N fsyncs, defeating the store's existing single-transaction batching concept (`GeoPackageSyncStore.UpsertFeaturesAsync`).

**Fix:** added `GeoPackageStorageService.StoreFeaturesAsync(features)`, which acquires the lock once and wraps all inserts in a single `BEGIN IMMEDIATE`/`COMMIT` (mirroring `UpsertFeaturesAsync`). `CreateFeaturesAsync` stamps creation metadata up front and calls it once. `SaveFeatureAsync` gained a `useTransaction` flag so a batch caller can own the surrounding transaction; the single-insert path is unchanged.

The batch insert is atomic: a failure rolls back the whole transaction and every item is reported failed in the `BatchResult` (previously each item could partially succeed).

## Tests
New `GeoPackageBatchStorageTests` (5 tests, all pass) exercise real SQLite:
- batch insert persists all features **and** their change records, atomically;
- empty-batch no-op;
- `GetAttachmentsForFeaturesAsync` IN-query grouping matches the per-feature method, respects layer scope, excludes deleted attachments by default, and handles empty input.

Full `Honua.Mobile.FieldCollection.Tests` suite passes (161/161). `FieldCollection.Core` builds clean and `dotnet format --verify-no-changes` passes.

## Note on verification scope
`GeoPackageFeatureService` lives in the `net10.0-android` MAUI app project, which cannot be linked in this environment (no Android SDK; `XA5300`). Its C# compiles with no `CS` diagnostics, and the storage-layer changes it depends on are fully covered by the new tests against `FieldCollection.Core`. CI builds the app project with the Android SDK.

## Out of scope (see not_done)
The third N+1 finding — sync pull applying server changes one-at-a-time (`GeoPackageSyncService.PullChangesInternalAsync`) — is deferred. Batching that path safely requires preserving the per-generation watermark gap-stop semantics, which is a larger, correctness-sensitive change than a coarse fix.
