### PR TITLE
docs: refresh README for public audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,46 @@
 # Honua Mobile SDK for .NET
 
+[![CI](https://github.com/honua-io/honua-mobile/actions/workflows/ci.yml/badge.svg?branch=trunk)](https://github.com/honua-io/honua-mobile/actions/workflows/ci.yml)
+[![Live Server Integration](https://github.com/honua-io/honua-mobile/actions/workflows/live-server-integration.yml/badge.svg?branch=trunk)](https://github.com/honua-io/honua-mobile/actions/workflows/live-server-integration.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/honua-io/honua-mobile/badge)](https://scorecard.dev/viewer/?uri=github.com/honua-io/honua-mobile)
 
-.NET MAUI mobile SDK for [Honua Server](https://github.com/honua-io/honua-server) --
-offline-first field data collection with GeoPackage storage, gRPC transport,
-dynamic forms, and background sync.
+.NET MAUI mobile SDK for [Honua Server](https://github.com/honua-io/honua-server),
+the multi-protocol cloud-native geospatial server. It gives .NET mobile developers
+an offline-first foundation for field apps: GeoPackage storage, gRPC-first
+transport with REST fallback, dynamic field-collection forms, routing, 3D scene
+metadata, and connectivity-aware background sync. It also ships
+[`@honua-io/embed`](src/Honua.Embed/), a framework-agnostic web component package
+for embedding Honua maps and scenes.
 
-Current mobile SDK roadmap coordination is tracked from
-[honua-server#811](https://github.com/honua-io/honua-server/issues/811) and the
-[mobile SDK roadmap](https://github.com/honua-io/honua-server/blob/trunk/docs/developer/mobile-sdk-roadmap.md).
-The current source-backed mobile feature map is in [docs/features/README.md](docs/features/README.md).
+This repo is the **SDK** (libraries, reference apps, templates). If you want a
+ready-made field data collection **app** built on this SDK, see
+[honua-collect](https://github.com/honua-io/honua-collect).
 
-## Validation status
+## Status
 
-| Layer | Status | Run on | Coverage |
-| --- | --- | --- | --- |
-| Unit | ✅ | every PR | Across 5 .NET projects (SDK, Offline, Field, FieldCollection, MAUI) |
-| Integration (in-process loopback) | ✅ | every PR | `Honua.Mobile.ServerIntegration.Tests` (`SdkServerIntegrationTests`, `OfflineServerIntegrationTests`, `FieldCollectionServerIntegrationTests`) against a real ASP.NET Core loopback server; the same project also hosts the `LiveHonuaServerFixtureOptionsTests` harness-config tests |
-| Smoke | ✅ | every PR | `Honua.Mobile.Smoke.Tests` (`quality-gates` job) |
-| Embed DOM | ✅ | every PR | jsdom suites under `src/Honua.Embed/tests/` |
-| Live server (Docker image) | ✅ | every PR via `Live Server Integration` workflow (hard gate; vendored seed at `tests/seed/mobile-offline-demo-v1.sql`) | `LiveHonuaServerInteractionTests` (incl. unary + server-streaming live gRPC); Testcontainers spins up `honuaio/honua-server:nightly` + PostGIS, vendored seed loaded into postgres before the live server starts |
-| Cloud acceptance (staging) | 🟡 | manual `workflow_dispatch` | `DisconnectedFieldWorkflowAcceptanceTests`; production promotion blocked on honua-server#965 |
-| Physical device | 🟡 | deferred to GA | AR/VR field workflow tracked under honua-mobile#23 (closed, follow-ups in `docs/guides/native-scene-anchoring-requirements.md`); emulator/simulator platform smoke covers part of the surface |
-
-Exact test counts are intentionally not pinned here (they drift every PR); the
-authoritative numbers are the per-project totals reported by each CI run.
-
-See [docs/guides/validation-strategy.md](docs/guides/validation-strategy.md) for
-the per-capability coverage matrix, known gaps, and which CI workflow runs
-which bucket.
+Pre-1.0, alpha. Package contracts can still change between releases — see the
+[SDK Contract Stability Roadmap](docs/guides/sdk-contract-stability.md) for the
+alpha → beta → stable exit criteria and
+[docs/guides/mobile-sdk-backlog-roadmap.md](docs/guides/mobile-sdk-backlog-roadmap.md)
+for the backlog roadmap. The source-backed feature map (what is actually
+implemented vs. planned) is in [docs/features/README.md](docs/features/README.md).
 
 ## Packages
 
-| Package | Purpose |
-|---------|---------|
-| **Honua.Mobile.Sdk** | Transport, auth, gRPC-first client, REST fallback, routing, and SDK scene metadata adapter |
-| **Honua.Mobile.Offline** | GeoPackage storage, sync queue, map area download, conflict resolution |
-| **Honua.Mobile.Maui** | MAUI service registration, DI extensions, native display boundaries, native scene anchoring, and device location orchestration |
-| **@honua/embed** | Framework-agnostic `<honua-map>` and `<honua-scene>` web components for ISV embeds |
+| Package | Purpose | Published |
+|---------|---------|-----------|
+| **Honua.Mobile.Sdk** | Transport, auth, gRPC-first client, REST fallback, routing, and SDK scene metadata adapter | NuGet on [GitHub Packages](https://github.com/orgs/honua-io/packages?repo_name=honua-mobile), from signed `mobile-dotnet-v*` release tags |
+| **Honua.Mobile.Offline** | GeoPackage storage, sync queue, map area download, conflict resolution | same |
+| **Honua.Mobile.Maui** | MAUI service registration, DI extensions, native display boundaries, native scene anchoring, and device location orchestration | same |
+| **@honua-io/embed** | Framework-agnostic `<honua-map>` and `<honua-scene>` web components (plus React/Vue/Angular wrappers) for ISV embeds | npm on GitHub Packages, from `mobile-embed-v*` release tags |
+
+The library packages target `net10.0` and build on any platform without the MAUI
+workload. The reference apps and templates are .NET MAUI (`net10.0-android`,
+plus `net10.0-ios`/`net10.0-maccatalyst` on macOS and `net10.0-windows` on
+Windows). Platform-neutral client logic comes from the
+[honua-sdk-dotnet](https://github.com/honua-io/honua-sdk-dotnet) `Honua.Sdk.*`
+packages, pinned as a single release train in
+[`Directory.Build.props`](Directory.Build.props).
 
 ## Quick Start
 
@@ -77,7 +80,15 @@ builder.Services
 After sign-in or bootstrap, store the API key or bearer token with `IAuthTokenProvider.StoreTokenAsync(...)`;
 the platform auth registration persists it in iOS Keychain or Android secure storage.
 
-## Offline Sync
+See [docs/getting-started/](docs/getting-started/) for installation, a full
+tutorial, and the field collector project template
+([`templates/honua-fieldcollector`](templates/honua-fieldcollector/)), and
+[examples/](examples/) for runnable samples (field data collection, embeds,
+scenes, AR utility visualization).
+
+## Key Features
+
+### Offline Sync
 
 GeoPackage-backed offline storage with queue-based sync:
 
@@ -89,13 +100,15 @@ GeoPackage-backed offline storage with queue-based sync:
 - **Delta sync** -- replica-based incremental downloads with cursor persistence
 - **Cache governance** -- per-layer TTL eviction and R-tree-backed bbox lookups for replicated features
 
-## Field Collection
+See [docs/guides/offline-sync.md](docs/guides/offline-sync.md).
+
+### Field Collection
 
 - **SDK-owned contracts** -- `Honua.Sdk.Field` owns form schemas, validation, calculated fields, duplicate detection, and record workflow
 - **Mobile capture adapters** -- local media paths stay mobile-owned and convert to portable SDK attachment metadata before sync
 - **Validation and workflow DI** -- `AddHonuaMobileFieldCollection()` registers a mobile adapter over SDK field services
 
-## gRPC Transport
+### gRPC Transport
 
 gRPC-first with automatic REST fallback:
 
@@ -122,7 +135,7 @@ await foreach (var page in client.QueryFeaturesStreamAsync(request))
 Transport security enforced -- API keys and bearer tokens are never sent over HTTP
 unless `AllowInsecureTransportForDevelopment` is explicitly set.
 
-## Routing
+### Routing
 
 Experimental GeoServices-compatible NAServer client for directions, service
 areas, closest facility, and route optimization:
@@ -143,7 +156,7 @@ var optimized = await client.Routing.Route()
 var reachable = await client.Routing.GetServiceAreaAsync(depot, TimeSpan.FromMinutes(30));
 ```
 
-## 3D Scene Metadata
+### 3D Scene Metadata
 
 Scene discovery resolves server-managed 3D Tiles and terrain URLs before a
 renderer loads them:
@@ -162,26 +175,54 @@ var tilesetUrl = scene.TilesetUrl;
 var terrainUrl = scene.TerrainUrl;
 ```
 
+## Migrating from the ArcGIS Maps SDK for .NET
+
+Moving a MAUI/Xamarin field app off the ArcGIS Maps SDK? See the
+[migration guide](docs/guides/migration-arcgis-maps-sdk-maui.md) (API-idiom
+mapping table, phased reimplement plan, transition bridge) and the
+`honua-migrate-maui` codemod CLI under [tools/](tools/). For
+platform-agnostic field-platform migrations (Fulcrum, Survey123, KoBo) see the
+[Migration Guide](docs/guides/migration-guide.md).
+
+## Validation Status
+
+| Layer | Status | Run on | Coverage |
+| --- | --- | --- | --- |
+| Unit | ✅ | every PR | Across the SDK, Offline, FieldCollection, and MAUI .NET projects |
+| Integration (in-process loopback) | ✅ | every PR | `Honua.Mobile.ServerIntegration.Tests` against a real ASP.NET Core loopback server |
+| Smoke | ✅ | every PR | `Honua.Mobile.Smoke.Tests` (`quality-gates` job) |
+| Embed DOM | ✅ | every PR | jsdom suites under `src/Honua.Embed/tests/` |
+| Live server (Docker image) | ✅ | every PR via the `Live Server Integration` workflow (hard gate) | `LiveHonuaServerInteractionTests` (incl. unary + server-streaming live gRPC); Testcontainers spins up `honuaio/honua-server:nightly` + PostGIS with the vendored seed at `tests/seed/mobile-offline-demo-v1.sql` |
+| Cloud acceptance (staging) | 🟡 | manual `workflow_dispatch` | `DisconnectedFieldWorkflowAcceptanceTests`; production promotion blocked on honua-server#965 |
+| Physical device | 🟡 | deferred to GA | AR/VR field workflow follow-ups in [docs/guides/native-scene-anchoring-requirements.md](docs/guides/native-scene-anchoring-requirements.md); emulator/simulator platform smoke covers part of the surface |
+
+Exact test counts are intentionally not pinned here (they drift every PR); the
+authoritative numbers are the per-project totals reported by each CI run. See
+[docs/guides/validation-strategy.md](docs/guides/validation-strategy.md) for the
+per-capability coverage matrix, known gaps, and which CI workflow runs which
+bucket, and
+[Disconnected Field Workflow Harness](docs/guides/disconnected-field-workflow-harness.md#live-server-integration-workflow)
+for the live-server workflow's scope and triggers.
+
 ## Repository Structure
 
 ```
 src/
-  Honua.Embed/                Embeddable map web component package
-    tests/                    Web component DOM behavior tests
-  Honua.Mobile.Sdk/           Core mobile client
-  Honua.Mobile.Offline/       GeoPackage sync engine
-  Honua.Mobile.Maui/          MAUI platform integration, native display, location, and scene anchoring
+  Honua.Mobile.Sdk/           Core mobile client: transport, auth, gRPC/REST, routing, scenes
+  Honua.Mobile.Offline/       GeoPackage storage, sync engine, conflicts, map download
+  Honua.Mobile.Maui/          MAUI platform integration, native display, location, scene anchoring
+  Honua.Embed/                @honua-io/embed web component package (tests/ inside)
 apps/
   Honua.Mobile.App/           Reference MAUI application
-tests/
-  Honua.Mobile.Sdk.Tests/     HTTP client, transport security, gRPC translation, routing, scenes
-  Honua.Mobile.FieldCollection.Tests/ FieldCollection auth, sync, storage, diagnostics
-  Honua.Mobile.ServerIntegration.Tests/ Loopback and opt-in live Honua image integration surface
-  Honua.Mobile.Offline.Tests/ Sync engine, conflicts, map download, GeoPackage
-  Honua.Mobile.Maui.Tests/    MAUI integration helpers, map annotations, native display, location, scene anchoring
-  Honua.Mobile.Smoke.Tests/   End-to-end smoke paths and optional live Honua query
-proto/
-  honua/v1/                   gRPC protocol definitions
+  Honua.Mobile.FieldCollection*/  Field collection reference app + core library
+tools/
+  Honua.Migrate.Maui*/        ArcGIS Maps SDK -> Honua migration codemod + CLI
+templates/                    honua-fieldcollector project template
+examples/                     Field collection, embed, scene, and AR samples
+tests/                        Sdk / Offline / FieldCollection / Maui / ServerIntegration /
+                              Smoke / PlatformSmoke test projects; tests/seed has the vendored seed SQL
+contracts/                    Cross-repo SDK contract harmonization fixtures
+docs/                         Getting started, guides, feature map, API reference
 ```
 
 ## Building
@@ -203,7 +244,7 @@ scripts/validate-local.sh
 ```
 
 The script restores, builds, runs .NET tests and smoke tests, verifies format
-for the core source projects, and runs the `@honua/embed` npm build/tests. It
+for the core source projects, and runs the `@honua-io/embed` npm build/tests. It
 uses a temporary NuGet config for `HONUA_GITHUB_PACKAGES_TOKEN` and removes it
 on exit. Without those environment variables it falls back to any existing
 NuGet credentials already configured for the `github-honua` source.
@@ -220,44 +261,49 @@ npm run build --prefix src/Honua.Embed
 npm test --prefix src/Honua.Embed
 ```
 
-Building Android targets requires a configured Android SDK. The library projects
-(`Sdk`, `Field`, `Offline`, `Maui`) target `net10.0` and build on any platform
-without the MAUI workload.
+Building Android targets requires a configured Android SDK; iOS/Mac Catalyst
+targets require macOS with Xcode. The library projects target `net10.0` and
+build on any platform without the MAUI workload.
 
 The server integration project starts a real ASP.NET Core loopback server and
-exercises the implemented SDK, offline, FieldCollection auth, and mobile
-exception-reporting HTTP paths without requiring external infrastructure. It
-also includes opt-in live Honua image tests that use Testcontainers or a
-pre-started Honua URL when `HONUA_MOBILE_LIVE_SERVER_TESTS=1` is set; see
-`docs/guides/offline-sync.md`.
-The smoke test project can also run an optional live Honua query when
+exercises the SDK, offline, FieldCollection auth, and mobile exception-reporting
+HTTP paths without external infrastructure. Opt-in live Honua image tests run
+when `HONUA_MOBILE_LIVE_SERVER_TESTS=1` is set (Testcontainers or a pre-started
+Honua URL; see [docs/guides/offline-sync.md](docs/guides/offline-sync.md)). The
+smoke test project can also run an optional live Honua query when
 `HONUA_MOBILE_SMOKE_BASE_URL`, `HONUA_MOBILE_SMOKE_SERVICE_ID`,
 `HONUA_MOBILE_SMOKE_LAYER_ID`, and optionally `HONUA_MOBILE_SMOKE_API_KEY` are
 set.
 
 Release workflow, branch-protection, package metadata, Dependabot, Trivy, and
-platform smoke guardrails for honua-server #826 are documented in
+platform smoke guardrails are documented in
 [Repo Scaffolding Gates](docs/guides/repo-scaffolding-gates.md).
-
-The `Live Server Integration` workflow
-(`.github/workflows/live-server-integration.yml`) runs
-`LiveHonuaServerInteractionTests` against a Docker-hosted Honua server stack
-on every PR and on pushes to `main`. See
-[Disconnected Field Workflow Harness](docs/guides/disconnected-field-workflow-harness.md#live-server-integration-workflow)
-for scope, triggers, and the seed-SQL gap.
-
-## Status
-
-Production-ready foundation for offline sync, forms, and gRPC transport.
-.NET test coverage across SDK, Field, FieldCollection, server integration,
-Offline, MAUI, and Smoke projects, plus DOM tests for the embeddable map package.
 
 ## Documentation
 
 - **[Getting Started](docs/getting-started/)** -- installation, tutorial, and developer checklist
-- **[Guides](docs/guides/)** -- in-depth guides for offline sync, security, camera, performance, and more
-- **[SDK Contract Stability Roadmap](docs/guides/sdk-contract-stability.md)** -- exit criteria for moving Honua.Sdk.* from alpha to beta to stable
-- **[API Reference](docs/api/)** -- core SDK API documentation
+- **[Guides](docs/guides/)** -- offline sync, security, camera, performance, 3D scenes, migrations, and more
+- **[Feature Map](docs/features/README.md)** -- source-backed map of implemented capabilities
+- **[SDK Contract Stability Roadmap](docs/guides/sdk-contract-stability.md)** -- exit criteria for moving from alpha to beta to stable
+- **[API Reference](docs/api/core.md)** -- core SDK API documentation
+- **[Hosted Honua docs](https://honua.gitbook.io/honuaio/)** -- platform-wide documentation
+
+## Related Honua Repositories
+
+| Repo | What it is |
+|------|------------|
+| [honua-server](https://github.com/honua-io/honua-server) | Flagship multi-protocol geospatial server this SDK talks to |
+| [honua-collect](https://github.com/honua-io/honua-collect) | Offline-first field data collection app built on this SDK |
+| [honua-sdk-dotnet](https://github.com/honua-io/honua-sdk-dotnet) | Platform-neutral `Honua.Sdk.*` .NET packages this repo consumes |
+| [honua-sdk-js](https://github.com/honua-io/honua-sdk-js) | JavaScript/TypeScript SDKs + MCP server |
+| [honua-console](https://github.com/honua-io/honua-console) | Unified web console (Studio, Catalog, Operate, Share) |
+| [honua-helm](https://github.com/honua-io/honua-helm) | Helm chart for deploying Honua Server on Kubernetes |
+
+## Security
+
+Report vulnerabilities to **security@honua.io** -- see the
+[org security policy](https://github.com/honua-io/.github/blob/main/SECURITY.md).
+Do not open public issues for security reports.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/honua-io/honua-mobile/actions/workflows/ci.yml/badge.svg?branch=trunk)](https://github.com/honua-io/honua-mobile/actions/workflows/ci.yml)
 [![Live Server Integration](https://github.com/honua-io/honua-mobile/actions/workflows/live-server-integration.yml/badge.svg?branch=trunk)](https://github.com/honua-io/honua-mobile/actions/workflows/live-server-integration.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/honua-io/honua-mobile/badge)](https://scorecard.dev/viewer/?uri=github.com/honua-io/honua-mobile)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 .NET MAUI mobile SDK for [Honua Server](https://github.com/honua-io/honua-server),
 the multi-protocol cloud-native geospatial server. It gives .NET mobile developers

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ implemented vs. planned) is in [docs/features/README.md](docs/features/README.md
 | **Honua.Mobile.Sdk** | Transport, auth, gRPC-first client, REST fallback, routing, and SDK scene metadata adapter | NuGet on [GitHub Packages](https://github.com/orgs/honua-io/packages?repo_name=honua-mobile), from signed `mobile-dotnet-v*` release tags |
 | **Honua.Mobile.Offline** | GeoPackage storage, sync queue, map area download, conflict resolution | same |
 | **Honua.Mobile.Maui** | MAUI service registration, DI extensions, native display boundaries, native scene anchoring, and device location orchestration | same |
-| **@honua-io/embed** | Framework-agnostic `<honua-map>` and `<honua-scene>` web components (plus React/Vue/Angular wrappers) for ISV embeds | npm on GitHub Packages, from `mobile-embed-v*` release tags |
+| **@honua-io/embed** | Framework-agnostic `<honua-map>` and `<honua-scene>` web components (plus React/Vue/Angular wrappers) for ISV embeds | npm on GitHub Packages, via the embed publish workflow (`mobile-embed-v*` release tags or manual dispatch) |
 
 The library packages target `net10.0` and build on any platform without the MAUI
 workload. The reference apps and templates are .NET MAUI (`net10.0-android`,


### PR DESCRIPTION
Refreshes the main README against actual repo contents on trunk.

Changes:
- Fixed the embed package name: it is `@honua-io/embed` (per `src/Honua.Embed/package.json`), not `@honua/embed`.
- Removed stale roadmap pointers: honua-server#811 is closed and `honua-server/docs/developer/mobile-sdk-roadmap.md` no longer exists (404); now points to the in-repo backlog roadmap and SDK contract stability docs.
- Fixed the repository structure block: removed the nonexistent `proto/honua/v1` directory, added `apps/Honua.Mobile.FieldCollection*`, `tools/` (migration codemod CLI), `templates/`, `examples/`, and `contracts/`.
- Replaced the 'Production-ready foundation' status claim with honest pre-1.0 alpha signaling, and documented where packages actually publish (GitHub Packages NuGet/npm from signed `mobile-dotnet-v*` / `mobile-embed-v*` release tags) and the supported target frameworks (verified against csproj files).
- Added a clear SDK-vs-app distinction and cross-links to honua-collect, honua-sdk-dotnet, honua-server, honua-sdk-js, honua-console, and honua-helm.
- Added CI and Live Server Integration badges (both workflows verified in `.github/workflows/`), a security contact section, and a pointer to the ArcGIS Maps SDK migration guide + `honua-migrate-maui` codemod.
- Verified every DI extension method, client API in code samples, doc path, and relative link against the repo (all resolve).