### PR TITLE
docs: replace raw HTTP examples with supported clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Enforce maintained documentation command policy
+        run: |
+          if git grep -n -i -w curl -- '*.md' '*.mdx' '*.rst' '*.txt'; then
+            echo "::error::Maintained documentation must use supported SDK, CLI, or API-reference workflows."
+            exit 1
+          fi
+
       - name: Check for source changes
         id: filter
         env:

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -263,13 +263,19 @@ dotnet build -t:Run -f net10.0-windows10.0.19041.0 # Windows
 ### Verify Sync
 
 ```bash
-# Check your server dashboard at:
-# https://api.honua.io/dashboard
+# Install the supported Honua command-line client once.
+npm install --global @honua/sdk-js
 
-# Or query via API:
-curl -H "X-API-Key: your-api-key" \
-     "https://api.honua.io/rest/services/mobile_offline_demo/FeatureServer/68910/query?where=1%3D1&outFields=*&f=json"
+# Point it at your deployment and use the same API key as the app.
+export HONUA_BASE_URL=https://api.honua.io
+export HONUA_API_KEY=your-api-key
+
+# Verify that synchronized records are queryable.
+honua query mobile_offline_demo/68910 --where "1=1" --limit 25 --format geojson
 ```
+
+You can also inspect the synchronized layer in the server dashboard at
+<https://api.honua.io/dashboard>.
 
 ## Compare to Competition
 

--- a/docs/guides/migration-guide.md
+++ b/docs/guides/migration-guide.md
@@ -54,16 +54,13 @@ Fulcrum is a popular field data collection platform charging $99-299/month per u
 
 #### 1. **Export Your Fulcrum Data** (30 minutes)
 
-```bash
-# Using Fulcrum API to export your data
-curl -H "X-ApiToken: YOUR_FULCRUM_TOKEN" \
-     "https://api.fulcrumapp.com/api/v2/forms.json" \
-     > fulcrum_forms.json
+Use Fulcrum's supported export workflow to download the form definition and
+records as `fulcrum_forms.json` and `fulcrum_records.json`. Keep attachments in
+the export directory so the later import can preserve their relative paths.
 
-curl -H "X-ApiToken: YOUR_FULCRUM_TOKEN" \
-     "https://api.fulcrumapp.com/api/v2/records.json" \
-     > fulcrum_records.json
-```
+`honua-migrate` does not currently claim a Fulcrum source adapter. Do not send
+Fulcrum tokens through hand-written raw HTTP commands; use Fulcrum's product
+export or an approved Fulcrum SDK until that adapter is available.
 
 #### 2. **Create Honua App** (5 minutes)
 

--- a/tests/conformance/UPSTREAM.md
+++ b/tests/conformance/UPSTREAM.md
@@ -40,23 +40,15 @@ deterministic and a fixture set unambiguously corresponds to one
 1. **Fetch (CI / local).** `tests/conformance/fetch-fixtures.sh --version
    <X.Y.Z> [--dest DIR]` downloads the release asset
    `conformance-fixtures-<version>.tar.gz` (+ `.sha256`) from the `v<version>`
-   GitHub Release of `honua-io/geospatial-grpc` (via `gh release download` when
-   available, else `curl`/`wget`), verifies the tarball SHA-256, extracts it,
+   GitHub Release of `honua-io/geospatial-grpc` (preferring the authenticated
+   GitHub CLI and using the helper's portable fallback otherwise), verifies the tarball SHA-256, extracts it,
    re-verifies every file against the in-tarball `SHA256SUMS`, and asserts the
    embedded `VERSION` equals the requested pin. It leaves `fixtures/`
    (+ `manifest.txt`), `golden/`, `run.sh`, and `VERSION` in `--dest`
    (default `./conformance-fixtures-<version>/`).
 
-   Equivalent raw pull (no helper):
-
-   ```bash
-   v=0.1.0-alpha.1
-   base="https://github.com/honua-io/geospatial-grpc/releases/download/v${v}"
-   curl -fsSLO "${base}/conformance-fixtures-${v}.tar.gz"
-   curl -fsSLO "${base}/conformance-fixtures-${v}.tar.gz.sha256"
-   sha256sum -c "conformance-fixtures-${v}.tar.gz.sha256"
-   tar -xzf "conformance-fixtures-${v}.tar.gz"
-   ```
+   Use the helper rather than reconstructing the release download by hand; it
+   verifies both the release checksum and the manifest inside the archive.
 
 2. **Locate (tests).** `LiveHonuaServerInteractionTests` discovers the fetched
    fixture directory via the `HONUA_MOBILE_CONFORMANCE_FIXTURES_DIR` environment


### PR DESCRIPTION
Part of honua-migrate#101. Uses the supported Honua JS CLI for sync verification, clarifies the Fulcrum adapter gap, and makes conformance downloads helper-only. Checks: maintained-doc scan and diff check. Mobile build intentionally not run for docs-only changes.