### PR TITLE
docs: correct stale SDK train pin in sdk-contract-stability guide

### DIFF
--- a/docs/guides/sdk-contract-stability.md
+++ b/docs/guides/sdk-contract-stability.md
@@ -13,11 +13,13 @@ the SDK to meet before it advances along that track.
 
 honua-mobile pins the SDK release train as a single property:
 
-- Pinned version: `0.1.17-alpha.1`
-- Pin location: [`Directory.Build.props`](../../Directory.Build.props) line 11
+- Pinned version: `1.3.0` (train packages published from `honua-sdk-dotnet`
+  trunk to GitHub Packages; see `<HonuaSdkDotNetTrainReleaseUrl>` /
+  `<HonuaSdkDotNetTrainReleasePublishedAt>` for the exact release run)
+- Pin location: [`Directory.Build.props`](../../Directory.Build.props)
   (`<HonuaSdkDotNetTrainVersion>`)
-- Release tag template: `dotnet-sdk-v$(HonuaSdkDotNetTrainVersion)` (line 12)
-- Upstream repo: `honua-io/honua-sdk-dotnet` (line 13)
+- Release channel: `<HonuaSdkDotNetTrainTag>` (currently `trunk`)
+- Upstream repo: `honua-io/honua-sdk-dotnet` (`<HonuaSdkDotNetTrainRepository>`)
 - Cross-repo handshake fixture:
   [`contracts/fixtures/mobile-sdk-contract-harmonization.v1.json`](../../contracts/fixtures/mobile-sdk-contract-harmonization.v1.json)
 
@@ -25,10 +27,14 @@ Mobile pins the **train tag**: a single `HonuaSdkDotNetTrainVersion` property
 moves the whole package set together. There is no per-package floating range in
 the mobile repo today, and we intend to keep that invariant.
 
-The SDK has cycled through 17+ alpha bumps over the past month
-(`0.1.1-alpha.1` through `0.1.17-alpha.1`). PR #187 consumed `0.1.17-alpha.1` and
-subsequent PRs (e.g. #190) continued that pin. Each alpha bump has historically
-required a mobile-side refactor PR.
+During the alpha phase the SDK cycled through 17+ alpha bumps in a month
+(`0.1.1-alpha.1` through `0.1.17-alpha.1`; PR #187 consumed `0.1.17-alpha.1`
+and subsequent PRs, e.g. #190, continued that pin), and each alpha bump
+historically required a mobile-side refactor PR. The train has since moved to
+`1.x` version numbers (currently `1.3.0`). Note that a `1.x` version number
+alone does not mean the "stable" bar below has been met: mobile has not yet
+re-graded the train against the beta/stable exit criteria in this doc, and the
+packages still ship only to GitHub Packages (no public nuget.org release).
 
 ## Package surface
 
@@ -55,7 +61,7 @@ These definitions are what honua-mobile treats as the contract; they are
 intentionally stricter than raw SemVer because alpha versions don't carry
 SemVer guarantees on their own.
 
-### alpha (`0.1.x-alpha.N`) — today
+### alpha (`0.1.x-alpha.N`)
 
 - Public API may change in any release, including signature changes, type
   renames, namespace moves, and package splits.

--- a/docs/guides/sdk-contract-stability.md
+++ b/docs/guides/sdk-contract-stability.md
@@ -14,8 +14,12 @@ the SDK to meet before it advances along that track.
 honua-mobile pins the SDK release train as a single property:
 
 - Pinned version: `1.3.0` (train packages published from `honua-sdk-dotnet`
-  trunk to GitHub Packages; see `<HonuaSdkDotNetTrainReleaseUrl>` /
-  `<HonuaSdkDotNetTrainReleasePublishedAt>` for the exact release run)
+  trunk to GitHub Packages). Note: the `<HonuaSdkDotNetTrainReleaseUrl>` /
+  `<HonuaSdkDotNetTrainReleaseCommit>` / `<HonuaSdkDotNetTrainReleasePublishedAt>`
+  provenance properties record the last manual refresh (currently the `1.0.0`
+  train run) and are not updated on routine version bumps — the authoritative
+  record for the pinned version is the GitHub Packages feed entry for
+  `<HonuaSdkDotNetTrainVersion>` itself.
 - Pin location: [`Directory.Build.props`](../../Directory.Build.props)
   (`<HonuaSdkDotNetTrainVersion>`)
 - Release channel: `<HonuaSdkDotNetTrainTag>` (currently `trunk`)


### PR DESCRIPTION
Fixes #342

## Summary
Doc-side follow-up from the README refresh (#341). Recon against current `trunk` confirmed the stale-doc item: `docs/guides/sdk-contract-stability.md` still claimed the SDK train pin was `0.1.17-alpha.1` while `Directory.Build.props` pins `<HonuaSdkDotNetTrainVersion>1.3.0</HonuaSdkDotNetTrainVersion>`.

## Changes Made
- `docs/guides/sdk-contract-stability.md`:
  - Current state now reports the actual pin (`1.3.0`), points at the property names instead of hardcoded (and drifted) line numbers, and documents the release channel via `<HonuaSdkDotNetTrainTag>` (currently `trunk`) rather than the obsolete `dotnet-sdk-v...` tag-template claim.
  - Reframed the 17-alpha-bump history as history and added an explicit caveat that the `1.x` version number alone does not mean the doc's beta/stable exit criteria have been met, and that packages still ship only to GitHub Packages.
  - Dropped the "— today" marker from the alpha section heading, since the pin is no longer on the `0.1.x-alpha` series.

## Operator items remaining (not addressed here)
- Decide/execute public publishing of the NuGet + npm packages to nuget.org and npmjs (currently GitHub Packages only, auth required) as part of the first-publish wave. This is a registry/release decision and action, operator-owned.
